### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ Surge is available on multiple platforms. Choose the method that works best for 
 | **Prebuilt Binary**          | [Download from Releases](https://github.com/surge-downloader/surge/releases/latest) | Easiest method. Just download and run.       |
 | **Arch Linux (AUR)**         | `yay -S surge`                                                                 | Managed via AUR.                             |
 | **macOS / Linux (Homebrew)** | `brew install surge-downloader/tap/surge`                                      | Recommended for Mac/Linux users.             |
-| **Windows (Winget)**         | `winget install surge-downloader.surge`<br />or<br />`scoop install surge` | Recommended for Windows users.               |
+| **Windows**         | `winget install surge-downloader.surge`<br />or<br />`scoop install surge` | Recommended for Windows users.               |
 | **Dockerfile**               | [See instructions](#4-server-mode-with-docker-compose)                              | Run Surge in server mode with Docker Compose |
-| **Go Install**               | `go install github.com/surge-downloader/surge@latest`                          | Requires Go 1.21+.                           |
+| **Go Install**               | `go install github.com/surge-downloader/surge@latest`                          | Requires Go 1.25+                           |
 
 ---
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes two small documentation fixes to the installation table in `README.md`:

- **Windows label fix**: Renames `**Windows (Winget)**` to `**Windows**`, which is more accurate since the cell already lists both `winget` and `scoop` as installation options.
- **Go version bump**: Updates the minimum Go requirement from `1.21+` to `1.25+`, correctly reflecting what `go.mod` specifies (`go 1.25.0`).

One minor issue was found: the trailing period was inadvertently dropped from "Requires Go 1.25+", creating a slight inconsistency with the punctuation style of other Notes cells in the table.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a documentation-only change with no code impact.
- Both changes are straightforward and accurate: the Windows label correction better reflects the dual winget/scoop options, and the Go version bump matches the actual `go.mod` requirement. The only issue is a missing trailing period, which is cosmetic.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Two minor documentation fixes: renamed "Windows (Winget)" to "Windows" (since both winget and scoop are listed), and updated the minimum Go version from 1.21 to 1.25 (matching go.mod). The trailing period was inadvertently dropped from the Go version note. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Install Surge] --> B{Choose Platform}
    B --> C[Prebuilt Binary]
    B --> D[Arch Linux AUR]
    B --> E[macOS / Linux Homebrew]
    B --> F[Windows]
    B --> G[Dockerfile / Docker Compose]
    B --> H[Go Install - Requires Go 1.25+]

    F --> F1[winget install surge-downloader.surge]
    F --> F2[scoop install surge]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: README.md
Line: 69

Comment:
**Missing trailing period in Notes cell**

The original text "Requires Go 1.21+." ended with a period, consistent with the other rows in the table (e.g., "Managed via AUR.", "Recommended for Mac/Linux users.", "Recommended for Windows users."). This PR removed the trailing period, introducing a minor formatting inconsistency.

```suggestion
| **Go Install**               | `go install github.com/surge-downloader/surge@latest`                          | Requires Go 1.25+.                           |
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["Update README.md"](https://github.com/surge-downloader/surge/commit/1b2b55513dd1195db7fe6817e0f438fb75c90f93)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->