### PR TITLE
fix(state): protect GetDB() against data race on db variable

### DIFF
--- a/internal/engine/state/db.go
+++ b/internal/engine/state/db.go
@@ -24,11 +24,9 @@ func Configure(path string) {
 	configured = true
 }
 
-// InitDB initializes the SQLite database connection using the configured path
-func initDB() error {
-	dbMu.Lock()
-	defer dbMu.Unlock()
-
+// initDBLocked initialises the database connection.
+// Caller must hold dbMu.
+func initDBLocked() error {
 	if db != nil {
 		return nil
 	}
@@ -37,9 +35,6 @@ func initDB() error {
 		return fmt.Errorf("state database not configured: call state.Configure() first")
 	}
 
-	// Ensure directory exists - caller should perhaps do this, but safe to do here if path is provided
-
-	// Open database
 	var err error
 	db, err = sql.Open("sqlite", dbPath)
 	if err != nil {
@@ -99,6 +94,12 @@ func initDB() error {
 	return nil
 }
 
+func initDB() error {
+	dbMu.Lock()
+	defer dbMu.Unlock()
+	return initDBLocked()
+}
+
 // ensureDownloadsSchema checks if required columns exist in the downloads table and adds them if missing.
 func ensureDownloadsSchema() error {
 	rows, err := db.Query("PRAGMA table_info(downloads)")
@@ -154,24 +155,17 @@ func CloseDB() {
 	configured = false
 }
 
-// GetDB returns the database instance, initializing it if necessary.
+// GetDB is safe for concurrent use; it lazily opens the database so callers
+// need not coordinate initialisation order with Configure().
 func GetDB() (*sql.DB, error) {
 	dbMu.Lock()
-	if db != nil {
-		d := db
-		dbMu.Unlock()
-		return d, nil
+	defer dbMu.Unlock()
+	if db == nil {
+		if err := initDBLocked(); err != nil {
+			return nil, err
+		}
 	}
-	dbMu.Unlock()
-
-	if err := initDB(); err != nil {
-		return nil, err
-	}
-
-	dbMu.Lock()
-	d := db
-	dbMu.Unlock()
-	return d, nil
+	return db, nil
 }
 
 // Helper to ensure DB is initialized and return it


### PR DESCRIPTION
## Summary

Fixes #306

- Protect `db` reads in `GetDB()` with `dbMu.Lock()` to prevent data race with concurrent `CloseDB()` or `initDB()` calls

## Changes

`internal/engine/state/db.go`:
- `GetDB()` now acquires `dbMu` before reading `db`, takes a local copy, and releases the lock before returning
- Preserves lazy initialization semantics — `initDB()` is only called when `db` is nil

## Test plan

- [x] `go build ./...` compiles successfully
- [x] `go test ./internal/engine/state/...` passes
- [x] `go test -race ./internal/engine/state/...` passes with race detector

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR correctly resolves a data race on the package-level `db` variable in `GetDB()` by introducing the `initDBLocked()` inner function (lock-free, caller must hold `dbMu`) and having `GetDB()` hold `dbMu` across the entire nil-check-and-initialise sequence. This eliminates the TOCTOU window identified in the linked issue, where a concurrent `CloseDB()` call could set `db = nil` between `initDB()` returning and `GetDB()` reading the pointer.

Key changes:
- `initDB()` is split into `initDBLocked()` (does the work, no lock) and `initDB()` (acquires lock, delegates) — a standard Go idiom for reentrant-safe helpers
- `GetDB()` now acquires `dbMu` before the nil check and holds it through the `initDBLocked()` call, making the lazy-init atomic with respect to `CloseDB()` and `Configure()`
- The `GetDB()` doc comment is updated to describe the concurrency contract rather than restating the function signature
- One P2 suggestion: a dedicated goroutine-level concurrent test for `GetDB()` + `CloseDB()` would directly validate the fix and guard against regression

<h3>Confidence Score: 5/5</h3>

- Safe to merge — the race fix is correct and idiomatic; one P2 suggestion for a concurrent test does not block merge.
- The core correctness issue (TOCTOU window) is properly resolved by holding the mutex across the full check-and-init path. All remaining feedback is P2 (missing concurrent stress test), which does not affect production correctness. Confidence guidance calls for 5/5 when only P2 findings remain.
- No files require special attention; the single changed file is well-structured and correct.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/engine/state/db.go | Correctly fixes the data race by splitting initDB into a lock-free initDBLocked inner function and a locking wrapper; GetDB now holds dbMu across the entire nil-check and lazy-initialization, closing the previous TOCTOU window. Comment on GetDB updated to explain concurrency semantics (the why) rather than restating the signature. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant GetDB
    participant dbMu as dbMu Mutex
    participant initDBLocked
    participant CloseDB

    Note over GetDB,CloseDB: After fix: mutex held across full lazy-init

    Caller->>GetDB: GetDB()
    GetDB->>dbMu: Lock()
    GetDB->>GetDB: db == nil?
    alt db is nil
        GetDB->>initDBLocked: initDBLocked()
        Note right of initDBLocked: No lock acquired, caller holds dbMu
        initDBLocked-->>GetDB: db initialised
    end
    GetDB->>dbMu: Unlock via defer
    GetDB-->>Caller: (*sql.DB, nil)

    Note over CloseDB: Concurrent CloseDB must wait for dbMu
    Caller->>CloseDB: CloseDB() concurrent
    CloseDB->>dbMu: Lock() blocks until GetDB releases
    CloseDB->>CloseDB: db.Close() then db = nil
    CloseDB->>dbMu: Unlock()
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/engine/state/db_test.go`, line 1-10 ([link](https://github.com/surge-downloader/surge/blob/d6c485ddca1434bcdfe93a7541d23c78ef22d3d6/internal/engine/state/db_test.go#L1-L10)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Missing concurrent race test for `GetDB` + `CloseDB`**

   The PR's stated goal is to fix a data race, but no test exercises the specific concurrent path that was broken. The existing tests only cover sequential lifecycle scenarios. A concurrent test that would catch the TOCTOU issue (and be caught by the race detector) would look like:

   ```go
   func TestGetDB_ConcurrentCloseDB(t *testing.T) {
       tempDir := setupTestDB(t)
       defer os.RemoveAll(tempDir)

       var wg sync.WaitGroup
       for i := 0; i < 50; i++ {
           wg.Add(2)
           go func() {
               defer wg.Done()
               d, err := GetDB()
               if err == nil && d == nil {
                   t.Errorf("GetDB returned (nil, nil)")
               }
           }()
           go func() {
               defer wg.Done()
               CloseDB()
               Configure(filepath.Join(tempDir, "surge.db"))
           }()
       }
       wg.Wait()
   }
   ```

   Running `go test -race` without an explicit concurrent test may not exercise the specific interleaving that triggers the bug.

   **Rule Used:** What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: internal/engine/state/db_test.go
   Line: 1-10
   
   Comment:
   **Missing concurrent race test for `GetDB` + `CloseDB`**
   
   The PR's stated goal is to fix a data race, but no test exercises the specific concurrent path that was broken. The existing tests only cover sequential lifecycle scenarios. A concurrent test that would catch the TOCTOU issue (and be caught by the race detector) would look like:
   
   ```go
   func TestGetDB_ConcurrentCloseDB(t *testing.T) {
       tempDir := setupTestDB(t)
       defer os.RemoveAll(tempDir)
   
       var wg sync.WaitGroup
       for i := 0; i < 50; i++ {
           wg.Add(2)
           go func() {
               defer wg.Done()
               d, err := GetDB()
               if err == nil && d == nil {
                   t.Errorf("GetDB returned (nil, nil)")
               }
           }()
           go func() {
               defer wg.Done()
               CloseDB()
               Configure(filepath.Join(tempDir, "surge.db"))
           }()
       }
       wg.Wait()
   }
   ```
   
   Running `go test -race` without an explicit concurrent test may not exercise the specific interleaving that triggers the bug.
   
   **Rule Used:** What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/engine/state/db_test.go
Line: 11

Comment:
**No concurrent test for the race condition being fixed**

The PR fixes a data race in `GetDB()`, but there is no test that explicitly exercises concurrent `GetDB()` and `CloseDB()` calls from multiple goroutines. The `go test -race` pass mentioned in the test plan relies on the race detector catching incidental races in existing sequential tests — it does not guarantee the specific scenario described in the bug is covered.

A targeted concurrent test would lock in the fix and prevent regression. For example:

```go
func TestGetDB_ConcurrentWithCloseDB(t *testing.T) {
    tmpDir := setupTestDB(t)
    defer func() { _ = os.RemoveAll(tmpDir) }()
    defer CloseDB()

    var wg sync.WaitGroup
    for i := 0; i < 50; i++ {
        wg.Add(2)
        go func() {
            defer wg.Done()
            d, err := GetDB()
            if err == nil && d == nil {
                t.Errorf("GetDB returned (nil, nil): non-error nil db is invalid")
            }
        }()
        go func() {
            defer wg.Done()
            CloseDB()
            dbPath := filepath.Join(tmpDir, "surge.db")
            Configure(dbPath)
        }()
    }
    wg.Wait()
}
```

Running this with `-race` would directly validate that the lock-holding approach in `GetDB()` prevents the TOCTOU window.

**Rule Used:** What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(state): eliminar TOCTOU window em Ge..."](https://github.com/surge-downloader/surge/commit/572e2ff6af19d3dba56f32966c32c03f64f44f8e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27042194)</sub>

**Context used:**

- Rule used - What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))
- Rule used - What: Comments must explain *why* code exists, not... ([source](https://app.greptile.com/review/custom-context?memory=4e45ef13-32c2-4753-8060-a44ef767144d))

<!-- /greptile_comment -->