### PR TITLE
docs: Add another installation method for Windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,14 +59,14 @@ _Totally optional—your stars, issues, and contributions already mean the world
 
 Surge is available on multiple platforms. Choose the method that works best for you.
 
-| Platform / Method            | Command / Instructions                                                              | Notes                                        |
-| :--------------------------- | :---------------------------------------------------------------------------------- | :------------------------------------------- |
+| Platform / Method                  | Command / Instructions                                                           | Notes                                        |
+| :--------------------------------- | :------------------------------------------------------------------------------- | :------------------------------------------- |
 | **Prebuilt Binary**          | [Download from Releases](https://github.com/surge-downloader/surge/releases/latest) | Easiest method. Just download and run.       |
-| **Arch Linux (AUR)**         | `yay -S surge`                                                                      | Managed via AUR.                             |
-| **macOS / Linux (Homebrew)** | `brew install surge-downloader/tap/surge`                                           | Recommended for Mac/Linux users.             |
-| **Windows (Winget)**         | `winget install surge-downloader.surge`                                             | Recommended for Windows users.               |
+| **Arch Linux (AUR)**         | `yay -S surge`                                                                 | Managed via AUR.                             |
+| **macOS / Linux (Homebrew)** | `brew install surge-downloader/tap/surge`                                      | Recommended for Mac/Linux users.             |
+| **Windows (Winget)**         | `winget install surge-downloader.surge`<br />or<br />`scoop install surge` | Recommended for Windows users.               |
 | **Dockerfile**               | [See instructions](#4-server-mode-with-docker-compose)                              | Run Surge in server mode with Docker Compose |
-| **Go Install**               | `go install github.com/surge-downloader/surge@latest`                               | Requires Go 1.21+.                           |
+| **Go Install**               | `go install github.com/surge-downloader/surge@latest`                          | Requires Go 1.21+.                           |
 
 ---
 
@@ -74,7 +74,7 @@ Surge is available on multiple platforms. Choose the method that works best for 
 
 Surge has two main modes: **TUI (Interactive)** and **Server (Headless)**.
 
-For a full reference, see the **[Settings & Configuration Guide](docs/SETTINGS.md)** and the **[CLI Usage Guide](docs/USAGE.md)**.
+For a full reference, see the **[Settings &amp; Configuration Guide](docs/SETTINGS.md)** and the **[CLI Usage Guide](docs/USAGE.md)**.
 
 ### 1. Interactive TUI Mode
 
@@ -190,12 +190,12 @@ licensing details.
 
 We tested Surge against standard tools. Because of our connection optimization logic, Surge significantly outperforms single-connection tools.
 
-| Tool      | Time       | Speed          | Comparison   |
-| --------- | ---------- | -------------- | ------------ |
-| **Surge** | **28.93s** | **35.40 MB/s** | **—**        |
-| aria2c    | 40.04s     | 25.57 MB/s     | 1.38× slower |
-| curl      | 57.57s     | 17.79 MB/s     | 1.99× slower |
-| wget      | 61.81s     | 16.57 MB/s     | 2.14× slower |
+| Tool            | Time             | Speed                | Comparison    |
+| --------------- | ---------------- | -------------------- | ------------- |
+| **Surge** | **28.93s** | **35.40 MB/s** | **—**  |
+| aria2c          | 40.04s           | 25.57 MB/s           | 1.38× slower |
+| curl            | 57.57s           | 17.79 MB/s           | 1.99× slower |
+| wget            | 61.81s           | 16.57 MB/s           | 2.14× slower |
 
 > _Test details: 1GB file, Windows 11, Ryzen 5 5600X, 360 Mbps Network. Results averaged over 5 runs._
 
@@ -209,21 +209,21 @@ The Surge extension intercepts browser downloads and sends them straight to your
 
 ### Chrome / Edge / Brave
 
-1.  Download `extension-chrome.zip` from the latest GitHub release.
-2.  Unzip it somewhere on disk.
-3.  Open your browser and navigate to `chrome://extensions`.
-4.  Enable **"Developer mode"** in the top right corner.
-5.  Click **"Load unpacked"**.
-6.  Select the unzipped `extension-chrome` folder.
+1. Download `extension-chrome.zip` from the latest GitHub release.
+2. Unzip it somewhere on disk.
+3. Open your browser and navigate to `chrome://extensions`.
+4. Enable **"Developer mode"** in the top right corner.
+5. Click **"Load unpacked"**.
+6. Select the unzipped `extension-chrome` folder.
 
 ### Firefox
 
-1.  **Stable:** [Get the Add-on](https://addons.mozilla.org/en-US/firefox/addon/surge/)
-2.  **Development:**
-    - Download `extension-firefox.zip` from the latest GitHub release.
-    - Navigate to `about:debugging#/runtime/this-firefox`.
-    - Click **"Load Temporary Add-on..."**.
-    - Select the zip file (or unzip and select `manifest.json`).
+1. **Stable:** [Get the Add-on](https://addons.mozilla.org/en-US/firefox/addon/surge/)
+2. **Development:**
+   - Download `extension-firefox.zip` from the latest GitHub release.
+   - Navigate to `about:debugging#/runtime/this-firefox`.
+   - Click **"Load Temporary Add-on..."**.
+   - Select the zip file (or unzip and select `manifest.json`).
 
 ---
 
@@ -248,7 +248,7 @@ Distributed under the MIT License. See [LICENSE](https://github.com/surge-downlo
    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=surge-downloader/surge&type=Date" />
  </picture>
 </a>
-  
+
 <br />
 If Surge saved you some time, consider giving it a ⭐ to help others find it!
 </div>


### PR DESCRIPTION
Surge has been uploaded to the [Main bucket](https://github.com/ScoopInstaller/Main/pull/7736) of [Scoop](https://github.com/ScoopInstaller/Scoop) (a command-line installer for Windows). Windows users can now install Surge via:
```bash
scoop install surge
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `scoop install surge` as an alternative Windows installation method to the `README.md`, following Surge's acceptance into the Scoop Main bucket. The core change is welcome and broadens discoverability for Windows users already using Scoop.

**Key observations:**
- The Windows installation row label remains **"Windows (Winget)"** despite now listing two separate package managers; this should be updated (e.g. "Windows (Winget / Scoop)") or Scoop should get its own dedicated row to match the one-method-per-row convention used by all other entries.
- Several changes in the diff are unrelated to the stated purpose: table column-width reformatting, ordered list indentation adjustments, `&` → `&amp;` in the Usage section, and trailing-whitespace removal on the last line. These are harmless but create noise in the diff and should ideally be kept out of a focused docs PR.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor label clarification recommended.
- The change is documentation-only with no risk to runtime behaviour. The one substantive concern — the misleading "Windows (Winget)" row label — is cosmetic and easy to fix. The unrelated formatting changes are benign.
- README.md — specifically the Windows installation row label (line 67) and the unrelated `&amp;` change (line 77).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Adds `scoop install surge` alongside the existing Winget command in the Windows installation row; also includes several unrelated formatting changes (table column widths, list indentation, `&` → `&amp;`, trailing-whitespace removal). Row label still reads "Windows (Winget)" despite now covering two package managers. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Windows User] --> B{Choose installer}
    B --> C[Winget\nwinget install surge-downloader.surge]
    B --> D[Scoop\nscoop install surge]
    C --> E[Surge installed]
    D --> E
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: README.md
Line: 67

Comment:
**Misleading platform/method label**

The row label still reads **Windows (Winget)** even though it now also advertises Scoop. A reader skimming the table for "Scoop" will likely overlook this row entirely. Consider either updating the label to reflect both package managers or giving Scoop its own dedicated row (which is how all other platform/method entries are structured — one entry per method):

```suggestion
| **Windows (Winget / Scoop)** | `winget install surge-downloader.surge`<br />or<br />`scoop install surge` | Recommended for Windows users.               |
```

Alternatively, a dedicated row keeps the table consistent and scannable:

```
| **Windows (Scoop)**          | `scoop install surge`                                                      | Via Scoop package manager.                   |
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: README.md
Line: 77

Comment:
**Unrelated HTML-entity change**

`&` was changed to `&amp;` in this line, which is unrelated to adding a Scoop installation method. While both render identically on GitHub, using raw HTML entities in Markdown source is unusual and harder to read. Since this change is outside the scope of the PR, consider reverting it to keep the diff focused.

```suggestion
For a full reference, see the **[Settings & Configuration Guide](docs/SETTINGS.md)** and the **[CLI Usage Guide](docs/USAGE.md)**.
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["docs: Add another in..."](https://github.com/surge-downloader/surge/commit/4f24ef63dcb079e60bcffbb74faf12646cc1777f)</sub>

> Greptile also left **2 inline comments** on this PR.

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->