### PR TITLE
Add workflow to close stale pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,27 @@
+name: Close Stale PRs
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Runs once a day at midnight
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write # Required to label and close PRs
+  issues: write        # Required by the action, even if we skip issues
+
+jobs:
+  close-stale-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close Stale PRs
+        uses: actions/stale@v10.2.0
+        with:
+          # --- PR Configuration ---
+          days-before-pr-stale: 7
+          days-before-pr-close: 0
+          stale-pr-message: 'This pull request is being closed because it has been inactive for 7 days.'
+          stale-pr-label: 'stale'
+          
+          # --- Issue Configuration (Disabled) ---
+          days-before-issue-stale: -1
+          days-before-issue-close: -1


### PR DESCRIPTION
This workflow automatically closes pull requests that have been inactive for 7 days.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a new GitHub Actions workflow (`.github/workflows/main.yml`) that uses `actions/stale@v10.2.0` to automatically close inactive pull requests. The overall approach is correct and the action is a standard, well-maintained choice for this purpose, but there is one significant behavioural issue and a few polish items.

**Key findings:**

- **P1 — Zero grace period:** `days-before-pr-close: 0` causes PRs to be labelled *and* immediately closed in the same workflow run. The stale warning message becomes meaningless because the PR is already being closed when contributors receive it. A typical stale workflow uses a two-phase approach (mark → wait → close) to give contributors a chance to respond.
- **P2 — Misleading filename:** All other workflows in `.github/workflows/` use descriptive, purpose-specific names. `main.yml` is ambiguous and may be mistaken for the primary CI/CD pipeline; `stale.yml` would be clearer.
- **P2 — No exemption label:** Without `exempt-pr-labels`, maintainers have no way to protect intentional long-running or parked PRs from automatic closure.
- **P2 — Redundant comment:** The cron comment restates what the expression already says rather than explaining the rationale for the chosen cadence.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the grace-period issue; the zero-day close window will immediately close PRs on the same run they are labelled stale, eliminating the intended warning period.

One P1 finding: `days-before-pr-close: 0` makes the stale warning message ineffective and closes PRs without any buffer for contributor response. The remaining findings are P2 style/polish items that do not block functionality.

`.github/workflows/main.yml` — specifically the `days-before-pr-close` value and the filename.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/main.yml | New stale-PR workflow using actions/stale@v10.2.0; `days-before-pr-close: 0` eliminates any grace period, closing PRs the same instant they are labelled stale; filename `main.yml` conflicts with naming conventions used by all other workflows. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Scheduler as GitHub Scheduler
    participant Workflow as close-stale-prs job
    participant Stale as actions/stale
    participant PR as Pull Request

    Scheduler->>Workflow: Trigger daily at midnight (cron)
    Workflow->>Stale: Run with configured inputs
    Stale->>PR: Check last activity date
    alt Inactive ≥ 7 days
        Stale->>PR: Apply "stale" label
        Stale->>PR: Post stale-pr-message
        Note over Stale,PR: days-before-pr-close=0 — closes immediately
        Stale->>PR: Close PR (same run, no grace period)
    else Active < 7 days
        Stale-->>PR: No action
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/main.yml
Line: 21

Comment:
**No grace period between stale label and closure**

`days-before-pr-close: 0` means a PR is closed in the **same workflow run** that it's first marked stale. The stale warning message is posted and the PR is closed simultaneously, so contributors never have a chance to react to the warning.

A typical stale workflow uses a two-phase approach: mark stale after N days of inactivity, then close after M more days if there's still no activity. This gives contributors a window to respond.

Consider giving at least a few days of grace period:

```suggestion
          days-before-pr-close: 7
```

With this change, PRs would be marked stale after 7 days of inactivity, and then closed 7 days later if still inactive — matching the two-phase pattern that most contributors expect.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/main.yml
Line: 5

Comment:
**Comment restates what the cron expression already says**

The comment `# Runs once a day at midnight` simply restates what `0 0 * * *` expresses directly. A more useful comment would explain *why* this cadence was chosen — for example, that daily is sufficient since staleness is measured in days and more frequent runs would waste GitHub Actions minutes.

```suggestion
    - cron: '0 0 * * *' # Daily is sufficient; staleness is measured in whole days
```

**Rule Used:** What: Comments must explain *why* code exists, not... ([source](https://app.greptile.com/review/custom-context?memory=4e45ef13-32c2-4753-8060-a44ef767144d))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/main.yml
Line: 1

Comment:
**Misleading filename — conflicts with the existing naming convention**

All other workflows in `.github/workflows/` use descriptive, purpose-specific names (`benchmark.yml`, `build.yml`, `lint.yml`, etc.). Naming this file `main.yml` is ambiguous and may mislead contributors into thinking it is the primary CI/CD pipeline.

Consider renaming the file to `stale.yml` or `close-stale-prs.yml` to match the established naming convention and make its purpose immediately clear.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/main.yml
Line: 17-27

Comment:
**No exemption label configured**

Without `exempt-pr-labels`, there is no way for maintainers to protect long-running or intentionally-parked PRs from being automatically closed. A common pattern is to allow a `pinned` or `do-not-close` label to opt PRs out of the stale policy.

Consider adding:
```yaml
          exempt-pr-labels: 'pinned,do-not-close'
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add workflow to close stale pull request..."](https://github.com/surge-downloader/surge/commit/70782e3e75fc23cf122dfd318fda62018873e829) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26679249)</sub>

> Greptile also left **4 inline comments** on this PR.

**Context used:**

- Rule used - What: Comments must explain *why* code exists, not... ([source](https://app.greptile.com/review/custom-context?memory=4e45ef13-32c2-4753-8060-a44ef767144d))

<!-- /greptile_comment -->