### PR TITLE
feat: add checksum verification library (SHA-256, SHA-1, MD5)

### DIFF
--- a/internal/processing/checksum.go
+++ b/internal/processing/checksum.go
@@ -24,8 +24,8 @@ type ChecksumResult struct {
 // VerifyChecksum computes the hash of a file and compares it to the expected value.
 // algorithm should be one of: md5, sha1, sha256.
 // expected should be a hex-encoded hash string.
-func VerifyChecksum(filepath string, algorithm string, expected string) (*ChecksumResult, error) {
-	if filepath == "" || algorithm == "" || expected == "" {
+func VerifyChecksum(filePath string, algorithm string, expected string) (*ChecksumResult, error) {
+	if filePath == "" || algorithm == "" || expected == "" {
 		return nil, fmt.Errorf("filepath, algorithm, and expected hash are all required")
 	}
 
@@ -37,14 +37,16 @@ func VerifyChecksum(filepath string, algorithm string, expected string) (*Checks
 	case "md5":
 		h = md5.New()
 	case "sha1", "sha-1":
+		algorithm = "sha1"
 		h = sha1.New()
 	case "sha256", "sha-256":
+		algorithm = "sha256"
 		h = sha256.New()
 	default:
 		return nil, fmt.Errorf("unsupported checksum algorithm: %s", algorithm)
 	}
 
-	f, err := os.Open(filepath)
+	f, err := os.Open(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file for checksum: %w", err)
 	}
@@ -81,7 +83,7 @@ func ParseDigestHeader(header string) (algorithm string, hexHash string) {
 	case "sha-1":
 		algo = "sha1"
 	case "md5":
-		// already correct
+		// no normalization needed
 	default:
 		return "", ""
 	}

--- a/internal/processing/checksum.go
+++ b/internal/processing/checksum.go
@@ -120,9 +120,5 @@ func ParseDigestHeader(header string) (algorithm string, hexHash string) {
 		}
 	}
 
-	// Hex fallback - only accept if length matches the expected hash size
-	if _, err := hex.DecodeString(value); err == nil && len(value) == expectedHexLen {
-		return algo, strings.ToLower(value)
-	}
 	return "", ""
 }

--- a/internal/processing/checksum.go
+++ b/internal/processing/checksum.go
@@ -50,7 +50,7 @@ func VerifyChecksum(filePath string, algorithm string, expected string) (*Checks
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file for checksum: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	if _, err := io.Copy(h, f); err != nil {
 		return nil, fmt.Errorf("failed to read file for checksum: %w", err)
@@ -66,12 +66,12 @@ func VerifyChecksum(filePath string, algorithm string, expected string) (*Checks
 }
 
 // ParseDigestHeader parses an HTTP Digest header (RFC 3230) and returns
-// the algorithm and hex-encoded hash. Returns empty strings if not parseable.
+// the algorithm and hex-encoded hash.
 // Example header: "sha-256=base64hash" or "SHA-256=base64hash"
-func ParseDigestHeader(header string) (algorithm string, hexHash string) {
+func ParseDigestHeader(header string) (algorithm string, hexHash string, err error) {
 	parts := strings.SplitN(header, "=", 2)
 	if len(parts) != 2 {
-		return "", ""
+		return "", "", nil
 	}
 
 	algo := strings.ToLower(strings.TrimSpace(parts[0]))
@@ -85,27 +85,28 @@ func ParseDigestHeader(header string) (algorithm string, hexHash string) {
 	case "md5":
 		// no normalization needed
 	default:
-		return "", ""
+		return "", "", nil
 	}
 
-	// Some servers provide hex directly in Digest; prefer that when it matches
-	// the expected hash length for the selected algorithm.
-	expectedHexLen := 0
+	expectedBytes := 0
 	switch algo {
 	case "md5":
-		expectedHexLen = 32
+		expectedBytes = md5.Size
 	case "sha1":
-		expectedHexLen = 40
+		expectedBytes = sha1.Size
 	case "sha256":
-		expectedHexLen = 64
+		expectedBytes = sha256.Size
 	}
+	expectedHexLen := expectedBytes * 2
 	if len(value) == expectedHexLen {
-		if _, err := hex.DecodeString(value); err == nil {
-			return algo, strings.ToLower(value)
+		if decoded, err := hex.DecodeString(value); err == nil {
+			if len(decoded) != expectedBytes {
+				return "", "", fmt.Errorf("digest length mismatch for %s", algo)
+			}
+			return algo, strings.ToLower(value), nil
 		}
 	}
 
-	// RFC 3230 uses base64 (padded or unpadded, standard or URL-safe)
 	for _, enc := range []*base64.Encoding{
 		base64.StdEncoding,
 		base64.URLEncoding,
@@ -113,12 +114,12 @@ func ParseDigestHeader(header string) (algorithm string, hexHash string) {
 		base64.RawURLEncoding,
 	} {
 		if decoded, err := enc.DecodeString(value); err == nil {
-			h := hex.EncodeToString(decoded)
-			if len(h) == expectedHexLen {
-				return algo, h
+			if len(decoded) != expectedBytes {
+				return "", "", fmt.Errorf("digest length mismatch for %s", algo)
 			}
+			return algo, hex.EncodeToString(decoded), nil
 		}
 	}
 
-	return "", ""
+	return "", "", nil
 }

--- a/internal/processing/checksum.go
+++ b/internal/processing/checksum.go
@@ -103,17 +103,24 @@ func ParseDigestHeader(header string) (algorithm string, hexHash string) {
 		}
 	}
 
-	// RFC 3230 uses base64
-	decoded, err := base64.StdEncoding.DecodeString(value)
-	if err != nil {
-		decoded, err = base64.URLEncoding.DecodeString(value)
-		if err != nil {
-			// Maybe it's already hex
-			if _, hexErr := hex.DecodeString(value); hexErr == nil {
-				return algo, strings.ToLower(value)
+	// RFC 3230 uses base64 (padded or unpadded, standard or URL-safe)
+	for _, enc := range []*base64.Encoding{
+		base64.StdEncoding,
+		base64.URLEncoding,
+		base64.RawStdEncoding,
+		base64.RawURLEncoding,
+	} {
+		if decoded, err := enc.DecodeString(value); err == nil {
+			h := hex.EncodeToString(decoded)
+			if len(h) == expectedHexLen {
+				return algo, h
 			}
-			return "", ""
 		}
 	}
-	return algo, hex.EncodeToString(decoded)
+
+	// Hex fallback - only accept if length matches the expected hash size
+	if _, err := hex.DecodeString(value); err == nil && len(value) == expectedHexLen {
+		return algo, strings.ToLower(value)
+	}
+	return "", ""
 }

--- a/internal/processing/checksum.go
+++ b/internal/processing/checksum.go
@@ -1,0 +1,119 @@
+package processing
+
+import (
+	"crypto/md5"
+	"crypto/sha1"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"io"
+	"os"
+	"strings"
+)
+
+// ChecksumResult holds the outcome of a checksum verification.
+type ChecksumResult struct {
+	Algorithm string
+	Expected  string
+	Actual    string
+	Match     bool
+}
+
+// VerifyChecksum computes the hash of a file and compares it to the expected value.
+// algorithm should be one of: md5, sha1, sha256.
+// expected should be a hex-encoded hash string.
+func VerifyChecksum(filepath string, algorithm string, expected string) (*ChecksumResult, error) {
+	if filepath == "" || algorithm == "" || expected == "" {
+		return nil, fmt.Errorf("filepath, algorithm, and expected hash are all required")
+	}
+
+	algorithm = strings.ToLower(algorithm)
+	expected = strings.ToLower(strings.TrimSpace(expected))
+
+	var h hash.Hash
+	switch algorithm {
+	case "md5":
+		h = md5.New()
+	case "sha1", "sha-1":
+		h = sha1.New()
+	case "sha256", "sha-256":
+		h = sha256.New()
+	default:
+		return nil, fmt.Errorf("unsupported checksum algorithm: %s", algorithm)
+	}
+
+	f, err := os.Open(filepath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file for checksum: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := io.Copy(h, f); err != nil {
+		return nil, fmt.Errorf("failed to read file for checksum: %w", err)
+	}
+
+	actual := hex.EncodeToString(h.Sum(nil))
+	return &ChecksumResult{
+		Algorithm: algorithm,
+		Expected:  expected,
+		Actual:    actual,
+		Match:     actual == expected,
+	}, nil
+}
+
+// ParseDigestHeader parses an HTTP Digest header (RFC 3230) and returns
+// the algorithm and hex-encoded hash. Returns empty strings if not parseable.
+// Example header: "sha-256=base64hash" or "SHA-256=base64hash"
+func ParseDigestHeader(header string) (algorithm string, hexHash string) {
+	parts := strings.SplitN(header, "=", 2)
+	if len(parts) != 2 {
+		return "", ""
+	}
+
+	algo := strings.ToLower(strings.TrimSpace(parts[0]))
+	value := strings.TrimSpace(parts[1])
+
+	switch algo {
+	case "sha-256":
+		algo = "sha256"
+	case "sha-1":
+		algo = "sha1"
+	case "md5":
+		// already correct
+	default:
+		return "", ""
+	}
+
+	// Some servers provide hex directly in Digest; prefer that when it matches
+	// the expected hash length for the selected algorithm.
+	expectedHexLen := 0
+	switch algo {
+	case "md5":
+		expectedHexLen = 32
+	case "sha1":
+		expectedHexLen = 40
+	case "sha256":
+		expectedHexLen = 64
+	}
+	if len(value) == expectedHexLen {
+		if _, err := hex.DecodeString(value); err == nil {
+			return algo, strings.ToLower(value)
+		}
+	}
+
+	// RFC 3230 uses base64
+	decoded, err := base64.StdEncoding.DecodeString(value)
+	if err != nil {
+		decoded, err = base64.URLEncoding.DecodeString(value)
+		if err != nil {
+			// Maybe it's already hex
+			if _, hexErr := hex.DecodeString(value); hexErr == nil {
+				return algo, strings.ToLower(value)
+			}
+			return "", ""
+		}
+	}
+	return algo, hex.EncodeToString(decoded)
+}

--- a/internal/processing/checksum_test.go
+++ b/internal/processing/checksum_test.go
@@ -1,0 +1,75 @@
+package processing
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyChecksum_SHA256(t *testing.T) {
+	// Create a temp file with known content
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.bin")
+	content := []byte("hello surge")
+	require.NoError(t, os.WriteFile(path, content, 0o644))
+
+	// Compute expected hash
+	h := sha256.Sum256(content)
+	expected := hex.EncodeToString(h[:])
+
+	result, err := VerifyChecksum(path, "sha256", expected)
+	require.NoError(t, err)
+	assert.True(t, result.Match)
+	assert.Equal(t, expected, result.Actual)
+}
+
+func TestVerifyChecksum_Mismatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.bin")
+	require.NoError(t, os.WriteFile(path, []byte("hello"), 0o644))
+
+	result, err := VerifyChecksum(path, "sha256", "0000000000000000000000000000000000000000000000000000000000000000")
+	require.NoError(t, err)
+	assert.False(t, result.Match)
+}
+
+func TestVerifyChecksum_UnsupportedAlgorithm(t *testing.T) {
+	_, err := VerifyChecksum("/tmp/test", "sha512", "abc")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported")
+}
+
+func TestVerifyChecksum_EmptyArgs(t *testing.T) {
+	_, err := VerifyChecksum("", "sha256", "abc")
+	assert.Error(t, err)
+}
+
+func TestParseDigestHeader_SHA256Base64(t *testing.T) {
+	// sha256 of empty string in base64
+	algo, hash := ParseDigestHeader("sha-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=")
+	assert.Equal(t, "sha256", algo)
+	assert.NotEmpty(t, hash)
+}
+
+func TestParseDigestHeader_MD5Hex(t *testing.T) {
+	algo, hash := ParseDigestHeader("md5=d41d8cd98f00b204e9800998ecf8427e")
+	assert.Equal(t, "md5", algo)
+	assert.Equal(t, "d41d8cd98f00b204e9800998ecf8427e", hash)
+}
+
+func TestParseDigestHeader_Invalid(t *testing.T) {
+	algo, hash := ParseDigestHeader("invalid")
+	assert.Empty(t, algo)
+	assert.Empty(t, hash)
+}
+
+func TestParseDigestHeader_UnsupportedAlgo(t *testing.T) {
+	algo, hash := ParseDigestHeader("sha-512=abc")
+	assert.Empty(t, algo)
+	assert.Empty(t, hash)
+}

--- a/internal/processing/checksum_test.go
+++ b/internal/processing/checksum_test.go
@@ -1,6 +1,8 @@
 package processing
 
 import (
+	"crypto/md5"
+	"crypto/sha1"
 	"crypto/sha256"
 	"encoding/hex"
 	"os"
@@ -25,6 +27,38 @@ func TestVerifyChecksum_SHA256(t *testing.T) {
 	result, err := VerifyChecksum(path, "sha256", expected)
 	require.NoError(t, err)
 	assert.True(t, result.Match)
+	assert.Equal(t, expected, result.Actual)
+}
+
+func TestVerifyChecksum_MD5(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.bin")
+	content := []byte("hello surge")
+	require.NoError(t, os.WriteFile(path, content, 0o644))
+
+	h := md5.Sum(content)
+	expected := hex.EncodeToString(h[:])
+
+	result, err := VerifyChecksum(path, "md5", expected)
+	require.NoError(t, err)
+	assert.True(t, result.Match)
+	assert.Equal(t, "md5", result.Algorithm)
+	assert.Equal(t, expected, result.Actual)
+}
+
+func TestVerifyChecksum_SHA1(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.bin")
+	content := []byte("hello surge")
+	require.NoError(t, os.WriteFile(path, content, 0o644))
+
+	h := sha1.Sum(content)
+	expected := hex.EncodeToString(h[:])
+
+	result, err := VerifyChecksum(path, "sha-1", expected)
+	require.NoError(t, err)
+	assert.True(t, result.Match)
+	assert.Equal(t, "sha1", result.Algorithm)
 	assert.Equal(t, expected, result.Actual)
 }
 
@@ -53,7 +87,7 @@ func TestParseDigestHeader_SHA256Base64(t *testing.T) {
 	// sha256 of empty string in base64
 	algo, hash := ParseDigestHeader("sha-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=")
 	assert.Equal(t, "sha256", algo)
-	assert.NotEmpty(t, hash)
+	assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", hash)
 }
 
 func TestParseDigestHeader_MD5Hex(t *testing.T) {

--- a/internal/processing/checksum_test.go
+++ b/internal/processing/checksum_test.go
@@ -83,27 +83,45 @@ func TestVerifyChecksum_EmptyArgs(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func mustParseDigestHeader(t *testing.T, header string) (string, string) {
+	t.Helper()
+	algo, hash, err := ParseDigestHeader(header)
+	require.NoError(t, err)
+	return algo, hash
+}
+
 func TestParseDigestHeader_SHA256Base64(t *testing.T) {
 	// sha256 of empty string in base64
-	algo, hash := ParseDigestHeader("sha-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=")
+	algo, hash := mustParseDigestHeader(t, "sha-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=")
 	assert.Equal(t, "sha256", algo)
 	assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", hash)
 }
 
 func TestParseDigestHeader_MD5Hex(t *testing.T) {
-	algo, hash := ParseDigestHeader("md5=d41d8cd98f00b204e9800998ecf8427e")
+	algo, hash := mustParseDigestHeader(t, "md5=d41d8cd98f00b204e9800998ecf8427e")
 	assert.Equal(t, "md5", algo)
 	assert.Equal(t, "d41d8cd98f00b204e9800998ecf8427e", hash)
 }
 
 func TestParseDigestHeader_Invalid(t *testing.T) {
-	algo, hash := ParseDigestHeader("invalid")
+	algo, hash := mustParseDigestHeader(t, "invalid")
 	assert.Empty(t, algo)
 	assert.Empty(t, hash)
 }
 
 func TestParseDigestHeader_UnsupportedAlgo(t *testing.T) {
-	algo, hash := ParseDigestHeader("sha-512=abc")
+	algo, hash := mustParseDigestHeader(t, "sha-512=abc")
 	assert.Empty(t, algo)
 	assert.Empty(t, hash)
+}
+
+func TestParseDigestHeader_SHA256UnpaddedBase64(t *testing.T) {
+	algo, hash := mustParseDigestHeader(t, "sha-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU")
+	assert.Equal(t, "sha256", algo)
+	assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", hash)
+}
+
+func TestParseDigestHeader_SHA256WrongLengthHex(t *testing.T) {
+	_, _, err := ParseDigestHeader("sha-256=d41d8cd98f00b204e9800998ecf8427e")
+	require.Error(t, err)
 }


### PR DESCRIPTION
## Summary

Add a checksum verification library that computes file hashes and compares them against expected values. Also parses HTTP Digest response headers (RFC 3230) for server-provided checksums.

## Why this matters

aria2 has `--checksum=sha-256=HASH`. wget verifies checksums. When downloading Linux ISOs or software releases, users expect integrity verification. Surge currently downloads files with no integrity check.

## Changes

- Add `VerifyChecksum(filepath, algorithm, expected)` supporting MD5, SHA-1, SHA-256
- Add `ParseDigestHeader(header)` to extract checksums from RFC 3230 HTTP Digest headers (base64 and hex)
- Both functions are in `internal/processing/checksum.go`
- This is the core library. Wiring into the download lifecycle and CLI `--checksum` flag will follow in a separate PR.

## Testing

![Tests](https://vhs.charm.sh/vhs-H7lJRKhxNG8SF0L1QO4Kn.gif)

```
go test ./... -count=1   # All 18 packages pass
```

This contribution was developed with AI assistance (Codex + Claude Code).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `internal/processing/checksum.go` with `VerifyChecksum` (MD5/SHA-1/SHA-256 file hashing) and `ParseDigestHeader` (RFC 3230 Digest header parsing), along with a comprehensive test suite. Previously raised concerns around unpadded base64 support, parameter shadowing, algorithm normalization inconsistency, and missing MD5/SHA-1 tests have all been addressed in this revision. The remaining findings are all P2: a dead error branch in the hex fast-path, an incomplete doc comment, and two untested code paths (URL-safe base64, SHA-1) in `ParseDigestHeader`.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all remaining findings are P2 style/cleanup items that don't affect correctness.

All previously flagged blocking issues have been resolved. The three remaining comments are P2: dead code that doesn't affect behavior, an incomplete doc string, and two untested code paths. None of these cause wrong results or silent failures in the changed code.

No files require special attention beyond the minor cleanup notes.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/processing/checksum.go | New checksum library implementing VerifyChecksum and ParseDigestHeader; previously raised issues (unpadded base64, parameter shadowing, normalization) are addressed, but the hex fast-path contains a dead error branch and the doc comment omits alias forms. |
| internal/processing/checksum_test.go | Good test coverage for happy paths and error cases; URL-safe base64 and SHA-1 paths in ParseDigestHeader are not exercised, leaving two supported code paths untested. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ParseDigestHeader] --> B{SplitN on '='}
    B -- "< 2 parts" --> C[return '', '', nil]
    B -- "2 parts" --> D{Normalize algo}
    D -- "unsupported" --> C
    D -- "sha-256/sha-1/md5" --> E[Compute expectedBytes & expectedHexLen]
    E --> F{len == expectedHexLen?}
    F -- "yes" --> G{hex.DecodeString ok?}
    G -- "yes" --> H[return algo, hex value]
    G -- "no" --> I[Try base64 variants]
    F -- "no" --> I
    I --> J{Any variant decodes ok?}
    J -- "yes" --> K{correct length?}
    K -- "yes" --> H
    K -- "no" --> Q[return error: length mismatch]
    J -- "no" --> O[return '', '', nil]

    R[VerifyChecksum] --> S{empty args?}
    S -- "yes" --> T[return error]
    S -- "no" --> U{switch algo}
    U -- "unsupported" --> T
    U -- "md5/sha1/sha256" --> V[os.Open file]
    V -- "error" --> T
    V -- "ok" --> W[io.Copy to hash]
    W --> X[hex.EncodeToString]
    X --> Y[return ChecksumResult]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/processing/checksum.go
Line: 101-107

Comment:
**Unreachable length guard in hex fast-path**

Inside the `if len(value) == expectedHexLen` branch, a successful `hex.DecodeString` on a valid hex string of length `2*N` always produces exactly `N` bytes. Because entry requires `len(value) == expectedHexLen` (= `expectedBytes * 2`), the condition `len(decoded) != expectedBytes` is always `false` after a clean decode and the `fmt.Errorf` at line 104 can never execute. The dead error path may mislead future maintainers into thinking there is a case where hex decoding can succeed but produce wrong-length output.

```suggestion
	if len(value) == expectedHexLen {
		if decoded, err := hex.DecodeString(value); err == nil {
			return algo, strings.ToLower(value), nil
		}
	}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/processing/checksum.go
Line: 24-26

Comment:
**Doc comment omits accepted alias forms**

The comment says `algorithm should be one of: md5, sha1, sha256`, but the switch also accepts the hyphenated aliases `sha-1` and `sha-256`. Callers reading only the doc comment won't know the aliases are valid.

```suggestion
// VerifyChecksum computes the hash of a file and compares it to the expected value.
// algorithm should be one of: md5, sha1 (or sha-1), sha256 (or sha-256).
// expected should be a hex-encoded hash string.
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/processing/checksum_test.go
Line: 93-127

Comment:
**URL-safe base64 and SHA-1 paths in `ParseDigestHeader` are untested**

The implementation tries four base64 variants (`StdEncoding`, `URLEncoding`, `RawStdEncoding`, `RawURLEncoding`), but no test exercises the URL-safe path (characters `-` and `_`). Likewise, `ParseDigestHeader` accepts `sha-1` but has no test for it — a future breakage in that branch would go undetected. Per the team's edge-case testing rule, each supported code path should have at least one passing test.

Consider adding:

```go
func TestParseDigestHeader_SHA256URLSafeBase64(t *testing.T) {
    // SHA-256 of empty string in URL-safe base64 (no padding)
    algo, hash := mustParseDigestHeader(t, "sha-256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU")
    assert.Equal(t, "sha256", algo)
    assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", hash)
}

func TestParseDigestHeader_SHA1Base64(t *testing.T) {
    h := sha1.Sum([]byte(""))
    encoded := base64.StdEncoding.EncodeToString(h[:])
    algo, hash := mustParseDigestHeader(t, "sha-1="+encoded)
    assert.Equal(t, "sha1", algo)
    assert.Equal(t, hex.EncodeToString(h[:]), hash)
}
```

**Rule Used:** What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (5): Last reviewed commit: ["fix: validate hash length and support un..."](https://github.com/surgedm/surge/commit/3a1a223a0fa1e4c8d65f1becb23880e187d6c0b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27384525)</sub>

**Context used:**

- Rule used - What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))

<!-- /greptile_comment -->