### PR TITLE
🧪 [testing improvement] Add comprehensive tests for chunk size calculation

### DIFF
--- a/internal/engine/concurrent/chunk_test.go
+++ b/internal/engine/concurrent/chunk_test.go
@@ -73,3 +73,91 @@ func TestTaskRangeAssignment(t *testing.T) {
 		})
 	}
 }
+
+func TestCalculateChunkSize_EdgeCases(t *testing.T) {
+	// Setup with known min chunk size
+	runtime := &types.RuntimeConfig{
+		MinChunkSize: 2 * types.MB,
+	}
+	d := &ConcurrentDownloader{
+		Runtime: runtime,
+	}
+
+	tests := []struct {
+		name      string
+		fileSize  int64
+		numConns  int
+		wantChunk int64
+	}{
+		{
+			name:      "Zero connections (safety check)",
+			fileSize:  100 * types.MB,
+			numConns:  0,
+			wantChunk: 2 * types.MB, // Fallback to MinChunkSize
+		},
+		{
+			name:      "Negative connections (safety check)",
+			fileSize:  100 * types.MB,
+			numConns:  -5,
+			wantChunk: 2 * types.MB, // Fallback to MinChunkSize
+		},
+		{
+			name:      "Chunk size smaller than MinChunkSize (clamping)",
+			fileSize:  10 * types.MB,
+			numConns:  10,                       // 1MB per conn
+			wantChunk: 2 * types.MB,             // Clamped to MinChunkSize (2MB)
+		},
+		{
+			name:      "Chunk size alignment (unaligned division)",
+			fileSize:  100*types.MB + 123,       // Not perfectly divisible
+			numConns:  4,                        // ~25MB
+			wantChunk: 25 * types.MB,            // 25MB is aligned to 4KB
+		},
+		{
+			name:      "Chunk size alignment (force unaligned)",
+			// 10MB + 2KB. 2 Conns.
+			// (10MB + 2KB) / 2 = 5MB + 1KB.
+			// 5MB + 1KB is NOT aligned to 4KB (AlignSize).
+			// Should round down to nearest 4KB -> 5MB.
+			fileSize:  10*types.MB + 2*types.KB,
+			numConns:  2,
+			wantChunk: 5 * types.MB,
+		},
+		{
+			name:      "Very small file (less than MinChunkSize)",
+			fileSize:  1 * types.MB,
+			numConns:  1,
+			wantChunk: 2 * types.MB, // Clamped to MinChunkSize
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := d.calculateChunkSize(tt.fileSize, tt.numConns)
+			assert.Equal(t, tt.wantChunk, got, "Chunk size mismatch for %s", tt.name)
+
+			// Verify alignment
+			if got > 0 {
+				assert.Equal(t, int64(0), got%types.AlignSize, "Chunk size %d is not aligned to %d", got, types.AlignSize)
+			}
+		})
+	}
+
+	// Special case for Zero Chunk Size logic:
+	// If MinChunkSize is very small (1 byte), we can test the alignment logic where it rounds down to 0.
+	t.Run("Zero chunk size logic", func(t *testing.T) {
+		runtimeSmall := &types.RuntimeConfig{
+			MinChunkSize: 1, // Set to 1 byte (must be > 0 to avoid default override)
+		}
+		dSmall := &ConcurrentDownloader{
+			Runtime: runtimeSmall,
+		}
+
+		// 1KB / 1 = 1KB.
+		// 1KB / 4KB = 0 (integer division).
+		// 0 * 4KB = 0.
+		// Should become 4KB (AlignSize) by the safety check.
+		got := dSmall.calculateChunkSize(1*types.KB, 1)
+		assert.Equal(t, int64(types.AlignSize), got, "Should be bumped to AlignSize")
+	})
+}


### PR DESCRIPTION
🎯 **What:** Added comprehensive unit tests for `calculateChunkSize` in `internal/engine/concurrent/downloader.go` to address the untested logic gap.

📊 **Coverage:** The new tests cover:
- `numConns <= 0` (Safety check fallback)
- `numConns` negative (Safety check fallback)
- `chunkSize < MinChunkSize` (Clamping logic)
- 4KB alignment verification (ensuring chunk size is a multiple of `types.AlignSize`)
- Large files and small files scenarios
- Zero/small chunk size logic (bumping to `AlignSize`)

✨ **Result:** Increased confidence in the chunk size calculation logic which is critical for performance and filesystem alignment. All tests passed.

---
*PR created automatically by Jules for task [16734020018721494662](https://jules.google.com/task/16734020018721494662) started by @SuperCoolPencil*