### PR TITLE
fix: isolate probe tests from leaked proxy config

### DIFF
--- a/internal/processing/probe_test.go
+++ b/internal/processing/probe_test.go
@@ -118,7 +118,7 @@ func TestProbeServer_ReadsBodyBeforeContextCancel(t *testing.T) {
 
 	result, err := processing.ProbeServerWithProxy(ctx, server.URL, "", nil, "")
 	if err != nil {
-		t.Fatalf("ProbeServer() failed: %v", err)
+		t.Fatalf("ProbeServerWithProxy() failed: %v", err)
 	}
 	if result.Filename != "delayed.txt" {
 		t.Errorf("Expected filename 'delayed.txt', got %q. The context might have been prematurely canceled.", result.Filename)


### PR DESCRIPTION
## Problem

`TestProbeServer_ReadsBodyBeforeContextCancel` intermittently fails with `proxyconnect tcp ... actively refused` because `TestProbeServer_UsesConfiguredProxy` writes proxy settings via `config.SaveSettings()` that leak into subsequent tests.

The root cause is incomplete config directory isolation on Windows: only `XDG_CONFIG_HOME` was set, but `config.GetSurgeDir()` on Windows prefers `APPDATA`.

Fixes #248

## Changes

1. **`TestProbeServer_UsesConfiguredProxy`**: Added `t.Setenv("APPDATA", t.TempDir())` alongside the existing `XDG_CONFIG_HOME` isolation to ensure cross-platform config isolation.

2. **`TestProbeServer_ReadsBodyBeforeContextCancel`**: Changed `ProbeServer(...)` to `ProbeServerWithProxy(..., "")` to explicitly bypass any persisted proxy config, fully decoupling this test from proxy state.

## Known Scope Limitation

Other test files (`events_internal_test.go`, `manager_test.go`) have the same pattern of only setting `XDG_CONFIG_HOME` before `SaveSettings()`. These could benefit from the same `APPDATA` isolation but are left for a follow-up to keep this PR focused on the reported flaky test.

## Testing

- `go test ./internal/processing -run "TestProbeServer_UsesConfiguredProxy|TestProbeServer_ReadsBodyBeforeContextCancel" -count=1 -v`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an intermittent test failure caused by proxy config leaking between tests. `TestProbeServer_UsesConfiguredProxy` was writing a proxy URL to disk via `config.SaveSettings()`, and because only `XDG_CONFIG_HOME` was redirected, the config file on Windows landed in the real `%APPDATA%/surge` directory — visible to subsequently-run `TestProbeServer_ReadsBodyBeforeContextCancel`, which would then attempt to connect through the already-closed proxy server.

**Changes:**
- `TestProbeServer_UsesConfiguredProxy`: adds `t.Setenv("APPDATA", t.TempDir())` alongside the existing `XDG_CONFIG_HOME` override, completing cross-platform config isolation (matches the `APPDATA`-first branch in `config.GetSurgeDir()` on Windows).
- `TestProbeServer_ReadsBodyBeforeContextCancel`: switches from `ProbeServer()` (which re-reads persisted settings) to `ProbeServerWithProxy(..., "")`, fully decoupling the body-reading test from any proxy state regardless of platform or test order. The `Fatalf` message is updated to match.
- The fix fits naturally into the existing layered API (`ProbeServer` → `ProbeServerWithProxy`) and does not touch production code.

**Known gap (acknowledged in PR description):** Several other test files (`events_internal_test.go`, `manager_test.go`, `tui/startup_test.go`, `tui/autoresume_test.go`) share the same `XDG_CONFIG_HOME`-only isolation pattern and could still leak on Windows. Extracting the two-env isolation into a shared `testutil.IsolateConfig(t)` helper would close this gap across the codebase in one shot rather than requiring repeated follow-up PRs.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — only test code is changed, the fix is logically sound, and no production behavior is altered.
- Both changes are minimal and well-targeted: the `APPDATA` env override directly matches the Windows-specific branch in `GetSurgeDir()`, and switching to `ProbeServerWithProxy("", ...)` is a clean, explicit way to bypass config. The only deduction is that the same Windows isolation gap remains in several other test files (acknowledged as out of scope), and there is no shared helper to prevent the pattern from diverging further.
- No files in the changeset require special attention, but `internal/processing/manager_test.go` and `internal/processing/events_internal_test.go` (outside this PR) carry the same incomplete isolation pattern.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/processing/probe_test.go | Adds `APPDATA` env isolation to fix Windows config leakage in `TestProbeServer_UsesConfiguredProxy`, and switches `TestProbeServer_ReadsBodyBeforeContextCancel` to `ProbeServerWithProxy(..., "")` to fully decouple it from persisted proxy state. Both changes are logically correct; error message label is also updated to match the new function name. Minor opportunity: extract the two-env isolation pattern into a shared helper. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant T1 as TestProbeServer_UsesConfiguredProxy
    participant T2 as TestProbeServer_ReadsBodyBeforeContextCancel
    participant CFG as config.GetSurgeDir()
    participant PS as ProbeServer / ProbeServerWithProxy
    participant FS as File System (settings.json)

    note over T1: t.Setenv("XDG_CONFIG_HOME", tmpA)<br/>t.Setenv("APPDATA", tmpB)  ← NEW
    T1->>CFG: SaveSettings(proxyURL)
    CFG-->>FS: write to tmpB/surge/ (Windows)<br/>or tmpA/surge/ (Linux/macOS)

    T1->>PS: ProbeServer() → resolveProxyURL() → LoadSettings()
    PS-->>FS: read from tmpB/surge/ (isolated ✓)
    PS-->>T1: result via proxy

    note over T2: (no env vars set — reads real config or none)
    T2->>PS: ProbeServerWithProxy(..., "") ← CHANGED
    note over PS: proxy="" → http.ProxyFromEnvironment<br/>never reads settings.json
    PS-->>T2: result (no proxy, no config read)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/processing/probe_test.go
Line: 15-17

Comment:
**Consider extracting a shared `isolateConfig` test helper**

The `t.Setenv("XDG_CONFIG_HOME", t.TempDir()) + t.Setenv("APPDATA", t.TempDir())` two-liner is now the canonical cross-platform config-isolation pattern, but it appears in at least 10 other test files with only the `XDG_CONFIG_HOME` half — the same gap this PR fixes here. Centralising this into a single helper would:

1. Ensure every future callsite gets both env vars without requiring a separate follow-up PR.
2. Make it trivially easy to add a third env var later (e.g. `HOME` on Linux, or a macOS-specific override) in one place.

```go
// internal/testutil/config.go (new file)
package testutil

import "testing"

// IsolateConfig redirects all platform-specific config directory lookups
// to per-test temp dirs, preventing tests from reading or writing the
// real user config and from leaking state to parallel/subsequent tests.
func IsolateConfig(t *testing.T) {
    t.Helper()
    t.Setenv("XDG_CONFIG_HOME", t.TempDir()) // Linux / macOS
    t.Setenv("APPDATA", t.TempDir())         // Windows
}
```

Then the call site becomes a single, self-documenting `testutil.IsolateConfig(t)`, and the follow-up fix for `events_internal_test.go` and `manager_test.go` reduces to a one-liner swap.

This also applies to the duplicated patterns at:
- `internal/processing/manager_test.go:400`, `430`
- `internal/processing/events_internal_test.go:106`, `198`, `248`, `293`
- `internal/tui/startup_test.go:169`
- `internal/tui/autoresume_test.go:27`, `112`

**Rule Used:** What: Eliminate duplicate logic, functions, or cod... ([source](https://app.greptile.com/review/custom-context?memory=f0a796a9-684f-4dfb-a5cf-8c99c16b63a1))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["fix: update error me..."](https://github.com/surge-downloader/surge/commit/7c4a91fb36bc10613101379d95bb0aaaa0f69660)</sub>

**Context used:**

- Rule used - What: Eliminate duplicate logic, functions, or cod... ([source](https://app.greptile.com/review/custom-context?memory=f0a796a9-684f-4dfb-a5cf-8c99c16b63a1))
- Rule used - # Code Review Rule: Suggest Architectural Improvem... ([source](https://app.greptile.com/review/custom-context?memory=4d82344e-33c4-4e14-bbc7-81d79af11b7e))

<!-- /greptile_comment -->