### PR TITLE
fix(notify): move notification icon from shared /tmp to user cache directory

### DIFF
--- a/internal/utils/notify.go
+++ b/internal/utils/notify.go
@@ -27,19 +27,22 @@ func ensureIcon() string {
 	iconOnce.Do(func() {
 		cacheDir, err := os.UserCacheDir()
 		if err != nil {
-			Debug("Failed to determine user cache dir: %v", err)
-			return
+			Debug("Failed to determine user cache dir, falling back to temp: %v", err)
+			cacheDir = os.TempDir()
 		}
 		surgeCache := filepath.Join(cacheDir, "surge")
 		if err := os.MkdirAll(surgeCache, 0o755); err != nil {
 			Debug("Failed to create icon cache dir: %v", err)
 			return
 		}
-		iconPath = filepath.Join(surgeCache, "surge_logo.png")
-		if err := os.WriteFile(iconPath, assets.LogoData, 0o644); err != nil {
-			iconPath = ""
-			Debug("Failed to write notification icon: %v", err)
+		path := filepath.Join(surgeCache, "surge_logo.png")
+		if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
+			if err := os.WriteFile(path, assets.LogoData, 0o644); err != nil {
+				Debug("Failed to write notification icon: %v", err)
+				return
+			}
 		}
+		iconPath = path
 	})
 	return iconPath
 }


### PR DESCRIPTION
## Summary

Fixes #308

- Move notification icon from shared `/tmp/surge_logo.png` to user-private `<cache-dir>/surge/surge_logo.png`
- Use `sync.Once` for lazy, thread-safe initialization instead of `init()`

## Changes

`internal/utils/notify.go`:
- Replace `init()` icon write with lazy `ensureIcon()` using `sync.Once`
- Use `os.UserCacheDir()` (cross-platform) instead of `os.TempDir()`
- `Notify()` calls `ensureIcon()` to get the icon path

## Behavior

| Platform | Before | After |
|----------|--------|-------|
| Linux | `/tmp/surge_logo.png` | `~/.cache/surge/surge_logo.png` |
| macOS | `/tmp/surge_logo.png` | `~/Library/Caches/surge/surge_logo.png` |
| Windows | `%TEMP%\surge_logo.png` | `%LocalAppData%\surge\surge_logo.png` |

## Test plan

- [x] `go build ./...` compiles successfully
- [x] `go test ./internal/utils/...` passes
- [ ] Manual: verify notification still shows icon after the change

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a security/privacy concern (#308) by relocating the notification icon from the world-readable shared `/tmp` directory to a user-private cache directory (`os.UserCacheDir()`), and replaces the eager `init()`-based write with a lazy `sync.Once`-guarded `ensureIcon()` helper.

- The `os.Stat` skip-if-present check is preserved, so the icon is only written once per user rather than on every process start.
- A `os.TempDir()` fallback is included for environments where `os.UserCacheDir()` is unavailable, addressing the failure-path concern raised in earlier review rounds.
- The comment on `ensureIcon()` correctly explains the *why* (TOCTOU race with shared `/tmp`) rather than restating what the code does.
- No `notify_test.go` has been added; the `sync.Once`-scoped edge cases (`MkdirAll` failure, concurrent callers, `WriteFile` failure) remain uncovered — consistent with the pattern already noted for `debug.go` in this package.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — the fix is correct, the TOCTOU race is resolved, and all failure paths degrade gracefully to an icon-less notification.
- All prior review concerns have been addressed: the unconditional overwrite is gone (os.Stat check re-added), the UserCacheDir failure now falls back to TempDir, and iconPath is only set on success. The only remaining gap is missing tests for ensureIcon() edge cases (already flagged in prior rounds), which is a P2 quality concern and does not block merge under the confidence guidance.
- No files require special attention; internal/utils/notify.go is the sole changed file and its logic is straightforward.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/utils/notify.go | Moves notification icon storage from shared /tmp to user-private cache dir via os.UserCacheDir(), adds sync.Once for lazy thread-safe init, preserves skip-if-present behavior via os.Stat check, and adds TempDir fallback when UserCacheDir fails. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Notify(title, message)"] --> B["ensureIcon()"]
    B --> C{iconOnce.Do already run?}
    C -- "Yes" --> D["return iconPath (cached)"]
    C -- "No" --> E["os.UserCacheDir()"]
    E -- "error" --> F["Debug log\ncacheDir = os.TempDir()"]
    E -- "ok" --> G["surgeCache = cacheDir/surge"]
    F --> G
    G --> H["os.MkdirAll(surgeCache, 0755)"]
    H -- "error" --> I["Debug log\nreturn (iconPath stays empty)"]
    H -- "ok" --> J["os.Stat(path)"]
    J -- "file exists" --> L["iconPath = path"]
    J -- "IsNotExist" --> K["os.WriteFile(path, assets.LogoData)"]
    K -- "error" --> M["Debug log\nreturn (iconPath stays empty)"]
    K -- "ok" --> L
    L --> D
    D --> N["beeep.Notify(title, message, iconPath)"]
```

<sub>Reviews (2): Last reviewed commit: ["fix(notify): adicionar check de existênc..."](https://github.com/surge-downloader/surge/commit/5c129d3fa9c634256f824361602624a0d73a684b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27042424)</sub>

**Context used:**

- Rule used - What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))

<!-- /greptile_comment -->