### PR TITLE
fix: update active workers count for single downloader

### DIFF
--- a/internal/engine/single/downloader.go
+++ b/internal/engine/single/downloader.go
@@ -134,6 +134,8 @@ func (d *SingleDownloader) Download(ctx context.Context, rawurl, destPath string
 	if d.State != nil {
 		d.State.SetURL(rawurl)
 		d.State.SetDestPath(destPath)
+		d.State.ActiveWorkers.Add(1)
+		defer d.State.ActiveWorkers.Add(-1)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawurl, nil)

--- a/internal/tui/components/add_download_modal.go
+++ b/internal/tui/components/add_download_modal.go
@@ -4,6 +4,7 @@ import (
 	"github.com/surge-downloader/surge/internal/tui/colors"
 
 	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/textarea"
 	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/lipgloss"
 )
@@ -11,7 +12,7 @@ import (
 // AddDownloadModal renders input-driven download forms (add download / extension prompt).
 type AddDownloadModal struct {
 	Title           string
-	Inputs          []textinput.Model
+	Inputs          []any
 	Labels          []string
 	FocusedInput    int
 	ShowURL         bool
@@ -38,7 +39,14 @@ func (m AddDownloadModal) View() string {
 	}
 
 	for i := 0; i < len(m.Inputs) && i < len(m.Labels); i++ {
-		row := lipgloss.JoinHorizontal(lipgloss.Left, labelStyle.Render(m.Labels[i]), m.Inputs[i].View())
+		var inputView string
+		switch v := m.Inputs[i].(type) {
+		case textinput.Model:
+			inputView = v.View()
+		case textarea.Model:
+			inputView = v.View()
+		}
+		row := lipgloss.JoinHorizontal(lipgloss.Left, labelStyle.Render(m.Labels[i]), inputView)
 		if m.BrowseHintIndex == i {
 			hintStyle := hintBase
 			if m.FocusedInput == i {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/bubbles/progress"
+	"github.com/charmbracelet/bubbles/textarea"
 	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
@@ -83,7 +84,7 @@ type RootModel struct {
 	height       int
 	state        UIState
 	activeTab    int // 0=Queued, 1=Active, 2=Done
-	inputs       []textinput.Model
+	inputs       []any
 	focusedInput int
 	// Service Interface
 	// Core
@@ -153,7 +154,7 @@ type RootModel struct {
 	catMgrCursor       int                // Selected category index
 	catMgrEditing      bool               // Whether editing a category
 	catMgrEditField    int                // 0=Name, 1=Description, 2=Pattern, 3=Path
-	catMgrInputs       [4]textinput.Model // Inputs for Name, Description, Pattern, Path
+	catMgrInputs       [4]any             // Inputs for Name, Description, Pattern, Path
 	catMgrIsNew        bool               // Whether adding a new category
 	catMgrFileBrowsing bool               // Whether browsing for a category path
 
@@ -213,10 +214,10 @@ func InitialRootModel(serverPort int, currentVersion string, service core.Downlo
 	filenameInput.Width = InputWidth
 	filenameInput.Prompt = ""
 
-	mirrorsInput := textinput.New()
-	mirrorsInput.Placeholder = "http://mirror1.com, http://mirror2.com"
-	mirrorsInput.Width = InputWidth
-	mirrorsInput.Prompt = ""
+	mirrorsInput := textarea.New()
+	mirrorsInput.Placeholder = "http://mirror1.com\nhttp://mirror2.com"
+	mirrorsInput.SetWidth(InputWidth)
+	mirrorsInput.SetHeight(3)
 
 	pwd, _ := os.Getwd()
 
@@ -332,10 +333,10 @@ func InitialRootModel(serverPort int, currentVersion string, service core.Downlo
 	catNameInput.Width = 30
 	catNameInput.Prompt = ""
 
-	catDescInput := textinput.New()
+	catDescInput := textarea.New()
 	catDescInput.Placeholder = "Video files (.mp4, .mkv)"
-	catDescInput.Width = 50
-	catDescInput.Prompt = ""
+	catDescInput.SetWidth(50)
+	catDescInput.SetHeight(2)
 
 	catPatternInput := textinput.New()
 	catPatternInput.Placeholder = "(?i)\\.(mp4|mkv)$"
@@ -351,7 +352,7 @@ func InitialRootModel(serverPort int, currentVersion string, service core.Downlo
 
 	m := RootModel{
 		downloads:             downloads,
-		inputs:                []textinput.Model{urlInput, mirrorsInput, pathInput, filenameInput},
+		inputs:                []any{urlInput, mirrorsInput, pathInput, filenameInput},
 		state:                 DashboardState,
 		filepicker:            fp,
 		help:                  helpModel,
@@ -366,7 +367,7 @@ func InitialRootModel(serverPort int, currentVersion string, service core.Downlo
 		SettingsInput:         settingsInput,
 		searchInput:           searchInput,
 		urlUpdateInput:        urlUpdateInput,
-		catMgrInputs:          [4]textinput.Model{catNameInput, catDescInput, catPatternInput, catPathInput},
+		catMgrInputs:          [4]any{catNameInput, catDescInput, catPatternInput, catPathInput},
 		keys:                  Keys,
 		ServerPort:            serverPort,
 		CurrentVersion:        currentVersion,
@@ -557,4 +558,66 @@ func (m *RootModel) ApplyTheme(mode int) {
 		lipgloss.SetHasDarkBackground(true)
 	}
 	m.logoCache = "" // Invalidate logo cache
+}
+
+func (m *RootModel) getInputValue(inputs []any, index int) string {
+	switch v := inputs[index].(type) {
+	case textinput.Model:
+		return v.Value()
+	case textarea.Model:
+		return v.Value()
+	}
+	return ""
+}
+
+func (m *RootModel) setInputValue(inputs []any, index int, val string) {
+	switch v := inputs[index].(type) {
+	case textinput.Model:
+		v.SetValue(val)
+		inputs[index] = v
+	case textarea.Model:
+		v.SetValue(val)
+		inputs[index] = v
+	}
+}
+
+func (m *RootModel) focusInput(inputs []any, index int) tea.Cmd {
+	switch v := inputs[index].(type) {
+	case textinput.Model:
+		cmd := v.Focus()
+		inputs[index] = v
+		return cmd
+	case textarea.Model:
+		cmd := v.Focus()
+		inputs[index] = v
+		return cmd
+	}
+	return nil
+}
+
+func (m *RootModel) blurInput(inputs []any, index int) {
+	switch v := inputs[index].(type) {
+	case textinput.Model:
+		v.Blur()
+		inputs[index] = v
+	case textarea.Model:
+		v.Blur()
+		inputs[index] = v
+	}
+}
+
+func (m *RootModel) updateInput(inputs []any, index int, msg tea.Msg) tea.Cmd {
+	switch v := inputs[index].(type) {
+	case textinput.Model:
+		var cmd tea.Cmd
+		v, cmd = v.Update(msg)
+		inputs[index] = v
+		return cmd
+	case textarea.Model:
+		var cmd tea.Cmd
+		v, cmd = v.Update(msg)
+		inputs[index] = v
+		return cmd
+	}
+	return nil
 }

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -126,18 +126,18 @@ func (m *RootModel) handleFilePickerSelection(path string) (tea.Model, tea.Cmd) 
 		return m, nil
 	}
 	if m.ExtensionFileBrowsing {
-		m.inputs[2].SetValue(path)
+		m.setInputValue(m.inputs, 2, path)
 		m.ExtensionFileBrowsing = false
 		m.state = ExtensionConfirmationState
 		return m, nil
 	}
 	if m.catMgrFileBrowsing {
-		m.catMgrInputs[3].SetValue(path)
+		m.setInputValue(m.catMgrInputs[:], 3, path)
 		m.catMgrFileBrowsing = false
 		m.state = CategoryManagerState
 		return m, nil
 	}
-	m.inputs[2].SetValue(path)
+	m.setInputValue(m.inputs, 2, path)
 	m.state = InputState
 	return m, nil
 }
@@ -452,15 +452,15 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.pendingPath = path
 			m.pendingIsDefaultPath = isDefaultPath
 			m.pendingFilename = msg.Filename
-			m.inputs[2].SetValue(path)
-			m.inputs[3].SetValue(msg.Filename)
+			m.setInputValue(m.inputs, 2, path)
+			m.setInputValue(m.inputs, 3, msg.Filename)
 			m.focusedInput = 2
 			for i := range m.inputs {
-				m.inputs[i].Blur()
+				m.blurInput(m.inputs, i)
 			}
-			m.inputs[m.focusedInput].Focus()
+			cmds = append(cmds, m.focusInput(m.inputs, m.focusedInput))
 			m.state = ExtensionConfirmationState
-			return m, nil
+			return m, tea.Batch(cmds...)
 		}
 
 		return m.startDownload(msg.URL, msg.Mirrors, msg.Headers, path, isDefaultPath, msg.Filename, msg.ID)
@@ -763,25 +763,25 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if key.Matches(msg, m.keys.Dashboard.Add) {
 				m.state = InputState
 				m.focusedInput = 0
-				m.inputs[0].Focus()
+				cmds = append(cmds, m.focusInput(m.inputs, 0))
 				// Use default download dir from settings
 				defaultDir := m.Settings.General.DefaultDownloadDir
 				if defaultDir == "" {
 					defaultDir = "."
 				}
-				m.inputs[2].SetValue(defaultDir)
-				m.inputs[2].Blur()
-				m.inputs[3].SetValue("")
-				m.inputs[3].Blur()
-				m.inputs[1].SetValue("") // Clear mirrors
-				m.inputs[1].Blur()
+				m.setInputValue(m.inputs, 2, defaultDir)
+				m.blurInput(m.inputs, 2)
+				m.setInputValue(m.inputs, 3, "")
+				m.blurInput(m.inputs, 3)
+				m.setInputValue(m.inputs, 1, "") // Clear mirrors
+				m.blurInput(m.inputs, 1)
 
 				url := ""
 				if m.Settings.General.ClipboardMonitor {
 					url = clipboard.ReadURL()
 				}
-				m.inputs[0].SetValue(url)
-				return m, nil
+				m.setInputValue(m.inputs, 0, url)
+				return m, tea.Batch(cmds...)
 			}
 
 			// Next Tab
@@ -1007,21 +1007,21 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if key.Matches(msg, m.keys.Input.Enter) {
 				// Navigate through inputs: URL -> Mirrors -> Path -> Filename -> Start
 				if m.focusedInput < 3 {
-					m.inputs[m.focusedInput].Blur()
+					m.blurInput(m.inputs, m.focusedInput)
 					m.focusedInput++
-					m.inputs[m.focusedInput].Focus()
-					return m, nil
+					cmds = append(cmds, m.focusInput(m.inputs, m.focusedInput))
+					return m, tea.Batch(cmds...)
 				}
 				// Start download (on last input)
-				inputVal := m.inputs[0].Value()
+				inputVal := m.getInputValue(m.inputs, 0)
 				if inputVal == "" {
 					// URL is mandatory - don't start
 					m.focusedInput = 0
-					m.inputs[0].Focus()
-					m.inputs[1].Blur()
-					m.inputs[2].Blur()
-					m.inputs[3].Blur()
-					return m, nil
+					cmds = append(cmds, m.focusInput(m.inputs, 0))
+					m.blurInput(m.inputs, 1)
+					m.blurInput(m.inputs, 2)
+					m.blurInput(m.inputs, 3)
+					return m, tea.Batch(cmds...)
 				}
 
 				// Parse comma-separated URLs from primary input (backward compatibility)
@@ -1044,9 +1044,12 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 
 				// Parse mirrors from dedicated input
-				mirrorsVal := m.inputs[1].Value()
+				mirrorsVal := m.getInputValue(m.inputs, 1)
 				if mirrorsVal != "" {
-					mirrorParts := strings.Split(mirrorsVal, ",")
+					// Support both comma and newline separation for textarea compatibility
+					mirrorParts := strings.FieldsFunc(mirrorsVal, func(r rune) bool {
+						return r == ',' || r == '\n'
+					})
 					for _, part := range mirrorParts {
 						cleaned := strings.TrimSpace(part)
 						if cleaned != "" {
@@ -1058,18 +1061,18 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if url == "" {
 					// Should ideally check valid URL format here too
 					m.focusedInput = 0
-					m.inputs[0].Focus()
-					return m, nil
+					cmds = append(cmds, m.focusInput(m.inputs, 0))
+					return m, tea.Batch(cmds...)
 				}
 
-				pathInput := strings.TrimSpace(m.inputs[2].Value())
+				pathInput := strings.TrimSpace(m.getInputValue(m.inputs, 2))
 				path := pathInput
 				isDefaultPath := m.isDefaultDownloadPath(path)
 				if path == "" {
 					isDefaultPath = true
 					path = m.defaultDownloadPath()
 				}
-				filename := m.inputs[3].Value()
+				filename := m.getInputValue(m.inputs, 3)
 
 				// Check for duplicate URL
 				if d := m.checkForDuplicate(url); d != nil {
@@ -1086,30 +1089,29 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 				m.state = DashboardState
 				// Clear inputs
-				m.inputs[0].SetValue("")
-				m.inputs[1].SetValue("")
-				m.inputs[2].SetValue(path) // Keep path
-				m.inputs[3].SetValue("")
+				m.setInputValue(m.inputs, 0, "")
+				m.setInputValue(m.inputs, 1, "")
+				m.setInputValue(m.inputs, 2, path) // Keep path
+				m.setInputValue(m.inputs, 3, "")
 
 				return m.startDownload(url, mirrors, nil, path, isDefaultPath, filename, "")
 			}
 
 			// Up/Down navigation between inputs
 			if key.Matches(msg, m.keys.Input.Up) && m.focusedInput > 0 {
-				m.inputs[m.focusedInput].Blur()
+				m.blurInput(m.inputs, m.focusedInput)
 				m.focusedInput--
-				m.inputs[m.focusedInput].Focus()
-				return m, nil
+				cmds = append(cmds, m.focusInput(m.inputs, m.focusedInput))
+				return m, tea.Batch(cmds...)
 			}
 			if key.Matches(msg, m.keys.Input.Down) && m.focusedInput < 3 {
-				m.inputs[m.focusedInput].Blur()
+				m.blurInput(m.inputs, m.focusedInput)
 				m.focusedInput++
-				m.inputs[m.focusedInput].Focus()
-				return m, nil
+				cmds = append(cmds, m.focusInput(m.inputs, m.focusedInput))
+				return m, tea.Batch(cmds...)
 			}
 
-			var cmd tea.Cmd
-			m.inputs[m.focusedInput], cmd = m.inputs[m.focusedInput].Update(msg)
+			cmd := m.updateInput(m.inputs, m.focusedInput, msg)
 			return m, cmd
 
 		case FilePickerState:
@@ -1714,12 +1716,12 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// Enter edit mode
 				m.catMgrEditing = true
 				m.catMgrEditField = 0
-				m.catMgrInputs[0].SetValue(newCat.Name)
-				m.catMgrInputs[1].SetValue(newCat.Description)
-				m.catMgrInputs[2].SetValue(newCat.Pattern)
-				m.catMgrInputs[3].SetValue(newCat.Path)
-				m.catMgrInputs[0].Focus()
-				return m, nil
+				m.setInputValue(m.catMgrInputs[:], 0, newCat.Name)
+				m.setInputValue(m.catMgrInputs[:], 1, newCat.Description)
+				m.setInputValue(m.catMgrInputs[:], 2, newCat.Pattern)
+				m.setInputValue(m.catMgrInputs[:], 3, newCat.Path)
+				cmds = append(cmds, m.focusInput(m.catMgrInputs[:], 0))
+				return m, tea.Batch(cmds...)
 			}
 
 			if key.Matches(msg, m.keys.CategoryMgr.Edit) {
@@ -1728,11 +1730,11 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					cat := cats[m.catMgrCursor]
 					m.catMgrEditing = true
 					m.catMgrEditField = 0
-					m.catMgrInputs[0].SetValue(cat.Name)
-					m.catMgrInputs[1].SetValue(cat.Description)
-					m.catMgrInputs[2].SetValue(cat.Pattern)
-					m.catMgrInputs[3].SetValue(cat.Path)
-					m.catMgrInputs[0].Focus()
+					m.setInputValue(m.catMgrInputs[:], 0, cat.Name)
+					m.setInputValue(m.catMgrInputs[:], 1, cat.Description)
+					m.setInputValue(m.catMgrInputs[:], 2, cat.Pattern)
+					m.setInputValue(m.catMgrInputs[:], 3, cat.Path)
+					cmds = append(cmds, m.focusInput(m.catMgrInputs[:], 0))
 				} else {
 					// On "+ Add Category" row, same as Add
 					newCat := config.Category{Name: "New Category"}
@@ -1741,13 +1743,13 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.catMgrIsNew = true
 					m.catMgrEditing = true
 					m.catMgrEditField = 0
-					m.catMgrInputs[0].SetValue(newCat.Name)
-					m.catMgrInputs[1].SetValue(newCat.Description)
-					m.catMgrInputs[2].SetValue(newCat.Pattern)
-					m.catMgrInputs[3].SetValue(newCat.Path)
-					m.catMgrInputs[0].Focus()
+					m.setInputValue(m.catMgrInputs[:], 0, newCat.Name)
+					m.setInputValue(m.catMgrInputs[:], 1, newCat.Description)
+					m.setInputValue(m.catMgrInputs[:], 2, newCat.Pattern)
+					m.setInputValue(m.catMgrInputs[:], 3, newCat.Path)
+					cmds = append(cmds, m.focusInput(m.catMgrInputs[:], 0))
 				}
-				return m, nil
+				return m, tea.Batch(cmds...)
 			}
 
 			return m, nil

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -87,7 +87,7 @@ func (m RootModel) View() string {
 	if m.state == InputState {
 		modal := components.AddDownloadModal{
 			Title:           "Add Download",
-			Inputs:          []textinput.Model{m.inputs[0], m.inputs[1], m.inputs[2], m.inputs[3]},
+			Inputs:          []any{m.inputs[0], m.inputs[1], m.inputs[2], m.inputs[3]},
 			Labels:          []string{"URL:", "Mirrors:", "Path:", "Filename:"},
 			FocusedInput:    m.focusedInput,
 			BrowseHintIndex: 2,
@@ -137,7 +137,7 @@ func (m RootModel) View() string {
 	}
 
 	if m.state == ExtensionConfirmationState {
-		extInputs := []textinput.Model{m.inputs[2], m.inputs[3]}
+		extInputs := []any{m.inputs[2], m.inputs[3]}
 		focused := 0
 		if m.focusedInput == 3 {
 			focused = 1
@@ -206,7 +206,7 @@ func (m RootModel) View() string {
 	if m.state == URLUpdateState {
 		modal := components.AddDownloadModal{
 			Title:           "Refresh URL",
-			Inputs:          []textinput.Model{m.urlUpdateInput},
+			Inputs:          []any{m.urlUpdateInput},
 			Labels:          []string{"New URL:"},
 			FocusedInput:    0,
 			BrowseHintIndex: -1, // No browse hint needed


### PR DESCRIPTION
Ensure that the single downloader increments the active workers counter so that the TUI shows "Conns: 1" instead of "Conns: 0" during the download.

Fixes #287

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses two concerns: (1) a targeted one-liner fix ensuring `SingleDownloader` increments `State.ActiveWorkers` so the TUI displays "Conns: 1" instead of "Conns: 0", and (2) a larger TUI refactor that replaces the `mirrors` and category-description inputs from `textinput.Model` to `textarea.Model` to allow multi-line entry, migrating `m.inputs` and `m.catMgrInputs` from concrete typed slices to `[]any` / `[4]any`.

- ✅ The `ActiveWorkers` fix in `internal/engine/single/downloader.go` is correct and atomic-safe.
- ❌ **Will not compile**: the `[]any` migration was applied to the diff hunks but was not applied to the `ExtensionConfirmationState` block (`update.go` lines 1223–1275) or the `CategoryManagerState` editing block (`update.go` lines 1587–1668, 1156), which still call `.Blur()`, `.Focus()`, `.Value()`, `.SetValue()`, and `.Update()` directly on `any`-typed values.
- ⚠️ The five new helper methods in `model.go` each contain an identical two-case type switch; a Go interface + thin wrapper types would be more idiomatic, type-safe, and extensible.
- ⚠️ No tests are included for either the `ActiveWorkers` counter behaviour or the new `textarea` input paths.

<h3>Confidence Score: 0/5</h3>

- Not safe to merge — the `[]any` migration is incomplete and the code will not compile.
- Multiple call sites in `update.go` still invoke typed methods (`.Blur()`, `.Focus()`, `.Value()`, `.Update()`, `.SetValue()`) directly on `any`-typed slice elements. Go's type system will reject these at compile time, so the binary cannot be produced in its current state.
- `internal/tui/update.go` requires the most attention — the `ExtensionConfirmationState` block (lines 1223–1275), line 1156, and the entire `CategoryManagerState` editing block (lines 1587–1668) all need to be migrated to the new helper methods before this can compile.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/engine/single/downloader.go | Adds `ActiveWorkers.Add(1)` / `defer ActiveWorkers.Add(-1)` around the download body; the fix is correct, atomic-safe, and well-scoped behind the existing `d.State != nil` guard. |
| internal/tui/update.go | Partially migrated to the `[]any` helper methods, but the `ExtensionConfirmationState` block (lines 1223–1275) and the entire `CategoryManagerState` editing block (lines 1587–1668), plus line 1156, still call methods directly on `any`-typed values — this will not compile. |
| internal/tui/model.go | Migrates `inputs` and `catMgrInputs` from concrete model slices to `[]any`/`[4]any` and introduces five helper methods with type switches; the helpers themselves are correct, but the `[]any` approach introduces significant boilerplate that a Go interface would eliminate. |
| internal/tui/components/add_download_modal.go | Updates `Inputs` field to `[]any` and renders each input via a type-switch; logically correct and consistent with the rest of the migration. |
| internal/tui/view.go | Straightforward update to pass `[]any` slices where `[]textinput.Model` was expected; no issues. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant TUI as TUI (RootModel)
    participant Engine as Engine
    participant SD as SingleDownloader
    participant State as ProgressState

    TUI->>Engine: startDownload(url, ...)
    Engine->>SD: Download(ctx, url, destPath, ...)
    SD->>State: ActiveWorkers.Add(+1)
    Note over TUI,State: TUI polls State — now shows "Conns: 1"
    SD->>SD: HTTP GET → io.CopyBuffer (progressReader)
    SD-->>State: Downloaded.Store(written) [periodic]
    SD->>State: ActiveWorkers.Add(-1)  [deferred]
    SD-->>Engine: return nil / error
    Engine-->>TUI: DownloadCompleteMsg
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `internal/tui/update.go`, line 1587-1668 ([link](https://github.com/surge-downloader/surge/blob/eefd725889920875be617f83628720b748c97ba3/internal/tui/update.go#L1587-L1668)) 

   <a href="#"><img alt="P0" src="https://greptile-static-assets.s3.amazonaws.com/badges/p0.svg?v=7" align="top"></a> **Compile error: direct method calls on `any`-typed `catMgrInputs`**

   The PR changes `catMgrInputs` from `[4]textinput.Model` to `[4]any`, but many call sites inside the `CategoryManagerState` block were not migrated to use the new helper methods. Since `m.catMgrInputs[i]` is now of type `any`, calling `.Blur()`, `.Focus()`, `.Value()`, or `.Update()` on it will **fail to compile**.

   The following lines all have this problem:

   - **Line 1587**: `m.catMgrInputs[i].Blur()`
   - **Line 1605**: `m.catMgrInputs[3].Value()`
   - **Line 1618**: `m.catMgrInputs[m.catMgrEditField].Blur()`
   - **Line 1620**: `m.catMgrInputs[m.catMgrEditField].Focus()` (also discards the returned `tea.Cmd`)
   - **Lines 1630–1633**: four `.Value()` calls
   - **Line 1661**: `m.catMgrInputs[i].Blur()`
   - **Line 1668**: `m.catMgrInputs[m.catMgrEditField], cmd = m.catMgrInputs[m.catMgrEditField].Update(msg)` (assignment target `m.catMgrInputs[…]` is `any`, and the method doesn't exist on `any`)

   All of these need to be replaced with the helper methods introduced in `model.go`. For example:

   ```go
   // Line 1585-1588: cancel editing loop
   m.catMgrEditing = false
   for i := range m.catMgrInputs {
       m.blurInput(m.catMgrInputs[:], i)
   }

   // Line 1604-1605: browse directory value
   browseDir := strings.TrimSpace(m.getInputValue(m.catMgrInputs[:], 3))

   // Lines 1618-1621: cycle fields
   m.blurInput(m.catMgrInputs[:], m.catMgrEditField)
   m.catMgrEditField = (m.catMgrEditField + 1) % 4
   cmds = append(cmds, m.focusInput(m.catMgrInputs[:], m.catMgrEditField))
   return m, tea.Batch(cmds...)

   // Lines 1630-1633: read values on save
   name := strings.TrimSpace(m.getInputValue(m.catMgrInputs[:], 0))
   description := strings.TrimSpace(m.getInputValue(m.catMgrInputs[:], 1))
   pattern := strings.TrimSpace(m.getInputValue(m.catMgrInputs[:], 2))
   path := strings.TrimSpace(m.getInputValue(m.catMgrInputs[:], 3))

   // Line 1660-1662: post-save blur loop
   for i := range m.catMgrInputs {
       m.blurInput(m.catMgrInputs[:], i)
   }

   // Line 1668: forward key events
   cmd := m.updateInput(m.catMgrInputs[:], m.catMgrEditField, msg)
   return m, cmd
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/tui/update.go
   Line: 1587-1668

   Comment:
   **Compile error: direct method calls on `any`-typed `catMgrInputs`**

   The PR changes `catMgrInputs` from `[4]textinput.Model` to `[4]any`, but many call sites inside the `CategoryManagerState` block were not migrated to use the new helper methods. Since `m.catMgrInputs[i]` is now of type `any`, calling `.Blur()`, `.Focus()`, `.Value()`, or `.Update()` on it will **fail to compile**.

   The following lines all have this problem:

   - **Line 1587**: `m.catMgrInputs[i].Blur()`
   - **Line 1605**: `m.catMgrInputs[3].Value()`
   - **Line 1618**: `m.catMgrInputs[m.catMgrEditField].Blur()`
   - **Line 1620**: `m.catMgrInputs[m.catMgrEditField].Focus()` (also discards the returned `tea.Cmd`)
   - **Lines 1630–1633**: four `.Value()` calls
   - **Line 1661**: `m.catMgrInputs[i].Blur()`
   - **Line 1668**: `m.catMgrInputs[m.catMgrEditField], cmd = m.catMgrInputs[m.catMgrEditField].Update(msg)` (assignment target `m.catMgrInputs[…]` is `any`, and the method doesn't exist on `any`)

   All of these need to be replaced with the helper methods introduced in `model.go`. For example:

   ```go
   // Line 1585-1588: cancel editing loop
   m.catMgrEditing = false
   for i := range m.catMgrInputs {
       m.blurInput(m.catMgrInputs[:], i)
   }

   // Line 1604-1605: browse directory value
   browseDir := strings.TrimSpace(m.getInputValue(m.catMgrInputs[:], 3))

   // Lines 1618-1621: cycle fields
   m.blurInput(m.catMgrInputs[:], m.catMgrEditField)
   m.catMgrEditField = (m.catMgrEditField + 1) % 4
   cmds = append(cmds, m.focusInput(m.catMgrInputs[:], m.catMgrEditField))
   return m, tea.Batch(cmds...)

   // Lines 1630-1633: read values on save
   name := strings.TrimSpace(m.getInputValue(m.catMgrInputs[:], 0))
   description := strings.TrimSpace(m.getInputValue(m.catMgrInputs[:], 1))
   pattern := strings.TrimSpace(m.getInputValue(m.catMgrInputs[:], 2))
   path := strings.TrimSpace(m.getInputValue(m.catMgrInputs[:], 3))

   // Line 1660-1662: post-save blur loop
   for i := range m.catMgrInputs {
       m.blurInput(m.catMgrInputs[:], i)
   }

   // Line 1668: forward key events
   cmd := m.updateInput(m.catMgrInputs[:], m.catMgrEditField, msg)
   return m, cmd
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `internal/tui/update.go`, line 1223-1275 ([link](https://github.com/surge-downloader/surge/blob/eefd725889920875be617f83628720b748c97ba3/internal/tui/update.go#L1223-L1275)) 

   <a href="#"><img alt="P0" src="https://greptile-static-assets.s3.amazonaws.com/badges/p0.svg?v=7" align="top"></a> **Compile error: direct method calls on `any`-typed `m.inputs` in `ExtensionConfirmationState`**

   The `ExtensionConfirmationState` block was not migrated to the new helper methods. `m.inputs` is now `[]any`, so calling `.Value()`, `.Blur()`, `.Focus()`, or `.Update()` on its elements will **fail to compile**.

   Affected lines:

   - **Line 1223**: `m.inputs[2].Value()`
   - **Line 1238**: `m.inputs[i].Blur()`
   - **Line 1240**: `m.inputs[m.focusedInput].Focus()` (also discards `tea.Cmd`)
   - **Line 1244**: `m.inputs[2].Value()`
   - **Line 1245**: `m.inputs[3].Value()`
   - **Line 1268**: `m.inputs[i].Blur()`
   - **Line 1275**: `m.inputs[m.focusedInput], cmd = m.inputs[m.focusedInput].Update(msg)` (invalid assignment to `any` + no method on `any`)

   These all need to be replaced with the helper methods from `model.go`. For example:

   ```go
   // Line 1223
   browseDir := strings.TrimSpace(m.getInputValue(m.inputs, 2))

   // Lines 1237-1241: toggle focus
   for i := range m.inputs {
       m.blurInput(m.inputs, i)
   }
   cmds = append(cmds, m.focusInput(m.inputs, m.focusedInput))
   return m, tea.Batch(cmds...)

   // Lines 1244-1245
   m.pendingPath = strings.TrimSpace(m.getInputValue(m.inputs, 2))
   m.pendingFilename = strings.TrimSpace(m.getInputValue(m.inputs, 3))

   // Line 1267-1269
   for i := range m.inputs {
       m.blurInput(m.inputs, i)
   }

   // Line 1275
   cmd := m.updateInput(m.inputs, m.focusedInput, msg)
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/tui/update.go
   Line: 1223-1275

   Comment:
   **Compile error: direct method calls on `any`-typed `m.inputs` in `ExtensionConfirmationState`**

   The `ExtensionConfirmationState` block was not migrated to the new helper methods. `m.inputs` is now `[]any`, so calling `.Value()`, `.Blur()`, `.Focus()`, or `.Update()` on its elements will **fail to compile**.

   Affected lines:

   - **Line 1223**: `m.inputs[2].Value()`
   - **Line 1238**: `m.inputs[i].Blur()`
   - **Line 1240**: `m.inputs[m.focusedInput].Focus()` (also discards `tea.Cmd`)
   - **Line 1244**: `m.inputs[2].Value()`
   - **Line 1245**: `m.inputs[3].Value()`
   - **Line 1268**: `m.inputs[i].Blur()`
   - **Line 1275**: `m.inputs[m.focusedInput], cmd = m.inputs[m.focusedInput].Update(msg)` (invalid assignment to `any` + no method on `any`)

   These all need to be replaced with the helper methods from `model.go`. For example:

   ```go
   // Line 1223
   browseDir := strings.TrimSpace(m.getInputValue(m.inputs, 2))

   // Lines 1237-1241: toggle focus
   for i := range m.inputs {
       m.blurInput(m.inputs, i)
   }
   cmds = append(cmds, m.focusInput(m.inputs, m.focusedInput))
   return m, tea.Batch(cmds...)

   // Lines 1244-1245
   m.pendingPath = strings.TrimSpace(m.getInputValue(m.inputs, 2))
   m.pendingFilename = strings.TrimSpace(m.getInputValue(m.inputs, 3))

   // Line 1267-1269
   for i := range m.inputs {
       m.blurInput(m.inputs, i)
   }

   // Line 1275
   cmd := m.updateInput(m.inputs, m.focusedInput, msg)
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


3. `internal/tui/update.go`, line 1156 ([link](https://github.com/surge-downloader/surge/blob/eefd725889920875be617f83628720b748c97ba3/internal/tui/update.go#L1156)) 

   <a href="#"><img alt="P0" src="https://greptile-static-assets.s3.amazonaws.com/badges/p0.svg?v=7" align="top"></a> **Compile error: `SetValue` called directly on `any`**

   `m.catMgrInputs[3]` is now of type `any`, so calling `.SetValue()` on it will not compile. This line needs to use the `setInputValue` helper:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/tui/update.go
   Line: 1156

   Comment:
   **Compile error: `SetValue` called directly on `any`**

   `m.catMgrInputs[3]` is now of type `any`, so calling `.SetValue()` on it will not compile. This line needs to use the `setInputValue` helper:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/tui/update.go
Line: 1587-1668

Comment:
**Compile error: direct method calls on `any`-typed `catMgrInputs`**

The PR changes `catMgrInputs` from `[4]textinput.Model` to `[4]any`, but many call sites inside the `CategoryManagerState` block were not migrated to use the new helper methods. Since `m.catMgrInputs[i]` is now of type `any`, calling `.Blur()`, `.Focus()`, `.Value()`, or `.Update()` on it will **fail to compile**.

The following lines all have this problem:

- **Line 1587**: `m.catMgrInputs[i].Blur()`
- **Line 1605**: `m.catMgrInputs[3].Value()`
- **Line 1618**: `m.catMgrInputs[m.catMgrEditField].Blur()`
- **Line 1620**: `m.catMgrInputs[m.catMgrEditField].Focus()` (also discards the returned `tea.Cmd`)
- **Lines 1630–1633**: four `.Value()` calls
- **Line 1661**: `m.catMgrInputs[i].Blur()`
- **Line 1668**: `m.catMgrInputs[m.catMgrEditField], cmd = m.catMgrInputs[m.catMgrEditField].Update(msg)` (assignment target `m.catMgrInputs[…]` is `any`, and the method doesn't exist on `any`)

All of these need to be replaced with the helper methods introduced in `model.go`. For example:

```go
// Line 1585-1588: cancel editing loop
m.catMgrEditing = false
for i := range m.catMgrInputs {
    m.blurInput(m.catMgrInputs[:], i)
}

// Line 1604-1605: browse directory value
browseDir := strings.TrimSpace(m.getInputValue(m.catMgrInputs[:], 3))

// Lines 1618-1621: cycle fields
m.blurInput(m.catMgrInputs[:], m.catMgrEditField)
m.catMgrEditField = (m.catMgrEditField + 1) % 4
cmds = append(cmds, m.focusInput(m.catMgrInputs[:], m.catMgrEditField))
return m, tea.Batch(cmds...)

// Lines 1630-1633: read values on save
name := strings.TrimSpace(m.getInputValue(m.catMgrInputs[:], 0))
description := strings.TrimSpace(m.getInputValue(m.catMgrInputs[:], 1))
pattern := strings.TrimSpace(m.getInputValue(m.catMgrInputs[:], 2))
path := strings.TrimSpace(m.getInputValue(m.catMgrInputs[:], 3))

// Line 1660-1662: post-save blur loop
for i := range m.catMgrInputs {
    m.blurInput(m.catMgrInputs[:], i)
}

// Line 1668: forward key events
cmd := m.updateInput(m.catMgrInputs[:], m.catMgrEditField, msg)
return m, cmd
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/tui/update.go
Line: 1223-1275

Comment:
**Compile error: direct method calls on `any`-typed `m.inputs` in `ExtensionConfirmationState`**

The `ExtensionConfirmationState` block was not migrated to the new helper methods. `m.inputs` is now `[]any`, so calling `.Value()`, `.Blur()`, `.Focus()`, or `.Update()` on its elements will **fail to compile**.

Affected lines:

- **Line 1223**: `m.inputs[2].Value()`
- **Line 1238**: `m.inputs[i].Blur()`
- **Line 1240**: `m.inputs[m.focusedInput].Focus()` (also discards `tea.Cmd`)
- **Line 1244**: `m.inputs[2].Value()`
- **Line 1245**: `m.inputs[3].Value()`
- **Line 1268**: `m.inputs[i].Blur()`
- **Line 1275**: `m.inputs[m.focusedInput], cmd = m.inputs[m.focusedInput].Update(msg)` (invalid assignment to `any` + no method on `any`)

These all need to be replaced with the helper methods from `model.go`. For example:

```go
// Line 1223
browseDir := strings.TrimSpace(m.getInputValue(m.inputs, 2))

// Lines 1237-1241: toggle focus
for i := range m.inputs {
    m.blurInput(m.inputs, i)
}
cmds = append(cmds, m.focusInput(m.inputs, m.focusedInput))
return m, tea.Batch(cmds...)

// Lines 1244-1245
m.pendingPath = strings.TrimSpace(m.getInputValue(m.inputs, 2))
m.pendingFilename = strings.TrimSpace(m.getInputValue(m.inputs, 3))

// Line 1267-1269
for i := range m.inputs {
    m.blurInput(m.inputs, i)
}

// Line 1275
cmd := m.updateInput(m.inputs, m.focusedInput, msg)
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/tui/update.go
Line: 1156

Comment:
**Compile error: `SetValue` called directly on `any`**

`m.catMgrInputs[3]` is now of type `any`, so calling `.SetValue()` on it will not compile. This line needs to use the `setInputValue` helper:

```suggestion
				m.setInputValue(m.catMgrInputs[:], 3, path)
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/tui/model.go
Line: 563-623

Comment:
**Consider a Go interface instead of `[]any` + repeated type switches**

Five helper methods (`getInputValue`, `setInputValue`, `focusInput`, `blurInput`, `updateInput`) all duplicate the same two-case type switch for `textinput.Model` and `textarea.Model`. Every time a new input widget is needed, all five functions must be updated.

A more idiomatic approach is to define a thin wrapper interface and satisfy it with lightweight adapter types:

```go
// inputWidget is the minimal contract required by the TUI input fields.
type inputWidget interface {
    Value() string
    SetValue(string)
    Focus() tea.Cmd
    Blur()
    View() string
    Update(tea.Msg) (inputWidget, tea.Cmd)
}
```

Because `textinput.Model.Update` and `textarea.Model.Update` each return their own concrete type rather than `inputWidget`, you would need thin wrappers:

```go
type textInputWidget struct{ m textinput.Model }
func (w textInputWidget) Value() string                          { return w.m.Value() }
func (w textInputWidget) SetValue(s string)                     { w.m.SetValue(s) }
func (w textInputWidget) Focus() tea.Cmd                        { return w.m.Focus() }
func (w textInputWidget) Blur()                                 { w.m.Blur() }
func (w textInputWidget) View() string                          { return w.m.View() }
func (w textInputWidget) Update(msg tea.Msg) (inputWidget, tea.Cmd) {
    m, cmd := w.m.Update(msg)
    return textInputWidget{m}, cmd
}
```

With this, `m.inputs` can be `[]inputWidget` and all five helper functions collapse into direct method calls with no switch statement, no risk of falling through an unhandled type, and no possibility of compile errors from an incomplete migration.

**Rule Used:** # Code Review Rule: Suggest Architectural Improvem... ([source](https://app.greptile.com/review/custom-context?memory=4d82344e-33c4-4e14-bbc7-81d79af11b7e))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/tui/update.go
Line: 1007-1100

Comment:
**No tests added for the new textarea integration or the active-workers fix**

This PR adds two distinct behaviors — incrementing `ActiveWorkers` for the single downloader and wiring a `textarea.Model` into the download form — but ships no tests for either.

Per the project contribution guidelines, edge cases and integration points should be covered. For example:
- A unit test asserting that `SingleDownloader.Download` increments `State.ActiveWorkers` to `1` during the download and back to `0` after it completes (including on error / context cancellation).
- A test that the mirrors field correctly parses newline-separated URLs (the splitting logic changed from `strings.Split(…, ",")` to `strings.FieldsFunc`).
- A test that `getInputValue` / `setInputValue` correctly handles both `textinput.Model` and `textarea.Model` inputs.

**Rule Used:** What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: update active workers count for sin..."](https://github.com/surge-downloader/surge/commit/eefd725889920875be617f83628720b748c97ba3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25960011)</sub>

> Greptile also left **2 inline comments** on this PR.

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Rule used - What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))
- Rule used - # Code Review Rule: Suggest Architectural Improvem... ([source](https://app.greptile.com/review/custom-context?memory=4d82344e-33c4-4e14-bbc7-81d79af11b7e))

<!-- /greptile_comment -->