### PR TITLE
Change module path to allow `go install` command to work

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module surge
+module github.com/junaid2005p/surge
 
 go 1.24.4
 


### PR DESCRIPTION
I get an error when trying to install this program using `go install github.com/junaid2005p/surge@latest` because the `go.mod` file uses the incorrect module path. It should be `github.com/junaid2005p/surge`, not just `surge`.

Below is the error I got:
```sh
go: downloading github.com/junaid2005p/surge v0.1.0
go: github.com/junaid2005p/surge@latest: version constraints conflict:
	github.com/junaid2005p/surge@v0.1.0: parsing go.mod:
	module declares its path as: surge
	        but was required as: github.com/junaid2005p/surge
```