### PR TITLE
feat(settings): add notification options, file-exists action, and reset all

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -52,6 +52,9 @@ Surge follows OS conventions for storing its files. Below is a breakdown of ever
 | Key                    | Type   | Description                                                                                        | Default |
 | :--------------------- | :----- | :------------------------------------------------------------------------------------------------- | :------ |
 | `default_download_dir` | string | Directory where new downloads are saved. If empty, defaults to `~/Downloads` or current directory. | `""`    |
+| `download_complete_notification` | bool | Show a system notification when a download finishes successfully. | `true` |
+| `download_failed_notification` | bool | Show a system notification when a download fails or errors. | `true` |
+| `file_exists_action` | string | Action when a downloaded file already exists: `"rename"` (append counter suffix) or `"overwrite"` (replace existing file). | `"rename"` |
 | `allow_remote_open_actions` | bool | Allow `/open-file` and `/open-folder` API requests from remote clients. Keep disabled unless you trust your network and auth setup. | `false` |
 | `warn_on_duplicate`    | bool   | Show a warning when adding a download that already exists in the list.                             | `true`  |
 | `extension_prompt`     | bool   | Prompt for confirmation in the TUI when adding downloads via the browser extension.                | `false` |

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -19,17 +19,24 @@ type GeneralSettings struct {
 	DefaultDownloadDir           string     `json:"default_download_dir"`
 	WarnOnDuplicate              bool       `json:"warn_on_duplicate"`
 	DownloadCompleteNotification bool       `json:"download_complete_notification"`
+	DownloadFailedNotification   bool       `json:"download_failed_notification"`
 	AllowRemoteOpenActions       bool       `json:"allow_remote_open_actions"`
 	ExtensionPrompt              bool       `json:"extension_prompt"`
 	AutoResume                   bool       `json:"auto_resume"`
 	SkipUpdateCheck              bool       `json:"skip_update_check"`
 	CategoryEnabled              bool       `json:"category_enabled"`
 	Categories                   []Category `json:"categories"`
+	FileExistsAction             string     `json:"file_exists_action"`
 
 	ClipboardMonitor  bool `json:"clipboard_monitor"`
 	Theme             int  `json:"theme"`
 	LogRetentionCount int  `json:"log_retention_count"`
 }
+
+const (
+	FileExistsRename    = "rename"
+	FileExistsOverwrite = "overwrite"
+)
 
 const (
 	ThemeAdaptive = 0
@@ -70,7 +77,9 @@ func GetSettingsMetadata() map[string][]SettingMeta {
 	return map[string][]SettingMeta{
 		"General": {
 			{Key: "default_download_dir", Label: "Default Download Dir", Description: "Default directory for new downloads. Leave empty to use current directory.", Type: "string"},
-			{Key: "download_complete_notification", Label: "Download Complete Notification", Description: "Show system notification when a download finishes.", Type: "bool"},
+			{Key: "download_complete_notification", Label: "Download Complete Notification", Description: "Show system notification when a download finishes successfully.", Type: "bool"},
+			{Key: "download_failed_notification", Label: "Download Failed Notification", Description: "Show system notification when a download fails or errors.", Type: "bool"},
+			{Key: "file_exists_action", Label: "File Exists Action", Description: "Action when downloaded file already exists: Rename or Overwrite.", Type: "string"},
 			{Key: "allow_remote_open_actions", Label: "Allow Remote Open Actions", Description: "Allow /open-file and /open-folder API calls from non-loopback clients. Disabled by default for security.", Type: "bool"},
 			{Key: "warn_on_duplicate", Label: "Warn on Duplicate", Description: "Show warning when adding a download that already exists.", Type: "bool"},
 			{Key: "extension_prompt", Label: "Extension Prompt", Description: "Prompt for confirmation when adding downloads via browser extension.", Type: "bool"},
@@ -123,11 +132,13 @@ func DefaultSettings() *Settings {
 			DefaultDownloadDir:           defaultDir,
 			WarnOnDuplicate:              true,
 			DownloadCompleteNotification: true,
+			DownloadFailedNotification:   true,
 			AllowRemoteOpenActions:       false,
 			ExtensionPrompt:              false,
 			AutoResume:                   false,
 			CategoryEnabled:              false,
 			Categories:                   DefaultCategories(),
+			FileExistsAction:             FileExistsRename,
 
 			ClipboardMonitor:  true,
 			Theme:             ThemeAdaptive,

--- a/internal/processing/events.go
+++ b/internal/processing/events.go
@@ -247,7 +247,7 @@ func (mgr *LifecycleManager) StartEventWorker(ch <-chan interface{}) {
 				if err != nil {
 					msg = err.Error()
 				}
-				if settings := mgr.GetSettings(); settings != nil && settings.General.DownloadCompleteNotification {
+				if settings := mgr.GetSettings(); settings != nil && settings.General.DownloadFailedNotification {
 					notify(fmt.Sprintf("Download failed: %s", filename), msg)
 				}
 				break
@@ -306,7 +306,7 @@ func (mgr *LifecycleManager) StartEventWorker(ch <-chan interface{}) {
 					utils.Debug("Lifecycle: Failed to remove incomplete file after error: %v", err)
 				}
 			}
-			if settings := mgr.GetSettings(); settings != nil && settings.General.DownloadCompleteNotification {
+			if settings := mgr.GetSettings(); settings != nil && settings.General.DownloadFailedNotification {
 
 				filename := m.Filename
 				if filename == "" && existing != nil {

--- a/internal/processing/file_utils.go
+++ b/internal/processing/file_utils.go
@@ -179,7 +179,14 @@ func ResolveDestination(url, candidateFilename, defaultDir string, routeToCatego
 		}
 	}
 
-	finalFilename := GetUniqueFilename(destPath, filename, isNameActive)
+	var finalFilename string
+	if settings != nil && settings.General.FileExistsAction == config.FileExistsOverwrite {
+		// Overwrite mode: use original filename without uniqueness check
+		finalFilename = filepath.Base(strings.TrimSpace(filename))
+	} else {
+		// Rename (default) or Ask: generate unique filename
+		finalFilename = GetUniqueFilename(destPath, filename, isNameActive)
+	}
 	if finalFilename == "" {
 		return "", "", fmt.Errorf("could not determine a unique filename for %s", url)
 	}

--- a/internal/processing/file_utils.go
+++ b/internal/processing/file_utils.go
@@ -189,6 +189,8 @@ func ResolveDestination(url, candidateFilename, defaultDir string, routeToCatego
 			finalFilename = ""
 		} else if isNameActive != nil && isNameActive(destPath, base) {
 			return "", "", fmt.Errorf("file %q is already being downloaded", base)
+		} else if _, err := os.Stat(filepath.Join(destPath, base) + types.IncompleteSuffix); !os.IsNotExist(err) {
+			return "", "", fmt.Errorf("file %q has a pending .surge working file; remove it or switch to Rename mode", base)
 		} else {
 			finalFilename = base
 		}

--- a/internal/processing/file_utils.go
+++ b/internal/processing/file_utils.go
@@ -181,10 +181,18 @@ func ResolveDestination(url, candidateFilename, defaultDir string, routeToCatego
 
 	var finalFilename string
 	if settings != nil && settings.General.FileExistsAction == config.FileExistsOverwrite {
-		// Overwrite mode: use original filename without uniqueness check
-		finalFilename = filepath.Base(strings.TrimSpace(filename))
+		// Overwrite mode: reuse the original filename so os.Rename atomically
+		// replaces the existing file at finalization instead of producing a
+		// numbered duplicate (e.g. file(1).zip).
+		base := filepath.Base(strings.TrimSpace(filename))
+		if base == "" || base == "." || base == ".." {
+			finalFilename = ""
+		} else {
+			finalFilename = base
+		}
 	} else {
-		// Rename (default) or Ask: generate unique filename
+		// Rename (default): append a counter suffix to avoid clobbering an
+		// existing file or another in-progress download with the same name.
 		finalFilename = GetUniqueFilename(destPath, filename, isNameActive)
 	}
 	if finalFilename == "" {

--- a/internal/processing/file_utils.go
+++ b/internal/processing/file_utils.go
@@ -187,6 +187,8 @@ func ResolveDestination(url, candidateFilename, defaultDir string, routeToCatego
 		base := filepath.Base(strings.TrimSpace(filename))
 		if base == "" || base == "." || base == ".." {
 			finalFilename = ""
+		} else if isNameActive != nil && isNameActive(destPath, base) {
+			return "", "", fmt.Errorf("file %q is already being downloaded", base)
 		} else {
 			finalFilename = base
 		}

--- a/internal/processing/file_utils_test.go
+++ b/internal/processing/file_utils_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/surge-downloader/surge/internal/config"
@@ -217,5 +218,87 @@ func TestResolveDestination_ErrorsWhenUniqueNameExhausted(t *testing.T) {
 	)
 	if err == nil {
 		t.Fatal("expected unique-name exhaustion error")
+	}
+}
+
+func TestResolveDestination_OverwriteReusesOriginalFilename(t *testing.T) {
+	tmpDir := t.TempDir()
+	settings := config.DefaultSettings()
+	settings.General.CategoryEnabled = false
+	settings.General.FileExistsAction = config.FileExistsOverwrite
+
+	// Create an existing file at the destination
+	existingFile := filepath.Join(tmpDir, "data.zip")
+	if err := os.WriteFile(existingFile, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, name, err := processing.ResolveDestination(
+		"http://example.com/data.zip", "data.zip", tmpDir,
+		false, settings, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != "data.zip" {
+		t.Errorf("overwrite mode should reuse original name, got %s", name)
+	}
+}
+
+func TestResolveDestination_OverwriteEmptyFilenameReturnsError(t *testing.T) {
+	settings := config.DefaultSettings()
+	settings.General.CategoryEnabled = false
+	settings.General.FileExistsAction = config.FileExistsOverwrite
+
+	// URL with no path component yields empty filename
+	_, _, err := processing.ResolveDestination(
+		"http://example.com/", "", "/downloads",
+		false, settings, &processing.ProbeResult{Filename: ""}, nil,
+	)
+	if err == nil {
+		t.Fatal("expected error for empty filename in overwrite mode")
+	}
+}
+
+func TestResolveDestination_OverwriteRejectsActiveDownload(t *testing.T) {
+	settings := config.DefaultSettings()
+	settings.General.CategoryEnabled = false
+	settings.General.FileExistsAction = config.FileExistsOverwrite
+
+	alwaysActive := func(dir, name string) bool { return true }
+
+	_, _, err := processing.ResolveDestination(
+		"http://example.com/active.bin", "active.bin", "/downloads",
+		false, settings, nil, alwaysActive,
+	)
+	if err == nil {
+		t.Fatal("expected error when file is already being downloaded")
+	}
+	if !strings.Contains(err.Error(), "already being downloaded") {
+		t.Errorf("expected 'already being downloaded' in error, got: %v", err)
+	}
+}
+
+func TestResolveDestination_RenameStillGeneratesSuffix(t *testing.T) {
+	tmpDir := t.TempDir()
+	settings := config.DefaultSettings()
+	settings.General.CategoryEnabled = false
+	// FileExistsAction defaults to "rename"
+
+	// Create existing file
+	existingFile := filepath.Join(tmpDir, "report.pdf")
+	if err := os.WriteFile(existingFile, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, name, err := processing.ResolveDestination(
+		"http://example.com/report.pdf", "report.pdf", tmpDir,
+		false, settings, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name == "report.pdf" {
+		t.Error("rename mode should generate a suffixed name when file exists")
 	}
 }

--- a/internal/processing/file_utils_test.go
+++ b/internal/processing/file_utils_test.go
@@ -302,3 +302,27 @@ func TestResolveDestination_RenameStillGeneratesSuffix(t *testing.T) {
 		t.Error("rename mode should generate a suffixed name when file exists")
 	}
 }
+
+func TestResolveDestination_OverwriteRejectsStaleSurgeFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	settings := config.DefaultSettings()
+	settings.General.CategoryEnabled = false
+	settings.General.FileExistsAction = config.FileExistsOverwrite
+
+	// Simulate a stale working file left by a crashed session
+	surgeFile := filepath.Join(tmpDir, "data.zip") + types.IncompleteSuffix
+	if err := os.WriteFile(surgeFile, []byte("partial"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := processing.ResolveDestination(
+		"http://example.com/data.zip", "data.zip", tmpDir,
+		false, settings, nil, nil,
+	)
+	if err == nil {
+		t.Fatal("expected error when stale .surge file exists in overwrite mode")
+	}
+	if !strings.Contains(err.Error(), ".surge working file") {
+		t.Errorf("expected '.surge working file' in error, got: %v", err)
+	}
+}

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -93,18 +93,19 @@ type ExtensionKeyMap struct {
 
 // SettingsKeyMap defines keybindings for the settings view
 type SettingsKeyMap struct {
-	Tab1    key.Binding
-	Tab2    key.Binding
-	Tab3    key.Binding
-	Tab4    key.Binding
-	NextTab key.Binding
-	PrevTab key.Binding
-	Browse  key.Binding
-	Edit    key.Binding
-	Up      key.Binding
-	Down    key.Binding
-	Reset   key.Binding
-	Close   key.Binding
+	Tab1     key.Binding
+	Tab2     key.Binding
+	Tab3     key.Binding
+	Tab4     key.Binding
+	NextTab  key.Binding
+	PrevTab  key.Binding
+	Browse   key.Binding
+	Edit     key.Binding
+	Up       key.Binding
+	Down     key.Binding
+	Reset    key.Binding
+	ResetAll key.Binding
+	Close    key.Binding
 }
 
 // SettingsEditorKeyMap defines keybindings for editing a setting
@@ -386,8 +387,12 @@ var Keys = KeyMap{
 			key.WithHelp("↓/j", "down"),
 		),
 		Reset: key.NewBinding(
-			key.WithKeys("r", "R"),
+			key.WithKeys("r"),
 			key.WithHelp("r", "reset"),
+		),
+		ResetAll: key.NewBinding(
+			key.WithKeys("R"),
+			key.WithHelp("R", "reset all"),
 		),
 		Close: key.NewBinding(
 			key.WithKeys("esc"),
@@ -495,13 +500,13 @@ func (k ExtensionKeyMap) FullHelp() [][]key.Binding {
 }
 
 func (k SettingsKeyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.PrevTab, k.NextTab, k.Edit, k.Reset, k.Close}
+	return []key.Binding{k.PrevTab, k.NextTab, k.Edit, k.Reset, k.ResetAll, k.Close}
 }
 
 func (k SettingsKeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.Tab1, k.Tab2, k.Tab3, k.Tab4},
-		{k.PrevTab, k.NextTab, k.Up, k.Down, k.Edit, k.Reset, k.Browse, k.Close},
+		{k.PrevTab, k.NextTab, k.Up, k.Down, k.Edit, k.Reset, k.ResetAll, k.Browse, k.Close},
 	}
 }
 

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -13,6 +13,7 @@ type KeyMap struct {
 	Settings       SettingsKeyMap
 	SettingsEditor SettingsEditorKeyMap
 	BatchConfirm   BatchConfirmKeyMap
+	ResetAllCfm    ResetAllConfirmKeyMap
 	Update         UpdateKeyMap
 	CategoryMgr    CategoryManagerKeyMap
 }
@@ -116,6 +117,12 @@ type SettingsEditorKeyMap struct {
 
 // BatchConfirmKeyMap defines keybindings for batch import confirmation
 type BatchConfirmKeyMap struct {
+	Confirm key.Binding
+	Cancel  key.Binding
+}
+
+// ResetAllConfirmKeyMap defines keybindings for reset-all confirmation modal
+type ResetAllConfirmKeyMap struct {
 	Confirm key.Binding
 	Cancel  key.Binding
 }
@@ -419,6 +426,16 @@ var Keys = KeyMap{
 			key.WithHelp("n", "cancel"),
 		),
 	},
+	ResetAllCfm: ResetAllConfirmKeyMap{
+		Confirm: key.NewBinding(
+			key.WithKeys("y", "Y", "enter"),
+			key.WithHelp("y/enter", "confirm"),
+		),
+		Cancel: key.NewBinding(
+			key.WithKeys("n", "N", "esc"),
+			key.WithHelp("n/esc", "cancel"),
+		),
+	},
 	Update: UpdateKeyMap{
 		OpenGitHub: key.NewBinding(
 			key.WithKeys("o", "O", "enter"),
@@ -523,6 +540,14 @@ func (k BatchConfirmKeyMap) ShortHelp() []key.Binding {
 }
 
 func (k BatchConfirmKeyMap) FullHelp() [][]key.Binding {
+	return [][]key.Binding{{k.Confirm, k.Cancel}}
+}
+
+func (k ResetAllConfirmKeyMap) ShortHelp() []key.Binding {
+	return []key.Binding{k.Confirm, k.Cancel}
+}
+
+func (k ResetAllConfirmKeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{{k.Confirm, k.Cancel}}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -128,6 +128,7 @@ type RootModel struct {
 	SettingsActiveTab     int              // Active category tab (0-3)
 	SettingsSelectedRow   int              // Selected setting within current tab
 	SettingsIsEditing     bool             // Whether currently editing a value
+	ResetAllPending       bool             // Whether waiting for reset-all confirmation
 	SettingsInput         textinput.Model  // Input for editing string/int values
 	SettingsFileBrowsing  bool             // Whether browsing for a directory
 	ExtensionFileBrowsing bool             // Whether browsing for extension prompt path

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -41,6 +41,7 @@ const (
 	UpdateAvailableState                      // UpdateAvailableState is 11
 	URLUpdateState                            // URLUpdateState is 12
 	CategoryManagerState                      // CategoryManagerState is 13
+	ResetAllConfirmState                      // ResetAllConfirmState is 14
 )
 
 const (
@@ -128,7 +129,6 @@ type RootModel struct {
 	SettingsActiveTab     int              // Active category tab (0-3)
 	SettingsSelectedRow   int              // Selected setting within current tab
 	SettingsIsEditing     bool             // Whether currently editing a value
-	ResetAllPending       bool             // Whether waiting for reset-all confirmation
 	SettingsInput         textinput.Model  // Input for editing string/int values
 	SettingsFileBrowsing  bool             // Whether browsing for a directory
 	ExtensionFileBrowsing bool             // Whether browsing for extension prompt path

--- a/internal/tui/settings_view.go
+++ b/internal/tui/settings_view.go
@@ -252,6 +252,8 @@ func (m RootModel) getSettingsValues(category string) map[string]interface{} {
 		values["default_download_dir"] = m.Settings.General.DefaultDownloadDir
 		values["warn_on_duplicate"] = m.Settings.General.WarnOnDuplicate
 		values["download_complete_notification"] = m.Settings.General.DownloadCompleteNotification
+		values["download_failed_notification"] = m.Settings.General.DownloadFailedNotification
+		values["file_exists_action"] = m.Settings.General.FileExistsAction
 		values["allow_remote_open_actions"] = m.Settings.General.AllowRemoteOpenActions
 		values["extension_prompt"] = m.Settings.General.ExtensionPrompt
 		values["auto_resume"] = m.Settings.General.AutoResume
@@ -332,6 +334,18 @@ func (m *RootModel) setGeneralSetting(key, value, typ string) error {
 		m.Settings.General.DefaultDownloadDir = value
 	case "warn_on_duplicate":
 		m.Settings.General.WarnOnDuplicate = !m.Settings.General.WarnOnDuplicate
+	case "download_complete_notification":
+		m.Settings.General.DownloadCompleteNotification = !m.Settings.General.DownloadCompleteNotification
+	case "download_failed_notification":
+		m.Settings.General.DownloadFailedNotification = !m.Settings.General.DownloadFailedNotification
+	case "file_exists_action":
+		// Cycle through: rename -> overwrite -> rename
+		switch m.Settings.General.FileExistsAction {
+		case config.FileExistsRename:
+			m.Settings.General.FileExistsAction = config.FileExistsOverwrite
+		default:
+			m.Settings.General.FileExistsAction = config.FileExistsRename
+		}
 	case "allow_remote_open_actions":
 		m.Settings.General.AllowRemoteOpenActions = !m.Settings.General.AllowRemoteOpenActions
 	case "extension_prompt":
@@ -553,6 +567,19 @@ func formatSettingValueForEdit(value interface{}, typ, key string) string {
 		}
 	}
 
+	if key == "file_exists_action" {
+		if s, ok := value.(string); ok {
+			switch s {
+			case config.FileExistsRename:
+				return "< Rename >"
+			case config.FileExistsOverwrite:
+				return "< Overwrite >"
+			default:
+				return "< Rename >"
+			}
+		}
+	}
+
 	if key == "theme" {
 		if v, ok := value.(int); ok {
 			switch v {
@@ -637,6 +664,10 @@ func (m *RootModel) resetSettingToDefault(category, key string, defaults *config
 			m.Settings.General.WarnOnDuplicate = defaults.General.WarnOnDuplicate
 		case "download_complete_notification":
 			m.Settings.General.DownloadCompleteNotification = defaults.General.DownloadCompleteNotification
+		case "download_failed_notification":
+			m.Settings.General.DownloadFailedNotification = defaults.General.DownloadFailedNotification
+		case "file_exists_action":
+			m.Settings.General.FileExistsAction = defaults.General.FileExistsAction
 		case "extension_prompt":
 			m.Settings.General.ExtensionPrompt = defaults.General.ExtensionPrompt
 		case "auto_resume":

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -1394,32 +1394,6 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			// Not editing - handle navigation
 
-			// Handle reset-all confirmation before any other key
-			if m.ResetAllPending {
-				m.ResetAllPending = false
-				if msg.String() == "y" || msg.String() == "Y" {
-					defaults := config.DefaultSettings()
-					if err := config.SaveSettings(defaults); err != nil {
-						m.addLogEntry(LogStyleError.Render(fmt.Sprintf("✖ Failed to persist reset: %s", err.Error())))
-						return m, nil
-					}
-					m.Settings = defaults
-					m.ApplyTheme(m.Settings.General.Theme)
-					if reloader, ok := m.Service.(interface{ ReloadSettings() error }); ok {
-						if err := reloader.ReloadSettings(); err != nil {
-							m.addLogEntry(LogStyleError.Render(fmt.Sprintf("✖ Failed to reload settings after reset: %s", err.Error())))
-						}
-					}
-					if m.Orchestrator != nil {
-						m.Orchestrator.ApplySettings(m.Settings)
-					}
-					m.addLogEntry(LogStyleComplete.Render("✔ All settings reset to defaults"))
-				} else {
-					m.addLogEntry(LogStyleComplete.Render("Reset cancelled."))
-				}
-				return m, nil
-			}
-
 			if key.Matches(msg, m.keys.Settings.Close) {
 				// Save settings and exit
 				_ = m.persistSettings()
@@ -1550,17 +1524,40 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 
-			// Reset All — requires confirmation
+			// Reset All — open confirmation modal
 			if key.Matches(msg, m.keys.Settings.ResetAll) {
-				if m.ResetAllPending {
-					// Already showing confirmation, ignore duplicate press
-					return m, nil
-				}
-				m.ResetAllPending = true
-				m.addLogEntry(LogStyleError.Render("⚠ Reset all settings to defaults? Press y to confirm, any other key to cancel."))
+				m.state = ResetAllConfirmState
 				return m, nil
 			}
 
+			return m, nil
+
+		case ResetAllConfirmState:
+			if key.Matches(msg, m.keys.ResetAllCfm.Confirm) {
+				defaults := config.DefaultSettings()
+				if err := config.SaveSettings(defaults); err != nil {
+					m.addLogEntry(LogStyleError.Render(fmt.Sprintf("✖ Failed to persist reset: %s", err.Error())))
+					m.state = SettingsState
+					return m, nil
+				}
+				m.Settings = defaults
+				m.ApplyTheme(m.Settings.General.Theme)
+				if reloader, ok := m.Service.(interface{ ReloadSettings() error }); ok {
+					if err := reloader.ReloadSettings(); err != nil {
+						m.addLogEntry(LogStyleError.Render(fmt.Sprintf("✖ Failed to reload settings after reset: %s", err.Error())))
+					}
+				}
+				if m.Orchestrator != nil {
+					m.Orchestrator.ApplySettings(m.Settings)
+				}
+				m.addLogEntry(LogStyleComplete.Render("✔ All settings reset to defaults"))
+				m.state = SettingsState
+				return m, nil
+			}
+			if key.Matches(msg, m.keys.ResetAllCfm.Cancel) {
+				m.state = SettingsState
+				return m, nil
+			}
 			return m, nil
 
 		case UpdateAvailableState:

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -1533,7 +1533,9 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.Settings = defaults
 				m.ApplyTheme(m.Settings.General.Theme)
 				if reloader, ok := m.Service.(interface{ ReloadSettings() error }); ok {
-					_ = reloader.ReloadSettings()
+					if err := reloader.ReloadSettings(); err != nil {
+						m.addLogEntry(LogStyleError.Render(fmt.Sprintf("✖ Failed to reload settings after reset: %s", err.Error())))
+					}
 				}
 				if m.Orchestrator != nil {
 					m.Orchestrator.ApplySettings(m.Settings)

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -1393,6 +1393,33 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 			// Not editing - handle navigation
+
+			// Handle reset-all confirmation before any other key
+			if m.ResetAllPending {
+				m.ResetAllPending = false
+				if msg.String() == "y" || msg.String() == "Y" {
+					defaults := config.DefaultSettings()
+					if err := config.SaveSettings(defaults); err != nil {
+						m.addLogEntry(LogStyleError.Render(fmt.Sprintf("✖ Failed to persist reset: %s", err.Error())))
+						return m, nil
+					}
+					m.Settings = defaults
+					m.ApplyTheme(m.Settings.General.Theme)
+					if reloader, ok := m.Service.(interface{ ReloadSettings() error }); ok {
+						if err := reloader.ReloadSettings(); err != nil {
+							m.addLogEntry(LogStyleError.Render(fmt.Sprintf("✖ Failed to reload settings after reset: %s", err.Error())))
+						}
+					}
+					if m.Orchestrator != nil {
+						m.Orchestrator.ApplySettings(m.Settings)
+					}
+					m.addLogEntry(LogStyleComplete.Render("✔ All settings reset to defaults"))
+				} else {
+					m.addLogEntry(LogStyleComplete.Render("Reset cancelled."))
+				}
+				return m, nil
+			}
+
 			if key.Matches(msg, m.keys.Settings.Close) {
 				// Save settings and exit
 				_ = m.persistSettings()
@@ -1523,24 +1550,14 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 
-			// Reset All
+			// Reset All — requires confirmation
 			if key.Matches(msg, m.keys.Settings.ResetAll) {
-				defaults := config.DefaultSettings()
-				if err := config.SaveSettings(defaults); err != nil {
-					m.addLogEntry(LogStyleError.Render(fmt.Sprintf("✖ Failed to persist reset: %s", err.Error())))
+				if m.ResetAllPending {
+					// Already showing confirmation, ignore duplicate press
 					return m, nil
 				}
-				m.Settings = defaults
-				m.ApplyTheme(m.Settings.General.Theme)
-				if reloader, ok := m.Service.(interface{ ReloadSettings() error }); ok {
-					if err := reloader.ReloadSettings(); err != nil {
-						m.addLogEntry(LogStyleError.Render(fmt.Sprintf("✖ Failed to reload settings after reset: %s", err.Error())))
-					}
-				}
-				if m.Orchestrator != nil {
-					m.Orchestrator.ApplySettings(m.Settings)
-				}
-				m.addLogEntry(LogStyleComplete.Render("✔ All settings reset to defaults"))
+				m.ResetAllPending = true
+				m.addLogEntry(LogStyleError.Render("⚠ Reset all settings to defaults? Press y to confirm, any other key to cancel."))
 				return m, nil
 			}
 

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -1526,13 +1526,19 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Reset All
 			if key.Matches(msg, m.keys.Settings.ResetAll) {
 				defaults := config.DefaultSettings()
+				if err := config.SaveSettings(defaults); err != nil {
+					m.addLogEntry(LogStyleError.Render(fmt.Sprintf("✖ Failed to persist reset: %s", err.Error())))
+					return m, nil
+				}
 				m.Settings = defaults
 				m.ApplyTheme(m.Settings.General.Theme)
-				if err := m.persistSettings(); err != nil {
-					m.addLogEntry(LogStyleError.Render(fmt.Sprintf("✖ Failed to reset settings: %s", err.Error())))
-				} else {
-					m.addLogEntry(LogStyleComplete.Render("✔ All settings reset to defaults"))
+				if reloader, ok := m.Service.(interface{ ReloadSettings() error }); ok {
+					_ = reloader.ReloadSettings()
 				}
+				if m.Orchestrator != nil {
+					m.Orchestrator.ApplySettings(m.Settings)
+				}
+				m.addLogEntry(LogStyleComplete.Render("✔ All settings reset to defaults"))
 				return m, nil
 			}
 

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -1476,6 +1476,14 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return m, nil
 				}
 
+				// Special handling for File Exists Action cycling
+				if key == "file_exists_action" {
+					categories := config.CategoryOrder()
+					currentCategory := categories[m.SettingsActiveTab]
+					_ = m.setSettingValue(currentCategory, key, "")
+					return m, nil
+				}
+
 				// Toggle bool or enter edit mode for other types
 				typ := m.getCurrentSettingType()
 				if typ == "bool" {
@@ -1511,6 +1519,19 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// Special handling for Theme reset to ensure it applies immediately
 				if key == "theme" {
 					m.ApplyTheme(m.Settings.General.Theme)
+				}
+				return m, nil
+			}
+
+			// Reset All
+			if key.Matches(msg, m.keys.Settings.ResetAll) {
+				defaults := config.DefaultSettings()
+				m.Settings = defaults
+				m.ApplyTheme(m.Settings.General.Theme)
+				if err := m.persistSettings(); err != nil {
+					m.addLogEntry(LogStyleError.Render(fmt.Sprintf("✖ Failed to reset settings: %s", err.Error())))
+				} else {
+					m.addLogEntry(LogStyleComplete.Render("✔ All settings reset to defaults"))
 				}
 				return m, nil
 			}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -188,6 +188,20 @@ func (m RootModel) View() string {
 		return m.renderModalWithOverlay(box)
 	}
 
+	if m.state == ResetAllConfirmState {
+		modal := components.ConfirmationModal{
+			Title:       "⚠ Reset All Settings",
+			Message:     "Are you sure you want to reset all settings to defaults?",
+			Keys:        m.keys.ResetAllCfm,
+			Help:        m.help,
+			BorderColor: colors.NeonPink,
+			Width:       60,
+			Height:      10,
+		}
+		box := modal.RenderWithBtopBox(renderBtopBox, PaneTitleStyle)
+		return m.renderModalWithOverlay(box)
+	}
+
 	if m.state == UpdateAvailableState && m.UpdateInfo != nil {
 		modal := components.ConfirmationModal{
 			Title:       "⬆ Update Available",


### PR DESCRIPTION
## Summary

- **#264**: Split the single `DownloadCompleteNotification` toggle into separate settings for download completion and download failure notifications. Previously, disabling completion notifications also silenced failure alerts.
- **#265** (partial): Add `FileExistsAction` setting with Rename (default, current behavior) and Overwrite modes. In overwrite mode, new downloads reuse the original filename and `os.Rename` atomically replaces the existing file at finalization. The "Always Ask" option from the issue is not included in this PR and can be implemented separately with a TUI confirmation dialog.
- **#266**: Add `Shift+R` keybinding in the settings view to reset all settings to factory defaults.
- Bonus: fix `download_complete_notification` toggle that was missing from `setGeneralSetting` (pressing Enter on it previously did nothing).

## Changes

| File | What |
|------|------|
| `internal/config/settings.go` | Add `DownloadFailedNotification`, `FileExistsAction` fields + constants + metadata |
| `internal/processing/events.go` | Use `DownloadFailedNotification` for error/failure notifications |
| `internal/processing/file_utils.go` | Skip `GetUniqueFilename` in overwrite mode |
| `internal/tui/keys.go` | Add `ResetAll` keybinding (`Shift+R`) |
| `internal/tui/settings_view.go` | Wire new settings (values, toggles, cycling, reset) |
| `internal/tui/update.go` | Handle Reset All + file-exists-action cycling |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/config/... ./internal/processing/... ./internal/tui/...` passes
- [x] Verified `os.Rename` overwrites existing files on Windows (Go 1.26.1 windows/amd64)
- [ ] Open Settings → General tab, verify new toggles appear
- [ ] Toggle Download Failed Notification off → trigger a failed download → no notification
- [ ] Cycle File Exists Action between Rename / Overwrite
- [ ] Press `Shift+R` → all settings reset to defaults

closes: #264
closes: #266
related: #265

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the settings system with three well-scoped additions: separate notification toggles for download completion and failure (fixing the original single-flag conflation), an overwrite vs. rename `file_exists_action` setting with correct atomic-rename semantics, and a `Shift+R` → confirm-modal flow for resetting all settings to factory defaults. The overwrite path in `ResolveDestination` is carefully guarded against empty filenames, concurrent downloads, and stale `.surge` files, and is backed by a solid set of new unit tests.

**Key points:**
- The bonus fix for the `download_complete_notification` toggle (previously a no-op when pressing Enter) is a welcome correctness improvement.
- `allow_remote_open_actions` is absent from the `resetSettingToDefault` General switch — pressing `r` on that row silently does nothing. This pre-existing omission was surfaced by the PR's additions to the same function and should be fixed here.
- The comment on the `file_exists_action` cycling block in `setGeneralSetting` describes *what* the code does rather than *why* (e.g. why `default:` normalises unknown values back to rename).
- The split notification flags in `events.go` lack dedicated tests verifying that `notify()` is suppressed when the relevant flag is `false`.

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing the missing `allow_remote_open_actions` case in `resetSettingToDefault`; all other issues are minor style or test-coverage gaps.
- Core logic is correct — overwrite mode is well-guarded, ResetAll saves before mutating in-memory state, and the notification flag split is accurate. The P1 issue (per-row reset silently broken for `allow_remote_open_actions`) is a pre-existing gap exposed by this PR's additions to the same switch; it is trivial to fix. No regressions or security concerns are introduced.
- internal/tui/settings_view.go — `resetSettingToDefault` is missing the `allow_remote_open_actions` case.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/config/settings.go | Adds `DownloadFailedNotification` and `FileExistsAction` fields with constants and metadata; defaults are sensible and JSON serialisation is correct. |
| internal/processing/events.go | Correctly switches two failure-event notification checks from `DownloadCompleteNotification` to `DownloadFailedNotification`; no test coverage for the toggling behaviour of either notification flag. |
| internal/processing/file_utils.go | Adds overwrite-mode path in `ResolveDestination` with active-download and stale-surge-file guards; logic is sound and well-guarded against empty/dot filenames. |
| internal/processing/file_utils_test.go | Adds five targeted tests covering overwrite happy-path, empty filename, active-download rejection, rename-mode suffix, and stale `.surge` file detection; edge cases are well exercised. |
| internal/tui/keys.go | Splits `Reset` from `"r","R"` into separate `Reset`/`ResetAll` bindings and adds `ResetAllConfirmKeyMap` with `ShortHelp`/`FullHelp` implementations; clean change with no issues. |
| internal/tui/settings_view.go | Wires new settings into `getSettingsValues`, `setGeneralSetting`, `formatSettingValueForEdit`, and `resetSettingToDefault`; correctly fixes the pre-existing `download_complete_notification` toggle, but `allow_remote_open_actions` remains missing from `resetSettingToDefault`. Comment on the cycling logic describes "what" rather than "why". |
| internal/tui/update.go | Adds `file_exists_action` cycling intercept, `ResetAll` trigger, and `ResetAllConfirmState` handler; save-before-mutate ordering is correct. `ReloadSettings` failure is logged but does not abort the state transition, which is consistent with `persistSettings`. |
| internal/tui/view.go | Adds `ResetAllConfirmState` rendering block using the existing `ConfirmationModal` component; consistent with the `BatchConfirmState` pattern already in the file. |
| internal/tui/model.go | Adds `ResetAllConfirmState` iota constant; straightforward one-line change with correct ordering. |
| docs/SETTINGS.md | Documents the three new settings with correct keys, types, descriptions, and defaults; accurately reflects the implementation. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User presses Enter on setting] --> B{key == file_exists_action?}
    B -- Yes --> C[setSettingValue → setGeneralSetting\ncycle rename ↔ overwrite]
    B -- No --> D{type == bool?}
    D -- Yes --> E[setSettingValue → toggle bool]
    D -- No --> F[Enter edit mode\nsetInput from formatSettingValueForEdit]

    G[User presses Shift+R] --> H[state = ResetAllConfirmState\nshow modal]
    H --> I{key press}
    I -- y / enter --> J[SaveSettings defaults]
    J -- error --> K[log error\nstate = SettingsState]
    J -- ok --> L[m.Settings = defaults\nApplyTheme\nReloadSettings\nApplySettings\nstate = SettingsState]
    I -- n / esc --> M[state = SettingsState]

    N[ResolveDestination called] --> O{FileExistsAction == overwrite?}
    O -- Yes --> P{filepath.Base empty / dot / dotdot?}
    P -- Yes --> Q[return error: empty filename]
    P -- No --> R{isNameActive?}
    R -- Yes --> S[return error: already downloading]
    R -- No --> T{stale .surge file on disk?}
    T -- Yes --> U[return error: pending working file]
    T -- No --> V[return base filename as-is]
    O -- No --> W[GetUniqueFilename\nappend counter suffix]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (5)</h3></summary>

1. `internal/processing/file_utils.go`, line 182-195 ([link](https://github.com/surge-downloader/surge/blob/9bcaecbaa57392eaa945e846c14431db9436cd56/internal/processing/file_utils.go#L182-L195)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **No tests for the overwrite mode path or its edge cases**

   The `FileExistsOverwrite` branch in `ResolveDestination` is a new code path with meaningful edge cases (empty filename, `.` and `..` filenames, existing file present, filename with only whitespace) and no tests cover it. The existing `file_utils_test.go` only exercises `GetUniqueFilename` and `InferFilenameFromURL`.

   At minimum the following should be covered:
   - Overwrite mode with a pre-existing file at the destination returns the original filename unchanged (not a numbered duplicate)
   - Overwrite mode with an empty `filename` (e.g. URL with no path) returns an error rather than resolving to `"."` 
   - Rename mode still generates a numbered suffix when the file already exists (regression guard)

   **Rule Used:** What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: internal/processing/file_utils.go
   Line: 182-195
   
   Comment:
   **No tests for the overwrite mode path or its edge cases**
   
   The `FileExistsOverwrite` branch in `ResolveDestination` is a new code path with meaningful edge cases (empty filename, `.` and `..` filenames, existing file present, filename with only whitespace) and no tests cover it. The existing `file_utils_test.go` only exercises `GetUniqueFilename` and `InferFilenameFromURL`.
   
   At minimum the following should be covered:
   - Overwrite mode with a pre-existing file at the destination returns the original filename unchanged (not a numbered duplicate)
   - Overwrite mode with an empty `filename` (e.g. URL with no path) returns an error rather than resolving to `"."` 
   - Rename mode still generates a numbered suffix when the file already exists (regression guard)
   
   **Rule Used:** What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `internal/processing/file_utils_test.go`, line 193-221 ([link](https://github.com/surge-downloader/surge/blob/dc75c98fe71dff8ab26140ae138a52ad2034dd48/internal/processing/file_utils_test.go#L193-L221)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **No test coverage for `FileExistsOverwrite` mode in `ResolveDestination`**

   The existing `TestResolveDestination_Priority` and `TestResolveDestination_ErrorsWhenUniqueNameExhausted` tests only exercise the default Rename mode. The new Overwrite branch in `ResolveDestination` is entirely untested. Important cases to cover include:

   - Overwrite mode with a normal filename returns the bare base name (no counter suffix)
   - Overwrite mode with an empty filename (e.g. URL with no path component) returns an error
   - Overwrite mode with an in-progress download of the same name (via `isNameActive`) to verify the conflict detection mentioned above

   **Rule Used:** What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: internal/processing/file_utils_test.go
   Line: 193-221
   
   Comment:
   **No test coverage for `FileExistsOverwrite` mode in `ResolveDestination`**
   
   The existing `TestResolveDestination_Priority` and `TestResolveDestination_ErrorsWhenUniqueNameExhausted` tests only exercise the default Rename mode. The new Overwrite branch in `ResolveDestination` is entirely untested. Important cases to cover include:
   
   - Overwrite mode with a normal filename returns the bare base name (no counter suffix)
   - Overwrite mode with an empty filename (e.g. URL with no path component) returns an error
   - Overwrite mode with an in-progress download of the same name (via `isNameActive`) to verify the conflict detection mentioned above
   
   **Rule Used:** What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

3. `internal/tui/settings_view.go`, line 660-684 ([link](https://github.com/surge-downloader/surge/blob/9e7efbd47fd36a0c011037a32d293f4754285cc9/internal/tui/settings_view.go#L660-L684)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`allow_remote_open_actions` missing from `resetSettingToDefault`**

   The `General` branch of `resetSettingToDefault` is missing a `case "allow_remote_open_actions"` entry. As a result, pressing `r` (Reset) while the cursor is on the **Allow Remote Open Actions** setting is a silent no-op — the setting keeps its current value instead of reverting to `false`. Because this function was directly touched by this PR (two new cases were inserted here), the omission is easy to overlook.

   ```go
   case "allow_remote_open_actions":
       m.Settings.General.AllowRemoteOpenActions = defaults.General.AllowRemoteOpenActions
   ```

   Add the case between `file_exists_action` and `extension_prompt` to match the metadata ordering.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/tui/settings_view.go
   Line: 660-684

   Comment:
   **`allow_remote_open_actions` missing from `resetSettingToDefault`**

   The `General` branch of `resetSettingToDefault` is missing a `case "allow_remote_open_actions"` entry. As a result, pressing `r` (Reset) while the cursor is on the **Allow Remote Open Actions** setting is a silent no-op — the setting keeps its current value instead of reverting to `false`. Because this function was directly touched by this PR (two new cases were inserted here), the omission is easy to overlook.

   ```go
   case "allow_remote_open_actions":
       m.Settings.General.AllowRemoteOpenActions = defaults.General.AllowRemoteOpenActions
   ```

   Add the case between `file_exists_action` and `extension_prompt` to match the metadata ordering.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

4. `internal/processing/file_utils.go`, line 184-196 ([link](https://github.com/surge-downloader/surge/blob/535929e34abe4ffdf919d1fbf2e8ad6014bd19db/internal/processing/file_utils.go#L184-L196)) 

   **`base == ""` guard is dead code — `filepath.Base` never returns `""`**

   Per the Go standard library, `filepath.Base` always returns at least `"."` — it never returns an empty string. This means the `base == ""` branch in the condition can never be true and constitutes unreachable dead code. The `"."` and `".."` guards are the ones that do real work here.

5. `internal/processing/file_utils_test.go`, line 252-273 ([link](https://github.com/surge-downloader/surge/blob/535929e34abe4ffdf919d1fbf2e8ad6014bd19db/internal/processing/file_utils_test.go#L252-L273)) 

   **Missing test coverage for overwrite mode with a `"."` / `".."` filename**

   The `TestResolveDestination_OverwriteEmptyFilenameReturnsError` test only covers a blank `filename` input. The new dead-code finding above (removing `base == ""`) reveals that the real guards are `"."` and `".."`. There are no tests that pass a URL or candidate filename that would produce one of those values from `filepath.Base` (e.g. `"http://example.com/"` with `candidateFilename = ""`), ensuring the sentinel path returns an error rather than silently resolving to `"."`.

   Adding a test like:

   ```go
   func TestResolveDestination_OverwriteDotFilenameReturnsError(t *testing.T) {
       settings := config.DefaultSettings()
       settings.General.CategoryEnabled = false
       settings.General.FileExistsAction = config.FileExistsOverwrite

       // filepath.Base("") == "." — should be rejected
       _, _, err := processing.ResolveDestination(
           "http://example.com/", "", "/downloads",
           false, settings, nil, nil,
       )
       if err == nil {
           t.Fatal("expected error for '.' filename in overwrite mode")
       }
   }
   ```

   would lock in the correct behaviour and prevent future regressions if the guard logic is refactored.

   **Rule Used:** What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/tui/settings_view.go
Line: 660-684

Comment:
**`allow_remote_open_actions` missing from `resetSettingToDefault`**

The `resetSettingToDefault` General switch has no case for `"allow_remote_open_actions"`. Pressing `r` while that row is selected silently does nothing — the outer `case "General":` matches, but the inner switch finds no case and returns without touching the setting.

`ResetAll` (which replaces the entire `m.Settings` pointer) is unaffected, but the per-row reset is broken for this one setting. The PR already fixed the analogous omission in `setGeneralSetting` for `download_complete_notification`; the same gap exists here.

```suggestion
		case "default_download_dir":
			m.Settings.General.DefaultDownloadDir = defaults.General.DefaultDownloadDir
		case "warn_on_duplicate":
			m.Settings.General.WarnOnDuplicate = defaults.General.WarnOnDuplicate
		case "download_complete_notification":
			m.Settings.General.DownloadCompleteNotification = defaults.General.DownloadCompleteNotification
		case "download_failed_notification":
			m.Settings.General.DownloadFailedNotification = defaults.General.DownloadFailedNotification
		case "file_exists_action":
			m.Settings.General.FileExistsAction = defaults.General.FileExistsAction
		case "allow_remote_open_actions":
			m.Settings.General.AllowRemoteOpenActions = defaults.General.AllowRemoteOpenActions
		case "extension_prompt":
			m.Settings.General.ExtensionPrompt = defaults.General.ExtensionPrompt
		case "auto_resume":
			m.Settings.General.AutoResume = defaults.General.AutoResume
		case "skip_update_check":
			m.Settings.General.SkipUpdateCheck = defaults.General.SkipUpdateCheck

		case "clipboard_monitor":
			m.Settings.General.ClipboardMonitor = defaults.General.ClipboardMonitor
		case "theme":
			m.Settings.General.Theme = defaults.General.Theme
		case "log_retention_count":
			m.Settings.General.LogRetentionCount = defaults.General.LogRetentionCount
		}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/tui/settings_view.go
Line: 341

Comment:
**"What" comment, not "why"**

The comment `// Cycle through: rename -> overwrite -> rename` only restates what the switch does; anyone reading the code can see the cycling. What's useful to explain is *why* this is a `default:` catch-all (so that an unknown value stored by manual JSON edit also normalises back to `rename`) and why the cycling exists at all.

```suggestion
	case "file_exists_action":
		// Cycle to the next mode; default catches any unrecognised value from
		// manual config edits and normalises it back to rename.
		switch m.Settings.General.FileExistsAction {
```

**Rule Used:** What: Comments must explain *why* code exists, not... ([source](https://app.greptile.com/review/custom-context?memory=4e45ef13-32c2-4753-8060-a44ef767144d))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/processing/events.go
Line: 247-252

Comment:
**Missing test coverage for `DownloadFailedNotification` toggle**

The split of `DownloadCompleteNotification` into two separate flags (lines 250 and 309) is a meaningful behavioural change — a user who disables failure notifications should never see them, even when completion notifications are on, and vice versa. Neither path has a dedicated event-worker test verifying that `notify()` is suppressed when the relevant flag is `false`.

The existing `file_utils_test.go` tests cover `ResolveDestination` edge cases well, but there are no tests at the `events.go` layer checking notification gating. Consider adding table-driven tests that mock `GetSettings()` with each flag independently toggled and assert whether `notify` is (or is not) called.

**Rule Used:** What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["refactor(settings): ..."](https://github.com/surge-downloader/surge/commit/8a4851dfa997edffbfb4729ae0caf4a06efea6a3)</sub>

**Context used:**

- Rule used - What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))
- Rule used - What: Comments must explain *why* code exists, not... ([source](https://app.greptile.com/review/custom-context?memory=4e45ef13-32c2-4753-8060-a44ef767144d))

<!-- /greptile_comment -->