### PR TITLE
feat: Prioritize XDG_DOWNLOAD_DIR for the default download directory and update tests to reflect the new fallback logic.

### DIFF
--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -114,7 +114,23 @@ const (
 // DefaultSettings returns a new Settings instance with sensible defaults.
 func DefaultSettings() *Settings {
 	homeDir, _ := os.UserHomeDir()
-	defaultDir := filepath.Join(homeDir, "Downloads")
+	
+	defaultDir := ""
+	
+	// Check XDG_DOWNLOAD_DIR
+	if xdgDir := os.Getenv("XDG_DOWNLOAD_DIR"); xdgDir != "" {
+		if info, err := os.Stat(xdgDir); err == nil && info.IsDir() {
+			defaultDir = xdgDir
+		}
+	}
+
+	// Check ~/Downloads if not set
+	if defaultDir == "" && homeDir != "" {
+		downloadsDir := filepath.Join(homeDir, "Downloads")
+		if info, err := os.Stat(downloadsDir); err == nil && info.IsDir() {
+			defaultDir = downloadsDir
+		}
+	}
 
 	return &Settings{
 		General: GeneralSettings{


### PR DESCRIPTION
Closes #104 