### PR TITLE
feat: add Real-Debrid API client for premium download speeds

### DIFF
--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -41,13 +41,21 @@ const (
 
 // NetworkSettings contains network connection parameters.
 type NetworkSettings struct {
-	MaxConnectionsPerHost  int    `json:"max_connections_per_host"`
-	MaxConcurrentDownloads int    `json:"max_concurrent_downloads"`
-	UserAgent              string `json:"user_agent"`
-	ProxyURL               string `json:"proxy_url"`
-	SequentialDownload     bool   `json:"sequential_download"`
-	MinChunkSize           int64  `json:"min_chunk_size"`
-	WorkerBufferSize       int    `json:"worker_buffer_size"`
+	MaxConnectionsPerHost  int            `json:"max_connections_per_host"`
+	MaxConcurrentDownloads int            `json:"max_concurrent_downloads"`
+	UserAgent              string         `json:"user_agent"`
+	ProxyURL               string         `json:"proxy_url"`
+	SequentialDownload     bool           `json:"sequential_download"`
+	MinChunkSize           int64          `json:"min_chunk_size"`
+	WorkerBufferSize       int            `json:"worker_buffer_size"`
+	Debrid                 DebridSettings `json:"debrid"`
+}
+
+// DebridSettings contains debrid service settings.
+type DebridSettings struct {
+	Enabled  bool   `json:"enabled"`
+	Provider string `json:"provider"`
+	APIKey   string `json:"api_key"`
 }
 
 // PerformanceSettings contains performance tuning parameters.
@@ -102,12 +110,17 @@ func GetSettingsMetadata() map[string][]SettingMeta {
 			{Key: "stall_timeout", Label: "Stall Timeout", Description: "Restart workers with no data for this duration (e.g., 5s).", Type: "duration"},
 			{Key: "speed_ema_alpha", Label: "Speed EMA Alpha", Description: "Exponential moving average smoothing factor (0.0-1.0).", Type: "float64"},
 		},
+		"Debrid": {
+			{Key: "enabled", Label: "Enable Debrid", Description: "Route downloads through a debrid service for premium speeds from file hosts.", Type: "bool"},
+			{Key: "provider", Label: "Provider", Description: "Debrid service provider (currently only real-debrid).", Type: "string"},
+			{Key: "api_key", Label: "API Key", Description: "Your debrid service API key.", Type: "string"},
+		},
 	}
 }
 
 // CategoryOrder returns the order of categories for UI tabs.
 func CategoryOrder() []string {
-	return []string{"General", "Network", "Performance", "Categories"}
+	return []string{"General", "Network", "Performance", "Debrid", "Categories"}
 }
 
 const (
@@ -142,6 +155,11 @@ func DefaultSettings() *Settings {
 			SequentialDownload:     false,
 			MinChunkSize:           2 * MB,
 			WorkerBufferSize:       512 * KB,
+			Debrid: DebridSettings{
+				Enabled:  false,
+				Provider: "real-debrid",
+				APIKey:   "",
+			},
 		},
 		Performance: PerformanceSettings{
 			MaxTaskRetries:        3,

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -453,7 +453,7 @@ func TestCategoryOrder(t *testing.T) {
 	}
 
 	// Should have all expected categories
-	expectedCount := 4 // General, Network, Performance, Categories
+	expectedCount := 5 // General, Network, Performance, Debrid, Categories
 	if len(order) != expectedCount {
 		t.Errorf("Expected %d categories, got %d", expectedCount, len(order))
 	}

--- a/internal/debrid/realdebrid.go
+++ b/internal/debrid/realdebrid.go
@@ -1,0 +1,140 @@
+package debrid
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Client is a Real-Debrid API client.
+type Client struct {
+	apiKey     string
+	httpClient *http.Client
+	baseURL    string
+}
+
+// NewClient creates a new Real-Debrid client with the given API key.
+func NewClient(apiKey string) *Client {
+	return &Client{
+		apiKey: apiKey,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		baseURL: "https://api.real-debrid.com/rest/1.0",
+	}
+}
+
+// UnrestrictResult holds the response from unrestricting a link.
+type UnrestrictResult struct {
+	ID       string `json:"id"`
+	Filename string `json:"filename"`
+	FileSize int64  `json:"filesize"`
+	Link     string `json:"link"`     // Original link
+	Download string `json:"download"` // Unrestricted direct download URL
+	Host     string `json:"host"`
+	MimeType string `json:"mimeType"`
+}
+
+// apiError represents an error response from Real-Debrid.
+type apiError struct {
+	ErrorCode int    `json:"error_code"`
+	Error     string `json:"error"`
+}
+
+// Unrestrict takes a hosted file URL and returns a direct download URL.
+func (c *Client) Unrestrict(link string) (*UnrestrictResult, error) {
+	if c.apiKey == "" {
+		return nil, fmt.Errorf("debrid: API key is required")
+	}
+
+	data := url.Values{}
+	data.Set("link", link)
+
+	req, err := http.NewRequest(http.MethodPost, c.baseURL+"/unrestrict/link", strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("debrid: failed to create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("debrid: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("debrid: failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var apiErr apiError
+		if json.Unmarshal(body, &apiErr) == nil && apiErr.Error != "" {
+			return nil, fmt.Errorf("debrid: API error %d: %s", apiErr.ErrorCode, apiErr.Error)
+		}
+		return nil, fmt.Errorf("debrid: unexpected status %d", resp.StatusCode)
+	}
+
+	var result UnrestrictResult
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("debrid: failed to parse response: %w", err)
+	}
+
+	if result.Download == "" {
+		return nil, fmt.Errorf("debrid: no download URL in response")
+	}
+
+	return &result, nil
+}
+
+// SupportedHosts returns the list of supported file hosting domains.
+func (c *Client) SupportedHosts() ([]string, error) {
+	req, err := http.NewRequest(http.MethodGet, c.baseURL+"/hosts/domains", nil)
+	if err != nil {
+		return nil, fmt.Errorf("debrid: failed to create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("debrid: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("debrid: unexpected status %d", resp.StatusCode)
+	}
+
+	var domains []string
+	if err := json.NewDecoder(resp.Body).Decode(&domains); err != nil {
+		return nil, fmt.Errorf("debrid: failed to parse hosts response: %w", err)
+	}
+
+	return domains, nil
+}
+
+// IsSupported checks if a URL's host is supported by Real-Debrid.
+func (c *Client) IsSupported(rawURL string) bool {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(parsed.Hostname())
+
+	hosts, err := c.SupportedHosts()
+	if err != nil {
+		return false
+	}
+
+	for _, h := range hosts {
+		h = strings.ToLower(h)
+		if h == host || strings.HasSuffix(host, "."+h) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/debrid/realdebrid.go
+++ b/internal/debrid/realdebrid.go
@@ -121,11 +121,13 @@ func (c *Client) SupportedHosts() ([]string, error) {
 	return domains, nil
 }
 
-// supportedHostsCached returns the supported hosts list, caching for 1 hour
-// to avoid making a live HTTP call on every invocation.
+// supportedHostsCached returns the supported hosts list, caching briefly to
+// avoid making a live HTTP call on every invocation.
 func (c *Client) supportedHostsCached() ([]string, error) {
+	now := time.Now()
+
 	c.mu.RLock()
-	if c.cachedHosts != nil && time.Since(c.hostsCached) < time.Hour {
+	if c.cachedHosts != nil && now.Sub(c.hostsCached) < 5*time.Minute {
 		hosts := c.cachedHosts
 		c.mu.RUnlock()
 		return hosts, nil
@@ -135,7 +137,8 @@ func (c *Client) supportedHostsCached() ([]string, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	// Double-check after acquiring write lock.
-	if c.cachedHosts != nil && time.Since(c.hostsCached) < time.Hour {
+	now = time.Now()
+	if c.cachedHosts != nil && now.Sub(c.hostsCached) < 5*time.Minute {
 		return c.cachedHosts, nil
 	}
 	hosts, err := c.SupportedHosts()
@@ -143,7 +146,7 @@ func (c *Client) supportedHostsCached() ([]string, error) {
 		return nil, err
 	}
 	c.cachedHosts = hosts
-	c.hostsCached = time.Now()
+	c.hostsCached = now
 	return hosts, nil
 }
 

--- a/internal/debrid/realdebrid.go
+++ b/internal/debrid/realdebrid.go
@@ -12,9 +12,11 @@ import (
 
 // Client is a Real-Debrid API client.
 type Client struct {
-	apiKey     string
-	httpClient *http.Client
-	baseURL    string
+	apiKey      string
+	httpClient  *http.Client
+	baseURL     string
+	cachedHosts []string
+	hostsCached time.Time
 }
 
 // NewClient creates a new Real-Debrid client with the given API key.
@@ -117,6 +119,21 @@ func (c *Client) SupportedHosts() ([]string, error) {
 	return domains, nil
 }
 
+// supportedHostsCached returns the supported hosts list, caching for 1 hour
+// to avoid making a live HTTP call on every invocation.
+func (c *Client) supportedHostsCached() ([]string, error) {
+	if c.cachedHosts != nil && time.Since(c.hostsCached) < time.Hour {
+		return c.cachedHosts, nil
+	}
+	hosts, err := c.SupportedHosts()
+	if err != nil {
+		return nil, err
+	}
+	c.cachedHosts = hosts
+	c.hostsCached = time.Now()
+	return hosts, nil
+}
+
 // IsSupported checks if a URL's host is supported by Real-Debrid.
 func (c *Client) IsSupported(rawURL string) bool {
 	parsed, err := url.Parse(rawURL)
@@ -125,7 +142,7 @@ func (c *Client) IsSupported(rawURL string) bool {
 	}
 	host := strings.ToLower(parsed.Hostname())
 
-	hosts, err := c.SupportedHosts()
+	hosts, err := c.supportedHostsCached()
 	if err != nil {
 		return false
 	}

--- a/internal/debrid/realdebrid.go
+++ b/internal/debrid/realdebrid.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -15,6 +16,7 @@ type Client struct {
 	apiKey      string
 	httpClient  *http.Client
 	baseURL     string
+	mu          sync.RWMutex
 	cachedHosts []string
 	hostsCached time.Time
 }
@@ -122,6 +124,17 @@ func (c *Client) SupportedHosts() ([]string, error) {
 // supportedHostsCached returns the supported hosts list, caching for 1 hour
 // to avoid making a live HTTP call on every invocation.
 func (c *Client) supportedHostsCached() ([]string, error) {
+	c.mu.RLock()
+	if c.cachedHosts != nil && time.Since(c.hostsCached) < time.Hour {
+		hosts := c.cachedHosts
+		c.mu.RUnlock()
+		return hosts, nil
+	}
+	c.mu.RUnlock()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Double-check after acquiring write lock.
 	if c.cachedHosts != nil && time.Since(c.hostsCached) < time.Hour {
 		return c.cachedHosts, nil
 	}

--- a/internal/debrid/realdebrid.go
+++ b/internal/debrid/realdebrid.go
@@ -37,8 +37,8 @@ type UnrestrictResult struct {
 	ID       string `json:"id"`
 	Filename string `json:"filename"`
 	FileSize int64  `json:"filesize"`
-	Link     string `json:"link"`     // Original link
-	Download string `json:"download"` // Unrestricted direct download URL
+	Link     string `json:"link"`
+	Download string `json:"download"`
 	Host     string `json:"host"`
 	MimeType string `json:"mimeType"`
 }

--- a/internal/debrid/realdebrid_test.go
+++ b/internal/debrid/realdebrid_test.go
@@ -1,0 +1,90 @@
+package debrid
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnrestrict_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/unrestrict/link", r.URL.Path)
+		assert.Contains(t, r.Header.Get("Authorization"), "Bearer")
+
+		_ = json.NewEncoder(w).Encode(UnrestrictResult{
+			ID:       "test123",
+			Filename: "file.zip",
+			FileSize: 1024,
+			Download: "https://direct.example.com/file.zip",
+			Host:     "mega.nz",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-api-key")
+	client.baseURL = server.URL
+
+	result, err := client.Unrestrict("https://mega.nz/file/abc")
+	require.NoError(t, err)
+	assert.Equal(t, "file.zip", result.Filename)
+	assert.Equal(t, "https://direct.example.com/file.zip", result.Download)
+}
+
+func TestUnrestrict_NoAPIKey(t *testing.T) {
+	client := NewClient("")
+	_, err := client.Unrestrict("https://mega.nz/file/abc")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "API key is required")
+}
+
+func TestUnrestrict_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(apiError{
+			ErrorCode: 8,
+			Error:     "Bad token",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("bad-key")
+	client.baseURL = server.URL
+
+	_, err := client.Unrestrict("https://mega.nz/file/abc")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Bad token")
+}
+
+func TestSupportedHosts(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/hosts/domains", r.URL.Path)
+		_ = json.NewEncoder(w).Encode([]string{"mega.nz", "rapidgator.net", "uploaded.net"})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key")
+	client.baseURL = server.URL
+
+	hosts, err := client.SupportedHosts()
+	require.NoError(t, err)
+	assert.Contains(t, hosts, "mega.nz")
+}
+
+func TestIsSupported(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]string{"mega.nz", "rapidgator.net"})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key")
+	client.baseURL = server.URL
+
+	assert.True(t, client.IsSupported("https://mega.nz/file/abc"))
+	assert.True(t, client.IsSupported("https://www.mega.nz/file/abc"))
+	assert.False(t, client.IsSupported("https://example.com/file"))
+}

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -275,6 +275,10 @@ func (m RootModel) getSettingsValues(category string) map[string]interface{} {
 		values["slow_worker_grace_period"] = m.Settings.Performance.SlowWorkerGracePeriod
 		values["stall_timeout"] = m.Settings.Performance.StallTimeout
 		values["speed_ema_alpha"] = m.Settings.Performance.SpeedEmaAlpha
+	case "Debrid":
+		values["enabled"] = m.Settings.Network.Debrid.Enabled
+		values["provider"] = m.Settings.Network.Debrid.Provider
+		values["api_key"] = m.Settings.Network.Debrid.APIKey
 	case "Categories":
 		values["category_enabled"] = m.Settings.General.CategoryEnabled
 	}
@@ -302,6 +306,8 @@ func (m *RootModel) setSettingValue(category, key, value string) error {
 		return m.setNetworkSetting(key, value, meta.Type)
 	case "Performance":
 		return m.setPerformanceSetting(key, value, meta.Type)
+	case "Debrid":
+		return m.setDebridSetting(key, value, meta.Type)
 	case "Categories":
 		if key == "category_enabled" {
 			m.Settings.General.CategoryEnabled = !m.Settings.General.CategoryEnabled
@@ -461,6 +467,18 @@ func (m *RootModel) setPerformanceSetting(key, value, typ string) error {
 			}
 			m.Settings.Performance.SpeedEmaAlpha = v
 		}
+	}
+	return nil
+}
+
+func (m *RootModel) setDebridSetting(key, value, typ string) error {
+	switch key {
+	case "enabled":
+		m.Settings.Network.Debrid.Enabled = !m.Settings.Network.Debrid.Enabled
+	case "provider":
+		m.Settings.Network.Debrid.Provider = value
+	case "api_key":
+		m.Settings.Network.Debrid.APIKey = value
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Add a Real-Debrid API client that can unrestrict file hosting links to get direct download URLs. Includes host detection and debrid settings in the TUI.

## Why this matters

From the README: "Debrid Integration: Covering subscription costs so we can test and build native Debrid support" is listed as a donation goal. JDownloader has debrid support and it's a major reason power users choose it. No TUI download manager has debrid integration.

Real-Debrid unrestricts links from file hosts like Mega, RapidGator, and Uploaded, providing direct high-speed download URLs for ~$4/month.

## Changes

- Add `internal/debrid/` package with `Client` struct wrapping the Real-Debrid REST API
- `Unrestrict(link)` sends a URL to Real-Debrid and gets back a direct download URL
- `SupportedHosts()` fetches the list of supported file hosting domains
- `IsSupported(url)` checks if a URL's host is debrid-eligible
- Add `DebridSettings` to config (enabled, provider, API key) with TUI settings tab
- Error handling for expired tokens, unsupported hosts, quota exceeded

Wiring into the probe flow (auto-unrestrict debrid-eligible URLs) will follow in a separate PR. This PR establishes the client and settings.

## Testing

All tests use mock HTTP servers, no Real-Debrid account needed:

![Tests](https://vhs.charm.sh/vhs-315ZXtDjVqsW0inhKZCmdT.gif)

```
go test ./... -count=1   # All 19 packages pass
```

This contribution was developed with AI assistance (Codex + Claude Code).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `internal/debrid` package with a Real-Debrid API client, `DebridSettings` in config, and a working Debrid tab in the TUI settings UI. Previous concerns (data race on cached hosts, live HTTP call per `IsSupported` invocation, missing TUI wiring, redundant comments) have all been addressed in follow-up commits.

- **P1 — `resetSettingToDefault` in `view_settings.go` is missing a `case \"Debrid\"` branch.** Pressing the Reset key while on the Debrid settings tab calls `resetSettingToDefault(\"Debrid\", key, defaults)`, which falls through the switch silently, so no field is ever restored to its default.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the missing Debrid case in resetSettingToDefault; all other changes are correct.

One P1 defect remains: pressing Reset on any Debrid setting silently does nothing because resetSettingToDefault has no Debrid branch. All prior concerns from earlier review rounds are resolved. Everything else is P2 or lower.

internal/tui/view_settings.go — resetSettingToDefault function missing Debrid case

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/tui/view_settings.go | getSettingsValues and setSettingValue/setDebridSetting correctly wired for Debrid, but resetSettingToDefault is missing a Debrid case, silently dropping all reset actions on the Debrid tab. |
| internal/debrid/realdebrid.go | Well-structured Real-Debrid client with correct RWMutex double-check locking for the 5-minute host cache; no issues found. |
| internal/debrid/realdebrid_test.go | Good mock-server coverage for happy path and error cases; TestIsSupported doesn't verify the cache limits HTTP calls to one, leaving the caching contract untested. |
| internal/config/settings.go | Clean addition of DebridSettings struct, metadata, and defaults; CategoryOrder correctly includes Debrid. |
| internal/config/settings_test.go | Tests updated to expect 5 categories; comprehensive round-trip, corruption, and metadata validation coverage. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant TUI as TUI (view_settings)
    participant Client as debrid.Client
    participant Cache as Host Cache (RWMutex)
    participant RD as Real-Debrid API

    Note over TUI,RD: Unrestrict flow
    TUI->>Client: Unrestrict(link)
    Client->>RD: POST /unrestrict/link (Bearer token)
    RD-->>Client: UnrestrictResult{Download URL}
    Client-->>TUI: *UnrestrictResult

    Note over TUI,RD: IsSupported flow (with caching)
    TUI->>Client: IsSupported(url)
    Client->>Cache: RLock check cachedHosts (TTL 5m)
    alt cache hit
        Cache-->>Client: []string (cached)
    else cache miss
        Cache-->>Client: nil
        Client->>Cache: Lock (double-check)
        Client->>RD: GET /hosts/domains (no auth)
        RD-->>Client: []string domains
        Client->>Cache: store hosts + timestamp
        Cache-->>Client: []string
    end
    Client-->>TUI: bool
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `internal/tui/view_settings.go`, line 247-283 ([link](https://github.com/surgedm/surge/blob/9f71ea7f071793f9024651c5f9fc4a3459f8160f/internal/tui/view_settings.go#L247-L283)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Debrid tab will display nothing and edits won't apply**

   `getSettingsValues`, `setSettingValue`, and `resetSettingToDefault` all use `switch category` blocks that handle `"General"`, `"Network"`, `"Performance"`, and `"Categories"` — but none has a `"Debrid"` case. When the user opens the Debrid tab: values show empty, toggling `enabled` does nothing, editing `api_key` is silently discarded, and Reset has no effect. The tab is visible but completely inert.

   The three functions need `"Debrid"` cases wired to `m.Settings.Network.Debrid.{Enabled,Provider,APIKey}`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/tui/view_settings.go
   Line: 247-283

   Comment:
   **Debrid tab will display nothing and edits won't apply**

   `getSettingsValues`, `setSettingValue`, and `resetSettingToDefault` all use `switch category` blocks that handle `"General"`, `"Network"`, `"Performance"`, and `"Categories"` — but none has a `"Debrid"` case. When the user opens the Debrid tab: values show empty, toggling `enabled` does nothing, editing `api_key` is silently discarded, and Reset has no effect. The tab is visible but completely inert.

   The three functions need `"Debrid"` cases wired to `m.Settings.Network.Debrid.{Enabled,Provider,APIKey}`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `internal/tui/view_settings.go`, line 248-283 ([link](https://github.com/surgedm/surge/blob/6f1fa3af64c6e8b03e3be342deba50adbc2099e4/internal/tui/view_settings.go#L248-L283)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Debrid tab is silently non-functional in the TUI**

   `getSettingsValues`, `setSettingValue`, and `resetSettingToDefault` all dispatch on category name via `switch` statements, but none of them have a `"Debrid"` case. The result is:

   - **Display**: `getSettingsValues("Debrid")` returns an empty map, so every Debrid setting renders as blank in the right pane.
   - **Editing**: `setSettingValue("Debrid", ...)` falls through all cases and returns `nil` without writing anything — user edits are silently dropped.
   - **Reset**: `resetSettingToDefault("Debrid", ...)` is a no-op for the same reason.

   The tab is visible and navigable, but every interaction with it is a silent no-op. The three functions all need a `"Debrid"` arm wired to `m.Settings.Network.Debrid.*`. For example in `getSettingsValues`:

   ```go
   case "Debrid":
       values["enabled"]  = m.Settings.Network.Debrid.Enabled
       values["provider"] = m.Settings.Network.Debrid.Provider
       values["api_key"]  = m.Settings.Network.Debrid.APIKey
   ```

   And a corresponding `setDebridSetting` / reset block covering `enabled`, `provider`, and `api_key`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/tui/view_settings.go
   Line: 248-283

   Comment:
   **Debrid tab is silently non-functional in the TUI**

   `getSettingsValues`, `setSettingValue`, and `resetSettingToDefault` all dispatch on category name via `switch` statements, but none of them have a `"Debrid"` case. The result is:

   - **Display**: `getSettingsValues("Debrid")` returns an empty map, so every Debrid setting renders as blank in the right pane.
   - **Editing**: `setSettingValue("Debrid", ...)` falls through all cases and returns `nil` without writing anything — user edits are silently dropped.
   - **Reset**: `resetSettingToDefault("Debrid", ...)` is a no-op for the same reason.

   The tab is visible and navigable, but every interaction with it is a silent no-op. The three functions all need a `"Debrid"` arm wired to `m.Settings.Network.Debrid.*`. For example in `getSettingsValues`:

   ```go
   case "Debrid":
       values["enabled"]  = m.Settings.Network.Debrid.Enabled
       values["provider"] = m.Settings.Network.Debrid.Provider
       values["api_key"]  = m.Settings.Network.Debrid.APIKey
   ```

   And a corresponding `setDebridSetting` / reset block covering `enabled`, `provider`, and `api_key`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

3. `internal/tui/view_settings.go`, line 648-709 ([link](https://github.com/surgedm/surge/blob/2cb1c98f0a83d09c634381d400d4ef691589d8ee/internal/tui/view_settings.go#L648-L709)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`resetSettingToDefault` missing Debrid branch**

   `resetSettingToDefault` covers `"General"`, `"Network"`, `"Performance"`, and `"Categories"` but has no `"Debrid"` branch. Pressing the reset-to-default key while the Debrid tab is active silently does nothing — `Enabled`, `Provider`, and `APIKey` cannot be reset through the UI.

   A `case "Debrid"` block mirroring the pattern used for other categories (reset each key to its corresponding `defaults.Network.Debrid.*` value) is needed to close this gap.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/tui/view_settings.go
   Line: 648-709

   Comment:
   **`resetSettingToDefault` missing Debrid branch**

   `resetSettingToDefault` covers `"General"`, `"Network"`, `"Performance"`, and `"Categories"` but has no `"Debrid"` branch. Pressing the reset-to-default key while the Debrid tab is active silently does nothing — `Enabled`, `Provider`, and `APIKey` cannot be reset through the UI.

   A `case "Debrid"` block mirroring the pattern used for other categories (reset each key to its corresponding `defaults.Network.Debrid.*` value) is needed to close this gap.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/tui/view_settings.go
Line: 648-709

Comment:
**`resetSettingToDefault` silently ignores Debrid resets**

`resetSettingToDefault` has no `case "Debrid"` branch. When a user navigates to the Debrid tab and presses the Reset key, `update_settings.go:148` calls this function with `currentCategory == "Debrid"`, the switch falls through without doing anything, and the reset is silently discarded. A Debrid branch mirroring the same pattern used by the other categories is needed here.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/debrid/realdebrid_test.go
Line: 78-90

Comment:
**Cache behaviour is not verified by the test**

`TestIsSupported` makes three `IsSupported` calls but the mock server never counts requests, so the test won't catch a regression where the cache is bypassed and every call fires a separate HTTP round-trip. A request counter on the test server (e.g., `atomic.Int32`) would confirm only one network call is made for the three lookups.

**Rule Used:** What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (6): Last reviewed commit: ["fix: reduce host cache TTL to 5min and u..."](https://github.com/surgedm/surge/commit/491e35e42a91b042da6435067229acc74f5f0b9d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27384533)</sub>

<!-- /greptile_comment -->