### PR TITLE
add integration test

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,7 +18,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -34,7 +33,9 @@ jobs:
         with:
           path: current
 
+      # Only check out the baseline branch when the user asked for a comparison
       - name: Checkout Main Branch (Baseline)
+        if: github.event.inputs.baseline == 'y'
         uses: actions/checkout@v4
         with:
           ref: main
@@ -43,14 +44,19 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.0+auto"
+          go-version: "1.25.0"
+          cache: true
           cache-dependency-path: current/go.sum
 
-      - name: Update APT
-        run: sudo apt-get update
+      - name: Install Benchmark Tools
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y aria2 axel
 
-      - name: Install Benchmark Tools (Aria2, Axel, Speedtest)
-        run: sudo apt-get install -y aria2 axel speedtest-cli
+      - name: Verify benchmark script exists
+        run: |
+          [ -f current/benchmark.py ] \
+            || (echo "ERROR: benchmark.py not found in repo root" && exit 1)
 
       - name: Build Current
         run: |
@@ -58,64 +64,44 @@ jobs:
           go build -o ../surge-current .
 
       - name: Build Baseline
+        if: github.event.inputs.baseline == 'y'
         run: |
           cd baseline
+          go mod download
           go build -o ../surge-baseline .
 
       - name: Run Benchmark
         id: benchmark
         env:
-          # Use 'github.event.inputs' for manual triggers, default for others
           BENCH_URL: ${{ github.event.inputs.url }}
           BENCH_ITERATIONS: ${{ github.event.inputs.iterations }}
           BASELINE_COMPARE: ${{ github.event.inputs.baseline }}
-
         run: |
           cd current
 
-          # 1. Build the command arguments dynamically
-          ARGS=""
+          ARGS="$BENCH_URL -n $BENCH_ITERATIONS --surge --axel --aria2"
 
-          # Add URL (Positional argument in your script)
-          ARGS="$ARGS $BENCH_URL"
-
-          # Add Iterations
-          ARGS="$ARGS -n $BENCH_ITERATIONS"
-
-          # Add Baseline ONLY if requested
-          if [[ "$BASELINE_COMPARE" == "y" ]]; then
+          if [ "$BASELINE_COMPARE" = "y" ]; then
             echo "Comparing against baseline..."
             ARGS="$ARGS --surge-baseline ../surge-baseline"
           fi
 
-          # 2. Run the command using the constructed ARGS
-          # We pass the current build as the executable
-          python3 benchmark.py \
-            $ARGS \
-            --surge \
-            --speedtest \
-            --axel \
-            --aria2 \
-            | tee benchmark_output.txt
+          python3 benchmark.py $ARGS | tee benchmark_output.txt
 
-          # 3. Save output to GITHUB_ENV for the next step (multiline safe)
+          # Write to job summary
+          echo "## 🚀 Benchmark Results"                >> $GITHUB_STEP_SUMMARY
+          echo "**Target:** $BENCH_URL"                 >> $GITHUB_STEP_SUMMARY
+          echo "**Iterations:** $BENCH_ITERATIONS"      >> $GITHUB_STEP_SUMMARY
+          echo '```'                                    >> $GITHUB_STEP_SUMMARY
+          cat benchmark_output.txt                      >> $GITHUB_STEP_SUMMARY
+          echo '```'                                    >> $GITHUB_STEP_SUMMARY
+
+          # Save results for the artifact
           echo "BENCHMARK_RESULTS<<EOF" >> $GITHUB_ENV
-          cat benchmark_output.txt >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
+          cat benchmark_output.txt      >> $GITHUB_ENV
+          echo "EOF"                    >> $GITHUB_ENV
 
-          # 4. Write to Job Summary (Markdown)
-          echo "## 🚀 Benchmark Results" >> $GITHUB_STEP_SUMMARY
-          echo "**Target:** $BENCH_URL" >> $GITHUB_STEP_SUMMARY
-          echo "**Iterations:** $BENCH_ITERATIONS" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          cat benchmark_output.txt >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-
-          # Export env vars for the comment step
-          echo "BENCH_URL=$BENCH_URL" >> $GITHUB_ENV
-          echo "BENCH_ITERATIONS=$BENCH_ITERATIONS" >> $GITHUB_ENV
-
-      - name: Prepare Surge Logs
+      - name: Collect Surge Diagnostic Logs
         if: always()
         run: |
           mkdir -p current/surge_logs
@@ -127,5 +113,3 @@ jobs:
         with:
           name: surge-benchmark-logs
           path: current/surge_logs/
-
-

--- a/.github/workflows/binary-size-compare.yml
+++ b/.github/workflows/binary-size-compare.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.25.0"
-          check-latest: false
+          cache: true
 
       - name: Build and Compare
         id: compare
@@ -34,30 +34,34 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Build PR version (using stripped flags to get true production size)
+          # Build PR version
           go build -ldflags="-s -w" -o /tmp/binary-pr .
           size_pr=$(stat -c%s /tmp/binary-pr)
+          echo "PR binary size: $size_pr bytes"
 
-          # Fetch and build Main version
+          # Switch to main and build baseline
           git fetch origin main:refs/remotes/origin/main
           git checkout --detach origin/main
-          
+
+          # Re-download modules in case go.sum changed between branches
+          go mod download
+
           go build -ldflags="-s -w" -o /tmp/binary-main .
           size_main=$(stat -c%s /tmp/binary-main)
+          echo "Main binary size: $size_main bytes"
 
           diff=$((size_pr - size_main))
-          
-          echo "$size_pr" > size_pr.txt
-          echo "$size_main" > size_main.txt
-          echo "$diff" > diff.txt
-          
+
+          echo "$size_pr"                          > size_pr.txt
+          echo "$size_main"                        > size_main.txt
+          echo "$diff"                             > diff.txt
+          echo "${{ github.event.pull_request.number }}" > pr_number.txt
+
           if [ "$size_pr" -gt "$size_main" ]; then
-            echo "true" > exceeds.txt
+            echo "true"  > exceeds.txt
           else
             echo "false" > exceeds.txt
           fi
-          
-          echo "${{ github.event.pull_request.number }}" > pr_number.txt
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -41,7 +41,8 @@ jobs:
             echo "Using manually specified version: $SURGE_VERSION"
           else
             echo "Fetching latest Surge release..."
-            SURGE_VERSION=$(curl -s https://api.github.com/repos/surge-downloader/surge/releases/latest | jq -r .tag_name | sed 's/^v//')
+            SURGE_VERSION=$(curl -sf https://api.github.com/repos/surge-downloader/surge/releases/latest | jq -r .tag_name | sed 's/^v//')
+            [ -n "$SURGE_VERSION" ] || (echo "ERROR: could not determine latest version" && exit 1)
             echo "Latest Surge version: $SURGE_VERSION"
           fi
           echo "version=$SURGE_VERSION" >> $GITHUB_OUTPUT
@@ -69,7 +70,7 @@ jobs:
             type=raw,value=latest,enable=${{ inputs.tag_as_latest }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: docker
           file: docker/Dockerfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,11 @@
 name: Build and Release
 
 on:
-  # Trigger 1: Auto-run on pushes to main (merges)
   push:
     branches:
       - main
     tags:
       - "v*"
-
   pull_request:
     branches:
       - main
@@ -19,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  GO_VERSION: "1.25.0"
+
 jobs:
   test:
     name: Test and Check (${{ matrix.os }})
@@ -29,24 +30,29 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.0"
-          check-latest: false
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
+
       - name: Build
         shell: bash
         run: go build -v ./...
+
       - name: Test
         shell: bash
         run: |
-          cover_arg=""
           if [ "$RUNNER_OS" = "Linux" ]; then
-            cover_arg="-- -coverprofile=coverage.out"
+            gotestsum --junitfile test-results.xml --format testdox -- -coverprofile=coverage.out ./...
+          else
+            gotestsum --junitfile test-results.xml --format testdox ./...
           fi
-          gotestsum --junitfile test-results.xml --format testdox $cover_arg ./...
+
       - name: Upload Test Results
         uses: actions/upload-artifact@v4
         if: always()
@@ -54,7 +60,8 @@ jobs:
           name: test-results-${{ matrix.os }}
           path: test-results.xml
           retention-days: 7
-      - name: Upload coverage reports to Codecov
+
+      - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         if: matrix.os == 'ubuntu-latest' && success() && hashFiles('coverage.out') != ''
         with:
@@ -66,19 +73,24 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.0"
-          check-latest: false
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
+
       - name: Build
         shell: bash
         run: go build -v ./...
+
       - name: Test
         shell: bash
         run: gotestsum --junitfile test-results.xml --format testdox ./...
+
       - name: Upload Test Results
         uses: actions/upload-artifact@v4
         if: always()
@@ -97,10 +109,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.0+auto"
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/flaky-tests.yml
+++ b/.github/workflows/flaky-tests.yml
@@ -16,11 +16,11 @@ permissions:
 
 jobs:
   test-flakes:
-    name: Run Tests Multiple Times
+    name: Run Tests Multiple Times (${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.25.0"
-          check-latest: false
+          cache: true
 
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
@@ -44,7 +44,7 @@ jobs:
           COUNT="${{ github.event.inputs.runs || '10' }}"
           echo "Running tests $COUNT times to identify flakes..."
           gotestsum --junitfile test-results-${{ matrix.os }}.xml --format testdox -- -count=$COUNT ./...
-          
+
       - name: Upload Test Results
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -587,7 +587,7 @@ jobs:
         run: docker compose up -d
 
       - name: Wait for server to be healthy
-        run: |
+          cp docker/compose.yml .
           for i in $(seq 1 20); do
             STATUS=$(docker compose exec -T surge ./surge server status 2>&1 || true)
             echo "$STATUS" | grep -qi "running" && break || sleep 2

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -7,6 +7,9 @@ on:
     branches: [main, master]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # Cancel in-progress runs on the same branch to save CI minutes
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,703 @@
+name: Integration Tests
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+# Cancel in-progress runs on the same branch to save CI minutes
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GO_VERSION: "1.25"
+  # A small, stable, publicly-hosted test file (~1 MB) served by Cloudflare
+  TEST_URL_1: "https://speed.cloudflare.com/__down?bytes=1048576"
+  # Second mirror / URL for multi-mirror & batch tests
+  TEST_URL_2: "https://speed.cloudflare.com/__down?bytes=1048576&during=download2"
+  # Surge daemon default port
+  SURGE_PORT: "1700"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# JOB 1 – Build matrix (produces binaries used by every later job)
+# ─────────────────────────────────────────────────────────────────────────────
+jobs:
+  build:
+    name: Build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Build binary
+        run: go build -v -o surge${{ matrix.os == 'windows-latest' && '.exe' || '' }} .
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: surge-${{ matrix.os }}
+          path: surge${{ matrix.os == 'windows-latest' && '.exe' || '' }}
+          retention-days: 1
+
+# ─────────────────────────────────────────────────────────────────────────────
+# JOB 2 – Core CLI & server integration tests (Linux + macOS + Windows)
+# ─────────────────────────────────────────────────────────────────────────────
+  integration-cli:
+    name: CLI Integration (${{ matrix.os }})
+    needs: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download binary
+        uses: actions/download-artifact@v4
+        with:
+          name: surge-${{ matrix.os }}
+
+      # Make binary executable (Unix only)
+      - name: Make binary executable
+        if: matrix.os != 'windows-latest'
+        run: chmod +x ./surge
+
+      # ── Token command ──────────────────────────────────────────────────────
+      - name: "[token] Print API token"
+        id: token
+        shell: bash
+        run: |
+          TOKEN=$(./surge token 2>/dev/null || ./surge.exe token 2>/dev/null)
+          echo "TOKEN=$TOKEN" >> $GITHUB_ENV
+          echo "Token generated: ${#TOKEN} chars"
+          [ -n "$TOKEN" ] || (echo "ERROR: token is empty" && exit 1)
+
+      # ── Server lifecycle ───────────────────────────────────────────────────
+      - name: "[server] Start headless server in background"
+        shell: bash
+        run: |
+          BIN=./surge
+          [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe
+          $BIN server --port $SURGE_PORT &
+          echo "SERVER_PID=$!" >> $GITHUB_ENV
+          sleep 3   # give daemon time to bind
+
+      - name: "[server] Verify server is listening"
+        shell: bash
+        run: |
+          # Retry up to 10 seconds
+          for i in $(seq 1 10); do
+            curl -sf -o /dev/null http://localhost:$SURGE_PORT/health && break || sleep 1
+          done
+          curl -sf -o /dev/null http://localhost:$SURGE_PORT/health \
+            || (echo "Server did not start in time" && exit 1)
+
+      - name: "[server status] Check server status subcommand"
+        shell: bash
+        run: |
+          BIN=./surge; [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe
+          $BIN server status --host localhost:$SURGE_PORT --token $TOKEN
+
+      # ── Add & list downloads ───────────────────────────────────────────────
+      - name: "[add] Queue a single download"
+        shell: bash
+        run: |
+          BIN=./surge; [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe
+          $BIN add "$TEST_URL_1" \
+            --host localhost:$SURGE_PORT \
+            --token $TOKEN \
+            --output /tmp/surge-test/ 2>&1 | tee add_output.txt
+          grep -iE "(queued|added|download)" add_output.txt \
+            || (echo "Expected confirmation in output" && exit 1)
+
+      - name: "[ls] List all downloads (text)"
+        shell: bash
+        run: |
+          BIN=./surge; [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe
+          $BIN ls \
+            --host localhost:$SURGE_PORT \
+            --token $TOKEN | tee ls_output.txt
+          # Capture the first download ID for subsequent steps
+          DL_ID=$(grep -oE '[0-9a-f]{8,}' ls_output.txt | head -1)
+          echo "DL_ID=$DL_ID" >> $GITHUB_ENV
+          echo "Captured download ID: $DL_ID"
+
+      - name: "[ls] List all downloads (JSON)"
+        shell: bash
+        run: |
+          BIN=./surge; [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe
+          OUTPUT=$($BIN ls --json \
+            --host localhost:$SURGE_PORT \
+            --token $TOKEN)
+          echo "$OUTPUT" | python3 -c "import sys,json; data=json.load(sys.stdin); print(f'Found {len(data)} download(s)')"
+
+      - name: "[ls id] Show single download detail"
+        shell: bash
+        run: |
+          BIN=./surge; [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe
+          $BIN ls $DL_ID \
+            --host localhost:$SURGE_PORT \
+            --token $TOKEN
+
+      # ── Pause / resume cycle ───────────────────────────────────────────────
+      - name: "[pause] Pause the download"
+        shell: bash
+        run: |
+          BIN=./surge; [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe
+          $BIN pause $DL_ID \
+            --host localhost:$SURGE_PORT \
+            --token $TOKEN
+          sleep 1
+
+      - name: "[ls] Verify download is paused"
+        shell: bash
+        run: |
+          BIN=./surge; [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe
+          $BIN ls $DL_ID --json \
+            --host localhost:$SURGE_PORT \
+            --token $TOKEN | python3 -c "
+          import sys, json
+          data = json.load(sys.stdin)
+          item = data[0] if isinstance(data, list) else data
+          status = item.get('status', '').lower()
+          print(f'Status: {status}')
+          assert status == 'paused', f'Expected paused, got {status}'
+          "
+
+      - name: "[resume] Resume the download"
+        shell: bash
+        run: |
+          BIN=./surge; [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe
+          $BIN resume $DL_ID \
+            --host localhost:$SURGE_PORT \
+            --token $TOKEN
+          sleep 1
+
+      # ── Pause all / resume all ─────────────────────────────────────────────
+      - name: "[pause --all] Pause all downloads"
+        shell: bash
+        run: |
+          BIN=./surge; [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe
+          $BIN pause --all \
+            --host localhost:$SURGE_PORT \
+            --token $TOKEN
+
+      - name: "[resume --all] Resume all downloads"
+        shell: bash
+        run: |
+          BIN=./surge; [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe
+          $BIN resume --all \
+            --host localhost:$SURGE_PORT \
+            --token $TOKEN
+
+      # ── Batch download ─────────────────────────────────────────────────────
+      - name: "[add --batch] Queue downloads from a batch file"
+        shell: bash
+        run: |
+          printf '%s\n%s\n' "$TEST_URL_1" "$TEST_URL_2" > batch.txt
+          BIN=./surge; [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe
+          $BIN add --batch batch.txt \
+            --host localhost:$SURGE_PORT \
+            --token $TOKEN \
+            --output /tmp/surge-batch/
+
+      - name: "[ls] Confirm batch items are queued"
+        shell: bash
+        run: |
+          BIN=./surge; [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe
+          COUNT=$($BIN ls --json \
+            --host localhost:$SURGE_PORT \
+            --token $TOKEN | python3 -c "import sys,json; print(len(json.load(sys.stdin)))")
+          echo "Total downloads queued: $COUNT"
+          [ "$COUNT" -ge 2 ] || (echo "Expected at least 2 downloads, got $COUNT" && exit 1)
+
+      # ── refresh (URL update) ───────────────────────────────────────────────
+      - name: "[refresh] Update source URL on a paused download"
+        shell: bash
+        run: |
+          BIN=./surge; [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe
+          # Pause the first download before refreshing
+          $BIN pause $DL_ID --host localhost:$SURGE_PORT --token $TOKEN
+          sleep 1
+          $BIN refresh $DL_ID "$TEST_URL_2" \
+            --host localhost:$SURGE_PORT \
+            --token $TOKEN
+
+      # ── Remove download ────────────────────────────────────────────────────
+      - name: "[rm] Remove a download by ID prefix"
+        shell: bash
+        run: |
+          BIN=./surge; [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe
+          # Use first 6 chars as prefix (tests prefix matching)
+          PREFIX="${DL_ID:0:6}"
+          $BIN rm $PREFIX \
+            --host localhost:$SURGE_PORT \
+            --token $TOKEN
+
+      - name: "[rm --clean] Remove with partial file cleanup"
+        shell: bash
+        run: |
+          BIN=./surge; [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe
+          # Add a new download, then remove it cleanly
+          $BIN add "$TEST_URL_1" \
+            --host localhost:$SURGE_PORT \
+            --token $TOKEN \
+            --output /tmp/surge-clean/
+          sleep 1
+          NEW_ID=$($BIN ls --json \
+            --host localhost:$SURGE_PORT \
+            --token $TOKEN | python3 -c "
+          import sys,json
+          data=json.load(sys.stdin)
+          print(data[-1]['id'])
+          ")
+          $BIN rm $NEW_ID --clean \
+            --host localhost:$SURGE_PORT \
+            --token $TOKEN
+
+      # ── Server stop ────────────────────────────────────────────────────────
+      - name: "[server stop] Stop the daemon gracefully"
+        shell: bash
+        run: |
+          BIN=./surge; [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe
+          $BIN server stop || kill $SERVER_PID || true
+
+      - name: "[server status] Confirm server is stopped"
+        shell: bash
+        run: |
+          BIN=./surge; [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe
+          sleep 2
+          # Should report not-running; non-zero exit is acceptable here
+          $BIN server status --host localhost:$SURGE_PORT --token $TOKEN || true
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# JOB 3 – Settings & configuration tests (Linux only for speed)
+# ─────────────────────────────────────────────────────────────────────────────
+  integration-settings:
+    name: Settings Integration
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download binary
+        uses: actions/download-artifact@v4
+        with:
+          name: surge-ubuntu-latest
+
+      - name: Make binary executable
+        run: chmod +x ./surge
+
+      - name: Locate config directory
+        run: |
+          CONFIG_DIR="$HOME/.config/surge"
+          echo "CONFIG_DIR=$CONFIG_DIR" >> $GITHUB_ENV
+          mkdir -p "$CONFIG_DIR"
+
+      # Write a custom settings.json and verify Surge loads it
+      - name: Write custom settings.json
+        run: |
+          cat > "$CONFIG_DIR/settings.json" <<'EOF'
+          {
+            "general": {
+              "default_download_dir": "/tmp/surge-settings-test",
+              "warn_on_duplicate": true,
+              "auto_resume": false,
+              "skip_update_check": true,
+              "clipboard_monitor": false,
+              "theme": 2,
+              "log_retention_count": 3
+            },
+            "network": {
+              "max_connections_per_host": 8,
+              "max_concurrent_downloads": 2,
+              "sequential_download": false,
+              "min_chunk_size": 1048576,
+              "worker_buffer_size": 262144
+            },
+            "performance": {
+              "max_task_retries": 5,
+              "slow_worker_threshold": 0.2,
+              "slow_worker_grace_period": "8s",
+              "stall_timeout": "5s",
+              "speed_ema_alpha": 0.4
+            }
+          }
+          EOF
+          echo "settings.json written"
+          cat "$CONFIG_DIR/settings.json"
+
+      - name: Start server with custom settings
+        run: |
+          ./surge server --port $SURGE_PORT &
+          echo "SERVER_PID=$!" >> $GITHUB_ENV
+          sleep 3
+
+      - name: Retrieve token
+        run: |
+          TOKEN=$(./surge token)
+          echo "TOKEN=$TOKEN" >> $GITHUB_ENV
+
+      - name: Queue download and confirm custom output dir is used
+        run: |
+          ./surge add "$TEST_URL_1" \
+            --host localhost:$SURGE_PORT \
+            --token $TOKEN
+          sleep 1
+          # With default_download_dir set, the download should land there
+          DETAILS=$(./surge ls --json \
+            --host localhost:$SURGE_PORT \
+            --token $TOKEN)
+          echo "$DETAILS" | python3 -c "
+          import sys, json
+          data = json.load(sys.stdin)
+          item = data[0] if isinstance(data, list) else data
+          dl_dir = item.get('output_dir', item.get('dir', ''))
+          print(f'Download dir: {dl_dir}')
+          assert '/tmp/surge-settings-test' in dl_dir, \
+            f'Expected custom dir in output, got: {dl_dir}'
+          "
+
+      - name: Stop server
+        run: ./surge server stop || kill $SERVER_PID || true
+
+      # ── Partial settings (only override some keys) ─────────────────────────
+      - name: Write partial settings.json (only general.theme)
+        run: |
+          echo '{"general": {"theme": 1}}' > "$CONFIG_DIR/settings.json"
+
+      - name: Server starts with partial settings (no crash)
+        run: |
+          ./surge server --port $SURGE_PORT &
+          sleep 3
+          curl -sf http://localhost:$SURGE_PORT/health \
+            || (echo "Server failed with partial settings" && exit 1)
+          ./surge server stop || kill $! || true
+
+      # ── Invalid settings graceful handling ────────────────────────────────
+      - name: Write malformed settings.json
+        run: |
+          cat > "$CONFIG_DIR/settings.json" <<EOF
+          { "network": { "max_connections_per_host": "not-a-number" }
+          EOF
+
+      - name: Server handles malformed settings without panic
+        run: |
+          ./surge server --port $SURGE_PORT &
+          SPID=$!
+          sleep 3
+          # Either it starts (with defaults) or exits cleanly — must not panic/segfault
+          if kill -0 $SPID 2>/dev/null; then
+            echo "Server running despite bad config (using defaults) — OK"
+            ./surge server stop || kill $SPID || true
+          else
+            wait $SPID
+            EXIT=$?
+            [ $EXIT -ne 139 ] || (echo "SEGFAULT detected!" && exit 1)
+            echo "Server exited with code $EXIT (acceptable for bad config)"
+          fi
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# JOB 4 – Environment variable auth tests
+# ─────────────────────────────────────────────────────────────────────────────
+  integration-env-auth:
+    name: Env Var Auth
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download binary
+        uses: actions/download-artifact@v4
+        with:
+          name: surge-ubuntu-latest
+
+      - name: Make binary executable
+        run: chmod +x ./surge
+
+      - name: Start server
+        run: |
+          ./surge server --port $SURGE_PORT &
+          echo "SERVER_PID=$!" >> $GITHUB_ENV
+          sleep 3
+
+      - name: Get token and export as SURGE_TOKEN
+        run: |
+          echo "SURGE_TOKEN=$(./surge token)" >> $GITHUB_ENV
+          echo "SURGE_HOST=localhost:$SURGE_PORT" >> $GITHUB_ENV
+
+      - name: "[env] CLI works with SURGE_TOKEN + SURGE_HOST (no flags)"
+        run: |
+          # No --host or --token flags; relies purely on env vars
+          ./surge ls
+          ./surge add "$TEST_URL_1" --output /tmp/surge-env/
+
+      - name: "[env] Explicit flags override env vars"
+        run: |
+          WRONG_TOKEN="definitely-wrong-token"
+          # Using explicit --token that's wrong should fail auth, not crash
+          ./surge ls --token "$WRONG_TOKEN" || echo "Auth rejection confirmed (expected)"
+
+      - name: Stop server
+        run: ./surge server stop || kill $SERVER_PID || true
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# JOB 5 – Download completion & --exit-when-done tests (Linux)
+# ─────────────────────────────────────────────────────────────────────────────
+  integration-download-completion:
+    name: Download Completion
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download binary
+        uses: actions/download-artifact@v4
+        with:
+          name: surge-ubuntu-latest
+
+      - name: Make binary executable
+        run: chmod +x ./surge
+
+      - name: Create output directory
+        run: mkdir -p /tmp/surge-complete
+
+      - name: "[--exit-when-done] Server exits after all downloads finish"
+        timeout-minutes: 3
+        run: |
+          # Server should start, finish the download, then exit on its own
+          ./surge server "$TEST_URL_2" \
+            --port $SURGE_PORT \
+            --output /tmp/surge-complete \
+            --exit-when-done &
+          SPID=$!
+          wait $SPID
+          EXIT=$?
+          echo "Server exited with code $EXIT"
+          [ $EXIT -eq 0 ] || (echo "Non-zero exit after --exit-when-done" && exit 1)
+
+      - name: Verify downloaded file exists and is non-empty
+        run: |
+          FILE=$(find /tmp/surge-complete -type f | head -1)
+          echo "Downloaded: $FILE"
+          [ -n "$FILE" ] || (echo "No file found in output dir!" && exit 1)
+          SIZE=$(stat -c%s "$FILE")
+          echo "File size: $SIZE bytes"
+          [ "$SIZE" -gt 0 ] || (echo "File is empty!" && exit 1)
+
+      - name: "[--no-resume] Download starts fresh (no partial resume)"
+        timeout-minutes: 3
+        run: |
+          mkdir -p /tmp/surge-noresume
+          ./surge server "$TEST_URL_2" \
+            --port ${{ env.SURGE_PORT }}1 \
+            --output /tmp/surge-noresume \
+            --no-resume \
+            --exit-when-done &
+          wait $!
+          echo "no-resume download completed"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# JOB 6 – Sequential (Streaming Mode) download test
+# ─────────────────────────────────────────────────────────────────────────────
+  integration-sequential:
+    name: Sequential Download Mode
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download binary
+        uses: actions/download-artifact@v4
+        with:
+          name: surge-ubuntu-latest
+
+      - name: Make binary executable
+        run: chmod +x ./surge
+
+      - name: Write settings with sequential_download enabled
+        run: |
+          mkdir -p ~/.config/surge
+          echo '{"network":{"sequential_download":true,"max_connections_per_host":4}}' \
+            > ~/.config/surge/settings.json
+
+      - name: Download file in sequential mode and verify
+        timeout-minutes: 3
+        run: |
+          mkdir -p /tmp/surge-seq
+          ./surge server "$TEST_URL_1" \
+            --port $SURGE_PORT \
+            --output /tmp/surge-seq \
+            --exit-when-done &
+          wait $!
+          FILE=$(find /tmp/surge-seq -type f | head -1)
+          [ -n "$FILE" ] && echo "Sequential download OK: $FILE" \
+            || (echo "No file downloaded!" && exit 1)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# JOB 7 – Docker integration test
+# ─────────────────────────────────────────────────────────────────────────────
+  integration-docker:
+    name: Docker Server Mode
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download compose file
+        run: |
+          wget -q https://raw.githubusercontent.com/surge-downloader/surge/refs/heads/main/docker/compose.yml
+
+      - name: Start container
+        run: docker compose up -d
+
+      - name: Wait for server to be healthy
+        run: |
+          for i in $(seq 1 20); do
+            STATUS=$(docker compose exec -T surge ./surge server status 2>&1 || true)
+            echo "$STATUS" | grep -qi "running" && break || sleep 2
+          done
+          echo "Final status: $STATUS"
+
+      - name: Get token from container
+        run: |
+          TOKEN=$(docker compose exec -T surge surge token)
+          echo "TOKEN=$TOKEN" >> $GITHUB_ENV
+          echo "Container token length: ${#TOKEN}"
+
+      - name: "[docker] Add a download inside container"
+        run: |
+          docker compose exec -T surge surge add "$TEST_URL_2" \
+            --token $TOKEN
+
+      - name: "[docker] List downloads as JSON"
+        run: |
+          docker compose exec -T surge surge ls --json --token $TOKEN \
+            | python3 -c "import sys,json; d=json.load(sys.stdin); print(f'{len(d)} download(s) queued')"
+
+      - name: "[docker] Check logs are written"
+        run: |
+          docker compose logs surge | grep -i "surge" \
+            || echo "No logs found (acceptable for fresh instance)"
+
+      - name: Stop container
+        if: always()
+        run: docker compose down -v
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# JOB 8 – Remote connect test (two separate processes simulate client/server)
+# ─────────────────────────────────────────────────────────────────────────────
+  integration-remote-connect:
+    name: Remote Connect
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download binary
+        uses: actions/download-artifact@v4
+        with:
+          name: surge-ubuntu-latest
+
+      - name: Make binary executable
+        run: chmod +x ./surge
+
+      - name: Start server on non-default port
+        run: |
+          ./surge server --port 1701 &
+          echo "SERVER_PID=$!" >> $GITHUB_ENV
+          sleep 3
+
+      - name: Get token
+        run: echo "TOKEN=$(./surge token)" >> $GITHUB_ENV
+
+      - name: "[connect] CLI reaches server via explicit host flag"
+        run: |
+          ./surge ls \
+            --host localhost:1701 \
+            --token $TOKEN
+
+      - name: "[connect] Add download via explicit host"
+        run: |
+          ./surge add "$TEST_URL_1" \
+            --host localhost:1701 \
+            --token $TOKEN \
+            --output /tmp/surge-remote/
+
+      - name: "[connect] Wrong token is rejected"
+        run: |
+          ./surge ls --host localhost:1701 --token "bad-token" \
+            && (echo "Expected auth failure but got success" && exit 1) \
+            || echo "Auth correctly rejected bad token"
+
+      - name: Stop server
+        run: ./surge server stop || kill $SERVER_PID || true
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# JOB 9 – Summary
+# ─────────────────────────────────────────────────────────────────────────────
+  summary:
+    name: Integration Test Summary
+    needs:
+      - integration-cli
+      - integration-settings
+      - integration-env-auth
+      - integration-download-completion
+      - integration-sequential
+      - integration-docker
+      - integration-remote-connect
+    if: always()
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Report results
+        run: |
+          echo "## Surge Integration Test Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Job | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "| --- | ------ |" >> $GITHUB_STEP_SUMMARY
+          echo "| CLI Integration (ubuntu) | ${{ needs.integration-cli.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| CLI Integration (macos) | ${{ needs.integration-cli.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| CLI Integration (windows) | ${{ needs.integration-cli.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Settings | ${{ needs.integration-settings.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Env Var Auth | ${{ needs.integration-env-auth.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Download Completion | ${{ needs.integration-download-completion.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Sequential Mode | ${{ needs.integration-sequential.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Docker | ${{ needs.integration-docker.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Remote Connect | ${{ needs.integration-remote-connect.result }} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -525,7 +525,7 @@ jobs:
             --exit-when-done &
           wait $!
           echo "no-resume download completed"
-
+            --port 17001 \
 
 # ─────────────────────────────────────────────────────────────────────────────
 # JOB 6 – Sequential (Streaming Mode) download test

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -21,6 +21,9 @@ env:
   TEST_URL_1: "https://speed.cloudflare.com/__down?bytes=1048576"
   # Second mirror / URL for multi-mirror & batch tests
   TEST_URL_2: "https://speed.cloudflare.com/__down?bytes=1048576&during=download2"
+  # 1000 MB — slow enough to pause 
+  TEST_URL_SLOW: "https://speed.cloudflare.com/__down?bytes=1048576000"   
+
   # Surge daemon default port
   SURGE_PORT: "1700"
 
@@ -122,7 +125,7 @@ jobs:
         shell: bash
         run: |
           BIN=./surge; [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe
-          $BIN add "$TEST_URL_1" \
+          $BIN add "$TEST_URL_SLOW" \
             --host localhost:$SURGE_PORT \
             --token $TOKEN \
             --output "$RUNNER_TEMP/surge-test/" 2>&1 | tee add_output.txt
@@ -156,6 +159,17 @@ jobs:
         shell: bash
         run: |
           BIN=./surge; [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe
+          # Wait until the download is actively in-progress before pausing
+          for i in $(seq 1 10); do
+            STATUS=$($BIN ls $DL_ID --json \
+              --host localhost:$SURGE_PORT \
+              --token $TOKEN | python3 -c "
+          import sys,json; d=json.load(sys.stdin)
+          item=d[0] if isinstance(d,list) else d
+          print(item.get('status','').lower())")
+            echo "Status: $STATUS"
+            [ "$STATUS" = "downloading" ] && break || sleep 1
+          done
           $BIN pause $DL_ID \
             --host localhost:$SURGE_PORT \
             --token $TOKEN

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: "[ls] List all downloads (text)"
         shell: bash
-        run: |
+            --output "$RUNNER_TEMP/surge-test/" 2>&1 | tee add_output.txt
           BIN=./surge; [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe
           $BIN ls \
             --host localhost:$SURGE_PORT \
@@ -148,16 +148,18 @@ jobs:
           echo "DL_ID=$DL_ID" >> $GITHUB_ENV
           echo "Captured download ID: $DL_ID"
           [ -n "$DL_ID" ] || (echo "ERROR: could not extract a download ID from ls output" && exit 1)
-            --host localhost:$SURGE_PORT \
-            --token $TOKEN)
-          echo "$OUTPUT" | python3 -c "import sys,json; data=json.load(sys.stdin); print(f'Found {len(data)} download(s)')"
-
-      - name: "[ls id] Show single download detail"
+      - name: "[ls] List all downloads (JSON)"
         shell: bash
         run: |
           BIN=./surge; [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe
-          $BIN ls $DL_ID \
+          OUTPUT=$($BIN ls --json \
             --host localhost:$SURGE_PORT \
+            --token $TOKEN)
+          DL_ID=$(echo "$OUTPUT" | python3 -c "import sys,json; data=json.load(sys.stdin); print(data[0]['id'])")
+          echo "DL_ID=$DL_ID" >> $GITHUB_ENV
+          echo "Captured download ID: $DL_ID"
+          [ -n "$DL_ID" ] || (echo "ERROR: could not extract a download ID from ls output" && exit 1)
+          echo "$OUTPUT" | python3 -c "import sys,json; data=json.load(sys.stdin); print(f'Found {len(data)} download(s)')"
             --token $TOKEN
 
       # ── Pause / resume cycle ───────────────────────────────────────────────
@@ -532,7 +534,7 @@ jobs:
           echo "no-resume download completed"
             --port 17001 \
 
-# ─────────────────────────────────────────────────────────────────────────────
+          echo "no-resume download completed"
 # JOB 6 – Sequential (Streaming Mode) download test
 # ─────────────────────────────────────────────────────────────────────────────
   integration-sequential:
@@ -593,14 +595,13 @@ jobs:
 
       - name: Wait for server to be healthy
           cp docker/compose.yml .
+      - name: Wait for server to be healthy
+        run: |
           for i in $(seq 1 20); do
             STATUS=$(docker compose exec -T surge ./surge server status 2>&1 || true)
             echo "$STATUS" | grep -qi "running" && break || sleep 2
           done
           echo "Final status: $STATUS"
-
-      - name: Get token from container
-        run: |
           TOKEN=$(docker compose exec -T surge surge token)
           echo "TOKEN=$TOKEN" >> $GITHUB_ENV
           echo "Container token length: ${#TOKEN}"

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -87,7 +87,8 @@ jobs:
         id: token
         shell: bash
         run: |
-          TOKEN=$(./surge token 2>/dev/null || ./surge.exe token 2>/dev/null)
+          BIN=./surge; [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe
+          TOKEN=$($BIN token 2>/dev/null)
           echo "TOKEN=$TOKEN" >> $GITHUB_ENV
           echo "Token generated: ${#TOKEN} chars"
           [ -n "$TOKEN" ] || (echo "ERROR: token is empty" && exit 1)
@@ -96,8 +97,7 @@ jobs:
       - name: "[server] Start headless server in background"
         shell: bash
         run: |
-          BIN=./surge
-          [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe
+          BIN=./surge; [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe
           $BIN server --port $SURGE_PORT &
           echo "SERVER_PID=$!" >> $GITHUB_ENV
           sleep 3   # give daemon time to bind
@@ -105,7 +105,6 @@ jobs:
       - name: "[server] Verify server is listening"
         shell: bash
         run: |
-          # Retry up to 10 seconds
           for i in $(seq 1 10); do
             curl -sf -o /dev/null http://localhost:$SURGE_PORT/health && break || sleep 1
           done
@@ -126,7 +125,7 @@ jobs:
           $BIN add "$TEST_URL_1" \
             --host localhost:$SURGE_PORT \
             --token $TOKEN \
-            --output /tmp/surge-test/ 2>&1 | tee add_output.txt
+            --output "$RUNNER_TEMP/surge-test/" 2>&1 | tee add_output.txt
           grep -iE "(queued|added|download)" add_output.txt \
             || (echo "Expected confirmation in output" && exit 1)
 
@@ -212,7 +211,7 @@ jobs:
           $BIN add --batch batch.txt \
             --host localhost:$SURGE_PORT \
             --token $TOKEN \
-            --output /tmp/surge-batch/
+            --output "$RUNNER_TEMP/surge-batch/"
 
       - name: "[ls] Confirm batch items are queued"
         shell: bash
@@ -229,7 +228,6 @@ jobs:
         shell: bash
         run: |
           BIN=./surge; [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe
-          # Pause the first download before refreshing
           $BIN pause $DL_ID --host localhost:$SURGE_PORT --token $TOKEN
           sleep 1
           $BIN refresh $DL_ID "$TEST_URL_2" \
@@ -251,18 +249,17 @@ jobs:
         shell: bash
         run: |
           BIN=./surge; [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe
-          # Add a new download, then remove it cleanly
           $BIN add "$TEST_URL_1" \
             --host localhost:$SURGE_PORT \
             --token $TOKEN \
-            --output /tmp/surge-clean/
+            --output "$RUNNER_TEMP/surge-clean/"
           sleep 1
           NEW_ID=$($BIN ls --json \
             --host localhost:$SURGE_PORT \
             --token $TOKEN | python3 -c "
-          import sys,json
-          data=json.load(sys.stdin)
-          ids = [item['id'] for item in data if item.get('output_dir','').startswith('/tmp/surge-clean')]
+          import sys, json
+          data = json.load(sys.stdin)
+          ids = [item['id'] for item in data if item.get('output_dir','').find('surge-clean') != -1]
           print(ids[0] if ids else data[-1]['id'])
           ")
           $BIN rm $NEW_ID --clean \
@@ -271,12 +268,14 @@ jobs:
 
       # ── Server teardown ────────────────────────────────────────────────────
       - name: "[server] Stop server"
+        if: always()
         shell: bash
         run: |
           BIN=./surge; [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe
           $BIN server stop || kill $SERVER_PID || true
 
       - name: "[server status] Confirm server is stopped"
+        if: always()
         shell: bash
         run: |
           BIN=./surge; [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe
@@ -376,6 +375,7 @@ jobs:
           "
 
       - name: Stop server
+        if: always()
         run: ./surge server stop || kill $SERVER_PID || true
 
       # ── Partial settings (only override some keys) ─────────────────────────
@@ -455,10 +455,13 @@ jobs:
       - name: "[env] Explicit flags override env vars"
         run: |
           WRONG_TOKEN="definitely-wrong-token"
-          # Using explicit --token that's wrong should fail auth, not crash
-          ./surge ls --token "$WRONG_TOKEN" || echo "Auth rejection confirmed (expected)"
+          # Explicit --token that's wrong should fail auth; success here means the flag was ignored
+          ./surge ls --token "$WRONG_TOKEN" \
+            && (echo "Expected auth failure but got success — explicit flag not overriding env var" && exit 1) \
+            || echo "Auth rejection confirmed (expected)"
 
       - name: Stop server
+        if: always()
         run: ./surge server stop || kill $SERVER_PID || true
 
 
@@ -573,9 +576,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Download compose file
-        run: |
-          cp docker/compose.yml .
+      - name: Copy compose file
+        run: cp docker/compose.yml .
 
       - name: Start container
         run: docker compose up -d
@@ -587,6 +589,8 @@ jobs:
             echo "$STATUS" | grep -qi "running" && break || sleep 2
           done
           echo "Final status: $STATUS"
+          echo "$STATUS" | grep -qi "running" \
+            || (echo "ERROR: Docker server did not become healthy after 40s" && exit 1)
           TOKEN=$(docker compose exec -T surge surge token)
           echo "TOKEN=$TOKEN" >> $GITHUB_ENV
           echo "Container token length: ${#TOKEN}"
@@ -660,6 +664,7 @@ jobs:
             || echo "Auth correctly rejected bad token"
 
       - name: Stop server
+        if: always()
         run: ./surge server stop || kill $SERVER_PID || true
 
 
@@ -686,10 +691,12 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Job | Status |" >> $GITHUB_STEP_SUMMARY
           echo "| --- | ------ |" >> $GITHUB_STEP_SUMMARY
-          echo "| CLI Integration (ubuntu / macos / windows) | ${{ needs.integration-cli.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| CLI Integration (ubuntu) | ${{ needs.integration-cli.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| CLI Integration (macos) | ${{ needs.integration-cli.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| CLI Integration (windows) | ${{ needs.integration-cli.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Settings | ${{ needs.integration-settings.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Env Var Auth | ${{ needs.integration-env-auth.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Download Completion | ${{ needs.integration-download-completion.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Sequential Download | ${{ needs.integration-sequential.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Sequential Mode | ${{ needs.integration-sequential.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Docker | ${{ needs.integration-docker.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Remote Connect | ${{ needs.integration-remote-connect.result }} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: "[ls] List all downloads (text)"
         shell: bash
-            --output "$RUNNER_TEMP/surge-test/" 2>&1 | tee add_output.txt
+        run: |
           BIN=./surge; [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe
           $BIN ls \
             --host localhost:$SURGE_PORT \
@@ -141,13 +141,8 @@ jobs:
           DL_ID=$(grep -oE '[0-9a-f]{8,}' ls_output.txt | head -1)
           echo "DL_ID=$DL_ID" >> $GITHUB_ENV
           echo "Captured download ID: $DL_ID"
-
-      - name: "[ls] List all downloads (JSON)"
-        shell: bash
-          DL_ID=$(grep -oE '[0-9a-f]{8,}' ls_output.txt | head -1)
-          echo "DL_ID=$DL_ID" >> $GITHUB_ENV
-          echo "Captured download ID: $DL_ID"
           [ -n "$DL_ID" ] || (echo "ERROR: could not extract a download ID from ls output" && exit 1)
+
       - name: "[ls] List all downloads (JSON)"
         shell: bash
         run: |
@@ -155,12 +150,7 @@ jobs:
           OUTPUT=$($BIN ls --json \
             --host localhost:$SURGE_PORT \
             --token $TOKEN)
-          DL_ID=$(echo "$OUTPUT" | python3 -c "import sys,json; data=json.load(sys.stdin); print(data[0]['id'])")
-          echo "DL_ID=$DL_ID" >> $GITHUB_ENV
-          echo "Captured download ID: $DL_ID"
-          [ -n "$DL_ID" ] || (echo "ERROR: could not extract a download ID from ls output" && exit 1)
           echo "$OUTPUT" | python3 -c "import sys,json; data=json.load(sys.stdin); print(f'Found {len(data)} download(s)')"
-            --token $TOKEN
 
       # ── Pause / resume cycle ───────────────────────────────────────────────
       - name: "[pause] Pause the download"
@@ -272,18 +262,15 @@ jobs:
             --token $TOKEN | python3 -c "
           import sys,json
           data=json.load(sys.stdin)
-          print(data[-1]['id'])
-          ")
-          $BIN rm $NEW_ID --clean \
-          NEW_ID=$($BIN ls --json \
-            --host localhost:$SURGE_PORT \
-            --token $TOKEN | python3 -c "
-          import sys,json
-          data=json.load(sys.stdin)
-          # Sort descending by a stable field if one exists, or use the last entry as a best-effort
           ids = [item['id'] for item in data if item.get('output_dir','').startswith('/tmp/surge-clean')]
           print(ids[0] if ids else data[-1]['id'])
           ")
+          $BIN rm $NEW_ID --clean \
+            --host localhost:$SURGE_PORT \
+            --token $TOKEN
+
+      # ── Server teardown ────────────────────────────────────────────────────
+      - name: "[server] Stop server"
         shell: bash
         run: |
           BIN=./surge; [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe
@@ -532,9 +519,9 @@ jobs:
             --exit-when-done &
           wait $!
           echo "no-resume download completed"
-            --port 17001 \
 
-          echo "no-resume download completed"
+
+# ─────────────────────────────────────────────────────────────────────────────
 # JOB 6 – Sequential (Streaming Mode) download test
 # ─────────────────────────────────────────────────────────────────────────────
   integration-sequential:
@@ -588,13 +575,11 @@ jobs:
 
       - name: Download compose file
         run: |
-          wget -q https://raw.githubusercontent.com/surge-downloader/surge/refs/heads/main/docker/compose.yml
+          cp docker/compose.yml .
 
       - name: Start container
         run: docker compose up -d
 
-      - name: Wait for server to be healthy
-          cp docker/compose.yml .
       - name: Wait for server to be healthy
         run: |
           for i in $(seq 1 20); do
@@ -701,10 +686,10 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Job | Status |" >> $GITHUB_STEP_SUMMARY
           echo "| --- | ------ |" >> $GITHUB_STEP_SUMMARY
-          echo "| CLI Integration (ubuntu) | ${{ needs.integration-cli.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| CLI Integration (macos) | ${{ needs.integration-cli.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| CLI Integration (windows) | ${{ needs.integration-cli.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| CLI Integration (ubuntu / macos / windows) | ${{ needs.integration-cli.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Settings | ${{ needs.integration-settings.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Env Var Auth | ${{ needs.integration-env-auth.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Download Completion | ${{ needs.integration-download-completion.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| CLI Integration (ubuntu/macos/windows) | ${{ needs.integration-cli.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Sequential Download | ${{ needs.integration-sequential.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Docker | ${{ needs.integration-docker.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Remote Connect | ${{ needs.integration-remote-connect.result }} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -273,11 +273,15 @@ jobs:
           print(data[-1]['id'])
           ")
           $BIN rm $NEW_ID --clean \
+          NEW_ID=$($BIN ls --json \
             --host localhost:$SURGE_PORT \
-            --token $TOKEN
-
-      # ── Server stop ────────────────────────────────────────────────────────
-      - name: "[server stop] Stop the daemon gracefully"
+            --token $TOKEN | python3 -c "
+          import sys,json
+          data=json.load(sys.stdin)
+          # Sort descending by a stable field if one exists, or use the last entry as a best-effort
+          ids = [item['id'] for item in data if item.get('output_dir','').startswith('/tmp/surge-clean')]
+          print(ids[0] if ids else data[-1]['id'])
+          ")
         shell: bash
         run: |
           BIN=./surge; [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -701,6 +701,4 @@ jobs:
           echo "| Settings | ${{ needs.integration-settings.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Env Var Auth | ${{ needs.integration-env-auth.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Download Completion | ${{ needs.integration-download-completion.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Sequential Mode | ${{ needs.integration-sequential.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Docker | ${{ needs.integration-docker.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Remote Connect | ${{ needs.integration-remote-connect.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| CLI Integration (ubuntu/macos/windows) | ${{ needs.integration-cli.result }} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -144,9 +144,10 @@ jobs:
 
       - name: "[ls] List all downloads (JSON)"
         shell: bash
-        run: |
-          BIN=./surge; [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe
-          OUTPUT=$($BIN ls --json \
+          DL_ID=$(grep -oE '[0-9a-f]{8,}' ls_output.txt | head -1)
+          echo "DL_ID=$DL_ID" >> $GITHUB_ENV
+          echo "Captured download ID: $DL_ID"
+          [ -n "$DL_ID" ] || (echo "ERROR: could not extract a download ID from ls output" && exit 1)
             --host localhost:$SURGE_PORT \
             --token $TOKEN)
           echo "$OUTPUT" | python3 -c "import sys,json; data=json.load(sys.stdin); print(f'Found {len(data)} download(s)')"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,8 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25.0'
+          go-version: "1.25.0"
+          cache: true
+
       - name: golangci-lint
-        run: go run github.com/golangci/golangci-lint/cmd/golangci-lint@latest run
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a comprehensive integration test workflow (`.github/workflows/integration-test.yml`) covering CLI commands, settings loading, env-var auth, download completion, sequential mode, Docker mode, and remote connect — spanning Linux, macOS, and Windows. It also cleans up five existing workflows with consistent Go caching, gated baseline comparisons, and a golangci-lint action migration.

- **New integration workflow** introduces 9 jobs with proper artifact sharing, `if: always()` teardown guards, and cross-platform binary handling.
- **Benchmark workflow** correctly gates the baseline checkout/build behind the `baseline == 'y'` input and removes the unused `--speedtest` dependency.
- **Build / lint / flaky-test workflows** gain Go module caching, a shared `GO_VERSION` constant, and `windows-latest` flaky-test coverage.
- **`BIN` path duplication** — the `BIN=./surge; [...] && BIN=./surge.exe` one-liner is repeated in 13+ steps of `integration-cli`; setting it once in `$GITHUB_ENV` would eliminate all copies.
- **Fragile `sleep 3` server startup** — `integration-settings`, `integration-env-auth`, and `integration-remote-connect` start the server and immediately sleep 3 seconds with no readiness check, unlike `integration-cli` which polls the `/health` endpoint. This is a source of potential flakiness on slow runners.
- **Missing token validation** — three jobs (`integration-settings`, `integration-env-auth`, `integration-remote-connect`) capture the token without checking whether it is non-empty, unlike `integration-cli` which asserts `[ -n "$TOKEN" ]`.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for CI infrastructure purposes, but the new integration workflow has reliability rough edges that will likely cause intermittent failures on slow runners.
- The supporting workflow changes (benchmark, build, lint, flaky-tests, binary-size-compare, build-push-images) are straightforward improvements with no regressions. The new integration-test.yml is structurally sound and covers a wide surface area, but three jobs rely on `sleep 3` for server startup instead of health polling, the `BIN` path is copy-pasted into 13+ steps, and token capture lacks validation in several jobs — all of which increase the chance of spurious CI failures and make future maintenance harder.
- .github/workflows/integration-test.yml — specifically the server startup steps in `integration-settings` (line 362), `integration-env-auth` (line 454), and `integration-remote-connect` (line 653), and the token-capture steps in those same jobs.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/integration-test.yml | New 716-line workflow adding 9 integration jobs (build, CLI, settings, env-auth, download-completion, sequential, Docker, remote-connect, summary). Solid overall structure with good use of matrix builds, artifact sharing, and `if: always()` on teardown steps. Key issues: `BIN` path computed redundantly in 13+ steps, server startup in three jobs relies on a fragile `sleep 3` rather than health polling (risk of flakiness), and token capture in three jobs lacks empty-string validation. |
| .github/workflows/benchmark.yml | Cleans up the benchmark workflow: removes dead `--speedtest` flag (and its dependency), gates the baseline checkout and build behind `if: baseline == 'y'`, adds an explicit script-existence check, and writes results to `$GITHUB_STEP_SUMMARY`. Trigger is `workflow_dispatch`-only so empty-arg concerns don't apply. |
| .github/workflows/build.yml | Extracts a `GO_VERSION` env constant to reduce duplication across three jobs, enables Go module caching, and simplifies the coverage conditional. Clean refactoring with no functional regressions. |
| .github/workflows/lint.yml | Migrates from ad-hoc `go run golangci-lint@latest` to the official `golangci/golangci-lint-action@v6`, which provides better caching, versioning, and GitHub problem matchers. Adds Go module cache. Clear improvement. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Build["**Job 1: Build**\nubuntu / macos / windows\ngo build → upload artifact"]

    Build --> CLI["**Job 2: integration-cli**\nubuntu / macos / windows\ntoken · server · add · ls · pause\nresume · batch · refresh · rm"]
    Build --> Settings["**Job 3: integration-settings**\nubuntu only\ncustom settings.json · partial · malformed"]
    Build --> EnvAuth["**Job 4: integration-env-auth**\nubuntu only\nSURGE_TOKEN / SURGE_HOST env vars\nexplicit flag override"]
    Build --> Completion["**Job 5: integration-download-completion**\nubuntu only\n--exit-when-done · --no-resume"]
    Build --> Sequential["**Job 6: integration-sequential**\nubuntu only\nsequential_download setting"]
    Build --> Docker["**Job 7: integration-docker**\nubuntu only\ndocker compose up · add · ls · logs"]
    Build --> Remote["**Job 8: integration-remote-connect**\nubuntu only\nexplicit --host · bad-token rejection"]

    CLI --> Summary["**Job 9: Summary**\nif: always()\nMarkdown results table"]
    Settings --> Summary
    EnvAuth --> Summary
    Completion --> Summary
    Sequential --> Summary
    Docker --> Summary
    Remote --> Summary
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/integration-test.yml
Line: 93

Comment:
**`BIN` path recomputed in every step — eliminate duplication**

The line `BIN=./surge; [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe` appears in **13 separate steps** of `integration-cli` (lines 93, 103, 120, 127, 138, 151, 161, 181, 196, 206, 214, 224, 233, 244, 255, 265, 288, 295). This is repeated boilerplate that increases maintenance burden — if the binary naming convention ever changes, every step must be updated in sync.

Compute the value once (right after downloading the artifact) and export it to `$GITHUB_ENV` so all subsequent steps inherit it automatically:

```suggestion
          BIN=./surge; [ "${{ matrix.os }}" = "windows-latest" ] && BIN=./surge.exe
          echo "BIN=$BIN" >> $GITHUB_ENV
```

Then remove the one-liner from every subsequent step body and just reference `$BIN` directly.

**Rule Used:** What: Eliminate duplicate logic, functions, or cod... ([source](https://app.greptile.com/review/custom-context?memory=f0a796a9-684f-4dfb-a5cf-8c99c16b63a1))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/integration-test.yml
Line: 362-364

Comment:
**Fragile `sleep 3` server startup — inconsistent with `integration-cli` approach**

`integration-cli` correctly polls the health endpoint in a loop (lines 111–115) before proceeding. However, `integration-settings` (here), `integration-env-auth` (line 454–456), and `integration-remote-connect` (line 653–656) all just sleep for 3 seconds with no readiness check. On a slow or loaded runner this is a common source of flakiness — the server may not have bound the port by the time the next step runs.

Apply the same polling approach used by `integration-cli`:

```
./surge server --port $SURGE_PORT &
echo "SERVER_PID=$!" >> $GITHUB_ENV
for i in $(seq 1 10); do
  curl -sf -o /dev/null http://localhost:$SURGE_PORT/health && break || sleep 1
done
curl -sf -o /dev/null http://localhost:$SURGE_PORT/health \
  || (echo "Server did not start in time" && exit 1)
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/integration-test.yml
Line: 367-369

Comment:
**Token captured without empty-string validation**

`integration-cli` validates the captured token is non-empty (line 97: `[ -n "$TOKEN" ] || ...`). Here, and also in `integration-env-auth` (line 460) and `integration-remote-connect` (line 659), there is no such check. If `./surge token` exits non-zero or returns an empty string (e.g. the server didn't start in time), subsequent steps that pass `$TOKEN` will fail with a confusing auth error rather than a clear root-cause message.

Add a guard immediately after capturing the value — the same pattern already used in `integration-cli` at line 97 — and apply it consistently in all three jobs.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (5): Last reviewed commit: ["slow url"](https://github.com/surge-downloader/surge/commit/95db484222ccf987e725d04853cf8a94ba117746) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25973741)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->