### PR TITLE
feat: handle clean download cancellations and retry probes without Range header on 403/405 errors

### DIFF
--- a/internal/download/manager.go
+++ b/internal/download/manager.go
@@ -251,6 +251,12 @@ func TUIDownload(ctx context.Context, cfg *types.DownloadConfig) error {
 			}
 		}
 	} else if downloadErr != nil && !isPaused {
+		// Verify it's not a cancellation error
+		if errors.Is(downloadErr, context.Canceled) {
+			utils.Debug("Download canceled cleanly")
+			return nil
+		}
+
 		// Persist error state
 		if err := state.AddToMasterList(types.DownloadEntry{
 			ID:         cfg.ID,


### PR DESCRIPTION
Close #126 
Close #123 