### PR TITLE
 feat: add separate notification settings for download added, completed, failed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 # binary
-surge
 *.surge
 Surge
-surge_bin
 
 # python + uv stuff
 .python-version
@@ -19,10 +17,3 @@ logs/
 dist/
 build/
 .goreleaser-extra/
-
-# secrets
-.github_token
-.env
-
-# temp markdowns
-implementation_plan.md

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -54,6 +54,9 @@ Surge follows OS conventions for storing its files. Below is a breakdown of ever
 | `default_download_dir` | string | Directory where new downloads are saved. If empty, defaults to `~/Downloads` or current directory. | `""`    |
 | `allow_remote_open_actions` | bool | Allow `/open-file` and `/open-folder` API requests from remote clients. Keep disabled unless you trust your network and auth setup. | `false` |
 | `warn_on_duplicate`    | bool   | Show a warning when adding a download that already exists in the list.                             | `true`  |
+| `download_complete_notification` | bool | Show system notification when a download finishes successfully.                                    | `true`  |
+| `download_failed_notification` | bool | Show system notification when a download fails.                                                    | `true`  |
+| `download_added_notification` | bool | Show system notification when a download is added to the queue.                                  | `false` |
 | `extension_prompt`     | bool   | Prompt for confirmation in the TUI when adding downloads via the browser extension.                | `false` |
 | `auto_resume`          | bool   | Automatically resume paused downloads when Surge starts.                                           | `false` |
 | `skip_update_check`    | bool   | Disable automatic check for new versions on startup.                                               | `false` |

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -128,7 +128,7 @@ func DefaultSettings() *Settings {
 		General: GeneralSettings{
 			DefaultDownloadDir:           defaultDir,
 			WarnOnDuplicate:              true,
-			DownloadCompleteNotification: false,
+			DownloadCompleteNotification: true,
 			DownloadFailedNotification:   true,
 			DownloadAddedNotification:    false,
 			AllowRemoteOpenActions:       false,

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -21,6 +21,8 @@ type GeneralSettings struct {
 	DefaultDownloadDir           string     `json:"default_download_dir"`
 	WarnOnDuplicate              bool       `json:"warn_on_duplicate"`
 	DownloadCompleteNotification bool       `json:"download_complete_notification"`
+	DownloadFailedNotification   bool       `json:"download_failed_notification"`
+	DownloadAddedNotification    bool       `json:"download_added_notification"`
 	AllowRemoteOpenActions       bool       `json:"allow_remote_open_actions"`
 	ExtensionPrompt              bool       `json:"extension_prompt"`
 	AutoResume                   bool       `json:"auto_resume"`
@@ -73,6 +75,8 @@ func GetSettingsMetadata() map[string][]SettingMeta {
 		"General": {
 			{Key: "default_download_dir", Label: "Default Download Dir", Description: "Default directory for new downloads. Leave empty to use current directory.", Type: "string"},
 			{Key: "download_complete_notification", Label: "Download Complete Notification", Description: "Show system notification when a download finishes.", Type: "bool"},
+			{Key: "download_added_notification", Label: "Download Added Notification", Description: "Show system notification when a download is added.", Type: "bool"},
+			{Key: "download_failed_notification", Label: "Download Failed Notification", Description: "Show system notification when a download fails.", Type: "bool"},
 			{Key: "allow_remote_open_actions", Label: "Allow Remote Open Actions", Description: "Allow /open-file and /open-folder API calls from non-loopback clients. Disabled by default for security.", Type: "bool"},
 			{Key: "warn_on_duplicate", Label: "Warn on Duplicate", Description: "Show warning when adding a download that already exists.", Type: "bool"},
 			{Key: "extension_prompt", Label: "Extension Prompt", Description: "Prompt for confirmation when adding downloads via browser extension.", Type: "bool"},
@@ -124,7 +128,9 @@ func DefaultSettings() *Settings {
 		General: GeneralSettings{
 			DefaultDownloadDir:           defaultDir,
 			WarnOnDuplicate:              true,
-			DownloadCompleteNotification: true,
+			DownloadCompleteNotification: false,
+			DownloadFailedNotification:   true,
+			DownloadAddedNotification:    false,
 			AllowRemoteOpenActions:       false,
 			ExtensionPrompt:              false,
 			AutoResume:                   false,

--- a/internal/processing/events.go
+++ b/internal/processing/events.go
@@ -107,7 +107,7 @@ func (mgr *LifecycleManager) StartEventWorker(ch <-chan interface{}) {
 				if m.Total > 0 {
 					totalStr = fmt.Sprintf(" — %s", utils.ConvertBytesToHumanReadable(m.Total))
 				}
-				notify(fmt.Sprintf("Download Added: %s", m.Filename), fmt.Sprintf("Started downloading%s", totalStr))
+				notify(fmt.Sprintf("Download Started: %s", m.Filename), fmt.Sprintf("Started downloading%s", totalStr))
 			}
 
 		case events.DownloadPausedMsg:
@@ -255,7 +255,7 @@ func (mgr *LifecycleManager) StartEventWorker(ch <-chan interface{}) {
 				if err != nil {
 					msg = err.Error()
 				}
-				if settings := mgr.GetSettings(); settings != nil && settings.General.DownloadCompleteNotification {
+				if settings := mgr.GetSettings(); settings != nil && settings.General.DownloadFailedNotification {
 					notify(fmt.Sprintf("Download failed: %s", filename), msg)
 				}
 				break
@@ -314,7 +314,7 @@ func (mgr *LifecycleManager) StartEventWorker(ch <-chan interface{}) {
 					utils.Debug("Lifecycle: Failed to remove incomplete file after error: %v", err)
 				}
 			}
-			if settings := mgr.GetSettings(); settings != nil && settings.General.DownloadCompleteNotification {
+			if settings := mgr.GetSettings(); settings != nil && settings.General.DownloadFailedNotification {
 
 				filename := m.Filename
 				if filename == "" && existing != nil {

--- a/internal/processing/events.go
+++ b/internal/processing/events.go
@@ -102,14 +102,6 @@ func (mgr *LifecycleManager) StartEventWorker(ch <-chan interface{}) {
 				utils.Debug("Lifecycle: Failed to save initial download state: %v", err)
 			}
 
-			if settings := mgr.GetSettings(); settings != nil && settings.General.DownloadAddedNotification {
-				totalStr := ""
-				if m.Total > 0 {
-					totalStr = fmt.Sprintf(" — %s", utils.ConvertBytesToHumanReadable(m.Total))
-				}
-				notify(fmt.Sprintf("Download Started: %s", m.Filename), fmt.Sprintf("Started downloading%s", totalStr))
-			}
-
 		case events.DownloadPausedMsg:
 			if m.State == nil {
 				existing, _ := state.GetDownload(m.DownloadID)

--- a/internal/processing/events.go
+++ b/internal/processing/events.go
@@ -102,6 +102,14 @@ func (mgr *LifecycleManager) StartEventWorker(ch <-chan interface{}) {
 				utils.Debug("Lifecycle: Failed to save initial download state: %v", err)
 			}
 
+			if settings := mgr.GetSettings(); settings != nil && settings.General.DownloadAddedNotification {
+				totalStr := ""
+				if m.Total > 0 {
+					totalStr = fmt.Sprintf(" — %s", utils.ConvertBytesToHumanReadable(m.Total))
+				}
+				notify(fmt.Sprintf("Download Added: %s", m.Filename), fmt.Sprintf("Started downloading%s", totalStr))
+			}
+
 		case events.DownloadPausedMsg:
 			if m.State == nil {
 				existing, _ := state.GetDownload(m.DownloadID)
@@ -355,6 +363,10 @@ func (mgr *LifecycleManager) StartEventWorker(ch <-chan interface{}) {
 				Status:   "queued",
 			}); err != nil {
 				utils.Debug("Lifecycle: Failed to persist queued download: %v", err)
+			}
+
+			if settings := mgr.GetSettings(); settings != nil && settings.General.DownloadAddedNotification {
+				notify(fmt.Sprintf("Download Added: %s", m.Filename), "Download added to queue")
 			}
 
 		case events.BatchProgressMsg, events.ProgressMsg:

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -252,6 +252,8 @@ func (m RootModel) getSettingsValues(category string) map[string]interface{} {
 		values["default_download_dir"] = m.Settings.General.DefaultDownloadDir
 		values["warn_on_duplicate"] = m.Settings.General.WarnOnDuplicate
 		values["download_complete_notification"] = m.Settings.General.DownloadCompleteNotification
+		values["download_added_notification"] = m.Settings.General.DownloadAddedNotification
+		values["download_failed_notification"] = m.Settings.General.DownloadFailedNotification
 		values["allow_remote_open_actions"] = m.Settings.General.AllowRemoteOpenActions
 		values["extension_prompt"] = m.Settings.General.ExtensionPrompt
 		values["auto_resume"] = m.Settings.General.AutoResume
@@ -332,6 +334,12 @@ func (m *RootModel) setGeneralSetting(key, value, typ string) error {
 		m.Settings.General.DefaultDownloadDir = value
 	case "warn_on_duplicate":
 		m.Settings.General.WarnOnDuplicate = !m.Settings.General.WarnOnDuplicate
+	case "download_complete_notification":
+		m.Settings.General.DownloadCompleteNotification = !m.Settings.General.DownloadCompleteNotification
+	case "download_added_notification":
+		m.Settings.General.DownloadAddedNotification = !m.Settings.General.DownloadAddedNotification
+	case "download_failed_notification":
+		m.Settings.General.DownloadFailedNotification = !m.Settings.General.DownloadFailedNotification
 	case "allow_remote_open_actions":
 		m.Settings.General.AllowRemoteOpenActions = !m.Settings.General.AllowRemoteOpenActions
 	case "extension_prompt":
@@ -637,6 +645,10 @@ func (m *RootModel) resetSettingToDefault(category, key string, defaults *config
 			m.Settings.General.WarnOnDuplicate = defaults.General.WarnOnDuplicate
 		case "download_complete_notification":
 			m.Settings.General.DownloadCompleteNotification = defaults.General.DownloadCompleteNotification
+		case "download_added_notification":
+			m.Settings.General.DownloadAddedNotification = defaults.General.DownloadAddedNotification
+		case "download_failed_notification":
+			m.Settings.General.DownloadFailedNotification = defaults.General.DownloadFailedNotification
 		case "extension_prompt":
 			m.Settings.General.ExtensionPrompt = defaults.General.ExtensionPrompt
 		case "auto_resume":


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds separate, independently toggleable notification settings for three download lifecycle events: download added (queued), download complete, and download failed. It also repairs a pre-existing bug where failed-download notifications were gated on `DownloadCompleteNotification` instead of a dedicated `DownloadFailedNotification` flag.

The core implementation — new `GeneralSettings` fields, updated `DefaultSettings()`, `GetSettingsMetadata()`, and the TUI `get/set/reset` handlers — is complete and internally consistent. Documentation is accurately updated.

**Key issues:**
- `.gitignore` accidentally removes `.env` and `.github_token` secret-file patterns in an unrelated hunk, allowing contributors to inadvertently commit credentials.
- The new `DownloadQueuedMsg` notification handler does not fall back to `DownloadID` when `Filename` is empty, unlike the existing complete and error handlers — producing a blank notification title for downloads without a known filename at queue time.
- No tests cover the three new/repaired notification code paths.

<h3>Confidence Score: 3/5</h3>

Do not merge until the .gitignore secret-pattern regression and the empty-filename notification bug are fixed.

Two P1 defects block merge: accidental removal of .env and .github_token from .gitignore (real commit-secret risk, unrelated to this feature) and missing filename fallback in the DownloadQueuedMsg notification path (will produce blank notification titles, inconsistent with the existing complete and error handlers). The rest of the implementation — new settings fields, TUI handlers, default values, and documentation — is solid.

.gitignore (secret pattern removal) and internal/processing/events.go (empty filename fallback in DownloadQueuedMsg handler)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .gitignore | Unrelated cleanup accidentally removes .env and .github_token secret-file patterns, introducing commit-secret risk; also drops trailing newline |
| docs/SETTINGS.md | Documentation correctly updated with all three new notification settings and accurate default values |
| internal/config/settings.go | New struct fields, metadata entries, and default values are correct, consistent, and correctly ordered |
| internal/processing/events.go | DownloadFailedNotification flag correctly repaired; new DownloadQueuedMsg notification path is missing filename fallback to DownloadID |
| internal/tui/view_settings.go | TUI get/set/reset handlers added for all three notification settings; complete and internally consistent |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Caller
    participant EW as StartEventWorker
    participant S as Settings
    participant N as notify()

    C->>EW: DownloadQueuedMsg{DownloadID, Filename, ...}
    EW->>EW: state.AddToMasterList(queued)
    EW->>S: mgr.GetSettings()
    S-->>EW: settings
    alt DownloadAddedNotification == true
        EW->>N: notify("Download Added: {Filename}", "Download added to queue")
    end

    C->>EW: DownloadCompleteMsg{DownloadID, Filename, Elapsed, Total}
    EW->>EW: finalizeCompletedFile(destPath)
    EW->>S: mgr.GetSettings()
    S-->>EW: settings
    alt DownloadCompleteNotification == true
        EW->>N: notify("Download Complete: {filename}", speed+elapsed)
    end

    C->>EW: DownloadErrorMsg{DownloadID, Filename, Err}
    EW->>S: mgr.GetSettings()
    S-->>EW: settings
    alt DownloadFailedNotification == true
        EW->>N: notify("Download failed: {filename}", err.Error())
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (4)</h3></summary>

1. `internal/processing/events.go`, line 258-260 ([link](https://github.com/surgedm/surge/blob/b960f587a0ce7e1cd80a453bd32ad2b80fd31a05/internal/processing/events.go#L258-L260)) 

   <a href="#"><img alt="P0" src="https://greptile-static-assets.s3.amazonaws.com/badges/p0.svg?v=7" align="top"></a> **`DownloadFailedNotification` is never consulted — failure notifications check the wrong flag**

   This failure notification path (finalization error inside `DownloadCompleteMsg`) still checks `settings.General.DownloadCompleteNotification` instead of the newly introduced `settings.General.DownloadFailedNotification`. The same bug exists at line 317 in the `DownloadErrorMsg` handler. As a result, the new setting is declared, defaulted, exposed in the UI, and persisted to disk — but is never actually read by the event worker. Toggling `Download Failed Notification` in settings has zero runtime effect.

   Fix both occurrences:

   **Rule Used:** What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: internal/processing/events.go
   Line: 258-260
   
   Comment:
   **`DownloadFailedNotification` is never consulted — failure notifications check the wrong flag**
   
   This failure notification path (finalization error inside `DownloadCompleteMsg`) still checks `settings.General.DownloadCompleteNotification` instead of the newly introduced `settings.General.DownloadFailedNotification`. The same bug exists at line 317 in the `DownloadErrorMsg` handler. As a result, the new setting is declared, defaulted, exposed in the UI, and persisted to disk — but is never actually read by the event worker. Toggling `Download Failed Notification` in settings has zero runtime effect.
   
   Fix both occurrences:
   
   
   **Rule Used:** What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `internal/processing/events.go`, line 317-319 ([link](https://github.com/surgedm/surge/blob/b960f587a0ce7e1cd80a453bd32ad2b80fd31a05/internal/processing/events.go#L317-L319)) 

   <a href="#"><img alt="P0" src="https://greptile-static-assets.s3.amazonaws.com/badges/p0.svg?v=7" align="top"></a> **Second failure notification site also checks the wrong flag**

   This `DownloadErrorMsg` handler gates on `settings.General.DownloadCompleteNotification` instead of `settings.General.DownloadFailedNotification`. This is the second of the two sites where failure notifications are fired — both need the same fix. See also the comment at line 258.

   **Rule Used:** What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: internal/processing/events.go
   Line: 317-319
   
   Comment:
   **Second failure notification site also checks the wrong flag**
   
   This `DownloadErrorMsg` handler gates on `settings.General.DownloadCompleteNotification` instead of `settings.General.DownloadFailedNotification`. This is the second of the two sites where failure notifications are fired — both need the same fix. See also the comment at line 258.
   
   
   
   **Rule Used:** What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

3. `internal/processing/events_internal_test.go`, line 291-334 ([link](https://github.com/surgedm/surge/blob/feff2fe98588297b9da63cc6a6f0e2f3779b2193/internal/processing/events_internal_test.go#L291-L334)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Broken test: wrong setting enables error notification**

   This test sends a `DownloadErrorMsg` (line 315) and enables `DownloadCompleteNotification = true` (line 295), then asserts exactly 1 notification call. After this PR, the `DownloadErrorMsg` handler is gated on `DownloadFailedNotification` (`events.go` line 317), not `DownloadCompleteNotification`. The test passes only because `DownloadFailedNotification` defaults to `true` in `DefaultSettings` — but it is asserting the wrong invariant and will silently mislead if that default ever changes.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/processing/events_internal_test.go
   Line: 291-334

   Comment:
   **Broken test: wrong setting enables error notification**

   This test sends a `DownloadErrorMsg` (line 315) and enables `DownloadCompleteNotification = true` (line 295), then asserts exactly 1 notification call. After this PR, the `DownloadErrorMsg` handler is gated on `DownloadFailedNotification` (`events.go` line 317), not `DownloadCompleteNotification`. The test passes only because `DownloadFailedNotification` defaults to `true` in `DefaultSettings` — but it is asserting the wrong invariant and will silently mislead if that default ever changes.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

4. `internal/processing/events_internal_test.go`, line 65-150 ([link](https://github.com/surgedm/surge/blob/feff2fe98588297b9da63cc6a6f0e2f3779b2193/internal/processing/events_internal_test.go#L65-L150)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Broken test: finalization-failure notification gated on wrong setting**

   Line 108 sets `DownloadCompleteNotification = true` and asserts that a `"Download failed"` notification fires when file finalization fails. After this PR, that code path (`events.go` line 258) is gated on `DownloadFailedNotification`, not `DownloadCompleteNotification`. The test passes only because `DownloadFailedNotification` defaults to `true`.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/processing/events_internal_test.go
   Line: 65-150

   Comment:
   **Broken test: finalization-failure notification gated on wrong setting**

   Line 108 sets `DownloadCompleteNotification = true` and asserts that a `"Download failed"` notification fires when file finalization fails. After this PR, that code path (`events.go` line 258) is gated on `DownloadFailedNotification`, not `DownloadCompleteNotification`. The test passes only because `DownloadFailedNotification` defaults to `true`.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .gitignore
Line: ?

Comment:
**Secret patterns removed from `.gitignore`**

This PR removes the `# secrets` block — `.github_token` and `.env` — along with unrelated entries (`surge`, `surge_bin`, `implementation_plan.md`). None of these are related to the notification feature. With `.env` and `.github_token` no longer gitignored, any contributor who has these files locally (a common pattern during development with OAuth tokens or local env vars) can now accidentally `git add .` and commit secrets. This looks like an unintentional inclusion in the diff. Recommend reverting the secret-pattern lines before merge.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/processing/events.go
Line: 360-362

Comment:
**Missing filename fallback — notification title will be blank**

When a download is queued without a known filename (e.g., a redirect URL or a URL with no path component), `m.Filename` is empty and the notification fires as `"Download Added: "` with no identifier. The existing `DownloadCompleteMsg` handler (lines 276–280) and `DownloadErrorMsg` handler (lines 311–316) both guard against this with an explicit fallback to `m.DownloadID`. Apply the same pattern here:

```suggestion
			if settings := mgr.GetSettings(); settings != nil && settings.General.DownloadAddedNotification {
				filename := m.Filename
				if filename == "" {
					filename = m.DownloadID
				}
				notify(fmt.Sprintf("Download Added: %s", filename), "Download added to queue")
			}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .gitignore
Line: 19

Comment:
**Missing newline at end of file**

The diff shows `\ No newline at end of file` after `.goreleaser-extra/`. POSIX requires text files to end with a newline, and most git tooling will flag this. Please add a trailing newline to the file.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/processing/events.go
Line: 360-362

Comment:
**No tests for new/repaired notification code paths**

The PR introduces one new notification path (`DownloadAddedNotification` on `DownloadQueuedMsg`) and repairs another (`DownloadFailedNotification`). Neither `internal/processing/events_test.go` nor `internal/config/settings_test.go` add coverage verifying that `notify` is called with the correct arguments when each flag is enabled, or that it is suppressed when disabled. Given that the `DownloadFailedNotification` bug existed precisely because the flag name was wrong, a targeted test per path would prevent regressions.

**Rule Used:** What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["docs: add notification settings for down..."](https://github.com/surgedm/surge/commit/6c19e045fe14c3693cee8ca5b5a8b0c34d1aef9e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27355200)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))

<!-- /greptile_comment -->