### PR TITLE
refactor: make LifecycleManager the sole owner of all download management logic

### DIFF
--- a/cmd/autoresume_test.go
+++ b/cmd/autoresume_test.go
@@ -83,14 +83,19 @@ func TestCmd_AutoResume_Execution(t *testing.T) {
 
 	GlobalLifecycle = processing.NewLifecycleManager(nil, nil, nil)
 	GlobalLifecycle.SetEngineHooks(processing.EngineHooks{
-		Pause:        GlobalPool.Pause,
-		Resume:       GlobalPool.Resume,
-		AddConfig:    GlobalPool.Add,
-		GetStatus:    GlobalPool.GetStatus,
-		PublishEvent: GlobalService.Publish,
+		Pause:               GlobalPool.Pause,
+		ExtractPausedConfig: GlobalPool.ExtractPausedConfig,
+		AddConfig:           GlobalPool.Add,
+		GetStatus:           GlobalPool.GetStatus,
+		Cancel:              GlobalPool.Cancel,
+		UpdateURL:           GlobalPool.UpdateURL,
+		PublishEvent:        GlobalService.Publish,
 	})
 	if svc, ok := GlobalService.(*core.LocalDownloadService); ok {
-		svc.SetLifecycleHooks(GlobalLifecycle.Pause, GlobalLifecycle.Resume, GlobalLifecycle.ResumeBatch)
+		svc.SetLifecycleHooks(
+			GlobalLifecycle.Pause, GlobalLifecycle.Resume, GlobalLifecycle.ResumeBatch,
+			GlobalLifecycle.Cancel, GlobalLifecycle.UpdateURL,
+		)
 	}
 	defer func() {
 		_ = GlobalService.Shutdown()

--- a/cmd/autoresume_test.go
+++ b/cmd/autoresume_test.go
@@ -92,10 +92,13 @@ func TestCmd_AutoResume_Execution(t *testing.T) {
 		PublishEvent:        GlobalService.Publish,
 	})
 	if svc, ok := GlobalService.(*core.LocalDownloadService); ok {
-		svc.SetLifecycleHooks(
-			GlobalLifecycle.Pause, GlobalLifecycle.Resume, GlobalLifecycle.ResumeBatch,
-			GlobalLifecycle.Cancel, GlobalLifecycle.UpdateURL,
-		)
+		svc.SetLifecycleHooks(core.LifecycleHooks{
+			Pause:       GlobalLifecycle.Pause,
+			Resume:      GlobalLifecycle.Resume,
+			ResumeBatch: GlobalLifecycle.ResumeBatch,
+			Cancel:      GlobalLifecycle.Cancel,
+			UpdateURL:   GlobalLifecycle.UpdateURL,
+		})
 	}
 	defer func() {
 		_ = GlobalService.Shutdown()

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/engine/state"
+	"github.com/SurgeDM/Surge/internal/utils"
 )
 
 func resetSharedStateDB() error {
@@ -20,6 +21,7 @@ func resetSharedStateDB() error {
 }
 
 func TestMain(m *testing.M) {
+	utils.SuppressNotifications = true
 	tmpDir, err := os.MkdirTemp("", "surge-cmd-test-*")
 	if err == nil {
 		_ = os.Setenv("XDG_CONFIG_HOME", tmpDir)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -225,13 +225,13 @@ func ensureGlobalLocalServiceAndLifecycle() error {
 			PublishEvent:        localService.Publish,
 		})
 
-		localService.SetLifecycleHooks(
-			lifecycle.Pause,
-			lifecycle.Resume,
-			lifecycle.ResumeBatch,
-			lifecycle.Cancel,
-			lifecycle.UpdateURL,
-		)
+		localService.SetLifecycleHooks(core.LifecycleHooks{
+			Pause:       lifecycle.Pause,
+			Resume:      lifecycle.Resume,
+			ResumeBatch: lifecycle.ResumeBatch,
+			Cancel:      lifecycle.Cancel,
+			UpdateURL:   lifecycle.UpdateURL,
+		})
 	} else {
 		_, err := ensureLocalLifecycle(GlobalService, currentPoolConfigs)
 		return err

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -216,14 +216,22 @@ func ensureGlobalLocalServiceAndLifecycle() error {
 		}
 
 		lifecycle.SetEngineHooks(processing.EngineHooks{
-			Pause:        GlobalPool.Pause,
-			Resume:       GlobalPool.Resume,
-			GetStatus:    GlobalPool.GetStatus,
-			AddConfig:    GlobalPool.Add,
-			PublishEvent: localService.Publish,
+			Pause:               GlobalPool.Pause,
+			ExtractPausedConfig: GlobalPool.ExtractPausedConfig,
+			GetStatus:           GlobalPool.GetStatus,
+			AddConfig:           GlobalPool.Add,
+			Cancel:              GlobalPool.Cancel,
+			UpdateURL:           GlobalPool.UpdateURL,
+			PublishEvent:        localService.Publish,
 		})
 
-		localService.SetLifecycleHooks(lifecycle.Pause, lifecycle.Resume, lifecycle.ResumeBatch)
+		localService.SetLifecycleHooks(
+			lifecycle.Pause,
+			lifecycle.Resume,
+			lifecycle.ResumeBatch,
+			lifecycle.Cancel,
+			lifecycle.UpdateURL,
+		)
 	} else {
 		_, err := ensureLocalLifecycle(GlobalService, currentPoolConfigs)
 		return err

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -347,7 +347,7 @@ func acquireRootInstanceLock() (func(), error) {
 	}
 
 	if !isMaster {
-		return nil, fmt.Errorf("Surge is already running. Use 'surge add <url>' to add a download to the active instance")
+		return nil, fmt.Errorf("surge is already running. Use 'surge add <url>' to add a download to the active instance")
 	}
 
 	return func() {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -37,7 +37,7 @@ var serverStartCmd = &cobra.Command{
 		}
 
 		if !isMaster {
-			return fmt.Errorf("Surge server is already running")
+			return fmt.Errorf("surge server is already running")
 		}
 		defer func() {
 			if err := ReleaseLock(); err != nil {

--- a/cmd/startup_test.go
+++ b/cmd/startup_test.go
@@ -39,14 +39,19 @@ func TestServer_Startup_HandlesResume(t *testing.T) {
 
 	GlobalLifecycle = processing.NewLifecycleManager(nil, nil, nil)
 	GlobalLifecycle.SetEngineHooks(processing.EngineHooks{
-		Pause:        GlobalPool.Pause,
-		Resume:       GlobalPool.Resume,
-		AddConfig:    GlobalPool.Add,
-		GetStatus:    GlobalPool.GetStatus,
-		PublishEvent: GlobalService.Publish,
+		Pause:               GlobalPool.Pause,
+		ExtractPausedConfig: GlobalPool.ExtractPausedConfig,
+		AddConfig:           GlobalPool.Add,
+		GetStatus:           GlobalPool.GetStatus,
+		Cancel:              GlobalPool.Cancel,
+		UpdateURL:           GlobalPool.UpdateURL,
+		PublishEvent:        GlobalService.Publish,
 	})
 	if svc, ok := GlobalService.(*core.LocalDownloadService); ok {
-		svc.SetLifecycleHooks(GlobalLifecycle.Pause, GlobalLifecycle.Resume, GlobalLifecycle.ResumeBatch)
+		svc.SetLifecycleHooks(
+			GlobalLifecycle.Pause, GlobalLifecycle.Resume, GlobalLifecycle.ResumeBatch,
+			GlobalLifecycle.Cancel, GlobalLifecycle.UpdateURL,
+		)
 	}
 	defer func() {
 		GlobalLifecycle = nil

--- a/cmd/startup_test.go
+++ b/cmd/startup_test.go
@@ -48,10 +48,13 @@ func TestServer_Startup_HandlesResume(t *testing.T) {
 		PublishEvent:        GlobalService.Publish,
 	})
 	if svc, ok := GlobalService.(*core.LocalDownloadService); ok {
-		svc.SetLifecycleHooks(
-			GlobalLifecycle.Pause, GlobalLifecycle.Resume, GlobalLifecycle.ResumeBatch,
-			GlobalLifecycle.Cancel, GlobalLifecycle.UpdateURL,
-		)
+		svc.SetLifecycleHooks(core.LifecycleHooks{
+			Pause:       GlobalLifecycle.Pause,
+			Resume:      GlobalLifecycle.Resume,
+			ResumeBatch: GlobalLifecycle.ResumeBatch,
+			Cancel:      GlobalLifecycle.Cancel,
+			UpdateURL:   GlobalLifecycle.UpdateURL,
+		})
 	}
 	defer func() {
 		GlobalLifecycle = nil

--- a/internal/core/local_service.go
+++ b/internal/core/local_service.go
@@ -66,11 +66,16 @@ type LocalDownloadService struct {
 	settings   *config.Settings
 	settingsMu sync.RWMutex
 
-	pauseFunc       func(id string) error
-	resumeFunc      func(id string) error
-	resumeBatchFunc func(ids []string) []error
-	deleteFunc      func(id string) error
-	updateURLFunc   func(id, newURL string) error
+	lifecycleHooks LifecycleHooks
+}
+
+// LifecycleHooks routes service-level management calls through the LifecycleManager.
+type LifecycleHooks struct {
+	Pause       func(id string) error
+	Resume      func(id string) error
+	ResumeBatch func(ids []string) []error
+	Cancel      func(id string) error
+	UpdateURL   func(id, newURL string) error
 }
 
 const (
@@ -517,24 +522,24 @@ func (s *LocalDownloadService) add(url string, path string, filename string, mir
 
 // Pause pauses an active download.
 func (s *LocalDownloadService) Pause(id string) error {
-	if s.pauseFunc != nil {
-		return s.pauseFunc(id)
+	if s.lifecycleHooks.Pause != nil {
+		return s.lifecycleHooks.Pause(id)
 	}
 	return fmt.Errorf("PauseFunc not initialized")
 }
 
 // Resume resumes a paused download.
 func (s *LocalDownloadService) Resume(id string) error {
-	if s.resumeFunc != nil {
-		return s.resumeFunc(id)
+	if s.lifecycleHooks.Resume != nil {
+		return s.lifecycleHooks.Resume(id)
 	}
 	return fmt.Errorf("ResumeFunc not initialized")
 }
 
 // ResumeBatch resumes multiple paused downloads efficiently.
 func (s *LocalDownloadService) ResumeBatch(ids []string) []error {
-	if s.resumeBatchFunc != nil {
-		return s.resumeBatchFunc(ids)
+	if s.lifecycleHooks.ResumeBatch != nil {
+		return s.lifecycleHooks.ResumeBatch(ids)
 	}
 	errs := make([]error, len(ids))
 	for i := range errs {
@@ -545,24 +550,14 @@ func (s *LocalDownloadService) ResumeBatch(ids []string) []error {
 
 // SetLifecycleHooks wires the processing layer into the service so
 // pause/resume/cancel/updateURL calls are routed through the lifecycle manager.
-func (s *LocalDownloadService) SetLifecycleHooks(
-	pause func(string) error,
-	resume func(string) error,
-	resumeBatch func([]string) []error,
-	cancel func(string) error,
-	updateURL func(string, string) error,
-) {
-	s.pauseFunc = pause
-	s.resumeFunc = resume
-	s.resumeBatchFunc = resumeBatch
-	s.deleteFunc = cancel
-	s.updateURLFunc = updateURL
+func (s *LocalDownloadService) SetLifecycleHooks(hooks LifecycleHooks) {
+	s.lifecycleHooks = hooks
 }
 
 // UpdateURL updates the URL of a paused or errored download
 func (s *LocalDownloadService) UpdateURL(id string, newURL string) error {
-	if s.updateURLFunc != nil {
-		return s.updateURLFunc(id, newURL)
+	if s.lifecycleHooks.UpdateURL != nil {
+		return s.lifecycleHooks.UpdateURL(id, newURL)
 	}
 	// Fallback: update pool in-memory only (no DB persistence)
 	if s.Pool == nil {
@@ -573,8 +568,8 @@ func (s *LocalDownloadService) UpdateURL(id string, newURL string) error {
 
 // Delete cancels and removes a download.
 func (s *LocalDownloadService) Delete(id string) error {
-	if s.deleteFunc != nil {
-		return s.deleteFunc(id)
+	if s.lifecycleHooks.Cancel != nil {
+		return s.lifecycleHooks.Cancel(id)
 	}
 	// Fallback when lifecycle hooks not wired (e.g. tests)
 	if s.Pool == nil {

--- a/internal/core/local_service.go
+++ b/internal/core/local_service.go
@@ -69,6 +69,8 @@ type LocalDownloadService struct {
 	pauseFunc       func(id string) error
 	resumeFunc      func(id string) error
 	resumeBatchFunc func(ids []string) []error
+	deleteFunc      func(id string) error
+	updateURLFunc   func(id, newURL string) error
 }
 
 const (
@@ -542,62 +544,51 @@ func (s *LocalDownloadService) ResumeBatch(ids []string) []error {
 }
 
 // SetLifecycleHooks wires the processing layer into the service so
-// pause/resume calls are routed through the event-worker lifecycle.
-func (s *LocalDownloadService) SetLifecycleHooks(pause func(string) error, resume func(string) error, resumeBatch func([]string) []error) {
+// pause/resume/cancel/updateURL calls are routed through the lifecycle manager.
+func (s *LocalDownloadService) SetLifecycleHooks(
+	pause func(string) error,
+	resume func(string) error,
+	resumeBatch func([]string) []error,
+	cancel func(string) error,
+	updateURL func(string, string) error,
+) {
 	s.pauseFunc = pause
 	s.resumeFunc = resume
 	s.resumeBatchFunc = resumeBatch
+	s.deleteFunc = cancel
+	s.updateURLFunc = updateURL
 }
 
 // UpdateURL updates the URL of a paused or errored download
 func (s *LocalDownloadService) UpdateURL(id string, newURL string) error {
+	if s.updateURLFunc != nil {
+		return s.updateURLFunc(id, newURL)
+	}
+	// Fallback: update pool in-memory only (no DB persistence)
 	if s.Pool == nil {
 		return fmt.Errorf("worker pool not initialized")
 	}
-
 	return s.Pool.UpdateURL(id, newURL)
 }
 
 // Delete cancels and removes a download.
 func (s *LocalDownloadService) Delete(id string) error {
+	if s.deleteFunc != nil {
+		return s.deleteFunc(id)
+	}
+	// Fallback when lifecycle hooks not wired (e.g. tests)
 	if s.Pool == nil {
 		return fmt.Errorf("worker pool not initialized")
 	}
-
-	removedFilename := ""
-	removedDestPath := ""
-	removedCompleted := false
-
-	// Capture runtime status before cancel; active downloads may not yet be in DB.
-	if st := s.Pool.GetStatus(id); st != nil {
-		if st.Filename != "" {
-			removedFilename = st.Filename
-		}
-		removedDestPath = st.DestPath
-		removedCompleted = st.Status == "completed"
-	}
-
 	s.Pool.Cancel(id)
-
-	// Cleanup persisted state if available
 	if entry, err := state.GetDownload(id); err == nil && entry != nil {
-		removedFilename = entry.Filename
-		if removedDestPath == "" {
-			removedDestPath = entry.DestPath
-		}
-		if entry.Status == "completed" {
-			removedCompleted = true
-		}
-	}
-
-	// Broadcast removal for multi-client UIs (including remote SSE clients).
-	// This also covers non-active (DB-only) deletes where WorkerPool.Cancel doesn't emit.
-	if s.InputCh != nil {
-		s.InputCh <- events.DownloadRemovedMsg{
-			DownloadID: id,
-			Filename:   removedFilename,
-			DestPath:   removedDestPath,
-			Completed:  removedCompleted,
+		if s.InputCh != nil {
+			s.InputCh <- events.DownloadRemovedMsg{
+				DownloadID: id,
+				Filename:   entry.Filename,
+				DestPath:   entry.DestPath,
+				Completed:  entry.Status == "completed",
+			}
 		}
 	}
 	return nil

--- a/internal/core/test_helpers_test.go
+++ b/internal/core/test_helpers_test.go
@@ -31,13 +31,15 @@ func startEventWorkerForTest(t *testing.T, svc *LocalDownloadService) func() {
 		mgr.StartEventWorker(stream)
 	}()
 
-	svc.SetLifecycleHooks(mgr.Pause, mgr.Resume, mgr.ResumeBatch)
+	svc.SetLifecycleHooks(mgr.Pause, mgr.Resume, mgr.ResumeBatch, mgr.Cancel, mgr.UpdateURL)
 	mgr.SetEngineHooks(processing.EngineHooks{
-		Pause:        svc.Pool.Pause,
-		Resume:       svc.Pool.Resume,
-		GetStatus:    svc.Pool.GetStatus,
-		AddConfig:    svc.Pool.Add,
-		PublishEvent: svc.Publish,
+		Pause:               svc.Pool.Pause,
+		ExtractPausedConfig: svc.Pool.ExtractPausedConfig,
+		GetStatus:           svc.Pool.GetStatus,
+		AddConfig:           svc.Pool.Add,
+		Cancel:              svc.Pool.Cancel,
+		UpdateURL:           svc.Pool.UpdateURL,
+		PublishEvent:        svc.Publish,
 	})
 
 	return func() {

--- a/internal/core/test_helpers_test.go
+++ b/internal/core/test_helpers_test.go
@@ -31,7 +31,13 @@ func startEventWorkerForTest(t *testing.T, svc *LocalDownloadService) func() {
 		mgr.StartEventWorker(stream)
 	}()
 
-	svc.SetLifecycleHooks(mgr.Pause, mgr.Resume, mgr.ResumeBatch, mgr.Cancel, mgr.UpdateURL)
+	svc.SetLifecycleHooks(LifecycleHooks{
+		Pause:       mgr.Pause,
+		Resume:      mgr.Resume,
+		ResumeBatch: mgr.ResumeBatch,
+		Cancel:      mgr.Cancel,
+		UpdateURL:   mgr.UpdateURL,
+	})
 	mgr.SetEngineHooks(processing.EngineHooks{
 		Pause:               svc.Pool.Pause,
 		ExtractPausedConfig: svc.Pool.ExtractPausedConfig,

--- a/internal/download/pool.go
+++ b/internal/download/pool.go
@@ -292,6 +292,9 @@ func (p *WorkerPool) ExtractPausedConfig(downloadID string) *types.DownloadConfi
 
 	cfg := ad.config
 	delete(p.downloads, downloadID)
+	if ad.config.State != nil {
+		ad.config.State.Resume()
+	}
 	return &cfg
 }
 

--- a/internal/download/pool.go
+++ b/internal/download/pool.go
@@ -8,8 +8,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/SurgeDM/Surge/internal/engine/events"
-	"github.com/SurgeDM/Surge/internal/engine/state"
 	"github.com/SurgeDM/Surge/internal/engine/types"
 	"github.com/SurgeDM/Surge/internal/utils"
 )
@@ -101,7 +99,8 @@ func resolveDestPath(cfg *types.DownloadConfig) string {
 	return destPath
 }
 
-// Add adds a new download task to the pool
+// Add adds a new download task to the pool. The caller (LifecycleManager) is
+// responsible for emitting any lifecycle events (e.g. DownloadQueuedMsg).
 func (p *WorkerPool) Add(cfg types.DownloadConfig) {
 	if cfg.ProgressCh == nil {
 		cfg.ProgressCh = p.progressCh
@@ -109,16 +108,6 @@ func (p *WorkerPool) Add(cfg types.DownloadConfig) {
 	p.mu.Lock()
 	p.queued[cfg.ID] = cfg
 	p.mu.Unlock()
-
-	if !cfg.IsResume {
-		p.trySendProgress(events.DownloadQueuedMsg{
-			DownloadID: cfg.ID,
-			Filename:   cfg.Filename,
-			URL:        cfg.URL,
-			DestPath:   resolveDestPath(&cfg),
-			Mirrors:    append([]string(nil), cfg.Mirrors...),
-		})
-	}
 
 	p.taskChan <- cfg
 }
@@ -177,7 +166,8 @@ func (p *WorkerPool) GetAll() []types.DownloadConfig {
 	return configs
 }
 
-// Pause pauses a specific download by ID. Returns true if found and pause initiated (or already paused), false otherwise.
+// Pause pauses a specific download by ID. Returns true if found and pause initiated
+// (or already paused), false otherwise. Pure mechanical operation — no events emitted.
 func (p *WorkerPool) Pause(downloadID string) bool {
 	p.mu.RLock()
 	ad, exists := p.downloads[downloadID]
@@ -230,8 +220,10 @@ func (p *WorkerPool) PauseAll() {
 	}
 }
 
-// Cancel cancels and removes a download by ID
-func (p *WorkerPool) Cancel(downloadID string) {
+// Cancel cancels and removes a download by ID. Returns metadata about what was
+// removed so the caller (LifecycleManager) can emit events and handle cleanup.
+// No events are emitted by the pool itself.
+func (p *WorkerPool) Cancel(downloadID string) types.CancelResult {
 	p.mu.Lock()
 	ad, activeExists := p.downloads[downloadID]
 	qCfg, queuedExists := p.queued[downloadID]
@@ -244,16 +236,15 @@ func (p *WorkerPool) Cancel(downloadID string) {
 	p.mu.Unlock()
 
 	if !activeExists && !queuedExists {
-		return
+		return types.CancelResult{}
 	}
 
-	removedFilename := ""
-	removedDestPath := ""
-	removedCompleted := false
+	result := types.CancelResult{Found: true, WasQueued: queuedExists && !activeExists}
+
 	if activeExists && ad != nil {
-		removedFilename = ad.config.Filename
-		removedDestPath = resolveDestPath(&ad.config)
-		removedCompleted = ad.config.State != nil && ad.config.State.Done.Load()
+		result.Filename = ad.config.Filename
+		result.DestPath = resolveDestPath(&ad.config)
+		result.Completed = ad.config.State != nil && ad.config.State.Done.Load()
 
 		// Cancel the context to stop workers
 		if ad.cancel != nil {
@@ -272,74 +263,40 @@ func (p *WorkerPool) Cancel(downloadID string) {
 			ad.config.State.Done.Store(true)
 		}
 	} else if queuedExists {
-		removedFilename = qCfg.Filename
-		removedDestPath = resolveDestPath(&qCfg)
+		result.Filename = qCfg.Filename
+		result.DestPath = resolveDestPath(&qCfg)
 	}
 
-	// Send removal message
-	p.trySendProgress(events.DownloadRemovedMsg{
-		DownloadID: downloadID,
-		Filename:   removedFilename,
-		DestPath:   removedDestPath,
-		Completed:  removedCompleted,
-	})
+	return result
 }
 
-// Resume resumes a paused download by ID. Returns true if found and resumed (or already running), false otherwise.
-func (p *WorkerPool) Resume(downloadID string) bool {
-	p.mu.RLock()
+// ExtractPausedConfig atomically removes a paused download from the pool and returns
+// its config (with state cleared for re-enqueue) so the LifecycleManager can resume it.
+// Returns nil if the download is not found, not paused, or still transitioning (pausing).
+func (p *WorkerPool) ExtractPausedConfig(downloadID string) *types.DownloadConfig {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	ad, exists := p.downloads[downloadID]
-	p.mu.RUnlock()
-
 	if !exists || ad == nil {
-		return false
+		return nil
 	}
 
-	// Prevent race: Don't resume if still pausing
-	if ad.config.State != nil && ad.config.State.IsPausing() {
-		utils.Debug("Resume ignored: download %s is still pausing", downloadID)
-		return false
+	// Cannot extract if still pausing or not actually paused
+	if ad.config.State == nil || !ad.config.State.IsPaused() || ad.config.State.IsPausing() {
+		return nil
 	}
 
-	// Idempotency: If already running (not paused), do nothing
-	if ad.config.State != nil && !ad.config.State.IsPaused() {
-		utils.Debug("Resume ignored: download %s is already running", downloadID)
-		return true
-	}
+	// Sync latest filename/path/mirrors from live state before handing off
+	syncConfigFromState(&ad.config)
 
-	// Clear paused flag and reset session start to avoid speed spikes/dips checks
-	if ad.config.State != nil {
-		ad.config.State.Resume()
-		ad.config.State.SyncSessionStart()
-		syncConfigFromState(&ad.config)
-	}
-
-	// Hydrate resume config from persisted pause snapshot when available.
-	if ad.config.URL != "" && ad.config.DestPath != "" {
-		if saved, err := state.LoadState(ad.config.URL, ad.config.DestPath); err == nil && saved != nil {
-			ad.config.SavedState = saved
-			if saved.TotalSize > 0 {
-				ad.config.TotalSize = saved.TotalSize
-			}
-			if len(saved.Tasks) > 0 {
-				ad.config.SupportsRange = true
-			}
-		}
-	}
-
-	// Re-queue the download
-	ad.config.IsResume = true
-	p.Add(ad.config)
-
-	// Send resume message
-	p.trySendProgress(events.DownloadResumedMsg{
-		DownloadID: downloadID,
-		Filename:   ad.config.Filename,
-	})
-	return true
+	cfg := ad.config
+	delete(p.downloads, downloadID)
+	return &cfg
 }
 
-// UpdateURL updates the URL of a download by ID.
+// UpdateURL updates the in-memory URL of a download by ID.
+// The caller (LifecycleManager) is responsible for persisting the change to the DB.
 // It fails if the download is actively downloading (not paused or errored).
 func (p *WorkerPool) UpdateURL(downloadID string, newURL string) error {
 	p.mu.RLock()
@@ -359,14 +316,14 @@ func (p *WorkerPool) UpdateURL(downloadID string, newURL string) error {
 			}
 		}
 
-		// Update the active download's config
+		// Update the active download's config (in-memory only)
 		ad.config.URL = newURL
 		if ad.config.State != nil {
 			ad.config.State.SetURL(newURL)
 		}
 	}
 
-	return state.UpdateURL(downloadID, newURL)
+	return nil
 }
 
 func (p *WorkerPool) worker() {
@@ -413,7 +370,7 @@ func (p *WorkerPool) worker() {
 
 		if isPaused {
 			utils.Debug("WorkerPool: Download %s paused cleanly", cfg.ID)
-			// If paused, we keep it in downloads map for potential resume
+			// If paused, we keep it in downloads map for potential resume via ExtractPausedConfig
 		} else if err != nil {
 			if cfg.State != nil {
 				cfg.State.SetError(err)
@@ -542,10 +499,6 @@ func (p *WorkerPool) trySendProgress(msg any) {
 
 // GracefulShutdown pauses all downloads and waits for them to save state
 func (p *WorkerPool) GracefulShutdown() {
-	// Persist queued downloads first so they don't disappear on process shutdown.
-	// These entries may not have started yet, so they do not have a .surge state snapshot.
-	p.persistQueuedForShutdown()
-
 	p.PauseAll()
 
 	// Wait for any downloads in "Pausing" state to finish transitioning
@@ -593,9 +546,4 @@ func (p *WorkerPool) GracefulShutdown() {
 	// so worker goroutines exit their range loop.
 	close(p.progressDone)
 	close(p.taskChan)
-}
-
-func (p *WorkerPool) persistQueuedForShutdown() {
-	// No-op: queued items are persisted when Add emits DownloadQueuedMsg,
-	// so shutdown only needs to drain active workers.
 }

--- a/internal/download/pool.go
+++ b/internal/download/pool.go
@@ -482,24 +482,6 @@ func (p *WorkerPool) GetStatus(id string) *types.DownloadStatus {
 	return status
 }
 
-// trySendProgress sends msg on progressCh unless progressDone has been closed,
-// preventing a panic from sending on a closed channel after shutdown.
-func (p *WorkerPool) trySendProgress(msg any) {
-	if p.progressCh == nil {
-		return
-	}
-	select {
-	case <-p.progressDone:
-		return
-	default:
-	}
-	select {
-	case <-p.progressDone:
-		return
-	case p.progressCh <- msg:
-	}
-}
-
 // GracefulShutdown pauses all downloads and waits for them to save state
 func (p *WorkerPool) GracefulShutdown() {
 	p.PauseAll()

--- a/internal/download/pool.go
+++ b/internal/download/pool.go
@@ -418,12 +418,7 @@ func (p *WorkerPool) worker() {
 			if cfg.State != nil {
 				cfg.State.SetError(err)
 			}
-			p.trySendProgress(events.DownloadErrorMsg{
-				DownloadID: cfg.ID,
-				Filename:   cfg.Filename,
-				DestPath:   resolveDestPath(&cfg),
-				Err:        err,
-			})
+			// Note: DownloadErrorMsg is already emitted by TUIDownload on the same progressCh.
 			// Clean up errored download from tracking (don't save to .surge)
 			p.mu.Lock()
 			delete(p.downloads, cfg.ID)

--- a/internal/download/pool.go
+++ b/internal/download/pool.go
@@ -302,29 +302,28 @@ func (p *WorkerPool) ExtractPausedConfig(downloadID string) *types.DownloadConfi
 // The caller (LifecycleManager) is responsible for persisting the change to the DB.
 // It fails if the download is actively downloading (not paused or errored).
 func (p *WorkerPool) UpdateURL(downloadID string, newURL string) error {
-	p.mu.RLock()
+	p.mu.Lock()
 	ad, exists := p.downloads[downloadID]
 	_, qExists := p.queued[downloadID]
-	p.mu.RUnlock()
 
 	if qExists {
+		p.mu.Unlock()
 		return fmt.Errorf("cannot update URL for a queued download, please cancel or wait for it to start")
 	}
 
 	if exists && ad != nil {
-		// If it exists in the active pool, it must be paused
 		if ad.config.State != nil && !ad.config.State.IsPaused() {
 			if ad.running.Load() {
+				p.mu.Unlock()
 				return fmt.Errorf("download is currently active, please pause it before updating the URL")
 			}
 		}
-
-		// Update the active download's config (in-memory only)
 		ad.config.URL = newURL
 		if ad.config.State != nil {
 			ad.config.State.SetURL(newURL)
 		}
 	}
+	p.mu.Unlock()
 
 	return nil
 }

--- a/internal/download/pool_test.go
+++ b/internal/download/pool_test.go
@@ -445,10 +445,9 @@ func TestWorkerPool_Cancel_QueuedDownload_RemovesFromQueueAndReturnsResult(t *te
 	}
 }
 
-// Resume logic has moved to LifecycleManager.Resume() which calls
+// Resume logic has been promoted to LifecycleManager.Resume(), which calls
 // pool.ExtractPausedConfig() for the hot path and state.LoadState() for the cold path.
-// Tests for that behavior live in internal/processing/ and internal/download/pool_test.go
-// (see TestWorkerPool_ExtractPausedConfig_* above).
+// Note: LifecycleManager.Resume/Cancel/UpdateURL currently lack dedicated unit tests.
 
 func TestWorkerPool_GracefulShutdown_PausesAll(t *testing.T) {
 	ch := make(chan any, 10)

--- a/internal/download/pool_test.go
+++ b/internal/download/pool_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/SurgeDM/Surge/internal/engine/events"
-	"github.com/SurgeDM/Surge/internal/engine/state"
 	"github.com/SurgeDM/Surge/internal/engine/types"
 )
 
@@ -286,16 +284,18 @@ func TestWorkerPool_Cancel_RemovesFromMap(t *testing.T) {
 	pool.downloads["test-id"] = ad
 	pool.mu.Unlock()
 
-	pool.Cancel("test-id")
+	result := pool.Cancel("test-id")
 
-	// Consume removal message
+	if !result.Found {
+		t.Error("Expected CancelResult.Found to be true")
+	}
+
+	// Pool must NOT emit any event — that's the caller's responsibility
 	select {
 	case msg := <-ch:
-		if _, ok := msg.(events.DownloadRemovedMsg); !ok {
-			t.Errorf("Expected DownloadRemovedMsg, got %T", msg)
-		}
-	case <-time.After(100 * time.Millisecond):
-		t.Error("Expected removal message")
+		t.Errorf("Pool should not emit events on cancel, got %T", msg)
+	default:
+		// expected
 	}
 
 	pool.mu.RLock()
@@ -324,14 +324,17 @@ func TestWorkerPool_Cancel_CallsCancelFunc(t *testing.T) {
 	}
 	pool.mu.Unlock()
 
-	pool.Cancel("test-id")
+	result := pool.Cancel("test-id")
+	if !result.Found {
+		t.Error("Expected CancelResult.Found")
+	}
 
-	// Consume removal message
+	// No event should be emitted by pool
 	select {
-	case <-ch:
-		// OK
-	case <-time.After(100 * time.Millisecond):
-		t.Error("Expected removal message")
+	case msg := <-ch:
+		t.Errorf("Pool should not emit events on cancel, got %T", msg)
+	default:
+		// expected
 	}
 
 	// Context should be canceled
@@ -358,14 +361,9 @@ func TestWorkerPool_Cancel_MarksDone(t *testing.T) {
 	}
 	pool.mu.Unlock()
 
-	pool.Cancel("test-id")
-
-	// Consume removal message
-	select {
-	case <-ch:
-		// OK
-	case <-time.After(100 * time.Millisecond):
-		t.Error("Expected removal message")
+	result := pool.Cancel("test-id")
+	if !result.Found {
+		t.Error("Expected CancelResult.Found")
 	}
 
 	if !state.Done.Load() {
@@ -396,12 +394,9 @@ func TestWorkerPool_Cancel_DoesNotRemoveIncompleteFile(t *testing.T) {
 	}
 	pool.mu.Unlock()
 
-	pool.Cancel("test-id")
-
-	select {
-	case <-ch:
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("expected removal message")
+	result := pool.Cancel("test-id")
+	if !result.Found {
+		t.Fatal("expected cancel to find download")
 	}
 
 	if _, err := os.Stat(incompletePath); err != nil {
@@ -409,7 +404,7 @@ func TestWorkerPool_Cancel_DoesNotRemoveIncompleteFile(t *testing.T) {
 	}
 }
 
-func TestWorkerPool_Cancel_QueuedDownload_RemovesFromQueueAndEmitsEvent(t *testing.T) {
+func TestWorkerPool_Cancel_QueuedDownload_RemovesFromQueueAndReturnsResult(t *testing.T) {
 	ch := make(chan any, 10)
 	pool := &WorkerPool{
 		progressCh: ch,
@@ -422,7 +417,7 @@ func TestWorkerPool_Cancel_QueuedDownload_RemovesFromQueueAndEmitsEvent(t *testi
 		},
 	}
 
-	pool.Cancel("queued-id")
+	result := pool.Cancel("queued-id")
 
 	pool.mu.RLock()
 	_, exists := pool.queued["queued-id"]
@@ -431,230 +426,29 @@ func TestWorkerPool_Cancel_QueuedDownload_RemovesFromQueueAndEmitsEvent(t *testi
 		t.Fatal("expected queued download to be removed from queue")
 	}
 
+	if !result.Found {
+		t.Fatal("expected CancelResult.Found for queued cancel")
+	}
+	if !result.WasQueued {
+		t.Fatal("expected CancelResult.WasQueued for queued cancel")
+	}
+	if result.Filename != "queued.bin" {
+		t.Fatalf("result.Filename = %q, want queued.bin", result.Filename)
+	}
+
+	// Pool must NOT emit events — caller handles that
 	select {
 	case msg := <-ch:
-		removed, ok := msg.(events.DownloadRemovedMsg)
-		if !ok {
-			t.Fatalf("expected DownloadRemovedMsg, got %T", msg)
-		}
-		if removed.DownloadID != "queued-id" {
-			t.Fatalf("removed id = %q, want queued-id", removed.DownloadID)
-		}
-		if removed.Filename != "queued.bin" {
-			t.Fatalf("removed filename = %q, want queued.bin", removed.Filename)
-		}
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("expected removal message for queued cancel")
-	}
-}
-
-func TestWorkerPool_Resume_NonExistentDownload(t *testing.T) {
-	ch := make(chan any, 10)
-	pool := NewWorkerPool(ch, 3)
-
-	// Should not panic
-	pool.Resume("non-existent-id")
-
-	// No message should be sent
-	select {
-	case <-ch:
-		t.Error("Should not send message for non-existent download")
+		t.Fatalf("pool should not emit events on cancel, got %T", msg)
 	default:
-		// Expected
+		// expected
 	}
 }
 
-func TestWorkerPool_Resume_WhilePausing(t *testing.T) {
-	ch := make(chan any, 10)
-	pool := NewWorkerPool(ch, 3)
-
-	state := types.NewProgressState("test-id", 1000)
-	state.Paused.Store(true)
-	state.SetPausing(true)
-
-	pool.mu.Lock()
-	pool.downloads["test-id"] = &activeDownload{
-		config: types.DownloadConfig{
-			ID:    "test-id",
-			State: state,
-		},
-	}
-	pool.mu.Unlock()
-
-	ok := pool.Resume("test-id")
-	if ok {
-		t.Fatal("Expected resume to be rejected while pausing")
-	}
-
-	select {
-	case msg := <-ch:
-		t.Fatalf("Did not expect any resume message while pausing, got %T", msg)
-	default:
-	}
-
-	if !state.IsPaused() {
-		t.Error("Expected state to remain paused while still pausing")
-	}
-}
-
-func TestWorkerPool_Resume_ClearsPausedFlag(t *testing.T) {
-	ch := make(chan any, 10)
-	pool := NewWorkerPool(ch, 3)
-
-	state := types.NewProgressState("test-id", 1000)
-	state.Paused.Store(true)
-
-	pool.mu.Lock()
-	pool.downloads["test-id"] = &activeDownload{
-		config: types.DownloadConfig{
-			ID:    "test-id",
-			State: state,
-		},
-	}
-	pool.mu.Unlock()
-
-	pool.Resume("test-id")
-
-	if state.IsPaused() {
-		t.Error("Expected paused flag to be cleared after resume")
-	}
-}
-
-func TestWorkerPool_Resume_UsesResolvedStatePathAndFilename(t *testing.T) {
-	ch := make(chan any, 10)
-	pool := &WorkerPool{
-		taskChan:   make(chan types.DownloadConfig, 10),
-		progressCh: ch,
-		downloads:  make(map[string]*activeDownload),
-		queued:     make(map[string]types.DownloadConfig),
-	}
-
-	state := types.NewProgressState("test-id", 1000)
-	state.Paused.Store(true)
-	state.SetDestPath("/tmp/final-name.bin")
-	state.SetFilename("final-name.bin")
-
-	pool.mu.Lock()
-	pool.downloads["test-id"] = &activeDownload{
-		config: types.DownloadConfig{
-			ID:       "test-id",
-			URL:      "http://example.com/file.zip",
-			Filename: "stale-name.bin",
-			DestPath: "",
-			State:    state,
-		},
-	}
-	pool.mu.Unlock()
-
-	ok := pool.Resume("test-id")
-	if !ok {
-		t.Fatal("expected resume to succeed")
-	}
-
-	pool.mu.RLock()
-	ad := pool.downloads["test-id"]
-	pool.mu.RUnlock()
-	if ad == nil {
-		t.Fatal("expected active download to remain tracked")
-	}
-	if ad.config.DestPath != "/tmp/final-name.bin" {
-		t.Fatalf("DestPath not propagated from state: got=%q", ad.config.DestPath)
-	}
-	if ad.config.Filename != "final-name.bin" {
-		t.Fatalf("Filename not propagated from state: got=%q", ad.config.Filename)
-	}
-
-	select {
-	case queued := <-pool.taskChan:
-		if queued.DestPath != "/tmp/final-name.bin" {
-			t.Fatalf("queued DestPath mismatch: got=%q", queued.DestPath)
-		}
-		if queued.Filename != "final-name.bin" {
-			t.Fatalf("queued Filename mismatch: got=%q", queued.Filename)
-		}
-	default:
-		t.Fatal("expected resumed config to be queued")
-	}
-}
-
-func TestWorkerPool_Resume_SendsResumedMessage(t *testing.T) {
-	ch := make(chan any, 10)
-	pool := NewWorkerPool(ch, 3)
-
-	state := types.NewProgressState("test-id", 1000)
-	state.Paused.Store(true)
-
-	pool.mu.Lock()
-	pool.downloads["test-id"] = &activeDownload{
-		config: types.DownloadConfig{
-			ID:    "test-id",
-			State: state,
-		},
-	}
-	pool.mu.Unlock()
-
-	pool.Resume("test-id")
-
-	// We can't reliably read from pool.taskChan because worker goroutines may consume the config before us. Just verify the resumed message was sent.
-	// Check for resumed message
-	select {
-	case msg := <-ch:
-		resumedMsg, ok := msg.(events.DownloadResumedMsg)
-		if !ok {
-			t.Errorf("Expected DownloadResumedMsg, got %T: %+v", msg, msg)
-		}
-		if resumedMsg.DownloadID != "test-id" {
-			t.Errorf("Expected download ID 'test-id', got '%s'", resumedMsg.DownloadID)
-		}
-	case <-time.After(100 * time.Millisecond):
-		t.Error("Expected resume message to be sent")
-	}
-}
-
-func TestWorkerPool_Resume_RequeuesDownload(t *testing.T) {
-	ch := make(chan any, 10)
-	pool := NewWorkerPool(ch, 3)
-
-	state := types.NewProgressState("test-id", 1000)
-	cfg := types.DownloadConfig{
-		ID:    "test-id",
-		URL:   "http://example.com/file.zip",
-		State: state,
-	}
-
-	// Resume checks idempotency, so we MUST start in Paused state
-	state.Paused.Store(true)
-
-	pool.mu.Lock()
-	pool.downloads["test-id"] = &activeDownload{
-		config: cfg,
-	}
-	pool.mu.Unlock()
-
-	pool.Resume("test-id")
-
-	// Note: We can't reliably read from pool.taskChan because worker goroutines
-	// may consume the config before us. Instead, verify Resume cleared the paused
-	// flag and sent the resumed message.
-
-	if state.IsPaused() {
-		t.Error("Expected paused flag to be cleared")
-	}
-
-	// Check for resumed message
-	select {
-	case msg := <-ch:
-		if resumedMsg, ok := msg.(events.DownloadResumedMsg); ok {
-			if resumedMsg.DownloadID != cfg.ID {
-				t.Errorf("Expected ID '%s', got '%s'", cfg.ID, resumedMsg.DownloadID)
-			}
-		} else {
-			t.Errorf("Expected DownloadResumedMsg, got %T: %+v", msg, msg)
-		}
-	case <-time.After(100 * time.Millisecond):
-		t.Error("Expected resumed message to be sent")
-	}
-}
+// Resume logic has moved to LifecycleManager.Resume() which calls
+// pool.ExtractPausedConfig() for the hot path and state.LoadState() for the cold path.
+// Tests for that behavior live in internal/processing/ and internal/download/pool_test.go
+// (see TestWorkerPool_ExtractPausedConfig_* above).
 
 func TestWorkerPool_GracefulShutdown_PausesAll(t *testing.T) {
 	ch := make(chan any, 10)
@@ -871,6 +665,125 @@ func TestWorkerPool_HasDownload(t *testing.T) {
 	// For now, this unit test covers the memory-check part of HasDownload which was the critical logic add.
 }
 
+// --- ExtractPausedConfig Tests (replaces old pool.Resume tests) ---
+
+func TestWorkerPool_ExtractPausedConfig_NonExistent(t *testing.T) {
+	ch := make(chan any, 10)
+	pool := NewWorkerPool(ch, 3)
+
+	// Should return nil for non-existent download
+	if cfg := pool.ExtractPausedConfig("non-existent-id"); cfg != nil {
+		t.Errorf("Expected nil for non-existent download, got %+v", cfg)
+	}
+}
+
+func TestWorkerPool_ExtractPausedConfig_WhilePausing(t *testing.T) {
+	ch := make(chan any, 10)
+	pool := NewWorkerPool(ch, 3)
+
+	state := types.NewProgressState("test-id", 1000)
+	state.Paused.Store(true)
+	state.SetPausing(true)
+
+	pool.mu.Lock()
+	pool.downloads["test-id"] = &activeDownload{
+		config: types.DownloadConfig{
+			ID:    "test-id",
+			State: state,
+		},
+	}
+	pool.mu.Unlock()
+
+	// Should return nil — still pausing (not safe to extract)
+	if cfg := pool.ExtractPausedConfig("test-id"); cfg != nil {
+		t.Fatal("Expected nil while still pausing")
+	}
+
+	// Download must still be in pool
+	pool.mu.RLock()
+	_, exists := pool.downloads["test-id"]
+	pool.mu.RUnlock()
+	if !exists {
+		t.Error("Expected download to remain in pool while pausing")
+	}
+}
+
+func TestWorkerPool_ExtractPausedConfig_NotPaused(t *testing.T) {
+	ch := make(chan any, 10)
+	pool := NewWorkerPool(ch, 3)
+
+	state := types.NewProgressState("test-id", 1000)
+	// NOT paused
+
+	pool.mu.Lock()
+	pool.downloads["test-id"] = &activeDownload{
+		config: types.DownloadConfig{
+			ID:    "test-id",
+			State: state,
+		},
+	}
+	pool.mu.Unlock()
+
+	if cfg := pool.ExtractPausedConfig("test-id"); cfg != nil {
+		t.Fatal("Expected nil for non-paused download")
+	}
+}
+
+func TestWorkerPool_ExtractPausedConfig_Success(t *testing.T) {
+	ch := make(chan any, 10)
+	pool := NewWorkerPool(ch, 3)
+
+	state := types.NewProgressState("test-id", 1000)
+	state.Paused.Store(true)
+	state.SetDestPath("/tmp/final.bin")
+	state.SetFilename("final.bin")
+
+	pool.mu.Lock()
+	pool.downloads["test-id"] = &activeDownload{
+		config: types.DownloadConfig{
+			ID:       "test-id",
+			URL:      "http://example.com/file.zip",
+			Filename: "stale.bin",
+			State:    state,
+		},
+	}
+	pool.mu.Unlock()
+
+	cfg := pool.ExtractPausedConfig("test-id")
+	if cfg == nil {
+		t.Fatal("Expected config to be returned")
+	}
+
+	// State sync: filename and destpath must come from live state
+	if cfg.Filename != "final.bin" {
+		t.Errorf("Filename = %q, want final.bin", cfg.Filename)
+	}
+	if cfg.DestPath != "/tmp/final.bin" {
+		t.Errorf("DestPath = %q, want /tmp/final.bin", cfg.DestPath)
+	}
+
+	// Download must be removed from pool
+	pool.mu.RLock()
+	_, exists := pool.downloads["test-id"]
+	pool.mu.RUnlock()
+	if exists {
+		t.Error("Expected download to be removed from pool after extract")
+	}
+
+	// Pause state should be cleared
+	if state.IsPaused() {
+		t.Error("Expected pause state to be cleared after extract")
+	}
+
+	// No events emitted by pool
+	select {
+	case msg := <-ch:
+		t.Errorf("Pool should not emit events on ExtractPausedConfig, got %T", msg)
+	default:
+		// expected
+	}
+}
+
 func TestWorkerPool_PauseResume_Idempotency(t *testing.T) {
 	ch := make(chan any, 10)
 	pool := NewWorkerPool(ch, 3)
@@ -894,39 +807,25 @@ func TestWorkerPool_PauseResume_Idempotency(t *testing.T) {
 		t.Error("Expected state to be Pausing after first Pause")
 	}
 
-	// Consume message
-	// select { ... } obsolete, now delegated to worker
-
 	// 2. Second Pause (Idempotent)
-	// Should NOT send another message or change state significantly (still Pausing/Paused)
 	pool.Pause("idempotent-test")
 
 	// Manually transition to Paused (simulating worker finish)
 	state.SetPausing(false)
 	state.Pause()
 
-	// 3. Resume
-	pool.Resume("idempotent-test")
+	// 3. ExtractPausedConfig (replaces Resume)
+	cfg := pool.ExtractPausedConfig("idempotent-test")
+	if cfg == nil {
+		t.Fatal("Expected config to be extracted after true pause")
+	}
 	if state.IsPaused() {
-		t.Error("Expected state to be Resumed (not paused)")
+		t.Error("Expected state to be cleared after extract")
 	}
 
-	// Consume resume message
-	select {
-	case <-ch:
-		// OK
-	case <-time.After(100 * time.Millisecond):
-		t.Error("Expected resume message")
-	}
-
-	// 4. Second Resume (Idempotent)
-	pool.Resume("idempotent-test")
-
-	select {
-	case <-ch:
-		t.Error("Did not expect second resume message")
-	default:
-		// OK
+	// 4. Second ExtractPausedConfig (idempotent — already extracted)
+	if cfg2 := pool.ExtractPausedConfig("idempotent-test"); cfg2 != nil {
+		t.Error("Expected nil on second extract (already removed from pool)")
 	}
 }
 
@@ -963,33 +862,41 @@ func TestWorkerPool_UpdateURL(t *testing.T) {
 
 	activeState := types.NewProgressState("active-id", 1000)
 	pool.mu.Lock()
-	activeDownload := &activeDownload{
+	ad := &activeDownload{
 		config: types.DownloadConfig{
 			ID:    "active-id",
 			URL:   "http://example.com/old.zip",
 			State: activeState,
 		},
 	}
-	activeDownload.running.Store(true)
-	pool.downloads["active-id"] = activeDownload
+	ad.running.Store(true)
+	pool.downloads["active-id"] = ad
 	pool.mu.Unlock()
 
-	// 1. Try updating a running download
+	// 1. Try updating a running download — should fail
 	err := pool.UpdateURL("active-id", "http://example.com/new.zip")
 	if err == nil {
 		t.Error("Expected error when updating URL for active download")
 	}
 
-	// 2. Try updating a paused download
+	// 2. Try updating a paused download — pool only updates in-memory (no DB)
 	activeState.Paused.Store(true)
-	activeDownload.running.Store(false)
+	ad.running.Store(false)
 
 	err = pool.UpdateURL("active-id", "http://example.com/new.zip")
-	if err != nil && err.Error() != "database not initialized" {
-		t.Errorf("Expected database not initialized error, got %v", err)
+	if err != nil {
+		t.Errorf("Expected no error for paused download, got %v", err)
 	}
 
-	// 3. Try updating a queued download
+	// Verify in-memory URL was updated
+	pool.mu.RLock()
+	gotURL := pool.downloads["active-id"].config.URL
+	pool.mu.RUnlock()
+	if gotURL != "http://example.com/new.zip" {
+		t.Errorf("in-memory URL not updated: got %q", gotURL)
+	}
+
+	// 3. Try updating a queued download — should fail
 	pool.mu.Lock()
 	pool.queued["queued-id"] = types.DownloadConfig{ID: "queued-id"}
 	pool.mu.Unlock()
@@ -1000,85 +907,5 @@ func TestWorkerPool_UpdateURL(t *testing.T) {
 	}
 }
 
-func TestWorkerPool_UpdateURL_PersistsToDB(t *testing.T) {
-	tempDir := t.TempDir()
-	state.CloseDB()
-	state.Configure(filepath.Join(tempDir, "surge.db"))
-	if _, err := state.GetDB(); err != nil {
-		t.Fatalf("failed to initialize db: %v", err)
-	}
-	defer state.CloseDB()
-
-	oldURL := "http://example.com/old.zip"
-	newURL := "http://example.com/new.zip"
-
-	if err := state.AddToMasterList(types.DownloadEntry{
-		ID:       "paused-id",
-		URL:      oldURL,
-		URLHash:  state.URLHash(oldURL),
-		DestPath: filepath.Join(tempDir, "paused.zip"),
-		Filename: "paused.zip",
-		Status:   "paused",
-	}); err != nil {
-		t.Fatalf("failed to seed paused entry: %v", err)
-	}
-	if err := state.AddToMasterList(types.DownloadEntry{
-		ID:       "db-only-id",
-		URL:      oldURL,
-		URLHash:  state.URLHash(oldURL),
-		DestPath: filepath.Join(tempDir, "db-only.zip"),
-		Filename: "db-only.zip",
-		Status:   "paused",
-	}); err != nil {
-		t.Fatalf("failed to seed db-only entry: %v", err)
-	}
-
-	ch := make(chan any, 10)
-	pool := NewWorkerPool(ch, 3)
-
-	pausedState := types.NewProgressState("paused-id", 1000)
-	pausedState.Paused.Store(true)
-	pausedState.SetURL(oldURL)
-
-	pool.mu.Lock()
-	pool.downloads["paused-id"] = &activeDownload{
-		config: types.DownloadConfig{
-			ID:    "paused-id",
-			URL:   oldURL,
-			State: pausedState,
-		},
-	}
-	pool.mu.Unlock()
-
-	if err := pool.UpdateURL("paused-id", newURL); err != nil {
-		t.Fatalf("UpdateURL(paused-id) failed: %v", err)
-	}
-	pool.mu.RLock()
-	gotURL := pool.downloads["paused-id"].config.URL
-	pool.mu.RUnlock()
-	if gotURL != newURL {
-		t.Fatalf("config URL = %q, want %q", gotURL, newURL)
-	}
-	if got := pausedState.GetURL(); got != newURL {
-		t.Fatalf("state URL = %q, want %q", got, newURL)
-	}
-
-	entry, err := state.GetDownload("paused-id")
-	if err != nil {
-		t.Fatalf("failed to load paused entry: %v", err)
-	}
-	if entry == nil || entry.URL != newURL || entry.URLHash != state.URLHash(newURL) {
-		t.Fatalf("paused entry not updated in db: %#v", entry)
-	}
-
-	if err := pool.UpdateURL("db-only-id", newURL); err != nil {
-		t.Fatalf("UpdateURL(db-only-id) failed: %v", err)
-	}
-	entry, err = state.GetDownload("db-only-id")
-	if err != nil {
-		t.Fatalf("failed to load db-only entry: %v", err)
-	}
-	if entry == nil || entry.URL != newURL || entry.URLHash != state.URLHash(newURL) {
-		t.Fatalf("db-only entry not updated in db: %#v", entry)
-	}
-}
+// Note: UpdateURL DB persistence is now tested in internal/processing tests
+// since LifecycleManager.UpdateURL() is responsible for calling state.UpdateURL().

--- a/internal/download/pool_test.go
+++ b/internal/download/pool_test.go
@@ -445,9 +445,10 @@ func TestWorkerPool_Cancel_QueuedDownload_RemovesFromQueueAndReturnsResult(t *te
 	}
 }
 
-// Resume logic has been promoted to LifecycleManager.Resume(), which calls
-// pool.ExtractPausedConfig() for the hot path and state.LoadState() for the cold path.
-// Note: LifecycleManager.Resume/Cancel/UpdateURL currently lack dedicated unit tests.
+// Resume orchestration (hot/cold path, DB hydration, event emission) was promoted to
+// LifecycleManager so the pool remains a pure executor with no knowledge of persistence
+// or events. Tests for pool-level extraction live below; LifecycleManager integration
+// tests live in internal/processing/manager_test.go (see TestLifecycleManager_Cancel_NotFound).
 
 func TestWorkerPool_GracefulShutdown_PausesAll(t *testing.T) {
 	ch := make(chan any, 10)

--- a/internal/engine/types/models.go
+++ b/internal/engine/types/models.go
@@ -71,3 +71,14 @@ type DownloadStatus struct {
 	TimeTaken   int64   `json:"time_taken"`  // Duration in milliseconds (completed only)
 	AvgSpeed    float64 `json:"avg_speed"`   // Average speed in bytes/sec (completed only)
 }
+
+// CancelResult contains metadata about a cancelled download so callers
+// can handle event emission and cleanup without the pool needing to import
+// the events package (which would create an import cycle).
+type CancelResult struct {
+	Found     bool
+	Filename  string
+	DestPath  string
+	Completed bool
+	WasQueued bool
+}

--- a/internal/processing/manager.go
+++ b/internal/processing/manager.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/SurgeDM/Surge/internal/config"
+	"github.com/SurgeDM/Surge/internal/engine/events"
 	"github.com/SurgeDM/Surge/internal/engine/types"
 	"github.com/SurgeDM/Surge/internal/utils"
 )
@@ -259,6 +260,20 @@ func (mgr *LifecycleManager) enqueueResolved(ctx context.Context, req *DownloadR
 		if err != nil {
 			_ = os.Remove(surgePath)
 			return "", err
+		}
+
+		// Emit queued event now that the pool has accepted the download.
+		// The event worker persists this to DB so it survives a crash before the
+		// worker emits a started event.
+		hooks := mgr.getEngineHooks()
+		if hooks.PublishEvent != nil {
+			_ = hooks.PublishEvent(events.DownloadQueuedMsg{
+				DownloadID: newID,
+				Filename:   finalFilename,
+				URL:        req.URL,
+				DestPath:   filepath.Join(finalPath, finalFilename),
+				Mirrors:    append([]string(nil), req.Mirrors...),
+			})
 		}
 
 		return newID, nil

--- a/internal/processing/manager_test.go
+++ b/internal/processing/manager_test.go
@@ -894,6 +894,20 @@ func TestLifecycleManager_Cancel_Completed(t *testing.T) {
 	}
 }
 
+func TestLifecycleManager_Cancel_NotFound(t *testing.T) {
+	testutil.SetupStateDB(t)
+
+	mgr := newLifecycleManagerForTest()
+	mgr.SetEngineHooks(EngineHooks{
+		Cancel: func(id string) types.CancelResult { return types.CancelResult{Found: false} },
+	})
+
+	err := mgr.Cancel("ghost-id")
+	if err == nil {
+		t.Fatal("expected error for non-existent download")
+	}
+}
+
 func TestLifecycleManager_UpdateURL_Success(t *testing.T) {
 	tempDir := testutil.SetupStateDB(t)
 

--- a/internal/processing/manager_test.go
+++ b/internal/processing/manager_test.go
@@ -12,7 +12,10 @@ import (
 	"time"
 
 	"github.com/SurgeDM/Surge/internal/config"
+	"github.com/SurgeDM/Surge/internal/engine/events"
+	"github.com/SurgeDM/Surge/internal/engine/state"
 	"github.com/SurgeDM/Surge/internal/engine/types"
+	"github.com/SurgeDM/Surge/internal/testutil"
 )
 
 func newProbeTestServer(t *testing.T, size int64) *httptest.Server {
@@ -579,5 +582,367 @@ func TestLifecycleManager_Enqueue_ContextCancellationBeforeReservation(t *testin
 	}
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+// --- LifecycleManager.Resume / Cancel / UpdateURL Tests ---
+
+func TestLifecycleManager_Resume_HotPath(t *testing.T) {
+	var extractCalled, addCalled bool
+	var publishedEvent interface{}
+
+	mgr := newLifecycleManagerForTest()
+	mgr.SetEngineHooks(EngineHooks{
+		GetStatus: func(id string) *types.DownloadStatus {
+			return &types.DownloadStatus{Status: "paused"}
+		},
+		ExtractPausedConfig: func(id string) *types.DownloadConfig {
+			extractCalled = true
+			return &types.DownloadConfig{ID: "hot-id", Filename: "hot-file.zip"}
+		},
+		AddConfig: func(cfg types.DownloadConfig) {
+			addCalled = true
+			if cfg.ID != "hot-id" {
+				t.Errorf("AddConfig ID = %q, want hot-id", cfg.ID)
+			}
+			if !cfg.IsResume {
+				t.Error("expected IsResume flag to be set")
+			}
+		},
+		PublishEvent: func(msg interface{}) error {
+			publishedEvent = msg
+			return nil
+		},
+	})
+
+	if err := mgr.Resume("hot-id"); err != nil {
+		t.Fatalf("Resume failed: %v", err)
+	}
+	if !extractCalled {
+		t.Error("Expected ExtractPausedConfig to be called for hot path")
+	}
+	if !addCalled {
+		t.Error("Expected AddConfig to be called")
+	}
+	if publishedEvent == nil {
+		t.Fatal("Expected PublishEvent to be called")
+	}
+	msg, ok := publishedEvent.(events.DownloadResumedMsg)
+	if !ok {
+		t.Fatalf("Expected DownloadResumedMsg, got %T", publishedEvent)
+	}
+	if msg.DownloadID != "hot-id" {
+		t.Errorf("ResumedMsg.DownloadID = %q, want hot-id", msg.DownloadID)
+	}
+	if msg.Filename != "hot-file.zip" {
+		t.Errorf("ResumedMsg.Filename = %q, want hot-file.zip", msg.Filename)
+	}
+}
+
+func TestLifecycleManager_Resume_ColdPath(t *testing.T) {
+	tempDir := testutil.SetupStateDB(t)
+	destPath := filepath.Join(tempDir, "cold-file.zip")
+
+	testutil.SeedMasterList(t, types.DownloadEntry{
+		ID:         "cold-id",
+		URL:        "http://example.com/cold.zip",
+		URLHash:    state.URLHash("http://example.com/cold.zip"),
+		DestPath:   destPath,
+		Filename:   "cold-file.zip",
+		Status:     "paused",
+		Downloaded: 500,
+		TotalSize:  1000,
+	})
+
+	var addCalled bool
+	mgr := newLifecycleManagerForTest()
+	mgr.SetEngineHooks(EngineHooks{
+		ExtractPausedConfig: func(id string) *types.DownloadConfig { return nil },
+		AddConfig: func(cfg types.DownloadConfig) {
+			addCalled = true
+			if cfg.ID != "cold-id" {
+				t.Errorf("AddConfig ID = %q, want cold-id", cfg.ID)
+			}
+			if !cfg.IsResume {
+				t.Error("expected IsResume flag")
+			}
+		},
+	})
+
+	if err := mgr.Resume("cold-id"); err != nil {
+		t.Fatalf("Resume failed: %v", err)
+	}
+	if !addCalled {
+		t.Error("Expected AddConfig to be called for cold path")
+	}
+}
+
+func TestLifecycleManager_Resume_NotFound(t *testing.T) {
+	testutil.SetupStateDB(t)
+
+	mgr := newLifecycleManagerForTest()
+	mgr.SetEngineHooks(EngineHooks{
+		ExtractPausedConfig: func(id string) *types.DownloadConfig { return nil },
+	})
+
+	err := mgr.Resume("missing-id")
+	if err == nil {
+		t.Fatal("expected error for unknown download")
+	}
+}
+
+func TestLifecycleManager_Resume_Completed(t *testing.T) {
+	tempDir := testutil.SetupStateDB(t)
+
+	testutil.SeedMasterList(t, types.DownloadEntry{
+		ID:       "done-id",
+		URL:      "http://example.com/done.zip",
+		URLHash:  state.URLHash("http://example.com/done.zip"),
+		DestPath: filepath.Join(tempDir, "done.zip"),
+		Filename: "done.zip",
+		Status:   "completed",
+	})
+
+	mgr := newLifecycleManagerForTest()
+	mgr.SetEngineHooks(EngineHooks{
+		ExtractPausedConfig: func(id string) *types.DownloadConfig { return nil },
+	})
+
+	err := mgr.Resume("done-id")
+	if err == nil {
+		t.Fatal("expected error for completed download")
+	}
+}
+
+func TestLifecycleManager_Resume_StillPausing(t *testing.T) {
+	var extraCalled bool
+	mgr := newLifecycleManagerForTest()
+	mgr.SetEngineHooks(EngineHooks{
+		GetStatus: func(id string) *types.DownloadStatus {
+			return &types.DownloadStatus{Status: "pausing"}
+		},
+		ExtractPausedConfig: func(id string) *types.DownloadConfig {
+			extraCalled = true
+			return nil
+		},
+	})
+
+	err := mgr.Resume("pausing-id")
+	if err == nil {
+		t.Fatal("expected error when download is still pausing")
+	}
+	if extraCalled {
+		t.Error("Expected ExtractPausedConfig to NOT be called while pausing")
+	}
+}
+
+func TestLifecycleManager_Resume_HydratesFromDisk(t *testing.T) {
+	tempDir := testutil.SetupStateDB(t)
+	destPath := filepath.Join(tempDir, "hydrated.zip")
+
+	testutil.SeedMasterList(t, types.DownloadEntry{
+		ID:       "hydrate-id",
+		URL:      "http://example.com/hydrated.zip",
+		URLHash:  state.URLHash("http://example.com/hydrated.zip"),
+		DestPath: destPath,
+		Filename: "hydrated.zip",
+		Status:   "paused",
+	})
+
+	if err := state.SaveStateWithOptions("http://example.com/hydrated.zip", destPath, &types.DownloadState{
+		ID: "hydrate-id", URL: "http://example.com/hydrated.zip", Filename: "hydrated.zip",
+		DestPath: destPath, TotalSize: 5000,
+		Tasks: []types.Task{{Offset: 0, Length: 2500}, {Offset: 2500, Length: 2500}},
+	}, state.SaveStateOptions{SkipFileHash: true}); err != nil {
+		t.Fatalf("failed to seed state: %v", err)
+	}
+
+	var addedCfg *types.DownloadConfig
+	mgr := newLifecycleManagerForTest()
+	mgr.SetEngineHooks(EngineHooks{
+		GetStatus:           func(id string) *types.DownloadStatus { return &types.DownloadStatus{Status: "paused"} },
+		ExtractPausedConfig: func(id string) *types.DownloadConfig { return &types.DownloadConfig{ID: id, Filename: "hydrated.zip", URL: "http://example.com/hydrated.zip", DestPath: destPath} },
+		AddConfig:           func(cfg types.DownloadConfig) { addedCfg = &cfg },
+	})
+
+	if err := mgr.Resume("hydrate-id"); err != nil {
+		t.Fatalf("Resume failed: %v", err)
+	}
+	if addedCfg == nil {
+		t.Fatal("Expected AddConfig to be called")
+	}
+	if addedCfg.TotalSize != 5000 {
+		t.Errorf("TotalSize = %d, want 5000", addedCfg.TotalSize)
+	}
+	if !addedCfg.SupportsRange {
+		t.Error("Expected SupportsRange = true after loading tasks")
+	}
+}
+
+func TestLifecycleManager_Cancel_FromPool(t *testing.T) {
+	tempDir := testutil.SetupStateDB(t)
+
+	testutil.SeedMasterList(t, types.DownloadEntry{
+		ID:       "active-cancel",
+		URL:      "http://example.com/active.zip",
+		URLHash:  state.URLHash("http://example.com/active.zip"),
+		DestPath: filepath.Join(tempDir, "active.zip"),
+		Filename: "active.zip",
+		Status:   "downloading",
+	})
+
+	var publishedMsg interface{}
+	cancelResult := types.CancelResult{Found: true, Filename: "active.zip", DestPath: filepath.Join(tempDir, "active.zip")}
+
+	mgr := newLifecycleManagerForTest()
+	mgr.SetEngineHooks(EngineHooks{
+		Cancel:       func(id string) types.CancelResult { return cancelResult },
+		PublishEvent: func(msg interface{}) error { publishedMsg = msg; return nil },
+	})
+
+	if err := mgr.Cancel("active-cancel"); err != nil {
+		t.Fatalf("Cancel failed: %v", err)
+	}
+	if publishedMsg == nil {
+		t.Fatal("Expected DownloadRemovedMsg to be published")
+	}
+	removed, ok := publishedMsg.(events.DownloadRemovedMsg)
+	if !ok {
+		t.Fatalf("Expected DownloadRemovedMsg, got %T", publishedMsg)
+	}
+	if removed.DownloadID != "active-cancel" {
+		t.Errorf("RemovedMsg.DownloadID = %q, want active-cancel", removed.DownloadID)
+	}
+	if removed.Filename != "active.zip" {
+		t.Errorf("RemovedMsg.Filename = %q, want active.zip", removed.Filename)
+	}
+}
+
+func TestLifecycleManager_Cancel_DBOnly(t *testing.T) {
+	tempDir := testutil.SetupStateDB(t)
+	destPath := filepath.Join(tempDir, "db-only.zip")
+
+	testutil.SeedMasterList(t, types.DownloadEntry{
+		ID:       "db-only",
+		URL:      "http://example.com/db-only.zip",
+		URLHash:  state.URLHash("http://example.com/db-only.zip"),
+		DestPath: destPath,
+		Filename: "db-only.zip",
+		Status:   "paused",
+	})
+
+	var publishedMsg interface{}
+
+	mgr := newLifecycleManagerForTest()
+	mgr.SetEngineHooks(EngineHooks{
+		Cancel:       func(id string) types.CancelResult { return types.CancelResult{Found: false} },
+		PublishEvent: func(msg interface{}) error { publishedMsg = msg; return nil },
+	})
+
+	if err := mgr.Cancel("db-only"); err != nil {
+		t.Fatalf("Cancel failed: %v", err)
+	}
+
+	removed, ok := publishedMsg.(events.DownloadRemovedMsg)
+	if !ok {
+		t.Fatalf("Expected DownloadRemovedMsg, got %T", publishedMsg)
+	}
+	if removed.DownloadID != "db-only" {
+		t.Errorf("RemovedMsg.DownloadID = %q, want db-only", removed.DownloadID)
+	}
+	if removed.Filename != "db-only.zip" {
+		t.Errorf("RemovedMsg.Filename = %q, want db-only.zip", removed.Filename)
+	}
+}
+
+func TestLifecycleManager_Cancel_Completed(t *testing.T) {
+	tempDir := testutil.SetupStateDB(t)
+	destPath := filepath.Join(tempDir, "completed.zip")
+
+	testutil.SeedMasterList(t, types.DownloadEntry{
+		ID:       "completed-cancel",
+		URL:      "http://example.com/completed.zip",
+		URLHash:  state.URLHash("http://example.com/completed.zip"),
+		DestPath: destPath,
+		Filename: "completed.zip",
+		Status:   "completed",
+	})
+
+	var publishedMsg interface{}
+
+	mgr := newLifecycleManagerForTest()
+	mgr.SetEngineHooks(EngineHooks{
+		Cancel:       func(id string) types.CancelResult { return types.CancelResult{} },
+		PublishEvent: func(msg interface{}) error { publishedMsg = msg; return nil },
+	})
+
+	if err := mgr.Cancel("completed-cancel"); err != nil {
+		t.Fatalf("Cancel failed: %v", err)
+	}
+
+	removed, ok := publishedMsg.(events.DownloadRemovedMsg)
+	if !ok {
+		t.Fatalf("Expected DownloadRemovedMsg, got %T", publishedMsg)
+	}
+	if !removed.Completed {
+		t.Error("Expected Completed=true for a completed download")
+	}
+	if removed.Filename != "completed.zip" {
+		t.Errorf("RemovedMsg.Filename = %q, want completed.zip", removed.Filename)
+	}
+}
+
+func TestLifecycleManager_UpdateURL_Success(t *testing.T) {
+	tempDir := testutil.SetupStateDB(t)
+
+	testutil.SeedMasterList(t, types.DownloadEntry{
+		ID:       "update-id",
+		URL:      "http://example.com/old.zip",
+		URLHash:  state.URLHash("http://example.com/old.zip"),
+		DestPath: filepath.Join(tempDir, "update.zip"),
+		Filename: "update.zip",
+		Status:   "paused",
+	})
+
+	var hookCalled bool
+	mgr := newLifecycleManagerForTest()
+	mgr.SetEngineHooks(EngineHooks{
+		UpdateURL: func(id, newURL string) error {
+			hookCalled = true
+			if newURL != "http://example.com/new.zip" {
+				t.Errorf("UpdateURL newURL = %q", newURL)
+			}
+			return nil
+		},
+	})
+
+	if err := mgr.UpdateURL("update-id", "http://example.com/new.zip"); err != nil {
+		t.Fatalf("UpdateURL failed: %v", err)
+	}
+	if !hookCalled {
+		t.Error("Expected UpdateURL hook to be called")
+	}
+
+	entry, err := state.GetDownload("update-id")
+	if err != nil {
+		t.Fatalf("GetDownload failed: %v", err)
+	}
+	if entry == nil || entry.URL != "http://example.com/new.zip" {
+		t.Errorf("DB URL = %q, want http://example.com/new.zip", entry.URL)
+	}
+}
+
+func TestLifecycleManager_UpdateURL_HookError(t *testing.T) {
+	testutil.SetupStateDB(t)
+
+	expectedErr := fmt.Errorf("not in pausable state")
+	mgr := newLifecycleManagerForTest()
+	mgr.SetEngineHooks(EngineHooks{
+		UpdateURL: func(id, newURL string) error { return expectedErr },
+	})
+
+	err := mgr.UpdateURL("bad-id", "http://example.com/new.zip")
+	if err == nil {
+		t.Fatal("expected error from pool hook, got nil")
 	}
 }

--- a/internal/processing/manager_test.go
+++ b/internal/processing/manager_test.go
@@ -760,9 +760,11 @@ func TestLifecycleManager_Resume_HydratesFromDisk(t *testing.T) {
 	var addedCfg *types.DownloadConfig
 	mgr := newLifecycleManagerForTest()
 	mgr.SetEngineHooks(EngineHooks{
-		GetStatus:           func(id string) *types.DownloadStatus { return &types.DownloadStatus{Status: "paused"} },
-		ExtractPausedConfig: func(id string) *types.DownloadConfig { return &types.DownloadConfig{ID: id, Filename: "hydrated.zip", URL: "http://example.com/hydrated.zip", DestPath: destPath} },
-		AddConfig:           func(cfg types.DownloadConfig) { addedCfg = &cfg },
+		GetStatus: func(id string) *types.DownloadStatus { return &types.DownloadStatus{Status: "paused"} },
+		ExtractPausedConfig: func(id string) *types.DownloadConfig {
+			return &types.DownloadConfig{ID: id, Filename: "hydrated.zip", URL: "http://example.com/hydrated.zip", DestPath: destPath}
+		},
+		AddConfig: func(cfg types.DownloadConfig) { addedCfg = &cfg },
 	})
 
 	if err := mgr.Resume("hydrate-id"); err != nil {

--- a/internal/processing/pause_resume.go
+++ b/internal/processing/pause_resume.go
@@ -11,13 +11,24 @@ import (
 )
 
 // EngineHooks defines the minimal callbacks Processing needs to orchestrate the worker pool.
+// All management decisions (event emission, DB persistence, state loading) live here in
+// LifecycleManager; the pool itself is a pure executor.
 type EngineHooks struct {
-	Pause     func(id string) bool
-	Resume    func(id string) bool
+	// Pause signals the pool to mechanically pause a download (cancel context, set state).
+	Pause func(id string) bool
+	// ExtractPausedConfig atomically removes a paused download from the pool and returns
+	// its config so LifecycleManager can re-enqueue it after hydration from saved state.
+	// Returns nil when not found / not paused / still transitioning.
+	ExtractPausedConfig func(id string) *types.DownloadConfig
+	// GetStatus returns the in-memory status for a download.
 	GetStatus func(id string) *types.DownloadStatus
-	// AddConfig enqueues a download config. Implementations must ensure cfg.ProgressCh
-	// is set; pool.Add fills it from p.progressCh when nil.
-	AddConfig    func(cfg types.DownloadConfig)
+	// AddConfig enqueues a DownloadConfig. The pool sets cfg.ProgressCh when nil.
+	AddConfig func(cfg types.DownloadConfig)
+	// Cancel mechanically removes a download from the pool and returns removal metadata.
+	Cancel func(id string) types.CancelResult
+	// UpdateURL updates the in-memory URL only; LifecycleManager persists to DB.
+	UpdateURL func(id, newURL string) error
+	// PublishEvent sends an event into the service's broadcast channel.
 	PublishEvent func(msg interface{}) error
 }
 
@@ -50,22 +61,51 @@ func (mgr *LifecycleManager) Pause(id string) error {
 }
 
 // Resume resumes a paused download.
+//
+// Hot path: download is still in pool memory (same session) — extract config directly.
+// Cold path: download was paused in a prior session, only stored in DB.
 func (mgr *LifecycleManager) Resume(id string) error {
 	hooks := mgr.getEngineHooks()
-	if hooks.Resume == nil {
-		return fmt.Errorf("engine not initialized")
-	}
 
+	// Guard: still transitioning to paused
 	if hooks.GetStatus != nil {
 		if st := hooks.GetStatus(id); st != nil && st.Status == "pausing" {
 			return fmt.Errorf("download is still pausing, try again in a moment")
 		}
 	}
 
-	if hooks.Resume(id) {
-		return nil
+	// Hot path: pool still holds the paused download in memory.
+	if hooks.ExtractPausedConfig != nil {
+		if cfg := hooks.ExtractPausedConfig(id); cfg != nil {
+			// Hydrate with the latest persisted pause snapshot so we resume at the
+			// correct byte offset and task list even when the pool's in-memory state
+			// is stale (e.g. the event worker hasn't flushed yet).
+			if cfg.URL != "" && cfg.DestPath != "" {
+				if saved, err := state.LoadState(cfg.URL, cfg.DestPath); err == nil && saved != nil {
+					cfg.SavedState = saved
+					if saved.TotalSize > 0 {
+						cfg.TotalSize = saved.TotalSize
+					}
+					if len(saved.Tasks) > 0 {
+						cfg.SupportsRange = true
+					}
+				}
+			}
+			cfg.IsResume = true
+			if hooks.AddConfig != nil {
+				hooks.AddConfig(*cfg)
+			}
+			if hooks.PublishEvent != nil {
+				_ = hooks.PublishEvent(events.DownloadResumedMsg{
+					DownloadID: id,
+					Filename:   cfg.Filename,
+				})
+			}
+			return nil
+		}
 	}
 
+	// Cold path: download from a prior session (only in DB).
 	entry, err := state.GetDownload(id)
 	if err != nil || entry == nil {
 		return fmt.Errorf("download not found")
@@ -106,15 +146,16 @@ func (mgr *LifecycleManager) ResumeBatch(ids []string) []error {
 	errs := make([]error, len(ids))
 
 	hooks := mgr.getEngineHooks()
-	if hooks.Resume == nil {
-		for i := range errs {
-			errs[i] = fmt.Errorf("engine not initialized")
-		}
-		return errs
+
+	settings := mgr.GetSettings()
+	outputPath := settings.General.DefaultDownloadDir
+	if outputPath == "" {
+		outputPath = "."
 	}
 
-	var toLoad []string
-	idMap := make(map[string]int)
+	// Partition: downloads still in pool memory (hot) vs cold (DB-only).
+	var coldIDs []string
+	coldIdx := make(map[string]int)
 
 	for i, id := range ids {
 		if hooks.GetStatus != nil {
@@ -124,36 +165,55 @@ func (mgr *LifecycleManager) ResumeBatch(ids []string) []error {
 			}
 		}
 
-		if hooks.Resume(id) {
-			errs[i] = nil
-		} else {
-			toLoad = append(toLoad, id)
-			idMap[id] = i
+		// Try hot path first
+		if hooks.ExtractPausedConfig != nil {
+			if cfg := hooks.ExtractPausedConfig(id); cfg != nil {
+				if cfg.URL != "" && cfg.DestPath != "" {
+					if saved, err := state.LoadState(cfg.URL, cfg.DestPath); err == nil && saved != nil {
+						cfg.SavedState = saved
+						if saved.TotalSize > 0 {
+							cfg.TotalSize = saved.TotalSize
+						}
+						if len(saved.Tasks) > 0 {
+							cfg.SupportsRange = true
+						}
+					}
+				}
+				cfg.IsResume = true
+				if hooks.AddConfig != nil {
+					hooks.AddConfig(*cfg)
+				}
+				if hooks.PublishEvent != nil {
+					_ = hooks.PublishEvent(events.DownloadResumedMsg{
+						DownloadID: id,
+						Filename:   cfg.Filename,
+					})
+				}
+				errs[i] = nil
+				continue
+			}
 		}
+
+		// Tag for cold-path batch load
+		coldIDs = append(coldIDs, id)
+		coldIdx[id] = i
 	}
 
-	if len(toLoad) == 0 {
+	if len(coldIDs) == 0 {
 		return errs
 	}
 
-	settings := mgr.GetSettings()
-
-	outputPath := settings.General.DefaultDownloadDir
-	if outputPath == "" {
-		outputPath = "."
-	}
-
-	states, err := state.LoadStates(toLoad)
+	states, err := state.LoadStates(coldIDs)
 	if err != nil {
-		for _, id := range toLoad {
-			idx := idMap[id]
+		for _, id := range coldIDs {
+			idx := coldIdx[id]
 			errs[idx] = fmt.Errorf("failed to load state: %w", err)
 		}
 		return errs
 	}
 
-	for _, id := range toLoad {
-		idx := idMap[id]
+	for _, id := range coldIDs {
+		idx := coldIdx[id]
 		savedState, ok := states[id]
 		if !ok {
 			errs[idx] = fmt.Errorf("download not found or completed")
@@ -174,6 +234,64 @@ func (mgr *LifecycleManager) ResumeBatch(ids []string) []error {
 	}
 
 	return errs
+}
+
+// Cancel stops a download (both pool in-memory and DB) and emits a removal event.
+// The event worker handles file cleanup and DB removal via DownloadRemovedMsg.
+func (mgr *LifecycleManager) Cancel(id string) error {
+	hooks := mgr.getEngineHooks()
+
+	var filename, destPath string
+	var completed bool
+
+	// Mechanical cancel via pool
+	if hooks.Cancel != nil {
+		result := hooks.Cancel(id)
+		if result.Found {
+			filename = result.Filename
+			destPath = result.DestPath
+			completed = result.Completed
+		}
+	}
+
+	// Supplement with DB info (covers DB-only / completed entries)
+	if entry, err := state.GetDownload(id); err == nil && entry != nil {
+		if filename == "" {
+			filename = entry.Filename
+		}
+		if destPath == "" {
+			destPath = entry.DestPath
+		}
+		if entry.Status == "completed" {
+			completed = true
+		}
+	}
+
+	// Emit removal event — event worker handles DB deletion and file cleanup.
+	if hooks.PublishEvent != nil {
+		_ = hooks.PublishEvent(events.DownloadRemovedMsg{
+			DownloadID: id,
+			Filename:   filename,
+			DestPath:   destPath,
+			Completed:  completed,
+		})
+	}
+	return nil
+}
+
+// UpdateURL updates the URL of a download in both the pool (in-memory) and the DB.
+func (mgr *LifecycleManager) UpdateURL(id string, newURL string) error {
+	hooks := mgr.getEngineHooks()
+
+	// Update in-memory state via pool (validates download state too)
+	if hooks.UpdateURL != nil {
+		if err := hooks.UpdateURL(id, newURL); err != nil {
+			return err
+		}
+	}
+
+	// Persist to database
+	return state.UpdateURL(id, newURL)
 }
 
 // buildResumeConfig constructs a DownloadConfig for a cold-path resume from saved state.

--- a/internal/processing/pause_resume.go
+++ b/internal/processing/pause_resume.go
@@ -240,11 +240,13 @@ func (mgr *LifecycleManager) Cancel(id string) error {
 
 	var filename, destPath string
 	var completed bool
+	var found bool
 
 	// Mechanical cancel via pool
 	if hooks.Cancel != nil {
 		result := hooks.Cancel(id)
 		if result.Found {
+			found = true
 			filename = result.Filename
 			destPath = result.DestPath
 			completed = result.Completed
@@ -253,6 +255,7 @@ func (mgr *LifecycleManager) Cancel(id string) error {
 
 	// Supplement with DB info (covers DB-only / completed entries)
 	if entry, err := state.GetDownload(id); err == nil && entry != nil {
+		found = true
 		if filename == "" {
 			filename = entry.Filename
 		}
@@ -262,6 +265,10 @@ func (mgr *LifecycleManager) Cancel(id string) error {
 		if entry.Status == "completed" {
 			completed = true
 		}
+	}
+
+	if !found {
+		return fmt.Errorf("download not found")
 	}
 
 	// Emit removal event — event worker handles DB deletion and file cleanup.
@@ -285,9 +292,10 @@ func (mgr *LifecycleManager) UpdateURL(id string, newURL string) error {
 		if err := hooks.UpdateURL(id, newURL); err != nil {
 			return err
 		}
+		// Pool update succeeded; persist to DB.
+		return state.UpdateURL(id, newURL)
 	}
-
-	// Persist to database
+	// No pool connected — DB-only update is correct (no in-memory state to sync).
 	return state.UpdateURL(id, newURL)
 }
 

--- a/internal/processing/pause_resume.go
+++ b/internal/processing/pause_resume.go
@@ -60,6 +60,26 @@ func (mgr *LifecycleManager) Pause(id string) error {
 	return fmt.Errorf("download not found")
 }
 
+// hydrateConfigFromDisk loads the latest persisted pause snapshot from disk
+// and merges it into cfg so the download resumes at the correct byte offset
+// and task list even when the pool's in-memory state is stale.
+func hydrateConfigFromDisk(cfg *types.DownloadConfig) {
+	if cfg.URL == "" || cfg.DestPath == "" {
+		return
+	}
+	saved, err := state.LoadState(cfg.URL, cfg.DestPath)
+	if err != nil || saved == nil {
+		return
+	}
+	cfg.SavedState = saved
+	if saved.TotalSize > 0 {
+		cfg.TotalSize = saved.TotalSize
+	}
+	if len(saved.Tasks) > 0 {
+		cfg.SupportsRange = true
+	}
+}
+
 // Resume resumes a paused download.
 //
 // Hot path: download is still in pool memory (same session) — extract config directly.
@@ -77,20 +97,7 @@ func (mgr *LifecycleManager) Resume(id string) error {
 	// Hot path: pool still holds the paused download in memory.
 	if hooks.ExtractPausedConfig != nil {
 		if cfg := hooks.ExtractPausedConfig(id); cfg != nil {
-			// Hydrate with the latest persisted pause snapshot so we resume at the
-			// correct byte offset and task list even when the pool's in-memory state
-			// is stale (e.g. the event worker hasn't flushed yet).
-			if cfg.URL != "" && cfg.DestPath != "" {
-				if saved, err := state.LoadState(cfg.URL, cfg.DestPath); err == nil && saved != nil {
-					cfg.SavedState = saved
-					if saved.TotalSize > 0 {
-						cfg.TotalSize = saved.TotalSize
-					}
-					if len(saved.Tasks) > 0 {
-						cfg.SupportsRange = true
-					}
-				}
-			}
+			hydrateConfigFromDisk(cfg)
 			cfg.IsResume = true
 			if hooks.AddConfig != nil {
 				hooks.AddConfig(*cfg)
@@ -168,17 +175,7 @@ func (mgr *LifecycleManager) ResumeBatch(ids []string) []error {
 		// Try hot path first
 		if hooks.ExtractPausedConfig != nil {
 			if cfg := hooks.ExtractPausedConfig(id); cfg != nil {
-				if cfg.URL != "" && cfg.DestPath != "" {
-					if saved, err := state.LoadState(cfg.URL, cfg.DestPath); err == nil && saved != nil {
-						cfg.SavedState = saved
-						if saved.TotalSize > 0 {
-							cfg.TotalSize = saved.TotalSize
-						}
-						if len(saved.Tasks) > 0 {
-							cfg.SupportsRange = true
-						}
-					}
-				}
+				hydrateConfigFromDisk(cfg)
 				cfg.IsResume = true
 				if hooks.AddConfig != nil {
 					hooks.AddConfig(*cfg)

--- a/internal/testutil/state_db.go
+++ b/internal/testutil/state_db.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/SurgeDM/Surge/internal/engine/state"
+	"github.com/SurgeDM/Surge/internal/engine/types"
 )
 
 // SetupStateDB configures a fresh temp SQLite DB for tests that exercise state persistence.
@@ -19,4 +20,12 @@ func SetupStateDB(t *testing.T) string {
 	}
 	t.Cleanup(state.CloseDB)
 	return tempDir
+}
+
+// SeedMasterList inserts a DownloadEntry into the master list for test setups.
+func SeedMasterList(t *testing.T, entry types.DownloadEntry) {
+	t.Helper()
+	if err := state.AddToMasterList(entry); err != nil {
+		t.Fatalf("SeedMasterList failed: %v", err)
+	}
 }

--- a/internal/testutil/state_db.go
+++ b/internal/testutil/state_db.go
@@ -6,7 +6,18 @@ import (
 
 	"github.com/SurgeDM/Surge/internal/engine/state"
 	"github.com/SurgeDM/Surge/internal/engine/types"
+	"github.com/SurgeDM/Surge/internal/utils"
 )
+
+// SuppressNotificationsInTests disables desktop notifications for any test
+// that imports this package. Call this from a per-package init() or TestMain.
+func SuppressNotificationsInTests() {
+	utils.SuppressNotifications = true
+}
+
+func init() {
+	SuppressNotificationsInTests()
+}
 
 // SetupStateDB configures a fresh temp SQLite DB for tests that exercise state persistence.
 func SetupStateDB(t *testing.T) string {

--- a/internal/utils/notify.go
+++ b/internal/utils/notify.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"testing"
 
 	"github.com/SurgeDM/Surge/assets"
 	"github.com/gen2brain/beeep"
@@ -48,6 +49,9 @@ func ensureIcon() string {
 }
 
 func Notify(title, message string) {
+	if testing.Testing() {
+		return
+	}
 	err := beeep.Notify(title, message, ensureIcon())
 	if err != nil {
 		Debug("Failed to send notification: %v", err)

--- a/internal/utils/notify.go
+++ b/internal/utils/notify.go
@@ -4,13 +4,16 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"testing"
 
 	"github.com/SurgeDM/Surge/assets"
 	"github.com/gen2brain/beeep"
 )
 
 const NotificationAppName = "Surge"
+
+// SuppressNotifications can be set to true to prevent desktop notifications.
+// Tests should set this to true via TestMain or init() to avoid notification spam.
+var SuppressNotifications bool
 
 var (
 	iconPath string
@@ -49,7 +52,7 @@ func ensureIcon() string {
 }
 
 func Notify(title, message string) {
-	if testing.Testing() {
+	if SuppressNotifications {
 		return
 	}
 	err := beeep.Notify(title, message, ensureIcon())


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR promotes download management orchestration (`Resume`, `ResumeBatch`, `Cancel`, `UpdateURL`) from the worker pool level into `LifecycleManager`, making the pool a pure executor with no knowledge of DB persistence or event emission. The `EngineHooks` struct gains `ExtractPausedConfig`, `Cancel`, and `UpdateURL` hooks in place of the former pool-owned `Resume`. `SetLifecycleHooks` is refactored to accept a `LifecycleHooks` struct rather than individual function parameters, which is a cleaner API.

Key highlights:
- **Data race fixed**: `pool.UpdateURL` previously wrote `ad.config.URL` outside the write lock; it is now correctly performed under `p.mu.Lock()`.
- **New test coverage**: `manager_test.go` adds tests for `Resume` (hot path, cold path, still-pausing guard, disk hydration), `Cancel` (from pool, DB-only, completed, not found), and `UpdateURL` — addressing the coverage gap noted in prior review comments.
- **Pool decoupling**: `ExtractPausedConfig` atomically hands config out of the pool; the pool no longer emits `DownloadResumedMsg` or knows about `state.LoadState`.
- **`SuppressNotifications`**: Added to the `utils` package and wired into both `testutil.init()` and `cmd/main_test.go TestMain` to prevent desktop notification spam during tests.

Minor remaining gaps: two inline comments in `pause_resume.go` describe *what* the code does without explaining *why*, and the `UpdateURL` DB-only path (when no pool hook is wired) has no dedicated test.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no P0/P1 issues found; the pool data race is fixed, the new orchestration methods are well-tested, and the architectural separation is clean.

All remaining findings are P2 style/quality concerns (two what-only comments, one missing edge-case test for the UpdateURL DB-only path). All previously flagged P0/P1 issues from prior review threads are resolved in this PR.

internal/processing/pause_resume.go for comment quality; internal/processing/manager_test.go for the missing UpdateURL DB-only path test

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/processing/pause_resume.go | New file consolidating Resume/ResumeBatch/Cancel/UpdateURL orchestration into LifecycleManager; hot/cold resume paths and event emission are well-structured, with minor what-only comment issues |
| internal/processing/manager.go | Unchanged lifecycle core; SetEngineHooks and enqueueResolved logic untouched by this refactor |
| internal/processing/manager_test.go | Strong new test coverage for Resume (hot/cold/pausing/hydration), Cancel (pool/DB-only/completed/not-found), and UpdateURL; missing DB-only UpdateURL path test |
| internal/download/pool.go | pool.UpdateURL data race fixed (write now under p.mu.Lock()); Cancel and ExtractPausedConfig are clean pure-executor implementations that emit no events |
| internal/download/pool_test.go | Old Resume tests replaced with ExtractPausedConfig tests; comment about LifecycleManager test location updated and now accurate |
| internal/core/local_service.go | SetLifecycleHooks refactored to take LifecycleHooks struct; Cancel and UpdateURL now properly route through lifecycle manager hooks |
| cmd/root.go | Hook wiring updated to include Cancel/UpdateURL/ExtractPausedConfig; SetLifecycleHooks uses new struct form; lowercase 'surge' error message fix |
| cmd/autoresume_test.go | Test hook setup updated to match new EngineHooks/LifecycleHooks struct signatures |
| cmd/startup_test.go | Same hook-wiring update as autoresume_test.go |
| cmd/main_test.go | SuppressNotifications set in TestMain to prevent notification spam during cmd integration tests |
| cmd/server.go | Minor: 'Surge server' -> 'surge server' in error message for consistent capitalization |
| internal/engine/types/models.go | CancelResult struct added to carry cancel metadata (filename, destPath, completed, wasQueued) from pool back to LifecycleManager |
| internal/testutil/state_db.go | SuppressNotificationsInTests extracted to testutil init() so any test importing testutil suppresses desktop notifications automatically |
| internal/utils/notify.go | SuppressNotifications exported flag added; ensureIcon uses sync.Once to avoid TOCTOU race on icon file creation |
| internal/core/test_helpers_test.go | Test helpers updated to match new SetLifecycleHooks struct signature |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant LocalService
    participant LifecycleManager
    participant WorkerPool
    participant DB

    Note over Caller,DB: Resume (hot path — pool still holds download)
    Caller->>LocalService: Resume(id)
    LocalService->>LifecycleManager: Resume(id)
    LifecycleManager->>WorkerPool: GetStatus(id)
    WorkerPool-->>LifecycleManager: status (guard: reject if "pausing")
    LifecycleManager->>WorkerPool: ExtractPausedConfig(id)
    WorkerPool-->>LifecycleManager: *DownloadConfig (atomically removed)
    LifecycleManager->>DB: LoadState(url, destPath)
    DB-->>LifecycleManager: savedState (hydrateConfigFromDisk)
    LifecycleManager->>WorkerPool: AddConfig(cfg)
    LifecycleManager->>LocalService: PublishEvent(DownloadResumedMsg)

    Note over Caller,DB: Cancel
    Caller->>LocalService: Delete(id)
    LocalService->>LifecycleManager: Cancel(id)
    LifecycleManager->>WorkerPool: Cancel(id)
    WorkerPool-->>LifecycleManager: CancelResult\{filename, destPath, completed\}
    LifecycleManager->>DB: GetDownload(id)
    DB-->>LifecycleManager: entry (supplement missing metadata)
    LifecycleManager->>LocalService: PublishEvent(DownloadRemovedMsg)

    Note over Caller,DB: UpdateURL
    Caller->>LocalService: UpdateURL(id, newURL)
    LocalService->>LifecycleManager: UpdateURL(id, newURL)
    LifecycleManager->>WorkerPool: UpdateURL(id, newURL)
    WorkerPool-->>LifecycleManager: nil (in-memory only)
    LifecycleManager->>DB: UpdateURL(id, newURL)
    DB-->>LifecycleManager: nil
    LifecycleManager-->>LocalService: nil
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/processing/pause_resume.go
Line: 90-95

Comment:
**"What" comments should explain "why"**

Two inline comments in this file label *what* the code does without explaining *why* it must work that way:

`// Guard: still transitioning to paused` (line 90) doesn't explain the failure mode being avoided — that `ExtractPausedConfig` returns `nil` while the worker is mid-shutdown, so without this guard the call would silently fall through to a cold-path resume, potentially enqueuing a duplicate config or losing the in-memory byte progress.

`// Mechanical cancel via pool` (line 245) doesn't explain the ordering rationale — that the pool is cancelled first because it holds the live context and in-memory state, and the DB is queried afterwards to supplement metadata for downloads that may have no live pool entry at all.

Suggested rewrites:
```go
// Reject the resume if the worker is still mid-shutdown: ExtractPausedConfig
// would return nil, and we would fall through to a cold-path re-enqueue that
// either errors or silently duplicates the in-flight download.
```
```go
// Cancel the live pool entry first: the pool holds the running context and
// in-memory state. We then query the DB to fill in identity fields for
// downloads that are DB-only (paused in a prior session) or already completed.
```

**Rule Used:** What: Comments must explain *why* code exists, not... ([source](https://app.greptile.com/review/custom-context?memory=4e45ef13-32c2-4753-8060-a44ef767144d))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/processing/manager_test.go
Line: 911-964

Comment:
**Missing test: `UpdateURL` without a pool hook**

Both existing `UpdateURL` tests always wire `hooks.UpdateURL`. The second branch in `LifecycleManager.UpdateURL` — when `hooks.UpdateURL == nil` — calls `state.UpdateURL` directly (the DB-only path, for downloads that have no live pool entry). This path is reachable in production for cold/DB-only downloads and is not covered by any test.

A minimal addition:
```go
func TestLifecycleManager_UpdateURL_DBOnlyPath(t *testing.T) {
    tempDir := testutil.SetupStateDB(t)
    testutil.SeedMasterList(t, types.DownloadEntry{
        ID:       "db-only-id",
        URL:      "http://example.com/old.zip",
        URLHash:  state.URLHash("http://example.com/old.zip"),
        DestPath: filepath.Join(tempDir, "file.zip"),
        Filename: "file.zip",
        Status:   "paused",
    })

    mgr := newLifecycleManagerForTest()
    // No UpdateURL hook — exercises the DB-only path.
    mgr.SetEngineHooks(EngineHooks{})

    if err := mgr.UpdateURL("db-only-id", "http://example.com/new.zip"); err != nil {
        t.Fatalf("UpdateURL (DB-only path) failed: %v", err)
    }
    entry, err := state.GetDownload("db-only-id")
    if err != nil || entry == nil || entry.URL != "http://example.com/new.zip" {
        t.Errorf("DB URL not updated: %v", err)
    }
}
```

**Rule Used:** What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["address ai comments"](https://github.com/surgedm/surge/commit/23062e106eeac6a960305f0591f64928e34cbe6a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27364442)</sub>

<!-- /greptile_comment -->