### PR TITLE
refactor: Align file storage with XDG Base Directory specs

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -98,6 +98,10 @@ func TestFindAvailablePort_AllPortsOccupied(t *testing.T) {
 // =============================================================================
 
 func TestSaveAndRemoveActivePort(t *testing.T) {
+	// Setup temp dir
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
+	t.Setenv("XDG_CONFIG_HOME", tmpDir) // For EnsureDirs to work happily
 	// Ensure config dirs exist
 	if err := config.EnsureDirs(); err != nil {
 		t.Fatalf("Failed to ensure dirs: %v", err)
@@ -108,7 +112,7 @@ func TestSaveAndRemoveActivePort(t *testing.T) {
 	saveActivePort(testPort)
 
 	// Verify file exists and contains correct port
-	portFile := filepath.Join(config.GetSurgeDir(), "port")
+	portFile := filepath.Join(config.GetRuntimeDir(), "port")
 	data, err := os.ReadFile(portFile)
 	if err != nil {
 		t.Fatalf("Failed to read port file: %v", err)
@@ -955,6 +959,11 @@ func TestCorsMiddleware_AllMethods(t *testing.T) {
 // =============================================================================
 
 func TestPortFileLifecycle(t *testing.T) {
+	// Setup temp dir
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
 	if err := config.EnsureDirs(); err != nil {
 		t.Fatalf("Failed to ensure dirs: %v", err)
 	}
@@ -962,7 +971,7 @@ func TestPortFileLifecycle(t *testing.T) {
 	// Clean up first
 	removeActivePort()
 
-	portFile := filepath.Join(config.GetSurgeDir(), "port")
+	portFile := filepath.Join(config.GetRuntimeDir(), "port")
 
 	// Verify no port file initially
 	if _, err := os.Stat(portFile); !os.IsNotExist(err) {

--- a/cmd/lock.go
+++ b/cmd/lock.go
@@ -27,7 +27,7 @@ func AcquireLock() (bool, error) {
 		return false, fmt.Errorf("failed to ensure config dirs: %w", err)
 	}
 
-	lockPath := filepath.Join(config.GetSurgeDir(), "surge.lock")
+	lockPath := filepath.Join(config.GetRuntimeDir(), "surge.lock")
 	fileLock := flock.New(lockPath)
 
 	locked, err := fileLock.TryLock()

--- a/cmd/lock_test.go
+++ b/cmd/lock_test.go
@@ -14,6 +14,7 @@ func TestAcquireLock(t *testing.T) {
 	// Setup isolation
 	tempDir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tempDir)
+	t.Setenv("XDG_RUNTIME_DIR", tempDir) // Runtime dir for lock file
 
 	// Ensure dirs exist (mocking what root.go does)
 	err := config.EnsureDirs()
@@ -49,7 +50,7 @@ func TestAcquireLock(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Verify file exists
-	lockPath := filepath.Join(config.GetSurgeDir(), "surge.lock")
+	lockPath := filepath.Join(config.GetRuntimeDir(), "surge.lock")
 	_, err = os.Stat(lockPath)
 	assert.NoError(t, err, "Lock file should exist")
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -136,21 +136,21 @@ func init() {
 
 func savePID() {
 	pid := os.Getpid()
-	pidFile := filepath.Join(config.GetSurgeDir(), "pid")
+	pidFile := filepath.Join(config.GetRuntimeDir(), "pid")
 	if err := os.WriteFile(pidFile, []byte(fmt.Sprintf("%d", pid)), 0o644); err != nil {
 		utils.Debug("Error writing PID file: %v", err)
 	}
 }
 
 func removePID() {
-	pidFile := filepath.Join(config.GetSurgeDir(), "pid")
+	pidFile := filepath.Join(config.GetRuntimeDir(), "pid")
 	if err := os.Remove(pidFile); err != nil && !os.IsNotExist(err) {
 		utils.Debug("Error removing PID file: %v", err)
 	}
 }
 
 func readPID() int {
-	pidFile := filepath.Join(config.GetSurgeDir(), "pid")
+	pidFile := filepath.Join(config.GetRuntimeDir(), "pid")
 	data, err := os.ReadFile(pidFile)
 	if err != nil {
 		return 0

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -19,7 +19,7 @@ import (
 
 // readActivePort reads the port from the port file
 func readActivePort() int {
-	portFile := filepath.Join(config.GetSurgeDir(), "port")
+	portFile := filepath.Join(config.GetRuntimeDir(), "port")
 	data, err := os.ReadFile(portFile)
 	if err != nil {
 		return 0

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -1,11 +1,16 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 )
 
+// GetSurgeDir returns the directory for configuration files (settings.json).
+// Linux: $XDG_CONFIG_HOME/surge or ~/.config/surge
+// macOS: ~/Library/Application Support/surge
+// Windows: %APPDATA%/surge
 func GetSurgeDir() string {
 	switch runtime.GOOS {
 	case "windows":
@@ -27,23 +32,154 @@ func GetSurgeDir() string {
 	}
 }
 
-// Returns directory for state files
+// GetStateDir returns the directory for persistent state files (db, logs, token).
+// Linux: $XDG_STATE_HOME/surge or ~/.local/state/surge
+// macOS/Windows: matches GetSurgeDir()
 func GetStateDir() string {
-	return filepath.Join(GetSurgeDir(), "state")
+	if runtime.GOOS != "linux" {
+		// On non-Linux, we keep everything in the main app directory (SurgeDir)
+		return GetSurgeDir()
+	}
+
+	stateHome := os.Getenv("XDG_STATE_HOME")
+	if stateHome == "" {
+		home, _ := os.UserHomeDir()
+		stateHome = filepath.Join(home, ".local", "state")
+	}
+	return filepath.Join(stateHome, "surge")
 }
 
-// Returns directory for logs
+// GetRuntimeDir returns the directory for runtime files (pid, port, lock).
+// Linux: $XDG_RUNTIME_DIR/surge or fallback to GetStateDir() if unset
+// macOS: $TMPDIR/surge-runtime
+// Windows: %TEMP%/surge
+func GetRuntimeDir() string {
+	switch runtime.GOOS {
+	case "windows":
+		return filepath.Join(os.TempDir(), "surge")
+	case "darwin":
+		return filepath.Join(os.TempDir(), "surge-runtime")
+	default: // Linux
+		runtimeDir := os.Getenv("XDG_RUNTIME_DIR")
+		if runtimeDir != "" {
+			return filepath.Join(runtimeDir, "surge")
+		}
+		// Fallback to state dir if XDG_RUNTIME_DIR is not set (e.g. docker, headless)
+		return GetStateDir()
+	}
+}
+
+// GetLogsDir returns the directory for logs
 func GetLogsDir() string {
-	return filepath.Join(GetSurgeDir(), "logs")
+	return filepath.Join(GetStateDir(), "logs")
 }
 
 // EnsureDirs creates all required directories
 func EnsureDirs() error {
-	dirs := []string{GetSurgeDir(), GetStateDir(), GetLogsDir()}
+	dirs := []string{GetSurgeDir(), GetStateDir(), GetRuntimeDir(), GetLogsDir()}
 	for _, dir := range dirs {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			return err
 		}
 	}
+	// On Linux runtime dir, we might want stricter permissions (0700) if it's in /run/user
+	if runtime.GOOS == "linux" && os.Getenv("XDG_RUNTIME_DIR") != "" {
+		_ = os.Chmod(GetRuntimeDir(), 0o700)
+	}
+
+	return nil
+}
+
+// MigrateOldPaths moves files from the old flat layout (pre-XDG) to new locations.
+// Only relevant on Linux.
+func MigrateOldPaths() error {
+	if runtime.GOOS != "linux" {
+		return nil
+	}
+
+	configDir := GetSurgeDir()
+	stateDir := GetStateDir()
+
+	// If config dir doesn't exist, nothing to migrate (fresh install)
+	if _, err := os.Stat(configDir); os.IsNotExist(err) {
+		return nil
+	}
+
+	// Make sure target directories exist
+	if err := EnsureDirs(); err != nil {
+		return err
+	}
+
+	// Files to move from ConfigDir -> StateDir
+	// Old location: ~/.config/surge/<file>
+	// New location: ~/.local/state/surge/<file>
+	filesToMove := []string{
+		"surge.db",
+		"token",
+	}
+
+	for _, filename := range filesToMove {
+		oldPath := filepath.Join(configDir, filename)
+		newPath := filepath.Join(stateDir, filename)
+
+		// Move if old exists and new doesn't
+		if _, err := os.Stat(oldPath); err == nil {
+			if _, err := os.Stat(newPath); os.IsNotExist(err) {
+				if err := os.Rename(oldPath, newPath); err != nil {
+					// Log error but continue?
+					fmt.Fprintf(os.Stderr, "Failed to migrate %s: %v\n", filename, err)
+				} else {
+					fmt.Printf("Migrated %s to %s\n", filename, newPath)
+				}
+			} else {
+				// Destination exists, maybe just remove old? Or keep as backup?
+				// For now, let's just log and keep old
+				fmt.Printf("Target %s already exists, skipping migration of %s\n", newPath, filename)
+			}
+		}
+	}
+
+	// Directories to move
+	// Old: ~/.config/surge/state -> ~/.local/state/surge (contents merged if needed)
+	// Old: ~/.config/surge/logs -> ~/.local/state/surge/logs
+
+	// 1. Move 'logs' dir contents
+	oldLogs := filepath.Join(configDir, "logs")
+	newLogs := filepath.Join(stateDir, "logs")
+
+	if info, err := os.Stat(oldLogs); err == nil && info.IsDir() {
+		// Ensure new logs dir exists
+		if err := os.MkdirAll(newLogs, 0755); err != nil {
+			return err
+		}
+
+		entries, _ := os.ReadDir(oldLogs)
+		for _, entry := range entries {
+			oldPath := filepath.Join(oldLogs, entry.Name())
+			newPath := filepath.Join(newLogs, entry.Name())
+			if err := os.Rename(oldPath, newPath); err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to migrate log file %s: %v\n", entry.Name(), err)
+			}
+		}
+		_ = os.Remove(oldLogs)
+	}
+
+	// 2. Handle old 'state' subdir if it exists (some previous versions might have used it)
+	// In the previous codebase check, GetStateDir() was GetSurgeDir()/state
+	// So we need to move contents of ~/.config/surge/state/* to ~/.local/state/surge/*
+	oldStateDir := filepath.Join(configDir, "state")
+	if info, err := os.Stat(oldStateDir); err == nil && info.IsDir() {
+		entries, _ := os.ReadDir(oldStateDir)
+		for _, entry := range entries {
+			oldPath := filepath.Join(oldStateDir, entry.Name())
+			newPath := filepath.Join(stateDir, entry.Name())
+			if err := os.Rename(oldPath, newPath); err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to migrate state file %s: %v\n", entry.Name(), err)
+			}
+		}
+		// Remove empty old state dir
+		_ = os.Remove(oldStateDir)
+	}
+
 	return nil
 }


### PR DESCRIPTION
Closes #162 

## XDG Directory Mapping

| XDG Variable | Default | Purpose | Surge Files |
|---|---|---|---|
| `$XDG_CONFIG_HOME` | `~/.config` | User config | `settings.json` |
| `$XDG_STATE_HOME` | `~/.local/state` | Persistent state & logs | `surge.db`, `logs/`, `token` |
| `$XDG_RUNTIME_DIR` | `/run/user/$UID` | Runtime (volatile) | `pid`, `port`, `surge.lock` |

> [!NOTE]
> - On **macOS**: Uses `~/Library/Application Support/surge` for config+state (split not needed per Apple conventions). Runtime files use a temp-based dir.
> - On **Windows**: Uses `%APPDATA%\surge` for config+state. Runtime uses `%TEMP%\surge`.
> - Runtime files (`pid`, `port`, `lock`) go to `$XDG_RUNTIME_DIR` with fallback to `$XDG_STATE_HOME/surge` if the env var is unset (common in Docker/SSH sessions).
