### PR TITLE
⚡ Optimize task creation in concurrent downloader

### DIFF
--- a/internal/engine/concurrent/downloader.go
+++ b/internal/engine/concurrent/downloader.go
@@ -159,7 +159,12 @@ func createTasks(fileSize, chunkSize int64) []types.Task {
 	if chunkSize <= 0 {
 		return nil
 	}
-	var tasks []types.Task
+
+	// Pre-allocate slice capacity to avoid reallocations
+	// Number of chunks = ceil(fileSize / chunkSize)
+	count := (fileSize + chunkSize - 1) / chunkSize
+	tasks := make([]types.Task, 0, int(count))
+
 	for offset := int64(0); offset < fileSize; offset += chunkSize {
 		length := chunkSize
 		if offset+length > fileSize {


### PR DESCRIPTION
💡 **What:**
Pre-allocated the `tasks` slice in `createTasks` function within `internal/engine/concurrent/downloader.go` using `make([]types.Task, 0, capacity)`. The capacity is calculated based on the file size and chunk size.

🎯 **Why:**
The previous implementation used `append` in a loop, causing multiple memory reallocations as the slice grew. This is inefficient for large files with small chunk sizes, where thousands of tasks are created.

📊 **Measured Improvement:**
Benchmark `BenchmarkCreateTasks` (10GB file, 1MB chunks = 10,000 tasks):
- **Baseline:** 515,911 ns/op, 685,307 B/op, 19 allocs/op
- **Optimized:** 124,119 ns/op, 163,842 B/op, 1 allocs/op
- **Result:** ~4.15x speedup and ~4.18x reduction in memory allocation bytes. Allocations reduced from 19 to 1.

---
*PR created automatically by Jules for task [17716022432425247460](https://jules.google.com/task/17716022432425247460) started by @SuperCoolPencil*