### PR TITLE
fix stale pr

### DIFF
--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -17,11 +17,13 @@ jobs:
         uses: actions/stale@v10.2.0
         with:
           # --- PR Configuration ---
-          days-before-pr-stale: 7
-          days-before-pr-close: 0
-          stale-pr-message: 'This pull request is being closed because it has been inactive for 7 days.'
+          days-before-pr-stale: 5
+          days-before-pr-close: 2
+          stale-pr-message: 'This PR has had no activity for 5 days. It will be closed in 2 days if no further updates are made.'
           stale-pr-label: 'stale'
           
           # --- Issue Configuration (Disabled) ---
           days-before-issue-stale: -1
           days-before-issue-close: -1
+
+          exempt-pr-labels: 'pinned,do-not-close'


### PR DESCRIPTION
- **address**
- **address**

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the stale-PR workflow by renaming the file from `main.yml` to the more descriptive `close-stale-prs.yml`, tuning the staleness timers, and adding an exemption mechanism for important PRs.

Key changes:
- `days-before-pr-stale` reduced from **7 → 5** days; `days-before-pr-close` raised from **0 → 2** days — total time-to-close stays at 7 days, but contributors now receive a 2-day warning period instead of immediate closure.
- The `stale-pr-message` is updated to accurately reflect the new 5-day / 2-day timing.
- `exempt-pr-labels: 'pinned,do-not-close'` is introduced, allowing maintainers to protect important PRs from automatic closure.
- The workflow file is renamed to `close-stale-prs.yml`, which better communicates its purpose.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are correct, well-scoped, and introduce no breaking behavior.

All changes are straightforward configuration adjustments with no logic errors, security concerns, or regressions. The net close time is unchanged (7 days total), the message accurately reflects the new timing, and the exempt-label feature is a clean addition.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/close-stale-prs.yml | Renamed from main.yml; reduces stale threshold from 7 to 5 days, adds a 2-day grace period before closure, updates message accordingly, and introduces exempt-pr-labels for pinned/do-not-close PRs. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([Cron: daily at midnight UTC\nor workflow_dispatch]) --> B[actions/stale runs]
    B --> C{PR inactive\nfor 5 days?}
    C -- No --> D([No action])
    C -- Yes --> E{Has exempt label?\npinned or do-not-close}
    E -- Yes --> D
    E -- No --> F[Label PR as 'stale'\nPost warning message]
    F --> G{Stale for\n2 more days?}
    G -- No / Activity detected --> H[Remove stale label]
    G -- Yes --> I[Close PR]
```

<sub>Reviews (1): Last reviewed commit: ["address"](https://github.com/surge-downloader/surge/commit/7bf73467319e50ab47d85493a466a9870971d583) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26679579)</sub>

<!-- /greptile_comment -->