### PR TITLE
chore: migrate releases to goreleaser pro and add thanks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,9 +104,10 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
-          distribution: goreleaser
+          distribution: goreleaser-pro
           version: latest
           args: release --clean
         env:
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,6 +23,7 @@ release:
     ---
     **Enjoying Surge?** Consider supporting the project to keep it blazing fast!
     - [Buy Me a Coffee](https://buymeacoffee.com/surge.downloader)
+    - Release automation powered by [GoReleaser Pro](https://goreleaser.com/pro/)
   extra_files:
     - glob: .goreleaser-extra/extension-chrome.zip
     - glob: .goreleaser-extra/extension-firefox.zip

--- a/README.md
+++ b/README.md
@@ -227,6 +227,15 @@ The Surge extension intercepts browser downloads and sends them straight to your
 
 ---
 
+## Acknowledgements
+
+Huge thanks to the teams and sponsors helping us build and ship Surge:
+
+- [Charm](https://charm.sh/) for the incredible terminal UI ecosystem (Bubble Tea, Lip Gloss, and more).
+- [GoReleaser Pro](https://goreleaser.com/pro/) for release automation (provided free for open source).
+
+---
+
 ## Community & Contributing
 
 We love community contributions! Whether it's a bug fix, a new feature, or just cleaning up typos.


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates the release pipeline from GoReleaser (free) to GoReleaser Pro by updating the GitHub Actions workflow distribution and injecting the `GORELEASER_KEY` secret, and pairs that with light documentation updates acknowledging sponsors.

- **`.github/workflows/build.yml`**: Switches `distribution` from `goreleaser` to `goreleaser-pro` and adds the `GORELEASER_KEY` env var — correctly structured using a repository secret.
- **`.goreleaser.yaml`**: Adds a single attribution line to the release footer mentioning GoReleaser Pro, consistent with the existing footer style.
- **`README.md`**: Introduces an Acknowledgements section crediting Charm (Bubble Tea / Lip Gloss) and GoReleaser Pro; well-placed before the Community section and properly formatted.

No functional or logic changes are introduced. The `homebrew_casks` block already present in `.goreleaser.yaml` is a GoReleaser Pro-only feature, so this migration is a prerequisite for that configuration to work correctly — the change is well-motivated.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — all changes are configuration and documentation with no functional code impact.
- Three small, isolated changes: a two-line workflow tweak, a one-line YAML footer addition, and a README section. No logic, no new dependencies, no breaking changes. The only operational prerequisite (the `GORELEASER_KEY` repo secret) is a standard GitHub Actions pattern and is referenced correctly.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/build.yml | Migrates GoReleaser distribution from `goreleaser` to `goreleaser-pro` and injects the required `GORELEASER_KEY` secret — straightforward and correct. |
| .goreleaser.yaml | Appends a GoReleaser Pro attribution line to the release footer; change is minimal and consistent with the existing footer style. |
| README.md | Adds an Acknowledgements section crediting Charm and GoReleaser Pro; documentation-only change, no functional impact. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub Actions
    participant GPro as GoReleaser Pro
    participant GHR as GitHub Releases
    participant HB as Homebrew Tap

    Dev->>GH: Push tag (v*)
    GH->>GH: Run test matrix (ubuntu, macos, windows)
    GH->>GPro: goreleaser-action@v6 (distribution: goreleaser-pro)
    Note over GH,GPro: Authenticates via GORELEASER_KEY secret
    GPro->>GPro: Build binaries (linux/windows/darwin)
    GPro->>GPro: Run before.hooks (package-release-assets.sh)
    GPro->>GHR: Publish release + extra_files + footer
    GPro->>HB: Update homebrew_casks tap via HOMEBREW_TAP_GITHUB_TOKEN
```

<sub>Last reviewed commit: ["chore: migrate relea..."](https://github.com/surge-downloader/surge/commit/4d18537fcb87bb3e23e6dc797d4836d4f3df2ab1)</sub>

<!-- /greptile_comment -->