### PR TITLE
fix(tui): show Conns: 1 for single-connection downloads

### DIFF
--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -909,10 +909,11 @@ func renderFocusedDetails(d *DownloadModel, w int, spinnerView string) string {
 	}
 	isActive := !d.done && !d.paused && !d.pausing && d.Speed > 0
 	if isActive {
-		connStr := "0"
-		if d.Connections > 0 {
-			connStr = fmt.Sprintf("%d", d.Connections)
+		conns := d.Connections
+		if conns == 0 {
+			conns = 1 // Single-connection download (range requests not supported)
 		}
+		connStr := fmt.Sprintf("%d", conns)
 		leftColItems = append(leftColItems, lipgloss.JoinHorizontal(lipgloss.Left, StatsLabelStyle.Width(7).Render("Conns:"), StatsValueStyle.Render(connStr)))
 	}
 	leftCol := lipgloss.JoinVertical(lipgloss.Left, leftColItems...)


### PR DESCRIPTION
## Summary

When a download doesn't support range requests (SingleDownloader), the TUI shows "Conns: 0" even though there's an active connection transferring data.

## Why this matters

Showing 0 connections while a download is actively running with nonzero speed is confusing. The SingleDownloader uses one connection but the `ActiveWorkers` atomic counter doesn't track it, so `ProgressState.GetProgress()` returns 0 for the connections field.

## Changes

- `internal/tui/view.go` (line 912): When a download is active (`speed > 0`) and reports 0 connections, display 1 instead. An active download with speed must have at least one connection.

## Testing

- Verified the change only affects the display string in the TUI stats section
- Active multi-connection downloads still show the correct count from `d.Connections`
- The fallback to 1 only triggers when `d.Connections == 0` AND the download is active

Fixes #287

This contribution was developed with AI assistance (Claude Code).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a TUI cosmetic issue where single-connection downloads (served by `SingleDownloader`, which never increments `ActiveWorkers`) displayed "Conns: 0" during an active transfer. The fix adds a display-layer fallback in `renderFocusedDetails`: when `isActive` is true and `d.Connections == 0`, the rendered value is coerced to 1.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — change is display-only, scoped to a single render path, and has no effect on download logic or data integrity.
- All findings are P2 (comment quality, missing test, architectural suggestion). No logic bugs or data correctness issues were identified. The guard condition correctly mirrors the existing `isActive` check and cannot over-report connections for multi-connection downloads.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/tui/view.go | Display-layer fix to show "Conns: 1" instead of "Conns: 0" for active single-connection downloads; compensates for SingleDownloader never incrementing ActiveWorkers, but leaves the root value in ProgressState.GetProgress() still reporting 0. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[renderFocusedDetails] --> B{isActive?\nnot done, not paused,\nSpeed > 0}
    B -- No --> C[Skip Conns row]
    B -- Yes --> D{d.Connections == 0?}
    D -- No --> E[conns = d.Connections\nfrom ActiveWorkers]
    D -- Yes --> F["conns = 1\n(SingleDownloader fallback)"]
    E --> G[Render 'Conns: N']
    F --> G

    subgraph Root Cause
        H[SingleDownloader.Download] --> I[ActiveWorkers never\nincremented/decremented]
        I --> J[GetProgress returns\nconnections = 0]
        J --> D
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/tui/view.go
Line: 914

Comment:
**Comment explains "what", not "why"**

The comment restates what the guard does rather than explaining why this assumption is safe. A reader still needs to know *why* `conns` can be 0 for an active download. Consider something like: `// ActiveWorkers is only incremented by the concurrent downloader; SingleDownloader doesn't update it, so speed > 0 with 0 connections means exactly one single-threaded connection`.

```suggestion
			conns = 1 // ActiveWorkers is only updated by concurrent workers; SingleDownloader never increments it, so speed>0 with 0 reported conns means one active single-connection transfer
```

**Rule Used:** What: Comments must explain *why* code exists, not... ([source](https://app.greptile.com/review/custom-context?memory=4e45ef13-32c2-4753-8060-a44ef767144d))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/tui/view.go
Line: 911-918

Comment:
**Consider fixing at the source rather than the display layer**

This compensates for the missing `ActiveWorkers` increment in `SingleDownloader.Download()`. Patching the display layer means any other consumer of `ProgressState.GetProgress()` (e.g. remote service, polling events) still sees 0 connections for single-connection downloads. Incrementing `ActiveWorkers` at the start of `Download()` and decrementing it on return would fix the value at the source and remove the need for this view-layer special case.

**Rule Used:** # Code Review Rule: Suggest Architectural Improvem... ([source](https://app.greptile.com/review/custom-context?memory=4d82344e-33c4-4e14-bbc7-81d79af11b7e))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/tui/view.go
Line: 911-918

Comment:
**No test coverage for this render path**

`view_test.go` exists but has no test for `renderFocusedDetails` with `Connections == 0 && Speed > 0`. Adding a case there would prevent a future regression where someone removes the guard and the UI silently reverts to showing "Conns: 0".

**Rule Used:** What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tui): show Conns: 1 for single-conne..."](https://github.com/surgedm/surge/commit/9fd4805c277526e4c3ff86ce6a554957285e5a17) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27253834)</sub>

> Greptile also left **3 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Rule used - What: Comments must explain *why* code exists, not... ([source](https://app.greptile.com/review/custom-context?memory=4e45ef13-32c2-4753-8060-a44ef767144d))
- Rule used - # Code Review Rule: Suggest Architectural Improvem... ([source](https://app.greptile.com/review/custom-context?memory=4d82344e-33c4-4e14-bbc7-81d79af11b7e))
- Rule used - What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))
</details>

<!-- /greptile_comment -->