### PR TITLE
fix: clarify missing/invalid token error message in extension

### DIFF
--- a/extension-chrome/background.js
+++ b/extension-chrome/background.js
@@ -456,6 +456,11 @@ async function sendToSurge(url, filename, absolutePath) {
       const data = await response.json();
       console.log("[Surge] Download queued:", data);
       return { success: true, data };
+    } else if (response.status === 401 || response.status === 403) {
+      return {
+        success: false,
+        error: "Missing or invalid token. Please set your token in the extension settings.",
+      };
     } else if (response.status === 409) {
       const errorText = await response.text();
       let msg = "Download rejected: duplicate or approval required (headless mode)";

--- a/extension-firefox/background.js
+++ b/extension-firefox/background.js
@@ -472,6 +472,11 @@ async function sendToSurge(url, filename, absolutePath) {
       const data = await response.json();
       console.log('[Surge] Download queued:', data);
       return { success: true, data };
+    } else if (response.status === 401 || response.status === 403) {
+      return {
+        success: false,
+        error: "Missing or invalid token. Please set your token in the extension settings.",
+      };
     } else if (response.status === 409) {
       const errorText = await response.text();
       let msg = "Download rejected: duplicate or approval required (headless mode)";


### PR DESCRIPTION
Fixes #261 by providing a clearer error message in the extension when the API token is missing or invalid (401/403 errors). This ensures users know exactly why the download failed and how to fix it.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a specific `401`/`403` response handler in `sendToSurge` for both the Chrome and Firefox extensions, returning a human-readable error message instead of a raw server response when the API token is missing or invalid.

**Key observations:**
- The fix is logically correct and well-placed — the new branch sits before the existing `409` handler and before the generic fallback, so it intercepts auth errors first.
- The new 401/403 branch in `extension-firefox/background.js` uses double-quoted string literals (`"..."`) while the rest of that file consistently uses single quotes — a minor but easy-to-fix style inconsistency.
- Both new branches return silently without a `console.error`, which is inconsistent with every other error path in the function (409 and generic both log). Adding a log line would aid debugging from browser DevTools.
- No tests are included to cover the new error paths or verify the error message is surfaced correctly through the call chain.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor style fixes recommended before landing.
- The logic change is small, targeted, and correct. The only issues are cosmetic (quote style in Firefox) and best-practice gaps (missing console log, no tests), none of which affect runtime correctness.
- extension-firefox/background.js — quote style inconsistency on the new error string.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| extension-chrome/background.js | Adds a specific 401/403 handler before the 409 branch in `sendToSurge`, returning a clear user-facing error message. Minor issues: no `console.error` for the new branch (unlike all other error paths) and no tests. |
| extension-firefox/background.js | Mirrors the Chrome change. Additionally uses double-quoted string literal while the rest of the file uses single quotes, breaking the existing style convention. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Ext as Extension (background.js)
    participant Surge as Surge API /download

    Ext->>Surge: POST /download (with auth header)
    alt 2xx OK
        Surge-->>Ext: 200 { id, ... }
        Ext-->>Ext: return { success: true, data }
    else 401 / 403 (new branch)
        Surge-->>Ext: 401 or 403
        Ext-->>Ext: return { success: false, error: "Missing or invalid token..." }
    else 409 Conflict
        Surge-->>Ext: 409 { message? }
        Ext-->>Ext: return { success: false, error: msg }
    else Other error
        Surge-->>Ext: 4xx/5xx
        Ext-->>Ext: return { success: false, error: responseText }
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: extension-firefox/background.js
Line: 476-479

Comment:
**Quote style inconsistency**

The new error string uses double quotes while the rest of `extension-firefox/background.js` consistently uses single quotes (e.g., `'[Surge] Download queued:'`, `'Content-Type'`). This breaks the file's existing style convention.

```suggestion
        error: 'Missing or invalid token. Please set your token in the extension settings.',
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: extension-chrome/background.js
Line: 459-463

Comment:
**Missing console log for 401/403 path**

Every other error branch in this function emits a `console.error` (the 409 path and the generic `else` path both do), but the new 401/403 handler returns silently. Logging here helps developers diagnose auth problems from the browser DevTools console without having to guess why the download failed.

```suggestion
    } else if (response.status === 401 || response.status === 403) {
      console.error("[Surge] Auth error:", response.status, "- token missing or invalid");
      return {
        success: false,
        error: "Missing or invalid token. Please set your token in the extension settings.",
      };
```

The same applies to `extension-firefox/background.js` at line 475.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: extension-chrome/background.js
Line: 459-463

Comment:
**No tests for new error-handling branch**

The new 401/403 branch is a behavioural change with no accompanying tests. Edge cases worth covering include:
- a `401` response → returns `{ success: false, error: "Missing or invalid token…" }`
- a `403` response → same shape
- verify the message is surfaced correctly to the UI (integration with the caller of `sendToSurge`)

Without these, a future refactor could silently break the user-facing error path.

**Rule Used:** What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["fix: clarify missing..."](https://github.com/surge-downloader/surge/commit/10c105e612bfb10a73e186bada2f6b87d2ee6f87)</sub>

> Greptile also left **3 inline comments** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Rule used - What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))

<!-- /greptile_comment -->