### PR TITLE
fix: panic on 32-bit platforms

### DIFF
--- a/internal/engine/concurrent/health.go
+++ b/internal/engine/concurrent/health.go
@@ -1,7 +1,6 @@
 package concurrent
 
 import (
-	"sync/atomic"
 	"time"
 
 	"github.com/surge-downloader/surge/internal/utils"
@@ -67,7 +66,7 @@ func (d *ConcurrentDownloader) checkWorkerHealth() {
 
 		// Check for absolute stall: no data received for StallTimeout
 		// This catches dead connections that the relative speed check misses
-		lastActivity := atomic.LoadInt64(&active.LastActivity)
+		lastActivity := active.LastActivity.Load()
 		if lastActivity > 0 {
 			timeSinceData := now.Sub(time.Unix(0, lastActivity))
 			if timeSinceData >= stallTimeout {

--- a/internal/engine/concurrent/health_test.go
+++ b/internal/engine/concurrent/health_test.go
@@ -163,12 +163,13 @@ func TestHealth_StallDetection(t *testing.T) {
 
 	// Worker with last activity 2 seconds ago (exceeds 1s StallTimeout)
 	stalledCtx, stalledCancel := context.WithCancel(ctx)
-	d.activeTasks[0] = &ActiveTask{
-		StartTime:    now.Add(-10 * time.Second),
-		LastActivity: now.Add(-2 * time.Second).UnixNano(), // Stalled for 2s
-		Speed:        5 * 1024 * 1024,                      // 5 MB/s (fast speed, but stalled)
-		Cancel:       stalledCancel,
+	active := &ActiveTask{
+		StartTime: now.Add(-10 * time.Second),
+		Cancel:    stalledCancel,
 	}
+	active.LastActivity.Store(now.Add(-2 * time.Second).UnixNano()) // Stalled for 2s
+	active.Speed = 5 * 1024 * 1024                                  // 5 MB/s (fast speed, but stalled)
+	d.activeTasks[0] = active
 
 	d.checkWorkerHealth()
 


### PR DESCRIPTION
The application panics on 32-bit platforms (like i686) because `sync/atomic` requires 64-bit words to be 64-bit aligned. 

We use `int64` fields accessed via `sync/atomic` functions, but since they are not the first field in the allocated struct, their alignment is not guaranteed to be 64-bit on 32-bit architectures, causing a panic.

To fix this, we migrate to Go 1.19+ `atomic.Int64` and `atomic.Int32` types, which automatically handle alignment internally.

Close #201 