### PR TITLE
🧹 Remove obsolete comment in manager.go

### DIFF
--- a/internal/download/manager.go
+++ b/internal/download/manager.go
@@ -27,8 +27,6 @@ type ProbeResult struct {
 	ContentType   string
 }
 
-// probeServer has been moved to internal/engine/probe.go
-
 // uniqueFilePath returns a unique file path by appending (1), (2), etc. if the file exists
 func uniqueFilePath(path string) string {
 	// Check if file exists (both final and incomplete)


### PR DESCRIPTION
* 🎯 **What:** Removed the obsolete comment `// probeServer has been moved to internal/engine/probe.go` from `internal/download/manager.go`.
* 💡 **Why:** The comment is no longer relevant as the code has been moved and the comment is just a tombstone.
* ✅ **Verification:** Verified `internal/engine/probe.go` contains the moved code. Ran `go test ./internal/download/...` to ensure no regressions.
* ✨ **Result:** Cleaner code in `internal/download/manager.go`.

---
*PR created automatically by Jules for task [17157079443492389178](https://jules.google.com/task/17157079443492389178) started by @SuperCoolPencil*