### PR TITLE
feat: Stagger concurrent download worker starts and introduce live speed calculation for a more responsive TUI speed graph.

### DIFF
--- a/internal/engine/concurrent/concurrent_test.go
+++ b/internal/engine/concurrent/concurrent_test.go
@@ -32,6 +32,33 @@ func initTestState(t *testing.T) (string, func()) {
 	}
 }
 
+func TestConcurrentDownloader_WaitForWorkerStart_Staggers(t *testing.T) {
+	downloader := NewConcurrentDownloader("test-id", nil, nil, &types.RuntimeConfig{})
+
+	start := time.Now()
+	if err := downloader.waitForWorkerStart(context.Background(), 2); err != nil {
+		t.Fatalf("waitForWorkerStart returned error: %v", err)
+	}
+
+	elapsed := time.Since(start)
+	minDelay := 2*types.WorkerStartStagger - 40*time.Millisecond
+	if elapsed < minDelay {
+		t.Fatalf("worker start delay too short: got %v, want at least %v", elapsed, minDelay)
+	}
+}
+
+func TestConcurrentDownloader_WaitForWorkerStart_RespectsCancel(t *testing.T) {
+	downloader := NewConcurrentDownloader("test-id", nil, nil, &types.RuntimeConfig{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := downloader.waitForWorkerStart(ctx, 3)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("waitForWorkerStart error = %v, want %v", err, context.Canceled)
+	}
+}
+
 func TestConcurrentDownloader_Download(t *testing.T) {
 	tmpDir, cleanup := initTestState(t)
 	defer cleanup()

--- a/internal/engine/concurrent/downloader.go
+++ b/internal/engine/concurrent/downloader.go
@@ -502,6 +502,12 @@ func (d *ConcurrentDownloader) Download(ctx context.Context, rawurl string, cand
 		wg.Add(1)
 		go func(workerID int) {
 			defer wg.Done()
+			if err := d.waitForWorkerStart(downloadCtx, workerID); err != nil {
+				if err != context.Canceled {
+					workerErrors <- err
+				}
+				return
+			}
 			err := d.worker(downloadCtx, workerID, workerMirrors, outFile, queue, fileSize, client)
 			if err != nil && err != context.Canceled {
 				workerErrors <- err
@@ -603,4 +609,21 @@ func (d *ConcurrentDownloader) Download(ctx context.Context, rawurl string, cand
 
 	// Note: Download completion notifications are handled by the TUI via DownloadCompleteMsg
 	return finalizeCompletedDownload()
+}
+
+func (d *ConcurrentDownloader) waitForWorkerStart(ctx context.Context, workerID int) error {
+	startDelay := time.Duration(workerID) * types.WorkerStartStagger
+	if startDelay <= 0 {
+		return nil
+	}
+
+	timer := time.NewTimer(startDelay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }

--- a/internal/engine/types/config.go
+++ b/internal/engine/types/config.go
@@ -23,6 +23,7 @@ const (
 	// Batching constants for worker updates
 	WorkerBatchSize     = 1 * MB                 // Batch updates until 1MB is downloaded
 	WorkerBatchInterval = 200 * time.Millisecond // Or until 200ms passes
+	WorkerStartStagger  = 150 * time.Millisecond // Delay between starting each worker
 )
 
 // Connection limits

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -58,6 +58,7 @@ type DownloadModel struct {
 	Total         int64
 	Downloaded    int64
 	Speed         float64
+	LiveSpeed     float64
 	Connections   int
 
 	StartTime time.Time

--- a/internal/tui/process.go
+++ b/internal/tui/process.go
@@ -13,6 +13,19 @@ func (m *RootModel) processProgressMsg(msg events.ProgressMsg) {
 	}
 
 	prevDownloaded := d.Downloaded
+	prevElapsed := d.Elapsed
+
+	if deltaElapsed := msg.Elapsed - prevElapsed; deltaElapsed > 0 {
+		deltaDownloaded := msg.Downloaded - prevDownloaded
+		if deltaDownloaded > 0 {
+			d.LiveSpeed = float64(deltaDownloaded) / deltaElapsed.Seconds()
+		} else {
+			d.LiveSpeed = 0
+		}
+	} else if msg.Downloaded < prevDownloaded || msg.Elapsed < prevElapsed {
+		d.LiveSpeed = 0
+	}
+
 	d.Downloaded = msg.Downloaded
 	d.Total = msg.Total
 	d.Speed = msg.Speed
@@ -44,20 +57,11 @@ func (m *RootModel) processProgressMsg(msg events.ProgressMsg) {
 		d.progress.SetPercent(percentage)
 	}
 
-	// Update speed graph history with EMA smoothing for smooth transitions
+	// Sample graph history from live per-interval transfer rate.
 	if time.Since(m.lastSpeedHistoryUpdate) >= GraphUpdateInterval {
 		totalSpeed := m.calcTotalSpeed()
-		// EMA smooth against previous graph point for visual continuity
-		var smoothed float64
 		if len(m.SpeedHistory) > 0 {
-			prev := m.SpeedHistory[len(m.SpeedHistory)-1]
-			const graphAlpha = 0.3 // Graph smoothing factor
-			smoothed = graphAlpha*totalSpeed + (1-graphAlpha)*prev
-		} else {
-			smoothed = totalSpeed
-		}
-		if len(m.SpeedHistory) > 0 {
-			m.SpeedHistory = append(m.SpeedHistory[1:], smoothed)
+			m.SpeedHistory = append(m.SpeedHistory[1:], totalSpeed)
 		}
 		m.lastSpeedHistoryUpdate = time.Now()
 	}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -520,6 +520,7 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				d.Downloaded = d.Total
 				d.Elapsed = msg.Elapsed
 				d.Speed = msg.AvgSpeed
+				d.LiveSpeed = 0
 				d.done = true
 				cmds = append(cmds, d.progress.SetPercent(1.0))
 
@@ -538,6 +539,7 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case events.DownloadErrorMsg:
 		found := false
 		if d := m.FindDownloadByID(msg.DownloadID); d != nil {
+			d.LiveSpeed = 0
 			d.err = msg.Err
 			d.done = true
 			m.addLogEntry(LogStyleError.Render("✖ Error: " + d.Filename))
@@ -560,6 +562,7 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			d.resuming = false
 			d.Downloaded = msg.Downloaded
 			d.Speed = 0
+			d.LiveSpeed = 0
 			m.addLogEntry(LogStylePaused.Render("⏸ Paused: " + d.Filename))
 		}
 		m.UpdateListItems()
@@ -570,6 +573,7 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			d.paused = false
 			d.pausing = false
 			d.resuming = true
+			d.LiveSpeed = 0
 			m.addLogEntry(LogStyleStarted.Render("▶ Resumed: " + d.Filename))
 		}
 		m.UpdateListItems()

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -333,6 +333,52 @@ func TestProcessProgressMsg_UpdatesElapsed(t *testing.T) {
 	}
 }
 
+func TestProcessProgressMsg_UsesLiveSpeedForGraphHistory(t *testing.T) {
+	dm := NewDownloadModel("id-1", "http://example.com/file", "file", config.MB)
+	m := RootModel{
+		downloads:              []*DownloadModel{dm},
+		list:                   NewDownloadList(80, 20),
+		SpeedHistory:           make([]float64, GraphHistoryPoints),
+		lastSpeedHistoryUpdate: time.Now().Add(-GraphUpdateInterval),
+	}
+
+	m.processProgressMsg(events.ProgressMsg{
+		DownloadID: "id-1",
+		Downloaded: config.MB / 2,
+		Total:      config.MB,
+		Speed:      float64(config.MB),
+		Elapsed:    250 * time.Millisecond,
+	})
+
+	if dm.Speed != float64(config.MB) {
+		t.Fatalf("smoothed speed = %f, want %f", dm.Speed, float64(config.MB))
+	}
+
+	if dm.LiveSpeed != 2*float64(config.MB) {
+		t.Fatalf("live speed = %f, want %f", dm.LiveSpeed, 2*float64(config.MB))
+	}
+
+	got := m.SpeedHistory[len(m.SpeedHistory)-1]
+	if got != 2 {
+		t.Fatalf("graph speed = %f MB/s, want 2 MB/s", got)
+	}
+}
+
+func TestCalcTotalSpeed_UsesActiveLiveSpeedOnly(t *testing.T) {
+	m := RootModel{
+		downloads: []*DownloadModel{
+			{ID: "active", LiveSpeed: 2 * float64(config.MB)},
+			{ID: "paused", LiveSpeed: 5 * float64(config.MB), paused: true},
+			{ID: "pausing", LiveSpeed: 7 * float64(config.MB), pausing: true},
+			{ID: "done", LiveSpeed: 11 * float64(config.MB), done: true},
+		},
+	}
+
+	if got := m.calcTotalSpeed(); got != 2 {
+		t.Fatalf("calcTotalSpeed() = %f, want 2", got)
+	}
+}
+
 func TestGenerateUniqueFilename_IncompleteSuffixConstant(t *testing.T) {
 	// Verify the constant we're using is correct
 	if types.IncompleteSuffix != ".surge" {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -986,11 +986,10 @@ func getDownloadStatus(d *DownloadModel) string {
 func (m RootModel) calcTotalSpeed() float64 {
 	total := 0.0
 	for _, d := range m.downloads {
-		// Skip completed downloads
-		if d.done {
+		if d.done || d.paused || d.pausing {
 			continue
 		}
-		total += d.Speed
+		total += d.LiveSpeed
 	}
 	return total / float64(config.MB)
 }


### PR DESCRIPTION
…eed calculation for a more responsive TUI speed graph.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces two related improvements to the concurrent downloader: (1) staggered worker goroutine starts (`waitForWorkerStart`) so workers don't all hammer the server simultaneously at t=0, and (2) a live per-interval speed field (`LiveSpeed`) that replaces the previous EMA-smoothed approach for the TUI speed graph, producing a more responsive display.

- **Stagger**: `waitForWorkerStart` delays worker `i` by `i × 150 ms`; worker 0 returns immediately. Context cancellation is respected correctly via a `select` on the timer and `ctx.Done()`.
- **Live speed**: `processProgressMsg` now computes `LiveSpeed = deltaDownloaded / deltaElapsed` and stores it on each `DownloadModel`; `calcTotalSpeed` was updated to sum `LiveSpeed` (skipping done/paused/pausing downloads) instead of the engine-reported `Speed`.
- **EMA removed**: The graph smoothing alpha (`graphAlpha = 0.3`) was dropped entirely in favour of the raw live rate.
- **`LiveSpeed` reset**: All state-transition handlers in `update.go` (complete, error, pause, resume) correctly zero `LiveSpeed`.
- Minor: `downloader.go` uses a direct `err != context.Canceled` comparison rather than the idiomatic `errors.Is`; a test error message retains stale "smoothed speed" wording; the fast path for `workerID=0` and the backwards-elapsed reset branch in `processProgressMsg` lack dedicated tests.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor style and test-coverage clean-up recommended before landing.
- The core logic is straightforward and well-scoped. The stagger mechanism is correct, context cancellation is handled, and `LiveSpeed` is zeroed in all relevant state transitions. The only issues are non-critical: one non-idiomatic error comparison that works in practice, a stale test message, and two untested edge-case branches.
- `internal/engine/concurrent/downloader.go` (idiomatic error check) and `internal/engine/concurrent/concurrent_test.go` / `internal/tui/update_test.go` (missing edge-case coverage).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/engine/concurrent/downloader.go | Adds `waitForWorkerStart` to stagger worker goroutine starts; uses direct `err != context.Canceled` comparison instead of idiomatic `errors.Is`. |
| internal/tui/process.go | Introduces live per-interval speed (`LiveSpeed`) calculation and removes EMA smoothing from the graph; comment at graph update block describes what rather than why. |
| internal/engine/concurrent/concurrent_test.go | Adds stagger and cancellation tests for `waitForWorkerStart`; missing coverage for workerID=0 fast path and no test for the backwards-elapsed reset branch in `processProgressMsg`. |
| internal/tui/update_test.go | Adds tests for `LiveSpeed` graph sampling and `calcTotalSpeed` active-only filtering; stale "smoothed speed" wording in one fatalf message. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller as Download()
    participant W0 as Worker 0
    participant W1 as Worker 1
    participant W2 as Worker 2
    participant TUI as TUI (processProgressMsg)

    Caller->>W0: go worker(0) — no delay (startDelay=0)
    Caller->>W1: go worker(1) — waitForWorkerStart(150ms)
    Caller->>W2: go worker(2) — waitForWorkerStart(300ms)

    W0->>TUI: ProgressMsg {Downloaded, Elapsed}
    TUI->>TUI: deltaElapsed>0 → LiveSpeed = deltaDownloaded/deltaElapsed

    W1-->>W1: timer fires after 150ms
    W1->>TUI: ProgressMsg {Downloaded, Elapsed}
    TUI->>TUI: LiveSpeed updated

    W2-->>W2: timer fires after 300ms
    W2->>TUI: ProgressMsg {Downloaded, Elapsed}
    TUI->>TUI: LiveSpeed updated

    TUI->>TUI: calcTotalSpeed() sums LiveSpeed (active only)
    TUI->>TUI: SpeedHistory append(totalSpeed)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/engine/concurrent/downloader.go
Line: 506-508

Comment:
**Use `errors.Is` for idiomatic context error comparison**

The `err != context.Canceled` direct comparison works today because `ctx.Err()` returns the sentinel value unwrapped, but it's inconsistent with how `concurrent_test.go` checks the same error (`errors.Is(err, context.Canceled)`) and would silently fail if the error were ever wrapped. The idiomatic Go pattern is `errors.Is`.

```suggestion
			if err := d.waitForWorkerStart(downloadCtx, workerID); err != nil {
				if !errors.Is(err, context.Canceled) {
					workerErrors <- err
				}
				return
			}
```

**Rule Used:** What: Prioritize readable, idiomatic Go code over ... ([source](https://app.greptile.com/review/custom-context?memory=a792d438-3101-4554-a566-e21a5e164b1f))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/tui/update_test.go
Line: 353-355

Comment:
**Stale error message references removed smoothing**

The fatalf message `"smoothed speed"` is a leftover from when EMA smoothing was applied to `dm.Speed`. Now that smoothing has been removed from the graph path, this message is misleading — `dm.Speed` is simply the raw speed forwarded from `msg.Speed`.

```suggestion
	if dm.Speed != float64(config.MB) {
		t.Fatalf("assigned speed = %f, want %f", dm.Speed, float64(config.MB))
	}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/tui/process.go
Line: 60

Comment:
**Comment restates what the code does, not why**

`// Sample graph history from live per-interval transfer rate.` describes the mechanism, which is already apparent from reading the code. A more useful comment would explain the intent — e.g., why live per-interval rate is preferred here over the previous EMA-smoothed value.

```suggestion
	// Use the raw live rate (not EMA) so the graph reflects real bursts and pauses without lag.
```

**Rule Used:** What: Comments must explain *why* code exists, not... ([source](https://app.greptile.com/review/custom-context?memory=4e45ef13-32c2-4753-8060-a44ef767144d))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/engine/concurrent/concurrent_test.go
Line: 35-60

Comment:
**Edge cases for `waitForWorkerStart` not covered**

The two new tests cover worker 2 (stagger delay) and a pre-cancelled context (worker 3), but they miss two edge cases:

1. **`workerID = 0`**: the fast path (`startDelay <= 0 → return nil`) — verifying that worker 0 returns immediately with no delay and no timer allocation.
2. **Reset detection in `processProgressMsg`**: the `else if msg.Downloaded < prevDownloaded || msg.Elapsed < prevElapsed` branch that zeros `LiveSpeed` on a backwards jump has no corresponding test, making it easy to break silently.

Consider adding a `TestConcurrentDownloader_WaitForWorkerStart_Worker0_Immediate` test and a `TestProcessProgressMsg_LiveSpeed_ResetsOnBackwardsElapsed` test to cover these paths per the project's edge-case coverage requirement.

**Rule Used:** What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 4e1153d</sub>

> Greptile also left **4 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Rule used - What: Comments must explain *why* code exists, not... ([source](https://app.greptile.com/review/custom-context?memory=4e45ef13-32c2-4753-8060-a44ef767144d))
- Rule used - What: Prioritize readable, idiomatic Go code over ... ([source](https://app.greptile.com/review/custom-context?memory=a792d438-3101-4554-a566-e21a5e164b1f))
- Rule used - What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))
</details>

<!-- /greptile_comment -->