### PR TITLE
feat: implement adaptive UI theme support with light, dark, and system-based modes

### DIFF
--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -24,7 +24,14 @@ type GeneralSettings struct {
 	SkipUpdateCheck        bool   `json:"skip_update_check"`
 	MaxConcurrentDownloads int    `json:"max_concurrent_downloads"`
 	ClipboardMonitor       bool   `json:"clipboard_monitor"`
+	Theme                  int    `json:"theme"`
 }
+
+const (
+	ThemeAdaptive = 0
+	ThemeLight    = 1
+	ThemeDark     = 2
+)
 
 // ConnectionSettings contains network connection parameters.
 type ConnectionSettings struct {
@@ -69,6 +76,7 @@ func GetSettingsMetadata() map[string][]SettingMeta {
 			{Key: "skip_update_check", Label: "Skip Update Check", Description: "Disable automatic check for new versions on startup.", Type: "bool"},
 			{Key: "max_concurrent_downloads", Label: "Max Concurrent Downloads", Description: "Maximum number of downloads running at once (1-10). Requires restart.", Type: "int"},
 			{Key: "clipboard_monitor", Label: "Clipboard Monitor", Description: "Watch clipboard for URLs and prompt to download them.", Type: "bool"},
+			{Key: "theme", Label: "App Theme", Description: "UI Theme (System, Light, Dark).", Type: "int"},
 		},
 		"Connections": {
 			{Key: "max_connections_per_host", Label: "Max Connections/Host", Description: "Maximum concurrent connections per host (1-64).", Type: "int"},
@@ -114,6 +122,7 @@ func DefaultSettings() *Settings {
 			AutoResume:             false,
 			MaxConcurrentDownloads: 3,
 			ClipboardMonitor:       true,
+			Theme:                  ThemeAdaptive,
 		},
 		Connections: ConnectionSettings{
 			MaxConnectionsPerHost: 32,

--- a/internal/tui/colors/colors.go
+++ b/internal/tui/colors/colors.go
@@ -3,27 +3,27 @@ package colors
 import "github.com/charmbracelet/lipgloss"
 
 // === Color Palette ===
-// Vibrant "Cyberpunk" Neon Colors
+// Vibrant "Cyberpunk" Neon Colors (Dark Mode) + High Contrast (Light Mode)
 var (
-	NeonPurple = lipgloss.Color("#bd93f9")
-	NeonPink   = lipgloss.Color("#ff79c6")
-	NeonCyan   = lipgloss.Color("#8be9fd")
-	DarkGray   = lipgloss.Color("#282a36") // Background
-	Gray       = lipgloss.Color("#44475a") // Borders
-	LightGray  = lipgloss.Color("#a9b1d6") // Brighter text for secondary info
-	White      = lipgloss.Color("#f8f8f2")
+	NeonPurple = lipgloss.AdaptiveColor{Light: "#5d40c9", Dark: "#bd93f9"}
+	NeonPink   = lipgloss.AdaptiveColor{Light: "#d10074", Dark: "#ff79c6"}
+	NeonCyan   = lipgloss.AdaptiveColor{Light: "#0073a8", Dark: "#8be9fd"}
+	DarkGray   = lipgloss.AdaptiveColor{Light: "#ffffff", Dark: "#282a36"} // Background
+	Gray       = lipgloss.AdaptiveColor{Light: "#d0d0d0", Dark: "#44475a"} // Borders
+	LightGray  = lipgloss.AdaptiveColor{Light: "#4a4a4a", Dark: "#a9b1d6"} // Brighter text for secondary info
+	White      = lipgloss.AdaptiveColor{Light: "#1a1a1a", Dark: "#f8f8f2"}
 )
 
 // === Semantic State Colors ===
 var (
-	StateError       = lipgloss.Color("#ff5555") // 🔴 Red - Error/Stopped
-	StatePaused      = lipgloss.Color("#ffb86c") // 🟡 Orange - Paused/Queued
-	StateDownloading = lipgloss.Color("#50fa7b") // 🟢 Green - Downloading
-	StateDone        = lipgloss.Color("#bd93f9") // 🔵 Purple - Completed
+	StateError       = lipgloss.AdaptiveColor{Light: "#d32f2f", Dark: "#ff5555"} // 🔴 Red - Error/Stopped
+	StatePaused      = lipgloss.AdaptiveColor{Light: "#f57c00", Dark: "#ffb86c"} // 🟡 Orange - Paused/Queued
+	StateDownloading = lipgloss.AdaptiveColor{Light: "#2e7d32", Dark: "#50fa7b"} // 🟢 Green - Downloading
+	StateDone        = lipgloss.AdaptiveColor{Light: "#7b1fa2", Dark: "#bd93f9"} // 🔵 Purple - Completed
 )
 
 // === Progress Bar Colors ===
-const (
-	ProgressStart = "#ff79c6" // Pink
-	ProgressEnd   = "#bd93f9" // Purple
+var (
+	ProgressStart = lipgloss.AdaptiveColor{Light: "#d10074", Dark: "#ff79c6"} // Pink
+	ProgressEnd   = lipgloss.AdaptiveColor{Light: "#7b1fa2", Dark: "#bd93f9"} // Purple
 )

--- a/internal/tui/components/box.go
+++ b/internal/tui/components/box.go
@@ -9,13 +9,13 @@ import (
 )
 
 // BoxRenderer is the function signature for rendering btop-style boxes
-type BoxRenderer func(leftTitle, rightTitle, content string, width, height int, borderColor lipgloss.Color) string
+type BoxRenderer func(leftTitle, rightTitle, content string, width, height int, borderColor lipgloss.TerminalColor) string
 
 // RenderBtopBox creates a btop-style box with title embedded in the top border.
 // Supports left and right titles (e.g., search on left, pane name on right).
 // Accepts pre-styled title strings.
 // Example: ╭─ 🔍 Search... ─────────── Downloads ─╮
-func RenderBtopBox(leftTitle, rightTitle string, content string, width, height int, borderColor lipgloss.Color) string {
+func RenderBtopBox(leftTitle, rightTitle string, content string, width, height int, borderColor lipgloss.TerminalColor) string {
 	// Border characters
 	const (
 		topLeft     = "╭"

--- a/internal/tui/components/confirmation_modal.go
+++ b/internal/tui/components/confirmation_modal.go
@@ -12,10 +12,10 @@ import (
 type ConfirmationModal struct {
 	Title       string
 	Message     string
-	Detail      string         // Optional additional detail line (e.g., filename, URL)
-	Keys        help.KeyMap    // Key bindings to show in help
-	Help        help.Model     // Help model for rendering keys
-	BorderColor lipgloss.Color // Border color for the box
+	Detail      string                 // Optional additional detail line (e.g., filename, URL)
+	Keys        help.KeyMap            // Key bindings to show in help
+	Help        help.Model             // Help model for rendering keys
+	BorderColor lipgloss.TerminalColor // Border color for the box
 	Width       int
 	Height      int
 }
@@ -41,7 +41,7 @@ func (k ConfirmationKeyMap) FullHelp() [][]key.Binding {
 }
 
 // NewConfirmationModal creates a modal with default styling
-func NewConfirmationModal(title, message, detail string, keys help.KeyMap, helpModel help.Model, borderColor lipgloss.Color) ConfirmationModal {
+func NewConfirmationModal(title, message, detail string, keys help.KeyMap, helpModel help.Model, borderColor lipgloss.TerminalColor) ConfirmationModal {
 	return ConfirmationModal{
 		Title:       title,
 		Message:     message,
@@ -77,7 +77,7 @@ func (m ConfirmationModal) View() string {
 // RenderWithBtopBox renders the modal using the btop-style box with title in border
 // Help text is pushed to the last line of the modal
 func (m ConfirmationModal) RenderWithBtopBox(
-	renderBox func(leftTitle, rightTitle, content string, width, height int, borderColor lipgloss.Color) string,
+	renderBox func(leftTitle, rightTitle, content string, width, height int, borderColor lipgloss.TerminalColor) string,
 	titleStyle lipgloss.Style,
 ) string {
 	innerWidth := m.Width - 4 // Account for borders

--- a/internal/tui/components/filepicker_modal.go
+++ b/internal/tui/components/filepicker_modal.go
@@ -14,13 +14,13 @@ type FilePickerModal struct {
 	Picker      filepicker.Model
 	Help        help.Model
 	HelpKeys    help.KeyMap
-	BorderColor lipgloss.Color
+	BorderColor lipgloss.TerminalColor
 	Width       int
 	Height      int
 }
 
 // NewFilePickerModal creates a file picker modal with default styling
-func NewFilePickerModal(title string, picker filepicker.Model, helpModel help.Model, helpKeys help.KeyMap, borderColor lipgloss.Color) FilePickerModal {
+func NewFilePickerModal(title string, picker filepicker.Model, helpModel help.Model, helpKeys help.KeyMap, borderColor lipgloss.TerminalColor) FilePickerModal {
 	return FilePickerModal{
 		Title:       title,
 		Picker:      picker,
@@ -50,7 +50,7 @@ func (m FilePickerModal) View() string {
 
 // RenderWithBtopBox renders the modal using the btop-style box
 func (m FilePickerModal) RenderWithBtopBox(
-	renderBox func(leftTitle, rightTitle, content string, width, height int, borderColor lipgloss.Color) string,
+	renderBox func(leftTitle, rightTitle, content string, width, height int, borderColor lipgloss.TerminalColor) string,
 	titleStyle lipgloss.Style,
 ) string {
 	return renderBox(titleStyle.Render(m.Title), "", m.View(), m.Width, m.Height, m.BorderColor)

--- a/internal/tui/components/status.go
+++ b/internal/tui/components/status.go
@@ -21,7 +21,7 @@ const (
 type statusInfo struct {
 	icon  string
 	label string
-	color lipgloss.Color
+	color lipgloss.TerminalColor
 }
 
 var statusMap = map[DownloadStatus]statusInfo{
@@ -49,7 +49,7 @@ func (s DownloadStatus) Label() string {
 }
 
 // Color returns the status color
-func (s DownloadStatus) Color() lipgloss.Color {
+func (s DownloadStatus) Color() lipgloss.TerminalColor {
 	if info, ok := statusMap[s]; ok {
 		return info.color
 	}

--- a/internal/tui/gradient.go
+++ b/internal/tui/gradient.go
@@ -10,15 +10,16 @@ import (
 )
 
 // ApplyGradient applies a vertical gradient to a multi-line string
-func ApplyGradient(text string, startColor, endColor lipgloss.Color) string {
+// ApplyGradient applies a vertical gradient to a multi-line string
+func ApplyGradient(text string, startColor, endColor lipgloss.TerminalColor) string {
 	lines := strings.Split(text, "\n")
 	height := len(lines)
 	if height == 0 {
 		return text
 	}
 
-	startRGB, _ := hexToRGB(string(startColor))
-	endRGB, _ := hexToRGB(string(endColor))
+	startRGB, _ := hexToRGB(resolveColor(startColor))
+	endRGB, _ := hexToRGB(resolveColor(endColor))
 
 	var coloredLines []string
 	for i, line := range lines {
@@ -45,6 +46,19 @@ func ApplyGradient(text string, startColor, endColor lipgloss.Color) string {
 	}
 
 	return strings.Join(coloredLines, "\n")
+}
+
+func resolveColor(c lipgloss.TerminalColor) string {
+	if ac, ok := c.(lipgloss.AdaptiveColor); ok {
+		if lipgloss.HasDarkBackground() {
+			return ac.Dark
+		}
+		return ac.Light
+	}
+	if col, ok := c.(lipgloss.Color); ok {
+		return string(col)
+	}
+	return ""
 }
 
 type rgb struct {

--- a/internal/tui/graph.go
+++ b/internal/tui/graph.go
@@ -16,11 +16,11 @@ type GraphStats struct {
 	DownloadTotal int64   // Total downloaded bytes
 }
 
-var graphGradient = []lipgloss.Color{
-	lipgloss.Color("#5f005f"), // Dark Purple (Bottom)
-	lipgloss.Color("#8700af"), // Medium Purple
-	lipgloss.Color("#af00d7"), // Bright Purple
-	lipgloss.Color("#ff00ff"), // Neon Pink (Top)
+var graphGradient = []lipgloss.TerminalColor{
+	lipgloss.AdaptiveColor{Light: "#ce93d8", Dark: "#5f005f"}, // Bottom
+	lipgloss.AdaptiveColor{Light: "#ab47bc", Dark: "#8700af"},
+	lipgloss.AdaptiveColor{Light: "#8e24aa", Dark: "#af00d7"},
+	lipgloss.AdaptiveColor{Light: "#4a148c", Dark: "#ff00ff"}, // Top
 }
 
 // renderMultiLineGraph creates a multi-line bar graph with grid lines.
@@ -30,7 +30,7 @@ var graphGradient = []lipgloss.Color{
 // maxVal: maximum value for scaling
 // color: color for the data bars
 // stats: stats to display in overlay box (pass nil to skip)
-func renderMultiLineGraph(data []float64, width, height int, maxVal float64, color lipgloss.Color, stats *GraphStats) string {
+func renderMultiLineGraph(data []float64, width, height int, maxVal float64, color lipgloss.TerminalColor, stats *GraphStats) string {
 
 	if width < 1 || height < 1 {
 		return ""

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -22,7 +22,7 @@ var (
 )
 
 // Progress bar color constants
-const (
+var (
 	ProgressStart = colors.ProgressStart
 	ProgressEnd   = colors.ProgressEnd
 )

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -1203,6 +1203,14 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return m, nil
 				}
 
+				// Special handling for Theme cycling
+				if key == "theme" {
+					newTheme := (m.Settings.General.Theme + 1) % 3
+					m.Settings.General.Theme = newTheme
+					m.ApplyTheme(newTheme)
+					return m, nil
+				}
+
 				// Toggle bool or enter edit mode for other types
 				typ := m.getCurrentSettingType()
 				if typ == "bool" {
@@ -1234,6 +1242,11 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				categories := config.CategoryOrder()
 				currentCategory := categories[m.SettingsActiveTab]
 				m.resetSettingToDefault(currentCategory, key, defaults)
+
+				// Special handling for Theme reset to ensure it applies immediately
+				if key == "theme" {
+					m.ApplyTheme(m.Settings.General.Theme)
+				}
 				return m, nil
 			}
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -749,6 +749,6 @@ func renderTabs(activeTab, activeCount, queuedCount, doneCount int) string {
 // Accepts pre-styled title strings
 // Example: ╭─ 🔍 Search... ─────────── Downloads ─╮
 // Delegates to components.RenderBtopBox for the actual rendering
-func renderBtopBox(leftTitle, rightTitle string, content string, width, height int, borderColor lipgloss.Color) string {
+func renderBtopBox(leftTitle, rightTitle string, content string, width, height int, borderColor lipgloss.TerminalColor) string {
 	return components.RenderBtopBox(leftTitle, rightTitle, content, width, height, borderColor)
 }


### PR DESCRIPTION
This PR introduces full support for adaptive terminal colors and a manual theme toggle setting. Users can now switch between System (default behavior), Light, and Dark modes directly from the application settings, overriding the terminal's reported background color if desired.

- Adaptive Colors: The entire TUI now uses lipgloss.AdaptiveColor, ensuring high contrast and readability on both light and dark terminal backgrounds.
- Manual Theme Setting: Added a new "App Theme" option in Settings -> General.
- Instant Persistence: Theme changes utilize lipgloss.SetHasDarkBackground to apply immediately without a restart.

fixes #31 