### PR TITLE
Fix for always downloading to default directory with firefox extension

### DIFF
--- a/extension-firefox/background.js
+++ b/extension-firefox/background.js
@@ -685,7 +685,7 @@ async function handleDownloadIntercept(downloadItem) {
     pendingDuplicates.set(pendingId, {
       downloadItem,
       filename,
-      directory: '',
+      directory: directory,
       url: downloadItem.url,
       timestamp: Date.now()
     });
@@ -725,7 +725,7 @@ async function handleDownloadIntercept(downloadItem) {
     return; // Let browser continue - download is already in progress
   }
 
-  const { filename } = extractPathInfo(downloadItem);
+  const { filename, directory } = extractPathInfo(downloadItem);
 
   try {
     await browser.downloads.cancel(downloadItem.id);
@@ -734,7 +734,7 @@ async function handleDownloadIntercept(downloadItem) {
     const result = await sendToSurge(
       downloadItem.url,
       filename,
-      ''
+      directory
     );
 
     if (result.success) {

--- a/extension-firefox/background.js
+++ b/extension-firefox/background.js
@@ -685,7 +685,7 @@ async function handleDownloadIntercept(downloadItem) {
     pendingDuplicates.set(pendingId, {
       downloadItem,
       filename,
-      directory: directory,
+      directory,
       url: downloadItem.url,
       timestamp: Date.now()
     });


### PR DESCRIPTION
Pass non-empty directory information to `pendingDuplicates()` and `sendToSurge()`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a silent bug where the Firefox extension always sent an empty directory string to Surge, causing every download to land in Surge's default directory instead of the user-selected location.

The fix is minimal and correct: `handleDownloadIntercept` already called `extractPathInfo` to parse `downloadItem.filename` into `{ filename, directory }`, but the extracted `directory` was discarded in both the duplicate-confirmation path (`directory: ''` hardcoded in `pendingDuplicates.set`) and the normal download path (only `filename` was destructured before calling `sendToSurge`). Both call-sites now properly forward the extracted `directory`.

- `extractPathInfo` correctly handles Windows (`C:/…`) and POSIX (`/…`) absolute paths and is unchanged.
- `sendToSurge` already guards the path field with `if (absolutePath)`, so downloads with no directory information still fall back to Surge's default — no regression risk.
- The duplicate-confirmation handler (`confirmDuplicate` message case) also reads `pending.directory` when calling `sendToSurge`, so it too now benefits from the correct stored value.

<h3>Confidence Score: 5/5</h3>

Safe to merge — targeted two-line fix with no regression risk

The change is minimal and precisely correct: it stops discarding the already-extracted directory in two call-sites. The guard in sendToSurge (if absolutePath) preserves fallback behaviour when no directory is present. No new logic is introduced and no existing behaviour is broken.

No files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| extension-firefox/background.js | Passes extracted directory from extractPathInfo to both pendingDuplicates and sendToSurge, fixing the always-default-directory bug |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser
    participant handleDownloadIntercept
    participant extractPathInfo
    participant Target as sendToSurge / pendingDuplicates

    Browser->>handleDownloadIntercept: onCreated(downloadItem)
    alt duplicate detected
        handleDownloadIntercept->>extractPathInfo: extractPathInfo(downloadItem)
        extractPathInfo-->>handleDownloadIntercept: { filename, directory }
        handleDownloadIntercept->>Target: pendingDuplicates.set(id, { filename, directory, … })
        Note over Target: Previously directory was hardcoded ''
    else surge running
        handleDownloadIntercept->>extractPathInfo: extractPathInfo(downloadItem)
        extractPathInfo-->>handleDownloadIntercept: { filename, directory }
        handleDownloadIntercept->>Target: sendToSurge(url, filename, directory)
        Note over Target: Previously directory was hardcoded ''
        Target-->>handleDownloadIntercept: { success }
    end
```

<sub>**[Greploops](https://www.greptile.com/docs/mcp-v2/skills#greploop)** — Automatically fix all review issues by running `/greploops` in [Claude Code](https://claude.ai/download). It iterates: fix, push, re-review, repeat until 5/5 confidence.<br>Use the **[Greptile plugin for Claude Code](https://www.greptile.com/docs/integrations/claude-code#claude-code-plugin)** to query reviews, search comments, and manage custom context directly from your terminal.</sub>

<sub>Reviews (2): Last reviewed commit: ["shorthand for directory path"](https://github.com/surgedm/surge/commit/458765c51639f02d0155de02ba21e92eae85a6d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27357944)</sub>

<!-- /greptile_comment -->