### PR TITLE
feat: add new extension tab in settings to make it easier for new users.

### DIFF
--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -12,7 +12,9 @@ func TestResolveClientOutputPath(t *testing.T) {
 	originalHost := os.Getenv("SURGE_HOST")
 	originalGlobalHost := globalHost
 	defer func() {
-		os.Setenv("SURGE_HOST", originalHost)
+		if err := os.Setenv("SURGE_HOST", originalHost); err != nil {
+			t.Errorf("failed to restore SURGE_HOST: %v", err)
+		}
 		globalHost = originalGlobalHost
 	}()
 
@@ -31,7 +33,9 @@ func TestResolveClientOutputPath(t *testing.T) {
 		{
 			name: "Remote Host Set via Env - Pass Through Empty",
 			setupHost: func() {
-				os.Setenv("SURGE_HOST", "127.0.0.1:1234")
+				if err := os.Setenv("SURGE_HOST", "127.0.0.1:1234"); err != nil {
+					t.Fatalf("failed to set SURGE_HOST: %v", err)
+				}
 				globalHost = ""
 			},
 			outputDir: "",
@@ -40,7 +44,9 @@ func TestResolveClientOutputPath(t *testing.T) {
 		{
 			name: "Remote Host Set via Global - Pass Through Exact",
 			setupHost: func() {
-				os.Setenv("SURGE_HOST", "")
+				if err := os.Setenv("SURGE_HOST", ""); err != nil {
+					t.Fatalf("failed to clear SURGE_HOST: %v", err)
+				}
 				globalHost = "127.0.0.1:1234"
 			},
 			outputDir: ".",
@@ -49,7 +55,9 @@ func TestResolveClientOutputPath(t *testing.T) {
 		{
 			name: "Local Execution - Empty Dir returns CWD",
 			setupHost: func() {
-				os.Setenv("SURGE_HOST", "")
+				if err := os.Setenv("SURGE_HOST", ""); err != nil {
+					t.Fatalf("failed to clear SURGE_HOST: %v", err)
+				}
 				globalHost = ""
 			},
 			outputDir: "",
@@ -58,7 +66,9 @@ func TestResolveClientOutputPath(t *testing.T) {
 		{
 			name: "Local Execution - Dot returns Absolute CWD",
 			setupHost: func() {
-				os.Setenv("SURGE_HOST", "")
+				if err := os.Setenv("SURGE_HOST", ""); err != nil {
+					t.Fatalf("failed to clear SURGE_HOST: %v", err)
+				}
 				globalHost = ""
 			},
 			outputDir: ".",
@@ -67,7 +77,9 @@ func TestResolveClientOutputPath(t *testing.T) {
 		{
 			name: "Local Execution - Relative Subdir returns Absolute",
 			setupHost: func() {
-				os.Setenv("SURGE_HOST", "")
+				if err := os.Setenv("SURGE_HOST", ""); err != nil {
+					t.Fatalf("failed to clear SURGE_HOST: %v", err)
+				}
 				globalHost = ""
 			},
 			outputDir: "downloads",

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -14,6 +14,13 @@ type Settings struct {
 	General     GeneralSettings     `json:"general"`
 	Network     NetworkSettings     `json:"network"`
 	Performance PerformanceSettings `json:"performance"`
+	Extension   ExtensionSettings   `json:"extension"`
+}
+
+// ExtensionSettings holds extension management settings (display-only in TUI).
+type ExtensionSettings struct {
+	LastChromeStore  string `json:"last_chrome_store"`
+	LastFirefoxStore string `json:"last_firefox_store"`
 }
 
 // GeneralSettings contains application behavior settings.
@@ -75,10 +82,8 @@ func GetSettingsMetadata() map[string][]SettingMeta {
 			{Key: "download_complete_notification", Label: "Download Complete Notification", Description: "Show system notification when a download finishes.", Type: "bool"},
 			{Key: "allow_remote_open_actions", Label: "Allow Remote Open Actions", Description: "Allow /open-file and /open-folder API calls from non-loopback clients. Disabled by default for security.", Type: "bool"},
 			{Key: "warn_on_duplicate", Label: "Warn on Duplicate", Description: "Show warning when adding a download that already exists.", Type: "bool"},
-			{Key: "extension_prompt", Label: "Extension Prompt", Description: "Prompt for confirmation when adding downloads via browser extension.", Type: "bool"},
 			{Key: "auto_resume", Label: "Auto Resume", Description: "Automatically resume paused downloads on startup.", Type: "bool"},
 			{Key: "skip_update_check", Label: "Skip Update Check", Description: "Disable automatic check for new versions on startup.", Type: "bool"},
-
 			{Key: "clipboard_monitor", Label: "Clipboard Monitor", Description: "Watch clipboard for URLs and prompt to download them.", Type: "bool"},
 			{Key: "theme", Label: "App Theme", Description: "UI Theme (System, Light, Dark).", Type: "int"},
 			{Key: "log_retention_count", Label: "Log Retention Count", Description: "Number of recent log files to keep.", Type: "int"},
@@ -102,12 +107,19 @@ func GetSettingsMetadata() map[string][]SettingMeta {
 			{Key: "stall_timeout", Label: "Stall Timeout", Description: "Restart workers with no data for this duration (e.g., 5s).", Type: "duration"},
 			{Key: "speed_ema_alpha", Label: "Speed EMA Alpha", Description: "Exponential moving average smoothing factor (0.0-1.0).", Type: "float64"},
 		},
+		"Extension": {
+			{Key: "extension_prompt", Label: "Extension Prompt", Description: "Prompt for confirmation when adding downloads via browser extension.", Type: "bool"},
+			{Key: "chrome_extension_link", Label: "Chrome Extension", Description: "", Type: "link"},
+			{Key: "firefox_extension_link", Label: "Firefox Extension", Description: "", Type: "link"},
+			{Key: "auth_token", Label: "Auth Token", Description: "Used by the browser extension to authenticate with Surge. Press Enter to copy.", Type: "string"},
+			{Key: "connection_instructions", Label: "How to Connect", Description: "", Type: "instructions"},
+		},
 	}
 }
 
 // CategoryOrder returns the order of categories for UI tabs.
 func CategoryOrder() []string {
-	return []string{"General", "Network", "Performance", "Categories"}
+	return []string{"General", "Extension", "Network", "Performance", "Categories"}
 }
 
 const (
@@ -150,6 +162,7 @@ func DefaultSettings() *Settings {
 			StallTimeout:          3 * time.Second,
 			SpeedEmaAlpha:         0.3,
 		},
+		Extension: ExtensionSettings{},
 	}
 }
 

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -14,11 +14,6 @@ type Settings struct {
 	General     GeneralSettings     `json:"general"`
 	Network     NetworkSettings     `json:"network"`
 	Performance PerformanceSettings `json:"performance"`
-	Extension   ExtensionSettings   `json:"extension"`
-}
-
-// ExtensionSettings holds extension management settings (display-only in TUI).
-type ExtensionSettings struct {
 }
 
 // GeneralSettings contains application behavior settings.
@@ -160,7 +155,6 @@ func DefaultSettings() *Settings {
 			StallTimeout:          3 * time.Second,
 			SpeedEmaAlpha:         0.3,
 		},
-		Extension: ExtensionSettings{},
 	}
 }
 

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -19,8 +19,6 @@ type Settings struct {
 
 // ExtensionSettings holds extension management settings (display-only in TUI).
 type ExtensionSettings struct {
-	LastChromeStore  string `json:"last_chrome_store"`
-	LastFirefoxStore string `json:"last_firefox_store"`
 }
 
 // GeneralSettings contains application behavior settings.

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -426,17 +426,18 @@ func TestGetSettingsMetadata(t *testing.T) {
 			if setting.Label == "" {
 				t.Errorf("Category %s, key %s: Label is empty", category, setting.Key)
 			}
-			if setting.Description == "" {
+			if category != "Extension" && setting.Description == "" {
 				t.Errorf("Category %s, key %s: Description is empty", category, setting.Key)
 			}
 			if setting.Type == "" {
 				t.Errorf("Category %s, key %s: Type is empty", category, setting.Key)
 			}
 
-			// Verify Type is valid
+			// Verify Type is valid (Extension has additional types: link, instructions)
 			validTypes := map[string]bool{
 				"string": true, "int": true, "int64": true,
 				"bool": true, "duration": true, "float64": true,
+				"link": true, "instructions": true,
 			}
 			if !validTypes[setting.Type] {
 				t.Errorf("Category %s, key %s: Invalid type %q", category, setting.Key, setting.Type)
@@ -453,7 +454,7 @@ func TestCategoryOrder(t *testing.T) {
 	}
 
 	// Should have all expected categories
-	expectedCount := 4 // General, Network, Performance, Categories
+	expectedCount := 5 // General, Network, Performance, Categories, Extension
 	if len(order) != expectedCount {
 		t.Errorf("Expected %d categories, got %d", expectedCount, len(order))
 	}

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -332,11 +332,11 @@ var Keys = KeyMap{
 		),
 		Tab2: key.NewBinding(
 			key.WithKeys("2"),
-			key.WithHelp("2", "connections"),
+			key.WithHelp("2", "extension"),
 		),
 		Tab3: key.NewBinding(
 			key.WithKeys("3"),
-			key.WithHelp("3", "chunks"),
+			key.WithHelp("3", "network"),
 		),
 		Tab4: key.NewBinding(
 			key.WithKeys("4"),
@@ -344,7 +344,7 @@ var Keys = KeyMap{
 		),
 		Tab5: key.NewBinding(
 			key.WithKeys("5"),
-			key.WithHelp("5", "extension"),
+			key.WithHelp("5", "categories"),
 		),
 		NextTab: key.NewBinding(
 			key.WithKeys("right"),

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -89,6 +89,7 @@ type SettingsKeyMap struct {
 	Tab2    key.Binding
 	Tab3    key.Binding
 	Tab4    key.Binding
+	Tab5    key.Binding
 	NextTab key.Binding
 	PrevTab key.Binding
 	Browse  key.Binding
@@ -340,6 +341,10 @@ var Keys = KeyMap{
 		Tab4: key.NewBinding(
 			key.WithKeys("4"),
 			key.WithHelp("4", "performance"),
+		),
+		Tab5: key.NewBinding(
+			key.WithKeys("5"),
+			key.WithHelp("5", "extension"),
 		),
 		NextTab: key.NewBinding(
 			key.WithKeys("right"),

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -161,6 +161,10 @@ type RootModel struct {
 	// Keybindings
 	keys KeyMap
 
+	// Extension tab state
+	ExtensionTokenCopied    bool      // flash "Token copied!" feedback
+	ExtensionTokenCopyTimer time.Time // when token was last copied (for fade)
+
 	// Server port for display
 	ServerPort int
 	ServerHost string

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -252,6 +252,9 @@ func InitialRootModel(serverPort int, currentVersion string, service core.Downlo
 		settings.General.AutoResume = false
 	}
 
+	// Load auth token once at startup to avoid per-frame disk I/O
+	InitAuthToken()
+
 	applyColorModeForTheme(settings.General.Theme, initialDarkBackground)
 
 	// Load paused downloads from master list (now uses global config directory)

--- a/internal/tui/token.go
+++ b/internal/tui/token.go
@@ -1,0 +1,51 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/SurgeDM/Surge/internal/config"
+)
+
+// Cached auth token. Read once on startup or explicitly invalidated.
+var (
+	authToken         string
+	authTokenReadOnce bool
+)
+
+// InitAuthToken reads the token file once and caches the result.
+func InitAuthToken() {
+	tokenPath := filepath.Join(config.GetStateDir(), "token")
+	data, err := os.ReadFile(tokenPath)
+	if err != nil {
+		authToken = ""
+		authTokenReadOnce = true
+		return
+	}
+	authToken = strings.TrimSpace(string(data))
+	authTokenReadOnce = true
+}
+
+// GetAuthToken returns the cached auth token.
+func GetAuthToken() string {
+	return authToken
+}
+
+// ClearAuthToken resets the cached token to empty string.
+func ClearAuthToken() {
+	authToken = ""
+	authTokenReadOnce = false
+}
+
+// FormatTokenForDisplay returns a user-friendly representation of the token.
+// Long tokens are truncated with an ellipsis.
+func FormatTokenForDisplay(token string) string {
+	if token == "" {
+		return "<not set>"
+	}
+	if len(token) > 20 {
+		return token[:10] + "..." + token[len(token)-10:]
+	}
+	return token
+}

--- a/internal/tui/token.go
+++ b/internal/tui/token.go
@@ -27,11 +27,6 @@ func GetAuthToken() string {
 	return authToken
 }
 
-// ClearAuthToken resets the cached token to empty string.
-func ClearAuthToken() {
-	authToken = ""
-}
-
 // FormatTokenForDisplay returns a user-friendly representation of the token.
 // Long tokens are truncated with an ellipsis.
 func FormatTokenForDisplay(token string) string {

--- a/internal/tui/token.go
+++ b/internal/tui/token.go
@@ -9,10 +9,7 @@ import (
 )
 
 // Cached auth token. Read once on startup or explicitly invalidated.
-var (
-	authToken         string
-	authTokenReadOnce bool
-)
+var authToken string
 
 // InitAuthToken reads the token file once and caches the result.
 func InitAuthToken() {
@@ -20,11 +17,9 @@ func InitAuthToken() {
 	data, err := os.ReadFile(tokenPath)
 	if err != nil {
 		authToken = ""
-		authTokenReadOnce = true
 		return
 	}
 	authToken = strings.TrimSpace(string(data))
-	authTokenReadOnce = true
 }
 
 // GetAuthToken returns the cached auth token.
@@ -35,7 +30,6 @@ func GetAuthToken() string {
 // ClearAuthToken resets the cached token to empty string.
 func ClearAuthToken() {
 	authToken = ""
-	authTokenReadOnce = false
 }
 
 // FormatTokenForDisplay returns a user-friendly representation of the token.

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -125,6 +125,9 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.PasteMsg:
 		return m.updatePaste(msg)
 
+	case extensionTokenFlashFadeMsg:
+		return m.handleExtensionTokenFlashFade()
+
 	// Handle filepicker messages for all message types when in FilePickerState
 	default:
 		var cmds []tea.Cmd

--- a/internal/tui/update_settings.go
+++ b/internal/tui/update_settings.go
@@ -174,6 +174,8 @@ const (
 func (m *RootModel) handleExtensionAction() (tea.Model, tea.Cmd) {
 	settingKey := m.getCurrentSettingKey()
 	switch settingKey {
+	case "extension_prompt":
+		m.Settings.General.ExtensionPrompt = !m.Settings.General.ExtensionPrompt
 	case "chrome_extension_link":
 		utils.OpenBrowser(ChromeExtensionURL)
 	case "firefox_extension_link":
@@ -188,11 +190,12 @@ func (m *RootModel) handleExtensionAction() (tea.Model, tea.Cmd) {
 				return extensionTokenFlashFadeMsg{}
 			})
 		}
+
 	case "connection_instructions":
 		utils.OpenBrowser(ConnectInstructionURL)
 	}
-	return m, nil
 
+	return m, nil
 }
 
 type extensionTokenFlashFadeMsg struct{}

--- a/internal/tui/update_settings.go
+++ b/internal/tui/update_settings.go
@@ -210,7 +210,7 @@ func readAuthTokenFile() string {
 }
 
 // openURL opens a URL in the user's default browser
-func openURL(url string) error {
+func openURL(url string) {
 	var cmd *exec.Cmd
 	switch runtime.GOOS {
 	case "darwin":
@@ -220,7 +220,7 @@ func openURL(url string) error {
 	default:
 		cmd = exec.Command("xdg-open", url)
 	}
-	return cmd.Start()
+	_ = cmd.Start()
 }
 
 // writeToClipboard copies text to the system clipboard using platform-specific tools
@@ -229,11 +229,11 @@ func writeToClipboard(text string) {
 	case "darwin":
 		cmd := exec.Command("pbcopy")
 		cmd.Stdin = strings.NewReader(text)
-		cmd.Run()
+		_ = cmd.Run()
 	case "windows":
 		cmd := exec.Command("clip")
 		cmd.Stdin = strings.NewReader(text)
-		cmd.Run()
+		_ = cmd.Run()
 	default:
 		// Try xclip first, fall back to wl-clipboard
 		cmd := exec.Command("xclip", "-selection", "clipboard")
@@ -241,7 +241,7 @@ func writeToClipboard(text string) {
 		if err := cmd.Run(); err != nil {
 			cmd = exec.Command("wl-copy")
 			cmd.Stdin = strings.NewReader(text)
-			cmd.Run()
+			_ = cmd.Run()
 		}
 	}
 }

--- a/internal/tui/update_settings.go
+++ b/internal/tui/update_settings.go
@@ -1,6 +1,13 @@
 package tui
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 	"github.com/SurgeDM/Surge/internal/config"
@@ -45,7 +52,7 @@ func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.state = DashboardState
 		return m, nil
 	}
-	tabBindings := []key.Binding{m.keys.Settings.Tab1, m.keys.Settings.Tab2, m.keys.Settings.Tab3, m.keys.Settings.Tab4}
+	tabBindings := []key.Binding{m.keys.Settings.Tab1, m.keys.Settings.Tab2, m.keys.Settings.Tab3, m.keys.Settings.Tab4, m.keys.Settings.Tab5}
 	for i, binding := range tabBindings {
 		if key.Matches(msg, binding) {
 			if categoryCount > i {
@@ -107,6 +114,11 @@ func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
+		// Extension tab → copy token / open link
+		if m.SettingsActiveTab < len(categories) && categories[m.SettingsActiveTab] == "Extension" {
+			return m.handleExtensionAction()
+		}
+
 		settingKey := m.getCurrentSettingKey()
 		// Prevent editing ignored settings
 		if settingKey == "max_global_connections" {
@@ -156,3 +168,100 @@ func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 	return m, nil
 }
+
+// Constants for extension URLs
+const (
+	ChromeExtensionURL     = "https://github.com/SurgeDM/Surge/releases/latest"
+	FirefoxExtensionURL    = "https://addons.mozilla.org/en-US/firefox/addon/surge/"
+	connectionInstructions = "https://github.com/SurgeDM/Surge#browser-extension"
+)
+
+func (m *RootModel) handleExtensionAction() (tea.Model, tea.Cmd) {
+	settingKey := m.getCurrentSettingKey()
+	switch settingKey {
+	case "chrome_extension_link":
+		openURL(ChromeExtensionURL)
+		return m, nil
+	case "firefox_extension_link":
+		openURL(FirefoxExtensionURL)
+		return m, nil
+	case "auth_token":
+		token := readAuthTokenFile()
+		if token != "" {
+			writeToClipboard(token)
+			m.ExtensionTokenCopied = true
+			m.ExtensionTokenCopyTimer = time.Now()
+			return m, tea.Tick(time.Millisecond*2000, func(t time.Time) tea.Msg {
+				return extensionTokenFlashFadeMsg{}
+			})
+		}
+		return m, nil
+	}
+	return m, nil
+}
+
+func readAuthTokenFile() string {
+	tokenPath := filepath.Join(config.GetStateDir(), "token")
+	data, err := os.ReadFile(tokenPath)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+// openURL opens a URL in the user's default browser
+func openURL(url string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		cmd = exec.Command("cmd", "/c", "start", url)
+	default:
+		cmd = exec.Command("xdg-open", url)
+	}
+	return cmd.Start()
+}
+
+// writeToClipboard copies text to the system clipboard using platform-specific tools
+func writeToClipboard(text string) {
+	switch runtime.GOOS {
+	case "darwin":
+		cmd := exec.Command("pbcopy")
+		cmd.Stdin = strings.NewReader(text)
+		cmd.Run()
+	case "windows":
+		cmd := exec.Command("clip")
+		cmd.Stdin = strings.NewReader(text)
+		cmd.Run()
+	default:
+		// Try xclip first, fall back to wl-clipboard
+		cmd := exec.Command("xclip", "-selection", "clipboard")
+		cmd.Stdin = strings.NewReader(text)
+		if err := cmd.Run(); err != nil {
+			cmd = exec.Command("wl-copy")
+			cmd.Stdin = strings.NewReader(text)
+			cmd.Run()
+		}
+	}
+}
+
+// formatTokenForDisplay masks a token for safe display in the UI
+func formatTokenForDisplay(token string) string {
+	if token == "" {
+		return "No token generated. Start surge server to generate one."
+	}
+	if len(token) <= 10 {
+		return token[:2] + strings.Repeat("•", len(token)-2)
+	}
+	parts := strings.Split(token, "-")
+	if len(parts) >= 4 {
+		for i := 1; i < len(parts); i++ {
+			parts[i] = strings.Repeat("•", len(parts[i]))
+		}
+		return strings.Join(parts, "-")
+	}
+	return token[:2] + strings.Repeat("*", len(token)-2)
+}
+
+type extensionTokenFlashFadeMsg struct{}

--- a/internal/tui/update_settings.go
+++ b/internal/tui/update_settings.go
@@ -165,12 +165,7 @@ func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// Constants for extension URLs
-const (
-	ChromeExtensionURL     = "https://github.com/SurgeDM/Surge/releases/latest"
-	FirefoxExtensionURL    = "https://addons.mozilla.org/en-US/firefox/addon/surge/"
-	connectionInstructions = "https://github.com/SurgeDM/Surge#browser-extension"
-)
+// Extension URLs and instructions are sourced from internal/utils/open.go
 
 func (m *RootModel) handleExtensionAction() (tea.Model, tea.Cmd) {
 	settingKey := m.getCurrentSettingKey()

--- a/internal/tui/update_settings.go
+++ b/internal/tui/update_settings.go
@@ -1,9 +1,6 @@
 package tui
 
 import (
-	"os"
-	"path/filepath"
-	"strings"
 	"time"
 
 	"charm.land/bubbles/v2/key"
@@ -185,7 +182,7 @@ func (m *RootModel) handleExtensionAction() (tea.Model, tea.Cmd) {
 		utils.OpenBrowser(utils.FirefoxExtensionURL)
 		return m, nil
 	case "auth_token":
-		token := readAuthTokenFile()
+		token := GetAuthToken()
 		if token != "" {
 			utils.WriteToClipboard(token)
 			m.ExtensionTokenCopied = true
@@ -199,13 +196,9 @@ func (m *RootModel) handleExtensionAction() (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func readAuthTokenFile() string {
-	tokenPath := filepath.Join(config.GetStateDir(), "token")
-	data, err := os.ReadFile(tokenPath)
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(data))
-}
-
 type extensionTokenFlashFadeMsg struct{}
+
+func (m *RootModel) handleExtensionTokenFlashFade() (tea.Model, tea.Cmd) {
+	m.ExtensionTokenCopied = false
+	return m, nil
+}

--- a/internal/tui/update_settings.go
+++ b/internal/tui/update_settings.go
@@ -165,16 +165,20 @@ func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// Extension URLs and instructions are sourced from internal/utils/open.go
+const (
+	ChromeExtensionURL    = "https://github.com/SurgeDM/Surge/releases/latest"
+	FirefoxExtensionURL   = "https://addons.mozilla.org/en-US/firefox/addon/surge/"
+	ConnectInstructionURL = "https://github.com/SurgeDM/Surge#browser-extension"
+)
 
 func (m *RootModel) handleExtensionAction() (tea.Model, tea.Cmd) {
 	settingKey := m.getCurrentSettingKey()
 	switch settingKey {
 	case "chrome_extension_link":
-		utils.OpenBrowser(utils.ChromeExtensionURL)
+		utils.OpenBrowser(ChromeExtensionURL)
 		return m, nil
 	case "firefox_extension_link":
-		utils.OpenBrowser(utils.FirefoxExtensionURL)
+		utils.OpenBrowser(FirefoxExtensionURL)
 		return m, nil
 	case "auth_token":
 		token := GetAuthToken()
@@ -187,8 +191,12 @@ func (m *RootModel) handleExtensionAction() (tea.Model, tea.Cmd) {
 			})
 		}
 		return m, nil
+	case "connection_instructions":
+		utils.OpenBrowser(ConnectInstructionURL)
+		return m, nil
 	}
 	return m, nil
+
 }
 
 type extensionTokenFlashFadeMsg struct{}

--- a/internal/tui/update_settings.go
+++ b/internal/tui/update_settings.go
@@ -2,15 +2,14 @@ package tui
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 	"github.com/SurgeDM/Surge/internal/config"
+	"github.com/SurgeDM/Surge/internal/utils"
 )
 
 func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
@@ -180,15 +179,15 @@ func (m *RootModel) handleExtensionAction() (tea.Model, tea.Cmd) {
 	settingKey := m.getCurrentSettingKey()
 	switch settingKey {
 	case "chrome_extension_link":
-		openURL(ChromeExtensionURL)
+		utils.OpenBrowser(utils.ChromeExtensionURL)
 		return m, nil
 	case "firefox_extension_link":
-		openURL(FirefoxExtensionURL)
+		utils.OpenBrowser(utils.FirefoxExtensionURL)
 		return m, nil
 	case "auth_token":
 		token := readAuthTokenFile()
 		if token != "" {
-			writeToClipboard(token)
+			utils.WriteToClipboard(token)
 			m.ExtensionTokenCopied = true
 			m.ExtensionTokenCopyTimer = time.Now()
 			return m, tea.Tick(time.Millisecond*2000, func(t time.Time) tea.Msg {
@@ -207,61 +206,6 @@ func readAuthTokenFile() string {
 		return ""
 	}
 	return strings.TrimSpace(string(data))
-}
-
-// openURL opens a URL in the user's default browser
-func openURL(url string) {
-	var cmd *exec.Cmd
-	switch runtime.GOOS {
-	case "darwin":
-		cmd = exec.Command("open", url)
-	case "windows":
-		cmd = exec.Command("cmd", "/c", "start", url)
-	default:
-		cmd = exec.Command("xdg-open", url)
-	}
-	_ = cmd.Start()
-}
-
-// writeToClipboard copies text to the system clipboard using platform-specific tools
-func writeToClipboard(text string) {
-	switch runtime.GOOS {
-	case "darwin":
-		cmd := exec.Command("pbcopy")
-		cmd.Stdin = strings.NewReader(text)
-		_ = cmd.Run()
-	case "windows":
-		cmd := exec.Command("clip")
-		cmd.Stdin = strings.NewReader(text)
-		_ = cmd.Run()
-	default:
-		// Try xclip first, fall back to wl-clipboard
-		cmd := exec.Command("xclip", "-selection", "clipboard")
-		cmd.Stdin = strings.NewReader(text)
-		if err := cmd.Run(); err != nil {
-			cmd = exec.Command("wl-copy")
-			cmd.Stdin = strings.NewReader(text)
-			_ = cmd.Run()
-		}
-	}
-}
-
-// formatTokenForDisplay masks a token for safe display in the UI
-func formatTokenForDisplay(token string) string {
-	if token == "" {
-		return "No token generated. Start surge server to generate one."
-	}
-	if len(token) <= 10 {
-		return token[:2] + strings.Repeat("•", len(token)-2)
-	}
-	parts := strings.Split(token, "-")
-	if len(parts) >= 4 {
-		for i := 1; i < len(parts); i++ {
-			parts[i] = strings.Repeat("•", len(parts[i]))
-		}
-		return strings.Join(parts, "-")
-	}
-	return token[:2] + strings.Repeat("*", len(token)-2)
 }
 
 type extensionTokenFlashFadeMsg struct{}

--- a/internal/tui/update_settings.go
+++ b/internal/tui/update_settings.go
@@ -176,10 +176,8 @@ func (m *RootModel) handleExtensionAction() (tea.Model, tea.Cmd) {
 	switch settingKey {
 	case "chrome_extension_link":
 		utils.OpenBrowser(ChromeExtensionURL)
-		return m, nil
 	case "firefox_extension_link":
 		utils.OpenBrowser(FirefoxExtensionURL)
-		return m, nil
 	case "auth_token":
 		token := GetAuthToken()
 		if token != "" {
@@ -190,10 +188,8 @@ func (m *RootModel) handleExtensionAction() (tea.Model, tea.Cmd) {
 				return extensionTokenFlashFadeMsg{}
 			})
 		}
-		return m, nil
 	case "connection_instructions":
 		utils.OpenBrowser(ConnectInstructionURL)
-		return m, nil
 	}
 	return m, nil
 

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -15,10 +15,7 @@ import (
 	"charm.land/lipgloss/v2"
 )
 
-// Constants for extension settings UI
-const (
-	connectionInstructions = "https://github.com/SurgeDM/Surge#browser-extension"
-)
+
 
 // viewSettings renders the Btop-style settings page
 func (m RootModel) viewSettings() string {
@@ -602,7 +599,7 @@ func (m RootModel) getSettingsValues(category string) map[string]interface{} {
 		values["chrome_extension_link"] = utils.ChromeExtensionURL
 		values["firefox_extension_link"] = utils.FirefoxExtensionURL
 		values["auth_token"] = GetAuthToken()
-		values["connection_instructions"] = connectionInstructions
+		values["connection_instructions"] = utils.ChromeExtensionURL
 	}
 
 	return values

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -10,8 +10,14 @@ import (
 	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/tui/colors"
 	"github.com/SurgeDM/Surge/internal/tui/components"
+	"github.com/SurgeDM/Surge/internal/utils"
 
 	"charm.land/lipgloss/v2"
+)
+
+// Constants for extension settings UI
+const (
+	connectionInstructions = "https://github.com/SurgeDM/Surge#browser-extension"
 )
 
 // viewSettings renders the Btop-style settings page
@@ -593,8 +599,8 @@ func (m RootModel) getSettingsValues(category string) map[string]interface{} {
 		values["category_enabled"] = m.Settings.General.CategoryEnabled
 	case "Extension":
 		values["extension_prompt"] = m.Settings.General.ExtensionPrompt
-		values["chrome_extension_link"] = ChromeExtensionURL
-		values["firefox_extension_link"] = FirefoxExtensionURL
+		values["chrome_extension_link"] = utils.ChromeExtensionURL
+		values["firefox_extension_link"] = utils.FirefoxExtensionURL
 		values["auth_token"] = GetAuthToken()
 		values["connection_instructions"] = connectionInstructions
 	}

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -146,6 +146,8 @@ func shortSettingsCategoryLabel(label string) string {
 		return "Perf"
 	case "Categories":
 		return "Cats"
+	case "Extension":
+		return "Ext"
 	default:
 		return label
 	}
@@ -306,6 +308,53 @@ func (m RootModel) renderSettingsDetailBlock(settingsMeta []config.SettingMeta, 
 
 	meta := settingsMeta[selectedRow]
 	value := settingsValues[meta.Key]
+
+	// Extension tab: special rendering for certain settings
+	switch meta.Key {
+	case "connection_instructions":
+		url := ""
+		if s, ok := value.(string); ok {
+			url = s
+		}
+		label := lipgloss.NewStyle().Foreground(colors.NeonCyan).Bold(true).Render("[Enter] Open documentation:")
+		urlDisplay := lipgloss.NewStyle().Foreground(colors.White).Render(url)
+		detail := lipgloss.JoinVertical(lipgloss.Left,
+			label,
+			" "+urlDisplay,
+		)
+		return formatSettingsBlock(detail, innerWidth, rows)
+	case "auth_token":
+		token := ""
+		if s, ok := value.(string); ok {
+			token = s
+		}
+		displayToken := formatTokenForDisplay(token)
+		label := lipgloss.NewStyle().Foreground(colors.NeonCyan).Bold(true).Render("[Enter] Copy:")
+		valDisplay := lipgloss.NewStyle().Foreground(colors.White).Render(displayToken)
+		if m.ExtensionTokenCopied && time.Since(m.ExtensionTokenCopyTimer) < 2*time.Second {
+			valDisplay += " " + lipgloss.NewStyle().Foreground(colors.NeonPurple).Bold(true).Render("Copied!")
+		} else {
+			m.ExtensionTokenCopied = false
+		}
+		detail := lipgloss.JoinVertical(lipgloss.Left,
+			label,
+			" "+valDisplay,
+		)
+		return formatSettingsBlock(detail, innerWidth, rows)
+	case "chrome_extension_link", "firefox_extension_link":
+		extURL := ""
+		if s, ok := value.(string); ok {
+			extURL = s
+		}
+		label := lipgloss.NewStyle().Foreground(colors.NeonCyan).Bold(true).Render("[Enter] Open:")
+		urlDisplay := lipgloss.NewStyle().Foreground(colors.White).Render(extURL)
+		detail := lipgloss.JoinVertical(lipgloss.Left,
+			label,
+			" "+urlDisplay,
+		)
+		return formatSettingsBlock(detail, innerWidth, rows)
+	}
+
 	unit := m.getSettingUnit()
 	unitStyle := lipgloss.NewStyle().Foreground(colors.Gray)
 
@@ -524,10 +573,8 @@ func (m RootModel) getSettingsValues(category string) map[string]interface{} {
 		values["warn_on_duplicate"] = m.Settings.General.WarnOnDuplicate
 		values["download_complete_notification"] = m.Settings.General.DownloadCompleteNotification
 		values["allow_remote_open_actions"] = m.Settings.General.AllowRemoteOpenActions
-		values["extension_prompt"] = m.Settings.General.ExtensionPrompt
 		values["auto_resume"] = m.Settings.General.AutoResume
 		values["skip_update_check"] = m.Settings.General.SkipUpdateCheck
-
 		values["clipboard_monitor"] = m.Settings.General.ClipboardMonitor
 		values["theme"] = m.Settings.General.Theme
 		values["log_retention_count"] = m.Settings.General.LogRetentionCount
@@ -549,6 +596,12 @@ func (m RootModel) getSettingsValues(category string) map[string]interface{} {
 		values["speed_ema_alpha"] = m.Settings.Performance.SpeedEmaAlpha
 	case "Categories":
 		values["category_enabled"] = m.Settings.General.CategoryEnabled
+	case "Extension":
+		values["extension_prompt"] = m.Settings.General.ExtensionPrompt
+		values["chrome_extension_link"] = ChromeExtensionURL
+		values["firefox_extension_link"] = FirefoxExtensionURL
+		values["auth_token"] = readAuthTokenFile()
+		values["connection_instructions"] = connectionInstructions
 	}
 
 	return values
@@ -578,6 +631,10 @@ func (m *RootModel) setSettingValue(category, key, value string) error {
 		if key == "category_enabled" {
 			m.Settings.General.CategoryEnabled = !m.Settings.General.CategoryEnabled
 		}
+	case "Extension":
+		if key == "extension_prompt" {
+			m.Settings.General.ExtensionPrompt = !m.Settings.General.ExtensionPrompt
+		}
 	}
 
 	return nil
@@ -606,15 +663,12 @@ func (m *RootModel) setGeneralSetting(key, value, typ string) error {
 		m.Settings.General.WarnOnDuplicate = !m.Settings.General.WarnOnDuplicate
 	case "allow_remote_open_actions":
 		m.Settings.General.AllowRemoteOpenActions = !m.Settings.General.AllowRemoteOpenActions
-	case "extension_prompt":
-		m.Settings.General.ExtensionPrompt = !m.Settings.General.ExtensionPrompt
 	case "auto_resume":
 		m.Settings.General.AutoResume = !m.Settings.General.AutoResume
 	case "skip_update_check":
 		m.Settings.General.SkipUpdateCheck = !m.Settings.General.SkipUpdateCheck
 	case "clipboard_monitor":
 		m.Settings.General.ClipboardMonitor = !m.Settings.General.ClipboardMonitor
-
 	case "theme":
 		var theme int
 		valLower := strings.ToLower(value)
@@ -962,6 +1016,10 @@ func (m *RootModel) resetSettingToDefault(category, key string, defaults *config
 		switch key {
 		case "category_enabled":
 			m.Settings.General.CategoryEnabled = defaults.General.CategoryEnabled
+		}
+	case "Extension":
+		if key == "extension_prompt" {
+			m.Settings.General.ExtensionPrompt = defaults.General.ExtensionPrompt
 		}
 	}
 }

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -10,12 +10,9 @@ import (
 	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/tui/colors"
 	"github.com/SurgeDM/Surge/internal/tui/components"
-	"github.com/SurgeDM/Surge/internal/utils"
 
 	"charm.land/lipgloss/v2"
 )
-
-
 
 // viewSettings renders the Btop-style settings page
 func (m RootModel) viewSettings() string {
@@ -596,10 +593,10 @@ func (m RootModel) getSettingsValues(category string) map[string]interface{} {
 		values["category_enabled"] = m.Settings.General.CategoryEnabled
 	case "Extension":
 		values["extension_prompt"] = m.Settings.General.ExtensionPrompt
-		values["chrome_extension_link"] = utils.ChromeExtensionURL
-		values["firefox_extension_link"] = utils.FirefoxExtensionURL
+		values["chrome_extension_link"] = ChromeExtensionURL
+		values["firefox_extension_link"] = FirefoxExtensionURL
 		values["auth_token"] = GetAuthToken()
-		values["connection_instructions"] = utils.ChromeExtensionURL
+		values["connection_instructions"] = ConnectInstructionURL
 	}
 
 	return values

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -324,17 +324,12 @@ func (m RootModel) renderSettingsDetailBlock(settingsMeta []config.SettingMeta, 
 		)
 		return formatSettingsBlock(detail, innerWidth, rows)
 	case "auth_token":
-		token := ""
-		if s, ok := value.(string); ok {
-			token = s
-		}
-		displayToken := formatTokenForDisplay(token)
+		token := GetAuthToken()
+		displayToken := FormatTokenForDisplay(token)
 		label := lipgloss.NewStyle().Foreground(colors.NeonCyan).Bold(true).Render("[Enter] Copy:")
 		valDisplay := lipgloss.NewStyle().Foreground(colors.White).Render(displayToken)
 		if m.ExtensionTokenCopied && time.Since(m.ExtensionTokenCopyTimer) < 2*time.Second {
 			valDisplay += " " + lipgloss.NewStyle().Foreground(colors.NeonPurple).Bold(true).Render("Copied!")
-		} else {
-			m.ExtensionTokenCopied = false
 		}
 		detail := lipgloss.JoinVertical(lipgloss.Left,
 			label,
@@ -600,7 +595,7 @@ func (m RootModel) getSettingsValues(category string) map[string]interface{} {
 		values["extension_prompt"] = m.Settings.General.ExtensionPrompt
 		values["chrome_extension_link"] = ChromeExtensionURL
 		values["firefox_extension_link"] = FirefoxExtensionURL
-		values["auth_token"] = readAuthTokenFile()
+		values["auth_token"] = GetAuthToken()
 		values["connection_instructions"] = connectionInstructions
 	}
 

--- a/internal/utils/open.go
+++ b/internal/utils/open.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 func OpenFile(path string) error {
@@ -70,4 +71,65 @@ func buildOpenCommand(path string) *exec.Cmd {
 	default:
 		return exec.Command("xdg-open", path)
 	}
+}
+
+const (
+	ChromeExtensionURL     = "https://github.com/SurgeDM/Surge/releases/latest"
+	FirefoxExtensionURL    = "https://addons.mozilla.org/en-US/firefox/addon/surge/"
+	ConnectionInstructions = "https://github.com/SurgeDM/Surge#browser-extension"
+)
+
+// OpenBrowser opens a URL in the user's default browser
+func OpenBrowser(url string) {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		cmd = exec.Command("cmd", "/c", "start", url)
+	default:
+		cmd = exec.Command("xdg-open", url)
+	}
+	_ = cmd.Start()
+}
+
+// WriteToClipboard copies text to the system clipboard using platform-specific tools
+func WriteToClipboard(text string) {
+	switch runtime.GOOS {
+	case "darwin":
+		cmd := exec.Command("pbcopy")
+		cmd.Stdin = strings.NewReader(text)
+		_ = cmd.Run()
+	case "windows":
+		cmd := exec.Command("clip")
+		cmd.Stdin = strings.NewReader(text)
+		_ = cmd.Run()
+	default:
+		// Try xclip first, fall back to wl-clipboard
+		cmd := exec.Command("xclip", "-selection", "clipboard")
+		cmd.Stdin = strings.NewReader(text)
+		if err := cmd.Run(); err != nil {
+			cmd = exec.Command("wl-copy")
+			cmd.Stdin = strings.NewReader(text)
+			_ = cmd.Run()
+		}
+	}
+}
+
+// FormatTokenForDisplay masks a token for safe display
+func FormatTokenForDisplay(token string) string {
+	if token == "" {
+		return "No token generated. Start surge server to generate one."
+	}
+	if len(token) <= 10 {
+		return token[:2] + strings.Repeat("•", len(token)-2)
+	}
+	parts := strings.Split(token, "-")
+	if len(parts) >= 4 {
+		for i := 1; i < len(parts); i++ {
+			parts[i] = strings.Repeat("•", len(parts[i]))
+		}
+		return strings.Join(parts, "-")
+	}
+	return token[:2] + strings.Repeat("*", len(token)-2)
 }

--- a/internal/utils/open.go
+++ b/internal/utils/open.go
@@ -51,6 +51,10 @@ func OpenContainingFolder(path string) error {
 	return openWithSystem(targetPath)
 }
 
+func OpenBrowser(url string) error {
+	return openWithSystem(url)
+}
+
 func openWithSystem(path string) error {
 	cmd := buildOpenCommand(path)
 	err := cmd.Start()
@@ -71,25 +75,6 @@ func buildOpenCommand(path string) *exec.Cmd {
 	default:
 		return exec.Command("xdg-open", path)
 	}
-}
-
-const (
-	ChromeExtensionURL  = "https://github.com/SurgeDM/Surge/releases/latest"
-	FirefoxExtensionURL = "https://addons.mozilla.org/en-US/firefox/addon/surge/"
-)
-
-// OpenBrowser opens a URL in the user's default browser
-func OpenBrowser(url string) {
-	var cmd *exec.Cmd
-	switch runtime.GOOS {
-	case "darwin":
-		cmd = exec.Command("open", url)
-	case "windows":
-		cmd = exec.Command("cmd", "/c", "start", url)
-	default:
-		cmd = exec.Command("xdg-open", url)
-	}
-	_ = cmd.Start()
 }
 
 // WriteToClipboard copies text to the system clipboard using platform-specific tools

--- a/internal/utils/open.go
+++ b/internal/utils/open.go
@@ -74,9 +74,8 @@ func buildOpenCommand(path string) *exec.Cmd {
 }
 
 const (
-	ChromeExtensionURL     = "https://github.com/SurgeDM/Surge/releases/latest"
-	FirefoxExtensionURL    = "https://addons.mozilla.org/en-US/firefox/addon/surge/"
-	ConnectionInstructions = "https://github.com/SurgeDM/Surge#browser-extension"
+	ChromeExtensionURL  = "https://github.com/SurgeDM/Surge/releases/latest"
+	FirefoxExtensionURL = "https://addons.mozilla.org/en-US/firefox/addon/surge/"
 )
 
 // OpenBrowser opens a URL in the user's default browser
@@ -114,22 +113,4 @@ func WriteToClipboard(text string) {
 			_ = cmd.Run()
 		}
 	}
-}
-
-// FormatTokenForDisplay masks a token for safe display
-func FormatTokenForDisplay(token string) string {
-	if token == "" {
-		return "No token generated. Start surge server to generate one."
-	}
-	if len(token) <= 10 {
-		return token[:2] + strings.Repeat("•", len(token)-2)
-	}
-	parts := strings.Split(token, "-")
-	if len(parts) >= 4 {
-		for i := 1; i < len(parts); i++ {
-			parts[i] = strings.Repeat("•", len(parts[i]))
-		}
-		return strings.Join(parts, "-")
-	}
-	return token[:2] + strings.Repeat("*", len(token)-2)
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a dedicated Extension settings tab that lets users install browser extensions, copy their auth token, and toggle extension prompt confirmation from a single place. Token reading is properly cached at startup via `InitAuthToken()` and the flash-fade message is correctly wired into the TEA `Update` loop.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all previously raised P0/P1 concerns have been resolved and only minor P2 style nits remain.

Flash-fade message handling, value-receiver mutation, and per-frame disk I/O issues from prior review rounds are all addressed. The two remaining findings are a missing Tab5 in the help display and a stale inline comment — neither affects runtime behaviour.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/tui/update_settings.go | Adds Extension tab action handler; `extensionTokenFlashFadeMsg` is properly dispatched and handled via Update |
| internal/tui/view_settings.go | Adds special rendering for auth_token, link, and instructions types; token correctly read from cache via GetAuthToken() |
| internal/tui/token.go | New file: caches auth token at startup with InitAuthToken to avoid per-frame disk I/O |
| internal/tui/keys.go | Tab bindings renumbered for Extension tab; Tab5 shortcut missing from FullHelp |
| internal/config/settings.go | Moves extension_prompt to new Extension category; SettingMeta.Type comment is stale (missing 'link' and 'instructions') |
| internal/config/settings_test.go | Comprehensive tests added for new Extension category including type validation and category count |
| internal/utils/open.go | Adds OpenBrowser and WriteToClipboard helpers; clipboard errors are silently discarded |
| cmd/utils_test.go | Error handling added for os.Setenv calls in test setup/teardown |
| internal/tui/model.go | Adds ExtensionTokenCopied/ExtensionTokenCopyTimer fields; InitAuthToken called once at startup |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User presses Enter in Extension tab] --> B{getCurrentSettingKey}
    B -->|extension_prompt| C[Toggle ExtensionPrompt bool]
    B -->|chrome_extension_link| D[OpenBrowser ChromeExtensionURL]
    B -->|firefox_extension_link| E[OpenBrowser FirefoxExtensionURL]
    B -->|auth_token| F{token != empty?}
    F -->|yes| G[WriteToClipboard token]
    G --> H[ExtensionTokenCopied = true]
    H --> I[tea.Tick 2s → extensionTokenFlashFadeMsg]
    I --> J[Update: ExtensionTokenCopied = false]
    F -->|no| K[no-op]
    B -->|connection_instructions| L[OpenBrowser ConnectInstructionURL]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/tui/keys.go`, line 333-348 ([link](https://github.com/surgedm/surge/blob/41b1eaea92974d6000c0ba98b8f95772a788d423/internal/tui/keys.go#L333-L348)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Tab help labels out of sync with new tab order**

   Inserting Extension at index 1 shifted all subsequent tabs, but the `WithHelp` strings were not updated. A user pressing `2` sees the hint `"connections"` but lands on the **Extension** tab; pressing `3` shows `"chunks"` for **Network**; pressing `5` shows `"extension"` for **Categories**.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/tui/keys.go
   Line: 333-348

   Comment:
   **Tab help labels out of sync with new tab order**

   Inserting Extension at index 1 shifted all subsequent tabs, but the `WithHelp` strings were not updated. A user pressing `2` sees the hint `"connections"` but lands on the **Extension** tab; pressing `3` shows `"chunks"` for **Network**; pressing `5` shows `"extension"` for **Categories**.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/tui/keys.go
Line: 500-504

Comment:
**Tab5 shortcut missing from FullHelp**

There are now 5 tabs (`Tab5` = `"5"` → categories), but `FullHelp` only lists `{k.Tab1, k.Tab2, k.Tab3, k.Tab4}`. Users who expand the keybinding help won't see the `5` shortcut to jump directly to the Categories tab.

```suggestion
		{k.Tab1, k.Tab2, k.Tab3, k.Tab4, k.Tab5},
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/config/settings.go
Line: 67

Comment:
**Stale `Type` field comment**

The Extension category introduces two new valid values (`"link"` and `"instructions"`) not listed in the inline comment, making the full set of valid types harder to discover.

```suggestion
	Type        string // "string", "int", "int64", "bool", "duration", "float64", "link", "instructions"
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (6): Last reviewed commit: ["fix: extension\_prompt"](https://github.com/surgedm/surge/commit/f6df273a19d6f27aeba125fa56eb6a88245355f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27548132)</sub>

<!-- /greptile_comment -->