### PR TITLE
chore: update extension version

### DIFF
--- a/extension-chrome/manifest.json
+++ b/extension-chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Surge Download Manager",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "description": "High-performance download acceleration with live progress tracking. Intercepts downloads and accelerates them using Surge's multi-connection engine.",
   "permissions": ["downloads", "storage", "notifications", "webRequest"],
   "host_permissions": ["http://127.0.0.1/*", "<all_urls>"],

--- a/extension-firefox/manifest.json
+++ b/extension-firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Surge Download Manager",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "description": "High-performance download acceleration with live progress tracking. Intercepts downloads and accelerates them using Surge's multi-connection engine.",
   "permissions": [
     "downloads",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the extension version from `1.6.7` to `1.6.8` in both the Chrome and Firefox `manifest.json` files, keeping the two extensions in sync.

- Both `extension-chrome/manifest.json` and `extension-firefox/manifest.json` are updated consistently to `1.6.8`.
- No other fields in either manifest were modified.
- No logic, permissions, or structural changes are included in this PR.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a minimal, isolated version bump with no logic changes.
- The change is a single-line version string update applied identically to both manifests. There is no risk of runtime errors, security issues, or behavioural regressions.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| extension-chrome/manifest.json | Version bumped from 1.6.7 to 1.6.8 — straightforward, no other fields modified. |
| extension-firefox/manifest.json | Version bumped from 1.6.7 to 1.6.8 — consistent with Chrome manifest, no other fields modified. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR: chore/update-extension-version] --> B[extension-chrome/manifest.json]
    A --> C[extension-firefox/manifest.json]
    B --> D[version: 1.6.7 → 1.6.8]
    C --> E[version: 1.6.7 → 1.6.8]
    D --> F[Both extensions now at 1.6.8]
    E --> F
```

<sub>Last reviewed commit: ["chore: update extens..."](https://github.com/surge-downloader/surge/commit/8f924b71a7ebf43f26b1ad5309971a83beb60667)</sub>

<!-- /greptile_comment -->