### PR TITLE
fix: add consistent padding to extension popup

### DIFF
--- a/extension-chrome/popup.css
+++ b/extension-chrome/popup.css
@@ -68,7 +68,7 @@ body {
   display: flex;
   flex-direction: column;
   height: 100%;
-  padding: 16px;
+  padding: 20px;
   gap: 16px;
 }
 
@@ -227,7 +227,7 @@ body {
 .downloads-list {
   flex: 1;
   overflow-y: auto;
-  padding: 0 12px 12px 12px;
+  padding: 12px;
 }
 
 /* === Download Item (Collapsible) === */

--- a/extension-firefox/popup.css
+++ b/extension-firefox/popup.css
@@ -63,7 +63,7 @@ body {
   display: flex;
   flex-direction: column;
   height: 100%;
-  padding: 16px;
+  padding: 20px;
   gap: 16px;
 }
 
@@ -214,7 +214,7 @@ body {
 .downloads-list {
   flex: 1;
   overflow-y: auto;
-  padding: 0 12px 12px 12px;
+  padding: 12px;
 }
 
 /* === Download Item (Collapsible) === */


### PR DESCRIPTION
## Summary

Fixes #253

- Increase `.container` padding from 16px to 20px for more breathing room around the outer wrapper of the popup
- Add 12px top padding to `.downloads-list` so the first download item doesn't touch the header border
- Applied to both Chrome and Firefox extensions

## Changes

| File | Change |
|---|---|
| `extension-chrome/popup.css` | `.container` padding 16→20px, `.downloads-list` top padding 0→12px |
| `extension-firefox/popup.css` | Same as above |

## Test plan

- [ ] Load the Chrome extension and verify the popup has consistent padding around edges
- [ ] Verify spacing between download items and the header in the downloads list
- [ ] Check empty state and a long download list both look correct
- [ ] Repeat the above for the Firefox extension

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR applies a small but correct visual fix to both extension popups: bumping `.container` outer padding from 16px to 20px for more breathing room, and changing `.downloads-list` padding from the asymmetric `0 12px 12px 12px` to a uniform `12px`, so the first download item no longer sits flush against the header border.

Key points:
- The change is cosmetically correct — the old `0 12px 12px 12px` was clearly missing top padding, and `12px` is the right fix.
- With `padding: 20px` on the 360×540px fixed-size body, the effective content area shrinks from 328×508px to 320×500px. The `downloads-section` (`flex: 1; min-height: 0`) will absorb this gracefully, but it's worth being aware that usable vertical space is 8px tighter.
- The change is applied identically to both Chrome and Firefox extensions.
- No tests or snapshots are affected since this is a pure CSS change to popup styling.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — this is a small, correct, and consistent CSS spacing fix with no risk of functional regression.
- Both changes are straightforward and match the stated intent. The fixed-size popup layout handles the slightly reduced content area gracefully via `flex: 1` and `min-height: 0` on the downloads section. The change is applied consistently across both extensions.
- No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| extension-chrome/popup.css | Increases `.container` padding from 16px to 20px and changes `.downloads-list` padding from `0 12px 12px 12px` to `12px` (adding missing top padding). Changes are cosmetically correct and match the Firefox counterpart. |
| extension-firefox/popup.css | Identical two-line change as the Chrome counterpart — `.container` padding 16→20px and `.downloads-list` padding from `0 12px 12px 12px` to `12px`. Consistent and correct. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Body["body (360×540px, overflow:hidden)"]
    Container[".container\npadding: 20px ✦ was 16px\ngap: 16px\nContent area: 320×500px"]
    Header[".header\n(logo + status badge)"]
    DownloadsSection[".downloads-section\nflex:1, min-height:0"]
    DLHeader[".downloads-header\npadding: 14px 16px\nborder-bottom"]
    DLList[".downloads-list\npadding: 12px ✦ was 0 12px 12px 12px\noverflow-y: auto"]
    Items["download-item(s)"]
    Footer[".footer\npadding: 14px 16px"]

    Body --> Container
    Container --> Header
    Container --> DownloadsSection
    Container --> Footer
    DownloadsSection --> DLHeader
    DownloadsSection --> DLList
    DLList --> Items
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `extension-chrome/popup.css`, line 67-73 ([link](https://github.com/surge-downloader/surge/blob/d71dcfb951c69d526ef97f2bf16479e907e21488/extension-chrome/popup.css#L67-L73)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Consider CSS spacing tokens for consistency**

   The `:root` block already defines `--radius-sm/md/lg` variables for reusable sizing, but padding values are hardcoded magic numbers throughout both files (`20px`, `16px`, `12px`, `14px`). Now that spacing is being actively adjusted, it would be a good time to introduce spacing tokens (e.g. `--spacing-xs`, `--spacing-sm`, `--spacing-md`) so all padding/gap values can be changed from a single source of truth.

   This also applies to `extension-firefox/popup.css` at line 62.

   **Rule Used:** # Code Review Rule: Suggest Architectural Improvem... ([source](https://app.greptile.com/review/custom-context?memory=4d82344e-33c4-4e14-bbc7-81d79af11b7e))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: extension-chrome/popup.css
   Line: 67-73
   
   Comment:
   **Consider CSS spacing tokens for consistency**
   
   The `:root` block already defines `--radius-sm/md/lg` variables for reusable sizing, but padding values are hardcoded magic numbers throughout both files (`20px`, `16px`, `12px`, `14px`). Now that spacing is being actively adjusted, it would be a good time to introduce spacing tokens (e.g. `--spacing-xs`, `--spacing-sm`, `--spacing-md`) so all padding/gap values can be changed from a single source of truth.
   
   This also applies to `extension-firefox/popup.css` at line 62.
   
   **Rule Used:** # Code Review Rule: Suggest Architectural Improvem... ([source](https://app.greptile.com/review/custom-context?memory=4d82344e-33c4-4e14-bbc7-81d79af11b7e))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   <sub>Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!</sub>
</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: ["fix: add consistent ..."](https://github.com/surge-downloader/surge/commit/5bd23554503cd439cb89ed15db9a7da054e00c88)</sub>

<!-- /greptile_comment -->