### PR TITLE
refactor: remove verbose flag and enable persistent debug logging

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,17 +24,13 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Logs**
-Surge only writes log files when run with `--verbose`. To capture a log:
+Surge automatically writes debug log files.
 
-1. Reproduce the bug with the `--verbose` flag:
-   ```
-   surge --verbose [your command]
-   ```
-2. The log file is written to:
+1. The log file is written to:
    - **Linux:** `~/.local/state/surge/logs/`
    - **macOS:** `~/Library/Application Support/surge/logs/`
    - **Windows:** `%APPDATA%\surge\logs\`
-3. Attach the most recent `debug-*.log` file by dragging it into this issue, or paste relevant excerpts in a code block.
+2. Attach the most recent `debug-*.log` file by dragging it into this issue, or paste relevant excerpts in a code block.
 
 **Please complete the following information:**
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # binary
 surge
 *.surge
+Surge
+surge_bin
 
 # python + uv stuff
 .python-version

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,7 +51,6 @@ var pendingEnqueue int32
 
 // Command line flags
 var (
-	verbose     bool
 	globalHost  string
 	globalToken string
 )
@@ -411,8 +410,6 @@ var rootCmd = &cobra.Command{
 	SilenceErrors: true, //errors are printed in main.go this prevents double printing
 	SilenceUsage:  true, // prevent usage text from being printed on every error
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		// Set global verbose mode
-		utils.SetVerbose(verbose)
 
 		GlobalProgressCh = make(chan any, 100)
 		globalSettings = getSettings()
@@ -534,7 +531,6 @@ func Execute() error {
 }
 
 func init() {
-	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")
 	rootCmd.PersistentFlags().StringVar(&globalHost, "host", "", "Server host to connect/control (or set SURGE_HOST), e.g. 127.0.0.1:1700")
 	rootCmd.PersistentFlags().StringVar(&globalToken, "token", "", "Bearer token (or set SURGE_TOKEN)")
 	rootCmd.Flags().StringP("batch", "b", "", "File containing URLs to download (one per line)")

--- a/cmd/root_startup.go
+++ b/cmd/root_startup.go
@@ -51,9 +51,13 @@ func initializeGlobalState() error {
 	// Config logging
 	utils.ConfigureDebug(logsDir)
 
-	// Clean up old logs
+	// Clean up old logs (keeping retention-1 because a new log will be created immediately after)
 	retention := getSettings().General.LogRetentionCount
-	utils.CleanupLogs(retention)
+	if retention > 0 {
+		utils.CleanupLogs(retention - 1)
+	} else {
+		utils.CleanupLogs(retention)
+	}
 	return nil
 }
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -33,7 +33,6 @@ These are persistent flags and can be used with all commands.
 | :------------------- | :------------------------------------- |
 | `--host <host:port>` | Target server for TUI and CLI actions. |
 | `--token <token>`    | Bearer token used for API requests.    |
-| `--verbose, -v`      | Enable verbose logging.                |
 
 ## Environment Variables
 

--- a/internal/processing/probe.go
+++ b/internal/processing/probe.go
@@ -200,7 +200,7 @@ func ProbeServerWithProxy(ctx context.Context, rawurl string, filenameHint strin
 		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 
-	name, _, err := utils.DetermineFilename(rawurl, resp, false)
+	name, _, err := utils.DetermineFilename(rawurl, resp)
 	if err != nil {
 		utils.Debug("Error determining filename: %v", err)
 		name = "download.bin"

--- a/internal/utils/debug.go
+++ b/internal/utils/debug.go
@@ -23,6 +23,17 @@ func ConfigureDebug(dir string) {
 	logsDir.Store(dir)
 }
 
+// IsLoggingEnabled returns true if debug logging is configured
+// This allows callers to skip expensive argument evaluation
+func IsLoggingEnabled() bool {
+	val := logsDir.Load()
+	if val == nil {
+		return false
+	}
+	dir, ok := val.(string)
+	return ok && dir != ""
+}
+
 // Debug writes a message to debug.log file in the configured directory
 func Debug(format string, args ...any) {
 	// Internal fast path check without lock

--- a/internal/utils/debug.go
+++ b/internal/utils/debug.go
@@ -16,7 +16,6 @@ var (
 	debugFile *os.File
 	debugOnce sync.Once
 	logsDir   atomic.Value // string
-	verbose   atomic.Bool
 )
 
 // ConfigureDebug sets the directory for debug logs
@@ -24,23 +23,8 @@ func ConfigureDebug(dir string) {
 	logsDir.Store(dir)
 }
 
-// SetVerbose enables or disables verbose logging
-func SetVerbose(enabled bool) {
-	verbose.Store(enabled)
-}
-
-// IsVerbose returns true if verbose logging is enabled
-func IsVerbose() bool {
-	return verbose.Load()
-}
-
 // Debug writes a message to debug.log file in the configured directory
 func Debug(format string, args ...any) {
-	// Fast path: check verbose flag first
-	if !verbose.Load() {
-		return
-	}
-
 	// Internal fast path check without lock
 	val := logsDir.Load()
 	if val == nil {

--- a/internal/utils/filename.go
+++ b/internal/utils/filename.go
@@ -69,11 +69,15 @@ func DetermineFilename(rawurl string, resp *http.Response) (string, io.Reader, e
 
 	body := io.MultiReader(bytes.NewReader(header), resp.Body)
 
-	mimeType := http.DetectContentType(header)
-	Debug("Detected MIME: %s", mimeType)
+	kind, _ := filetype.Match(header)
 
-	if kind, _ := filetype.Match(header); kind != filetype.Unknown {
-		Debug("Magic Type: %s %s", kind.Extension, kind.MIME)
+	if IsLoggingEnabled() {
+		mimeType := http.DetectContentType(header)
+		Debug("Detected MIME: %s", mimeType)
+
+		if kind != filetype.Unknown {
+			Debug("Magic Type: %s %s", kind.Extension, kind.MIME)
+		}
 	}
 
 	if candidate == "." && len(header) >= 4 && bytes.HasPrefix(header, []byte{0x50, 0x4B, 0x03, 0x04}) && len(header) >= 30 {
@@ -90,11 +94,9 @@ func DetermineFilename(rawurl string, resp *http.Response) (string, io.Reader, e
 	}
 
 	if filepath.Ext(filename) == "" {
-		if kind, _ := filetype.Match(header); kind != filetype.Unknown {
-			if kind.Extension != "" {
-				filename = filename + "." + kind.Extension
-				Debug("Added extension from magic type: %s", kind.Extension)
-			}
+		if kind != filetype.Unknown && kind.Extension != "" {
+			filename = filename + "." + kind.Extension
+			Debug("Added extension from magic type: %s", kind.Extension)
 		}
 	}
 

--- a/internal/utils/filename.go
+++ b/internal/utils/filename.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -18,7 +17,7 @@ import (
 // DetermineFilename extracts the filename from a URL and HTTP response,
 // applying various heuristics. It returns the determined filename,
 // a new io.Reader that includes any sniffed header bytes, and an error.
-func DetermineFilename(rawurl string, resp *http.Response, verbose bool) (string, io.Reader, error) {
+func DetermineFilename(rawurl string, resp *http.Response) (string, io.Reader, error) {
 	parsed, err := url.Parse(rawurl)
 	if err != nil {
 		return "", nil, err
@@ -31,9 +30,7 @@ func DetermineFilename(rawurl string, resp *http.Response, verbose bool) (string
 	// 1. Content-Disposition
 	if _, name, err := httpheader.ContentDisposition(resp.Header); err == nil && name != "" {
 		candidate = name
-		if verbose {
-			fmt.Fprintf(os.Stderr, "Filename from Content-Disposition: %s\n", candidate)
-		}
+		Debug("Filename from Content-Disposition: %s", candidate)
 	}
 
 	// 2. Query Parameters (if no Content-Disposition)
@@ -41,14 +38,10 @@ func DetermineFilename(rawurl string, resp *http.Response, verbose bool) (string
 		q := parsed.Query()
 		if name := q.Get("filename"); name != "" {
 			candidate = name
-			if verbose {
-				fmt.Fprintf(os.Stderr, "Filename from query param 'filename': %s\n", candidate)
-			}
+			Debug("Filename from query param 'filename': %s", candidate)
 		} else if name := q.Get("file"); name != "" {
 			candidate = name
-			if verbose {
-				fmt.Fprintf(os.Stderr, "Filename from query param 'file': %s\n", candidate)
-			}
+			Debug("Filename from query param 'file': %s", candidate)
 		}
 	}
 
@@ -76,13 +69,11 @@ func DetermineFilename(rawurl string, resp *http.Response, verbose bool) (string
 
 	body := io.MultiReader(bytes.NewReader(header), resp.Body)
 
-	if verbose {
-		mimeType := http.DetectContentType(header)
-		fmt.Fprintln(os.Stderr, "Detected MIME:", mimeType)
+	mimeType := http.DetectContentType(header)
+	Debug("Detected MIME: %s", mimeType)
 
-		if kind, _ := filetype.Match(header); kind != filetype.Unknown {
-			fmt.Fprintln(os.Stderr, "Magic Type:", kind.Extension, kind.MIME)
-		}
+	if kind, _ := filetype.Match(header); kind != filetype.Unknown {
+		Debug("Magic Type: %s %s", kind.Extension, kind.MIME)
 	}
 
 	if candidate == "." && len(header) >= 4 && bytes.HasPrefix(header, []byte{0x50, 0x4B, 0x03, 0x04}) && len(header) >= 30 {
@@ -93,9 +84,7 @@ func DetermineFilename(rawurl string, resp *http.Response, verbose bool) (string
 			zipName := string(header[start:end])
 			if zipName != "" {
 				filename = filepath.Base(zipName)
-				if verbose {
-					fmt.Fprintln(os.Stderr, "ZIP internal filename:", zipName)
-				}
+				Debug("ZIP internal filename: %s", zipName)
 			}
 		}
 	}
@@ -104,9 +93,7 @@ func DetermineFilename(rawurl string, resp *http.Response, verbose bool) (string
 		if kind, _ := filetype.Match(header); kind != filetype.Unknown {
 			if kind.Extension != "" {
 				filename = filename + "." + kind.Extension
-				if verbose {
-					fmt.Fprintf(os.Stderr, "Added extension from magic type: %s\n", kind.Extension)
-				}
+				Debug("Added extension from magic type: %s", kind.Extension)
 			}
 		}
 	}
@@ -117,9 +104,7 @@ func DetermineFilename(rawurl string, resp *http.Response, verbose bool) (string
 
 	if filename == "" || filename == "." || filename == "/" || filename == "_" {
 		filename = "download.bin"
-		if verbose {
-			fmt.Fprintln(os.Stderr, "Falling back to default filename: download.bin")
-		}
+		Debug("Falling back to default filename: download.bin")
 	}
 
 	return filename, body, nil

--- a/internal/utils/filename_test.go
+++ b/internal/utils/filename_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+	"os"
 	"testing"
 )
 
@@ -152,5 +153,31 @@ func TestDetermineFilename_PriorityOrder(t *testing.T) {
 				t.Errorf("got %q, want %q", filename, tt.expected)
 			}
 		})
+	}
+}
+
+func TestDetermineFilename_LoggingIntegration(t *testing.T) {
+	// Setup temp dir for logs
+	tempDir, err := os.MkdirTemp("", "surge-debug-integration")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tempDir) }()
+
+	// Enable logging
+	ConfigureDebug(tempDir)
+	defer ConfigureDebug("")
+
+	resp := &http.Response{
+		Header: http.Header{},
+		Body:   io.NopCloser(bytes.NewReader([]byte("%PDF-1.4\n"))),
+	}
+
+	filename, _, err := DetermineFilename("https://example.com/test", resp)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if filename != "test.pdf" {
+		t.Errorf("got %q, want test.pdf", filename)
 	}
 }

--- a/internal/utils/filename_test.go
+++ b/internal/utils/filename_test.go
@@ -143,7 +143,7 @@ func TestDetermineFilename_PriorityOrder(t *testing.T) {
 				Body:   io.NopCloser(bytes.NewReader(tt.body)),
 			}
 
-			filename, _, err := DetermineFilename(tt.url, resp, false)
+			filename, _, err := DetermineFilename(tt.url, resp)
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the `--verbose` / `-v` flag and replaces it with persistent, always-on debug logging: every Surge session now automatically writes a `debug-*.log` file to the platform-appropriate state directory, capped by the `log_retention_count` setting. The `verbose bool` parameter is removed from `DetermineFilename`, `SetVerbose`/`IsVerbose` are replaced by the leaner `IsLoggingEnabled`, and all `fmt.Fprintf(os.Stderr, …)` verbose prints are converted to `Debug(…)` calls. The previously-duplicate `filetype.Match(header)` call is collapsed into a single invocation whose result is shared between the debug block and the extension-inference logic.

**Key changes:**
- `internal/utils/debug.go` — drops `verbose atomic.Bool`; adds `IsLoggingEnabled()` so callers can gate expensive work behind a fast check without entering `Debug`.
- `internal/utils/filename.go` — `DetermineFilename` signature simplified; `filetype.Match` called once and result reused; `http.DetectContentType` guarded by `IsLoggingEnabled()`.
- `cmd/root_startup.go` — cleanup now uses `retention - 1` before creating the new session log, correctly bounding the on-disk count to `log_retention_count`.
- `internal/utils/filename_test.go` — existing tests updated; new `TestDetermineFilename_LoggingIntegration` added.
- Docs and issue template updated to reflect the always-on behaviour.

**Issues found:**
- The new `TestDetermineFilename_LoggingIntegration` test may not exercise the debug-write code path it is named after: `debugOnce` (a package-level `sync.Once`) can be spent by an earlier test in the binary before this test configures its temp directory, silently making the \"integration\" half a no-op.
- When `log_retention_count` is `0`, the current logic deletes all existing logs but still creates one new log for the session — leaving one file where the user may have intended zero.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are P2 quality concerns that do not affect production behaviour.

The production code changes are mechanically correct: the verbose flag is cleanly removed, Debug fast-paths are in place, and the retention-1 arithmetic is right for all non-zero values. The two remaining issues (test isolation via debugOnce and the retention==0 edge case) are P2 concerns that don't affect real users in the default configuration.

internal/utils/filename_test.go (integration test may not verify log writes), cmd/root_startup.go (retention==0 edge case)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/utils/debug.go | Removes verbose flag and adds IsLoggingEnabled(); Debug fast-path and ConfigureDebug contract are correct for production use; debugOnce singleton is not resettable (pre-existing design limitation affecting test isolation). |
| internal/utils/filename.go | Drops the verbose parameter and replaces fmt.Fprintf(os.Stderr) with Debug(); filetype.Match called once and result reused correctly; http.DetectContentType guarded by IsLoggingEnabled(). |
| cmd/root_startup.go | retention-1 logic correctly limits log count to the configured maximum; edge case where retention==0 still creates one log per session despite appearing to request zero logs. |
| internal/utils/filename_test.go | Existing tests correctly updated; new LoggingIntegration test may not exercise the debug-write path it claims to test due to debugOnce being spent by earlier tests in the binary. |
| cmd/root.go | verbose flag and SetVerbose call cleanly removed; stray blank line at top of PersistentPreRun is cosmetic. |
| internal/processing/probe.go | DetermineFilename call updated to drop the now-removed verbose argument; no other changes. |
| .github/ISSUE_TEMPLATE/bug_report.md | Bug-report template updated to reflect always-on logging; instructions simplified and numbered correctly. |
| docs/USAGE.md | --verbose/-v row removed from the persistent flags table; straightforward documentation cleanup. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Surge startup
initializeGlobalState] --> B[ConfigureDebug logsDir]
    B --> C{retention > 0?}
    C -- yes --> D[CleanupLogs retention-1]
    C -- no --> E[CleanupLogs retention]
    D --> F[New session log created
on first Debug call]
    E --> F

    G[DetermineFilename called] --> H[Apply heuristics
Content-Disposition / query / path]
    H --> I[Read 512-byte header]
    I --> J[filetype.Match header
one call, result cached]
    J --> K{IsLoggingEnabled?}
    K -- yes --> L[http.DetectContentType
Debug MIME + magic type]
    K -- no --> M[Skip expensive MIME log]
    L --> N[ZIP / extension inference
uses cached kind]
    M --> N
    N --> O[Return filename]

    subgraph Debug subsystem
        P[Debug format args] --> Q{logsDir empty?}
        Q -- yes --> R[return fast path]
        Q -- no --> S[debugOnce.Do
create log file]
        S --> T[Write timestamped line]
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/utils/filename_test.go
Line: 159-183

Comment:
**`debugOnce` may already be spent when this test runs**

`debugOnce` is a package-level `sync.Once` that fires exactly once for the entire test binary run. `TestCleanupLogs` (in `debug_test.go`) defers `utils.ConfigureDebug(config.GetLogsDir())`, which restores `logsDir` to the real system logs path before returning. If any subsequent test calls `Debug(...)` with that `logsDir` set (e.g., `TestDetermineFilename_PriorityOrder` calls `DetermineFilename` which calls `Debug` on several code paths), `debugOnce.Do` fires against the real logs directory — not a temp directory.

When `TestDetermineFilename_LoggingIntegration` then calls `ConfigureDebug(tempDir)` and invokes `DetermineFilename`, `debugOnce.Do` is already a no-op. All `Debug` writes still go to the original file (or to `nil` if that file couldn't be created), never to `tempDir`. The test therefore only validates the filename return value — already covered by `TestDetermineFilename_PriorityOrder` — rather than the debug-logging integration it is named after.

To reliably test the logging path, the debug subsystem needs a way to reset its state between tests (e.g., a `resetDebugForTesting()` function that zeroes out both `logsDir` and `debugOnce`), or the test should verify that a log file was actually written to `tempDir`:

```go
entries, err := os.ReadDir(tempDir)
if err != nil || len(entries) == 0 {
    t.Error("expected a debug log file to be written to the configured temp dir")
}
```

Without such an assertion, a future regression in the `Debug`→file-write path would not be caught by this test.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: cmd/root_startup.go
Line: 56-60

Comment:
**Retention of `0` still produces one log after cleanup**

The guard `if retention > 0` correctly avoids underflow, but when `retention == 0` the else-branch calls `CleanupLogs(0)` (deletes all existing logs) and then a new log is created immediately after. A user who explicitly sets `log_retention_count: 0` expecting zero persistent logs will end up with one log per session.

`CleanupLogs` already interprets negative values as "keep all logs". If `0` is intended to mean "keep none / disable logging", the startup code should also skip `ConfigureDebug` entirely (or call `ConfigureDebug("")`) in that case:

```go
if retention == 0 {
    // User requested no log persistence; skip logging entirely
    utils.ConfigureDebug("")
    return nil
}
utils.ConfigureDebug(logsDir)
utils.CleanupLogs(retention - 1)
```

If `0` is instead meant as "use default", that should be documented in the settings struct and handled accordingly.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor: optimize debug logging by addi..."](https://github.com/surgedm/surge/commit/d77cbd227fc6c30249c395d14ce1769ed9829f79) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27140159)</sub>

**Context used:**

- Rule used - What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))

<!-- /greptile_comment -->