### PR TITLE
🧪 Add comprehensive tests for clipboard validator

### DIFF
--- a/internal/clipboard/validator_test.go
+++ b/internal/clipboard/validator_test.go
@@ -1,0 +1,151 @@
+package clipboard
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewValidator(t *testing.T) {
+	v := NewValidator()
+	if v == nil {
+		t.Fatal("NewValidator() returned nil")
+	}
+	if v.allowedSchemes == nil {
+		t.Fatal("NewValidator() did not initialize allowedSchemes")
+	}
+	if !v.allowedSchemes["http"] {
+		t.Error("NewValidator() did not allow http")
+	}
+	if !v.allowedSchemes["https"] {
+		t.Error("NewValidator() did not allow https")
+	}
+}
+
+func TestValidator_ExtractURL(t *testing.T) {
+	v := NewValidator()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		// Valid cases
+		{
+			name:     "Simple HTTP",
+			input:    "http://example.com",
+			expected: "http://example.com",
+		},
+		{
+			name:     "Simple HTTPS",
+			input:    "https://example.com",
+			expected: "https://example.com",
+		},
+		{
+			name:     "URL with path",
+			input:    "https://example.com/path/to/resource",
+			expected: "https://example.com/path/to/resource",
+		},
+		{
+			name:     "URL with query params",
+			input:    "https://example.com?q=search&lang=en",
+			expected: "https://example.com?q=search&lang=en",
+		},
+		{
+			name:     "URL with fragment",
+			input:    "https://example.com#section",
+			expected: "https://example.com#section",
+		},
+		{
+			name:     "URL with port",
+			input:    "http://localhost:8080",
+			expected: "http://localhost:8080",
+		},
+
+		// Trimming
+		{
+			name:     "Leading/Trailing spaces",
+			input:    "  https://example.com  ",
+			expected: "https://example.com",
+		},
+
+		// Invalid cases - formatting/content
+		{
+			name:     "Empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "Just whitespace",
+			input:    "   ",
+			expected: "",
+		},
+		{
+			name:     "Contains newlines in middle",
+			input:    "https://exa\nmple.com",
+			expected: "",
+		},
+		{
+			name:     "Trailing newline",
+			input:    "https://example.com\n",
+			expected: "https://example.com",
+		},
+		{
+			name:     "Contains carriage return",
+			input:    "https://exa\rmple.com",
+			expected: "",
+		},
+		{
+			name:     "No scheme",
+			input:    "example.com",
+			expected: "",
+		},
+		{
+			name:     "Just scheme",
+			input:    "http://",
+			expected: "",
+		},
+		{
+			name:     "Just scheme s",
+			input:    "https://",
+			expected: "",
+		},
+
+		// Invalid cases - Schemes
+		{
+			name:     "FTP scheme",
+			input:    "ftp://example.com",
+			expected: "",
+		},
+		{
+			name:     "File scheme",
+			input:    "file:///etc/passwd",
+			expected: "",
+		},
+		{
+			name:     "Javascript scheme",
+			input:    "javascript:alert(1)",
+			expected: "",
+		},
+
+		// Edge cases
+		{
+			name:     "Too long",
+			input:    "https://" + strings.Repeat("a", 2048), // 8 + 2048 > 2048
+			expected: "",
+		},
+		{
+			name:     "Max length exactly",
+			input:    "https://" + strings.Repeat("a", 2048-8), // 8 + 2040 = 2048
+			expected: "https://" + strings.Repeat("a", 2040),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := v.ExtractURL(tt.input)
+			if got != tt.expected {
+				t.Errorf("ExtractURL(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
🎯 **What:**
Added missing tests for `internal/clipboard/validator.go` to ensure URL extraction and validation logic is robust.

📊 **Coverage:**
The new test suite covers:
- Valid HTTP and HTTPS URLs (simple, paths, queries, fragments, ports).
- Whitespace handling (leading/trailing trimming).
- Rejection of invalid schemes (ftp, file, javascript).
- Rejection of malformed URLs or invalid characters (newlines in middle).
- Length limits.
- Edge cases like empty strings.

✨ **Result:**
`internal/clipboard` package now has unit tests verifying its core logic, preventing regressions in URL validation.

---
*PR created automatically by Jules for task [9780365714346012592](https://jules.google.com/task/9780365714346012592) started by @SuperCoolPencil*