### PR TITLE
feat: improved linter config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,6 @@ linters:
     
     - prealloc
     - makezero
-    - goconst
     
     - bodyclose
     - noctx

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,29 +7,30 @@ run:
 linters:
   disable-all: true
   enable:
-    - staticcheck # The gold standard for Go bugs and basic performance
-    - govet       # Official Go bug catcher
-    - errcheck    # Unhandled errors hide performance regressions and leaks
+    - staticcheck
+    - govet
+    - errcheck
+    - unused
+    - ineffassign
+    - unparam
     
-    - unused      # Finds unused constants, variables, functions, and types
-    - ineffassign # Finds assignments to variables that are never read
-    - unparam     # Finds function parameters and return values that are never used
+    - prealloc
+    - makezero
+    - goconst
     
-    - prealloc    # Forces slice preallocation to prevent heap re-allocations
-    - makezero    # Catches `make([]int, 0, len)` bugs that cause double-allocations
-    - gocritic    # Enabled strictly for performance and diagnostic checks
+    - bodyclose
+    - noctx
+    - sqlclosecheck
+    - rowserrcheck
+    
+    - errorlint
+    - nilerr
+    - copyloopvar
+    - gocritic
 
 linters-settings:
+  govet:
+    enable:
+      - shadow
   unparam:
-    # Check exported functions too (crucial for finding dead code in libraries)
     check-exported: true
-
-  gocritic:
-    # Disable opinionated style checks, enable ONLY performance and bug diagnostics
-    enabled-tags:
-      - performance
-      - diagnostic
-    disabled-tags:
-      - style
-      - experimental
-      - opinionated

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,8 @@ linters:
     
     - prealloc
     - makezero
+    - usestdlibvars
+    - perfsprint
     
     - bodyclose
     - noctx
@@ -24,12 +26,12 @@ linters:
     
     - errorlint
     - nilerr
-    - copyloopvar
     - gocritic
 
 linters-settings:
   govet:
     enable:
       - shadow
+      - fieldalignment
   unparam:
     check-exported: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,35 @@
+# .golangci.yml
+version: "2"
+
+run:
+  tests: true
+
+linters:
+  disable-all: true
+  enable:
+    - staticcheck # The gold standard for Go bugs and basic performance
+    - govet       # Official Go bug catcher
+    - errcheck    # Unhandled errors hide performance regressions and leaks
+    
+    - unused      # Finds unused constants, variables, functions, and types
+    - ineffassign # Finds assignments to variables that are never read
+    - unparam     # Finds function parameters and return values that are never used
+    
+    - prealloc    # Forces slice preallocation to prevent heap re-allocations
+    - makezero    # Catches `make([]int, 0, len)` bugs that cause double-allocations
+    - gocritic    # Enabled strictly for performance and diagnostic checks
+
+linters-settings:
+  unparam:
+    # Check exported functions too (crucial for finding dead code in libraries)
+    check-exported: true
+
+  gocritic:
+    # Disable opinionated style checks, enable ONLY performance and bug diagnostics
+    enabled-tags:
+      - performance
+      - diagnostic
+    disabled-tags:
+      - style
+      - experimental
+      - opinionated

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,11 +27,10 @@ linters:
     - errorlint
     - nilerr
     - gocritic
-
-linters-settings:
-  govet:
-    enable:
-      - shadow
-      - fieldalignment
-  unparam:
-    check-exported: true
+  settings:
+    govet:
+      enable:
+        - shadow
+        - fieldalignment
+    unparam:
+      check-exported: true

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -13,7 +13,7 @@ var addCmd = &cobra.Command{
 	Short:   "Add a new download to the running Surge instance",
 	Long:    `Add one or more URLs to the download queue of a running Surge instance.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		//initializeGlobally is required to ensure that the config and logger are set up before we attempt to resolve the API connection or read the batch file.
+		// initializeGlobalState must run before resolving the API connection or reading the batch file.
 		if err := initializeGlobalState(); err != nil {
 			return err
 		}

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/SurgeDM/Surge/internal/utils"
@@ -66,10 +67,10 @@ var addCmd = &cobra.Command{
 		}
 
 		if attempted > 0 {
-			return fmt.Errorf("failed to add any downloads")
+			return errors.New("failed to add any downloads")
 		}
 
-		return fmt.Errorf("no valid URLs to add")
+		return errors.New("no valid URLs to add")
 	},
 }
 

--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -808,7 +808,8 @@ func TestSendToServer_SuccessAndServerError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var lc net.ListenConfig; ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+			var lc net.ListenConfig
+			ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
 			if err != nil {
 				t.Fatalf("listen failed: %v", err)
 			}
@@ -848,7 +849,8 @@ func TestSendToServer_SuccessAndServerError(t *testing.T) {
 func TestSendToServer_UsesBearerTokenFromEnv(t *testing.T) {
 	t.Setenv("SURGE_TOKEN", "env-token-123")
 
-	var lc net.ListenConfig; ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	var lc net.ListenConfig
+	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen failed: %v", err)
 	}
@@ -878,7 +880,8 @@ func TestSendToServer_UsesBearerTokenFromEnv(t *testing.T) {
 func TestGetRemoteDownloads_UsesBearerTokenFromEnv(t *testing.T) {
 	t.Setenv("SURGE_TOKEN", "env-token-123")
 
-	var lc net.ListenConfig; ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	var lc net.ListenConfig
+	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen failed: %v", err)
 	}
@@ -945,7 +948,8 @@ func TestGetRemoteDownloads_NonOKAndInvalidJSON(t *testing.T) {
 
 func TestProcessDownloads_RemoteAndLocal(t *testing.T) {
 	t.Run("remote-mode", func(t *testing.T) {
-		var lc net.ListenConfig; ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+		var lc net.ListenConfig
+		ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
 		if err != nil {
 			t.Fatalf("listen failed: %v", err)
 		}

--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -22,6 +23,8 @@ import (
 	"github.com/SurgeDM/Surge/internal/utils"
 )
 
+const listEndpoint = "/list"
+
 // TestResolveDownloadID_Remote verifies that resolveDownloadID queries the server
 func TestResolveDownloadID_Remote(t *testing.T) {
 	// 1. Mock Server
@@ -30,7 +33,7 @@ func TestResolveDownloadID_Remote(t *testing.T) {
 	}
 
 	server := testutil.NewHTTPServerT(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/list" {
+		if r.URL.Path == listEndpoint {
 			_ = json.NewEncoder(w).Encode(downloads)
 			return
 		}
@@ -74,7 +77,7 @@ func TestResolveDownloadID_RemoteStillWorksWhenDBUnavailable(t *testing.T) {
 	}
 
 	server := testutil.NewHTTPServerT(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/list" {
+		if r.URL.Path == listEndpoint {
 			_ = json.NewEncoder(w).Encode(downloads)
 			return
 		}
@@ -116,7 +119,7 @@ func TestResolveDownloadID_StrictRemoteDoesNotFallbackToDBOnRemoteError(t *testi
 	}
 
 	server := testutil.NewHTTPServerT(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/list" {
+		if r.URL.Path == listEndpoint {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
@@ -155,7 +158,7 @@ func TestResolveDownloadID_LocalModeFallsBackToDBWhenRemoteListFails(t *testing.
 	}
 
 	server := testutil.NewHTTPServerT(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/list" {
+		if r.URL.Path == listEndpoint {
 			http.Error(w, "boom", http.StatusInternalServerError)
 			return
 		}
@@ -621,7 +624,7 @@ func TestActionCommandsRunE_ReturnAmbiguousIDErrors(t *testing.T) {
 			resetCommandConnectionState(t)
 
 			server := testutil.NewHTTPServerT(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path == "/list" {
+				if r.URL.Path == listEndpoint {
 					http.Error(w, "boom", http.StatusInternalServerError)
 					return
 				}
@@ -739,7 +742,7 @@ func TestPrintDownloads_StrictRemoteEmpty_DoesNotFallbackToDB(t *testing.T) {
 	}
 
 	server := testutil.NewHTTPServerT(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/list" {
+		if r.URL.Path == listEndpoint {
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`[]`))
 			return
@@ -805,7 +808,7 @@ func TestSendToServer_SuccessAndServerError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ln, err := net.Listen("tcp", "127.0.0.1:0")
+			var lc net.ListenConfig; ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
 			if err != nil {
 				t.Fatalf("listen failed: %v", err)
 			}
@@ -845,7 +848,7 @@ func TestSendToServer_SuccessAndServerError(t *testing.T) {
 func TestSendToServer_UsesBearerTokenFromEnv(t *testing.T) {
 	t.Setenv("SURGE_TOKEN", "env-token-123")
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	var lc net.ListenConfig; ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen failed: %v", err)
 	}
@@ -875,14 +878,14 @@ func TestSendToServer_UsesBearerTokenFromEnv(t *testing.T) {
 func TestGetRemoteDownloads_UsesBearerTokenFromEnv(t *testing.T) {
 	t.Setenv("SURGE_TOKEN", "env-token-123")
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	var lc net.ListenConfig; ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen failed: %v", err)
 	}
 	defer func() { _ = ln.Close() }()
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/list", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(listEndpoint, func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") != "Bearer env-token-123" {
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
@@ -942,7 +945,7 @@ func TestGetRemoteDownloads_NonOKAndInvalidJSON(t *testing.T) {
 
 func TestProcessDownloads_RemoteAndLocal(t *testing.T) {
 	t.Run("remote-mode", func(t *testing.T) {
-		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		var lc net.ListenConfig; ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
 		if err != nil {
 			t.Fatalf("listen failed: %v", err)
 		}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -66,7 +67,7 @@ func TestFindAvailablePort_ReturnsListener(t *testing.T) {
 func TestFindAvailablePort_SkipsOccupiedPorts(t *testing.T) {
 	requireTCPListener(t)
 	// Occupy any port
-	ln1, err := net.Listen("tcp", fmt.Sprintf("%s:0", serverBindHost))
+	ln1, err := net.Listen("tcp", serverBindHost+":0")
 	if err != nil {
 		t.Fatalf("Failed to occupy any port: %v", err)
 	}
@@ -785,7 +786,7 @@ func TestStartHTTPServer_OptionsRequest(t *testing.T) {
 	go startHTTPServer(ln, port, "", svc, "")
 	time.Sleep(50 * time.Millisecond)
 
-	req, _ := http.NewRequest(http.MethodOptions, fmt.Sprintf("http://127.0.0.1:%d/download", port), nil)
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodOptions, fmt.Sprintf("http://127.0.0.1:%d/download", port), nil)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("Request failed: %v", err)

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -148,7 +148,7 @@ func TestCorsMiddleware_SetsCORSHeaders(t *testing.T) {
 
 	corsHandler := corsMiddleware(handler)
 
-	req := httptest.NewRequestWithContext(context.Background(),http.MethodGet, "/test", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/test", nil)
 	rec := httptest.NewRecorder()
 	corsHandler.ServeHTTP(rec, req)
 
@@ -165,7 +165,7 @@ func TestCorsMiddleware_OptionsHandledByMiddleware(t *testing.T) {
 
 	corsHandler := corsMiddleware(handler)
 
-	req := httptest.NewRequestWithContext(context.Background(),http.MethodOptions, "/test", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodOptions, "/test", nil)
 	rec := httptest.NewRecorder()
 	corsHandler.ServeHTTP(rec, req)
 
@@ -187,7 +187,7 @@ func TestCorsMiddleware_PassesThrough(t *testing.T) {
 
 	corsHandler := corsMiddleware(handler)
 
-	req := httptest.NewRequestWithContext(context.Background(),http.MethodPost, "/test", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/test", nil)
 	rec := httptest.NewRecorder()
 	corsHandler.ServeHTTP(rec, req)
 
@@ -343,7 +343,7 @@ func TestGetServerBindHost(t *testing.T) {
 // =============================================================================
 
 func TestHandleDownload_MethodNotAllowed(t *testing.T) {
-	req := httptest.NewRequestWithContext(context.Background(),http.MethodPut, "/download", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/download", nil)
 	rec := httptest.NewRecorder()
 
 	svc := core.NewLocalDownloadService(nil)
@@ -355,7 +355,7 @@ func TestHandleDownload_MethodNotAllowed(t *testing.T) {
 }
 
 func TestHandleDownload_InvalidJSON(t *testing.T) {
-	req := httptest.NewRequestWithContext(context.Background(),http.MethodPost, "/download", bytes.NewBufferString("not json"))
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/download", bytes.NewBufferString("not json"))
 	rec := httptest.NewRecorder()
 
 	svc := core.NewLocalDownloadService(nil)
@@ -371,7 +371,7 @@ func TestHandleDownload_InvalidJSON(t *testing.T) {
 
 func TestHandleDownload_MissingURL(t *testing.T) {
 	body := `{"filename": "test.bin"}`
-	req := httptest.NewRequestWithContext(context.Background(),http.MethodPost, "/download", bytes.NewBufferString(body))
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/download", bytes.NewBufferString(body))
 	rec := httptest.NewRecorder()
 
 	svc := core.NewLocalDownloadService(nil)
@@ -387,7 +387,7 @@ func TestHandleDownload_MissingURL(t *testing.T) {
 
 func TestHandleDownload_EmptyURL(t *testing.T) {
 	body := `{"url": ""}`
-	req := httptest.NewRequestWithContext(context.Background(),http.MethodPost, "/download", bytes.NewBufferString(body))
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/download", bytes.NewBufferString(body))
 	rec := httptest.NewRecorder()
 
 	svc := core.NewLocalDownloadService(nil)
@@ -412,7 +412,7 @@ func TestHandleDownload_PathTraversal(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequestWithContext(context.Background(),http.MethodPost, "/download", bytes.NewBufferString(tt.body))
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/download", bytes.NewBufferString(tt.body))
 			rec := httptest.NewRecorder()
 			svc := core.NewLocalDownloadService(nil)
 			handleDownload(rec, req, "", svc)
@@ -463,7 +463,7 @@ func TestHandleDownload_PathTraversal(t *testing.T) {
 // }
 
 func TestHandleDownload_StatusQuery_NotFound(t *testing.T) {
-	req := httptest.NewRequestWithContext(context.Background(),http.MethodGet, "/download?id=missing-id", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/download?id=missing-id", nil)
 	rec := httptest.NewRecorder()
 
 	svc := core.NewLocalDownloadService(nil)
@@ -922,7 +922,7 @@ func TestHandleDownload_ValidRequest_NoServerProgram(t *testing.T) {
 	defer func() { serverProgram = orig }()
 
 	body := `{"url": "https://example.com/file.zip"}`
-	req := httptest.NewRequestWithContext(context.Background(),http.MethodPost, "/download", bytes.NewBufferString(body))
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/download", bytes.NewBufferString(body))
 	rec := httptest.NewRecorder()
 
 	// This will panic because serverProgram is nil
@@ -939,7 +939,7 @@ func TestHandleDownload_ValidRequest_NoServerProgram(t *testing.T) {
 }
 
 func TestHandleDownload_EmptyBody(t *testing.T) {
-	req := httptest.NewRequestWithContext(context.Background(),http.MethodPost, "/download", bytes.NewBufferString(""))
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/download", bytes.NewBufferString(""))
 	rec := httptest.NewRecorder()
 
 	svc := core.NewLocalDownloadService(nil)
@@ -955,7 +955,7 @@ func TestHandleDownload_LargeURL(t *testing.T) {
 	largeURL := "https://example.com/" + string(make([]byte, 10000))
 	body := fmt.Sprintf(`{"url": "%s"}`, largeURL)
 
-	req := httptest.NewRequestWithContext(context.Background(),http.MethodPost, "/download", bytes.NewBufferString(body))
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/download", bytes.NewBufferString(body))
 	rec := httptest.NewRecorder()
 
 	// This should handle large URLs gracefully (validation issues)
@@ -968,7 +968,7 @@ func TestHandleDownload_LargeURL(t *testing.T) {
 
 func TestHandleDownload_SpecialCharactersInPath(t *testing.T) {
 	body := `{"url": "https://example.com/file.zip", "path": "/path/with spaces/and (parens)"}`
-	req := httptest.NewRequestWithContext(context.Background(),http.MethodPost, "/download", bytes.NewBufferString(body))
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/download", bytes.NewBufferString(body))
 	rec := httptest.NewRecorder()
 
 	defer func() {
@@ -1003,7 +1003,7 @@ func TestCorsMiddleware_AllMethods(t *testing.T) {
 
 	methods := []string{"GET", "POST", "PUT", "DELETE", "PATCH"}
 	for _, method := range methods {
-		req := httptest.NewRequestWithContext(context.Background(),method, "/test", nil)
+		req := httptest.NewRequestWithContext(context.Background(), method, "/test", nil)
 		rec := httptest.NewRecorder()
 		corsHandler.ServeHTTP(rec, req)
 

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1,5 +1,7 @@
 package cmd
 
+// nolint:noctx
+
 import (
 	"bytes"
 	"context"
@@ -43,7 +45,7 @@ func TestFindAvailablePort_Success(t *testing.T) {
 	}
 
 	// Verify we can't bind to the same port
-	_, err := net.Listen("tcp", ln.Addr().String())
+	_, err := net.Listen("tcp", ln.Addr().String()) // nolint:noctx
 	if err == nil {
 		t.Error("Should not be able to bind to same port")
 	}
@@ -67,7 +69,7 @@ func TestFindAvailablePort_ReturnsListener(t *testing.T) {
 func TestFindAvailablePort_SkipsOccupiedPorts(t *testing.T) {
 	requireTCPListener(t)
 	// Occupy any port
-	ln1, err := net.Listen("tcp", serverBindHost+":0")
+	ln1, err := net.Listen("tcp", serverBindHost+":0") // nolint:noctx
 	if err != nil {
 		t.Fatalf("Failed to occupy any port: %v", err)
 	}
@@ -146,7 +148,7 @@ func TestCorsMiddleware_SetsCORSHeaders(t *testing.T) {
 
 	corsHandler := corsMiddleware(handler)
 
-	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req := httptest.NewRequestWithContext(context.Background(),http.MethodGet, "/test", nil)
 	rec := httptest.NewRecorder()
 	corsHandler.ServeHTTP(rec, req)
 
@@ -163,7 +165,7 @@ func TestCorsMiddleware_OptionsHandledByMiddleware(t *testing.T) {
 
 	corsHandler := corsMiddleware(handler)
 
-	req := httptest.NewRequest(http.MethodOptions, "/test", nil)
+	req := httptest.NewRequestWithContext(context.Background(),http.MethodOptions, "/test", nil)
 	rec := httptest.NewRecorder()
 	corsHandler.ServeHTTP(rec, req)
 
@@ -185,7 +187,7 @@ func TestCorsMiddleware_PassesThrough(t *testing.T) {
 
 	corsHandler := corsMiddleware(handler)
 
-	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	req := httptest.NewRequestWithContext(context.Background(),http.MethodPost, "/test", nil)
 	rec := httptest.NewRecorder()
 	corsHandler.ServeHTTP(rec, req)
 
@@ -341,7 +343,7 @@ func TestGetServerBindHost(t *testing.T) {
 // =============================================================================
 
 func TestHandleDownload_MethodNotAllowed(t *testing.T) {
-	req := httptest.NewRequest(http.MethodPut, "/download", nil)
+	req := httptest.NewRequestWithContext(context.Background(),http.MethodPut, "/download", nil)
 	rec := httptest.NewRecorder()
 
 	svc := core.NewLocalDownloadService(nil)
@@ -353,7 +355,7 @@ func TestHandleDownload_MethodNotAllowed(t *testing.T) {
 }
 
 func TestHandleDownload_InvalidJSON(t *testing.T) {
-	req := httptest.NewRequest(http.MethodPost, "/download", bytes.NewBufferString("not json"))
+	req := httptest.NewRequestWithContext(context.Background(),http.MethodPost, "/download", bytes.NewBufferString("not json"))
 	rec := httptest.NewRecorder()
 
 	svc := core.NewLocalDownloadService(nil)
@@ -369,7 +371,7 @@ func TestHandleDownload_InvalidJSON(t *testing.T) {
 
 func TestHandleDownload_MissingURL(t *testing.T) {
 	body := `{"filename": "test.bin"}`
-	req := httptest.NewRequest(http.MethodPost, "/download", bytes.NewBufferString(body))
+	req := httptest.NewRequestWithContext(context.Background(),http.MethodPost, "/download", bytes.NewBufferString(body))
 	rec := httptest.NewRecorder()
 
 	svc := core.NewLocalDownloadService(nil)
@@ -385,7 +387,7 @@ func TestHandleDownload_MissingURL(t *testing.T) {
 
 func TestHandleDownload_EmptyURL(t *testing.T) {
 	body := `{"url": ""}`
-	req := httptest.NewRequest(http.MethodPost, "/download", bytes.NewBufferString(body))
+	req := httptest.NewRequestWithContext(context.Background(),http.MethodPost, "/download", bytes.NewBufferString(body))
 	rec := httptest.NewRecorder()
 
 	svc := core.NewLocalDownloadService(nil)
@@ -410,7 +412,7 @@ func TestHandleDownload_PathTraversal(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodPost, "/download", bytes.NewBufferString(tt.body))
+			req := httptest.NewRequestWithContext(context.Background(),http.MethodPost, "/download", bytes.NewBufferString(tt.body))
 			rec := httptest.NewRecorder()
 			svc := core.NewLocalDownloadService(nil)
 			handleDownload(rec, req, "", svc)
@@ -435,7 +437,7 @@ func TestHandleDownload_PathTraversal(t *testing.T) {
 
 // 	time.Sleep(50 * time.Millisecond) // Give worker time to pick it up
 
-// 	req := httptest.NewRequest(http.MethodGet, "/download?id="+id, nil)
+// 	req := httptest.NewRequestWithContext(context.Background(),http.MethodGet, "/download?id="+id, nil)
 // 	rec := httptest.NewRecorder()
 
 // 	handleDownload(rec, req, "")
@@ -461,7 +463,7 @@ func TestHandleDownload_PathTraversal(t *testing.T) {
 // }
 
 func TestHandleDownload_StatusQuery_NotFound(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/download?id=missing-id", nil)
+	req := httptest.NewRequestWithContext(context.Background(),http.MethodGet, "/download?id=missing-id", nil)
 	rec := httptest.NewRecorder()
 
 	svc := core.NewLocalDownloadService(nil)
@@ -598,7 +600,7 @@ func TestHealthEndpoint(t *testing.T) {
 	server := testutil.NewHTTPServerT(t, mux)
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/health")
+	resp, err := http.Get(server.URL + "/health") // nolint:noctx
 	if err != nil {
 		t.Fatalf("Failed to get health: %v", err)
 	}
@@ -714,7 +716,7 @@ func TestAddCmd_HasGetAlias(t *testing.T) {
 func TestStartHTTPServer_HealthEndpoint(t *testing.T) {
 	requireTCPListener(t)
 	// Create listener
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, err := net.Listen("tcp", "127.0.0.1:0") // nolint:noctx
 	if err != nil {
 		t.Fatalf("Failed to create listener: %v", err)
 	}
@@ -728,7 +730,7 @@ func TestStartHTTPServer_HealthEndpoint(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	// Test health endpoint
-	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/health", port))
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/health", port)) // nolint:noctx
 	if err != nil {
 		t.Fatalf("Failed to get health: %v", err)
 	}
@@ -753,7 +755,7 @@ func TestStartHTTPServer_HealthEndpoint(t *testing.T) {
 
 func TestStartHTTPServer_HasCORSHeaders(t *testing.T) {
 	requireTCPListener(t)
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, err := net.Listen("tcp", "127.0.0.1:0") // nolint:noctx
 	if err != nil {
 		t.Fatalf("Failed to create listener: %v", err)
 	}
@@ -763,7 +765,7 @@ func TestStartHTTPServer_HasCORSHeaders(t *testing.T) {
 	go startHTTPServer(ln, port, "", svc, "")
 	time.Sleep(50 * time.Millisecond)
 
-	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/health", port))
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/health", port)) // nolint:noctx
 	if err != nil {
 		t.Fatalf("Request failed: %v", err)
 	}
@@ -776,7 +778,7 @@ func TestStartHTTPServer_HasCORSHeaders(t *testing.T) {
 
 func TestStartHTTPServer_OptionsRequest(t *testing.T) {
 	requireTCPListener(t)
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, err := net.Listen("tcp", "127.0.0.1:0") // nolint:noctx
 	if err != nil {
 		t.Fatalf("Failed to create listener: %v", err)
 	}
@@ -801,7 +803,7 @@ func TestStartHTTPServer_OptionsRequest(t *testing.T) {
 
 func TestStartHTTPServer_DownloadEndpoint_MethodNotAllowed(t *testing.T) {
 	requireTCPListener(t)
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, err := net.Listen("tcp", "127.0.0.1:0") // nolint:noctx
 	if err != nil {
 		t.Fatalf("Failed to create listener: %v", err)
 	}
@@ -813,7 +815,7 @@ func TestStartHTTPServer_DownloadEndpoint_MethodNotAllowed(t *testing.T) {
 
 	token := ensureAuthToken()
 
-	req, _ := http.NewRequest(http.MethodPut, fmt.Sprintf("http://127.0.0.1:%d/download", port), nil)
+	req, _ := http.NewRequest(http.MethodPut, fmt.Sprintf("http://127.0.0.1:%d/download", port), nil) // nolint:noctx
 	req.Header.Set("Authorization", "Bearer "+token)
 
 	resp, err := http.DefaultClient.Do(req)
@@ -829,7 +831,7 @@ func TestStartHTTPServer_DownloadEndpoint_MethodNotAllowed(t *testing.T) {
 
 func TestStartHTTPServer_DownloadEndpoint_BadRequest(t *testing.T) {
 	requireTCPListener(t)
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, err := net.Listen("tcp", "127.0.0.1:0") // nolint:noctx
 	if err != nil {
 		t.Fatalf("Failed to create listener: %v", err)
 	}
@@ -840,7 +842,7 @@ func TestStartHTTPServer_DownloadEndpoint_BadRequest(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	// POST with invalid JSON
-	req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("http://127.0.0.1:%d/download", port), bytes.NewBufferString("not json"))
+	req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("http://127.0.0.1:%d/download", port), bytes.NewBufferString("not json")) // nolint:noctx
 	req.Header.Set("Authorization", "Bearer "+ensureAuthToken())
 	req.Header.Set("Content-Type", "application/json")
 
@@ -857,7 +859,7 @@ func TestStartHTTPServer_DownloadEndpoint_BadRequest(t *testing.T) {
 
 func TestStartHTTPServer_DownloadEndpoint_MissingURL(t *testing.T) {
 	requireTCPListener(t)
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, err := net.Listen("tcp", "127.0.0.1:0") // nolint:noctx
 	if err != nil {
 		t.Fatalf("Failed to create listener: %v", err)
 	}
@@ -868,7 +870,7 @@ func TestStartHTTPServer_DownloadEndpoint_MissingURL(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	// POST with missing URL
-	req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("http://127.0.0.1:%d/download", port), bytes.NewBufferString(`{"path": "/downloads"}`))
+	req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("http://127.0.0.1:%d/download", port), bytes.NewBufferString(`{"path": "/downloads"}`)) // nolint:noctx
 	req.Header.Set("Authorization", "Bearer "+ensureAuthToken())
 	req.Header.Set("Content-Type", "application/json")
 
@@ -885,7 +887,7 @@ func TestStartHTTPServer_DownloadEndpoint_MissingURL(t *testing.T) {
 
 func TestStartHTTPServer_NotFoundEndpoint(t *testing.T) {
 	requireTCPListener(t)
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, err := net.Listen("tcp", "127.0.0.1:0") // nolint:noctx
 	if err != nil {
 		t.Fatalf("Failed to create listener: %v", err)
 	}
@@ -895,7 +897,7 @@ func TestStartHTTPServer_NotFoundEndpoint(t *testing.T) {
 	go startHTTPServer(ln, port, "", svc, "")
 	time.Sleep(50 * time.Millisecond)
 
-	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/nonexistent", port), nil)
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/nonexistent", port), nil) // nolint:noctx
 	req.Header.Set("Authorization", "Bearer "+ensureAuthToken())
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -920,7 +922,7 @@ func TestHandleDownload_ValidRequest_NoServerProgram(t *testing.T) {
 	defer func() { serverProgram = orig }()
 
 	body := `{"url": "https://example.com/file.zip"}`
-	req := httptest.NewRequest(http.MethodPost, "/download", bytes.NewBufferString(body))
+	req := httptest.NewRequestWithContext(context.Background(),http.MethodPost, "/download", bytes.NewBufferString(body))
 	rec := httptest.NewRecorder()
 
 	// This will panic because serverProgram is nil
@@ -937,7 +939,7 @@ func TestHandleDownload_ValidRequest_NoServerProgram(t *testing.T) {
 }
 
 func TestHandleDownload_EmptyBody(t *testing.T) {
-	req := httptest.NewRequest(http.MethodPost, "/download", bytes.NewBufferString(""))
+	req := httptest.NewRequestWithContext(context.Background(),http.MethodPost, "/download", bytes.NewBufferString(""))
 	rec := httptest.NewRecorder()
 
 	svc := core.NewLocalDownloadService(nil)
@@ -953,7 +955,7 @@ func TestHandleDownload_LargeURL(t *testing.T) {
 	largeURL := "https://example.com/" + string(make([]byte, 10000))
 	body := fmt.Sprintf(`{"url": "%s"}`, largeURL)
 
-	req := httptest.NewRequest(http.MethodPost, "/download", bytes.NewBufferString(body))
+	req := httptest.NewRequestWithContext(context.Background(),http.MethodPost, "/download", bytes.NewBufferString(body))
 	rec := httptest.NewRecorder()
 
 	// This should handle large URLs gracefully (validation issues)
@@ -966,7 +968,7 @@ func TestHandleDownload_LargeURL(t *testing.T) {
 
 func TestHandleDownload_SpecialCharactersInPath(t *testing.T) {
 	body := `{"url": "https://example.com/file.zip", "path": "/path/with spaces/and (parens)"}`
-	req := httptest.NewRequest(http.MethodPost, "/download", bytes.NewBufferString(body))
+	req := httptest.NewRequestWithContext(context.Background(),http.MethodPost, "/download", bytes.NewBufferString(body))
 	rec := httptest.NewRecorder()
 
 	defer func() {
@@ -1001,7 +1003,7 @@ func TestCorsMiddleware_AllMethods(t *testing.T) {
 
 	methods := []string{"GET", "POST", "PUT", "DELETE", "PATCH"}
 	for _, method := range methods {
-		req := httptest.NewRequest(method, "/test", nil)
+		req := httptest.NewRequestWithContext(context.Background(),method, "/test", nil)
 		rec := httptest.NewRecorder()
 		corsHandler.ServeHTTP(rec, req)
 

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -27,7 +28,7 @@ var connectCmd = &cobra.Command{
 		} else {
 			port := readActivePort()
 			if port == 0 {
-				return fmt.Errorf("no local Surge server detected. Start one with 'surge' or 'surge server', or specify a target: surge connect <host:port>")
+				return errors.New("no local Surge server detected. Start one with 'surge' or 'surge server', or specify a target: surge connect <host:port>")
 			}
 			target = fmt.Sprintf("127.0.0.1:%d", port)
 			fmt.Printf("Auto-detected local server on port %d\n", port)
@@ -122,24 +123,24 @@ func resolveTokenForTarget(target string) (string, error) {
 	if isLocalHost(host) {
 		return ensureAuthToken(), nil
 	}
-	return "", fmt.Errorf("no token provided. Use --token or set SURGE_TOKEN")
+	return "", errors.New("no token provided. Use --token or set SURGE_TOKEN")
 }
 
 func resolveConnectBaseURL(target string, allowInsecureHTTP bool) (string, error) {
 	if strings.Contains(target, "://") {
 		u, err := url.Parse(target)
 		if err != nil {
-			return "", fmt.Errorf("invalid target: %v", err)
+			return "", fmt.Errorf("invalid target: %w", err)
 		}
 		if u.Scheme != "http" && u.Scheme != "https" {
 			return "", fmt.Errorf("unsupported scheme %q (use http or https)", u.Scheme)
 		}
 		if u.Host == "" {
-			return "", fmt.Errorf("invalid target: missing host")
+			return "", errors.New("invalid target: missing host")
 		}
 		host := u.Hostname()
 		if u.Scheme == "http" && !allowInsecureHTTP && !isLoopbackHost(host) && !isPrivateIPHost(host) {
-			return "", fmt.Errorf("refusing insecure HTTP for non-loopback target. Use https:// or --insecure-http")
+			return "", errors.New("refusing insecure HTTP for non-loopback target. Use https:// or --insecure-http")
 		}
 		return fmt.Sprintf("%s://%s", u.Scheme, u.Host), nil
 	}

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -64,7 +64,7 @@ func TestCLI_DeleteEndpoint_CleansPausedStateAndPartialFile(t *testing.T) {
 	client := &http.Client{Timeout: 3 * time.Second}
 
 	doRequest := func(method, url string) (*http.Response, error) {
-		req, err := http.NewRequest(method, url, nil)
+		req, err := http.NewRequest(method, url, nil) // nolint:noctx // nolint:noctx
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/http_api.go
+++ b/cmd/http_api.go
@@ -295,7 +295,7 @@ func ensureOpenActionRequestAllowed(r *http.Request) error {
 		return nil
 	}
 
-	return fmt.Errorf("open actions are only allowed from local host")
+	return errors.New("open actions are only allowed from local host")
 }
 
 func decodeJSONBody(r *http.Request, dst interface{}) error {

--- a/cmd/http_api_test.go
+++ b/cmd/http_api_test.go
@@ -94,7 +94,7 @@ func TestEnsureOpenActionRequestAllowed_RemoteToggle(t *testing.T) {
 		globalSettings = original
 	})
 
-	request := httptest.NewRequestWithContext(context.Background(),http.MethodPost, "/open-file?id=example", nil)
+	request := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/open-file?id=example", nil)
 	request.RemoteAddr = "203.0.113.8:12345"
 
 	globalSettings = config.DefaultSettings()
@@ -121,7 +121,7 @@ func TestHistoryEndpoint_SortsMostRecentFirst(t *testing.T) {
 	mux := http.NewServeMux()
 	registerHTTPRoutes(mux, 0, "", service)
 
-	request := httptest.NewRequestWithContext(context.Background(),http.MethodGet, "/history", nil)
+	request := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/history", nil)
 	recorder := httptest.NewRecorder()
 	mux.ServeHTTP(recorder, request)
 
@@ -285,7 +285,7 @@ func TestOpenEndpoints_ReturnMappedResolveStatuses(t *testing.T) {
 			}
 			registerHTTPRoutes(mux, 0, "", service)
 
-			request := httptest.NewRequestWithContext(context.Background(),http.MethodPost, test.path, nil)
+			request := httptest.NewRequestWithContext(context.Background(), http.MethodPost, test.path, nil)
 			request.RemoteAddr = "127.0.0.1:12345"
 			recorder := httptest.NewRecorder()
 
@@ -304,7 +304,7 @@ func TestEnsureOpenActionRequestAllowed_ForwardedLoopbackDenied(t *testing.T) {
 		globalSettings = original
 	})
 
-	request := httptest.NewRequestWithContext(context.Background(),http.MethodPost, "/open-file?id=example", nil)
+	request := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/open-file?id=example", nil)
 	request.RemoteAddr = "127.0.0.1:23456"
 	request.Header.Set("X-Forwarded-For", "198.51.100.10")
 

--- a/cmd/http_api_test.go
+++ b/cmd/http_api_test.go
@@ -94,7 +94,7 @@ func TestEnsureOpenActionRequestAllowed_RemoteToggle(t *testing.T) {
 		globalSettings = original
 	})
 
-	request := httptest.NewRequest(http.MethodPost, "/open-file?id=example", nil)
+	request := httptest.NewRequestWithContext(context.Background(),http.MethodPost, "/open-file?id=example", nil)
 	request.RemoteAddr = "203.0.113.8:12345"
 
 	globalSettings = config.DefaultSettings()
@@ -121,7 +121,7 @@ func TestHistoryEndpoint_SortsMostRecentFirst(t *testing.T) {
 	mux := http.NewServeMux()
 	registerHTTPRoutes(mux, 0, "", service)
 
-	request := httptest.NewRequest(http.MethodGet, "/history", nil)
+	request := httptest.NewRequestWithContext(context.Background(),http.MethodGet, "/history", nil)
 	recorder := httptest.NewRecorder()
 	mux.ServeHTTP(recorder, request)
 
@@ -285,7 +285,7 @@ func TestOpenEndpoints_ReturnMappedResolveStatuses(t *testing.T) {
 			}
 			registerHTTPRoutes(mux, 0, "", service)
 
-			request := httptest.NewRequest(http.MethodPost, test.path, nil)
+			request := httptest.NewRequestWithContext(context.Background(),http.MethodPost, test.path, nil)
 			request.RemoteAddr = "127.0.0.1:12345"
 			recorder := httptest.NewRecorder()
 
@@ -304,7 +304,7 @@ func TestEnsureOpenActionRequestAllowed_ForwardedLoopbackDenied(t *testing.T) {
 		globalSettings = original
 	})
 
-	request := httptest.NewRequest(http.MethodPost, "/open-file?id=example", nil)
+	request := httptest.NewRequestWithContext(context.Background(),http.MethodPost, "/open-file?id=example", nil)
 	request.RemoteAddr = "127.0.0.1:23456"
 	request.Header.Set("X-Forwarded-For", "198.51.100.10")
 

--- a/cmd/http_handler_test.go
+++ b/cmd/http_handler_test.go
@@ -141,7 +141,7 @@ func TestHandleDownload_PathResolution(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			body, _ := json.Marshal(tt.request) // nolint:noctx
-			req := httptest.NewRequestWithContext(context.Background(),"POST", "/download", bytes.NewBuffer(body))
+			req := httptest.NewRequestWithContext(context.Background(), "POST", "/download", bytes.NewBuffer(body))
 			w := httptest.NewRecorder()
 			svc := core.NewLocalDownloadService(GlobalPool)
 
@@ -278,8 +278,8 @@ func TestHandleDownload_SkipApprovalUsesLifecycleEnqueue(t *testing.T) {
 		"is_explicit_category": true,
 		"headers": {"Authorization": "Bearer test"}
 	}`, probeServer.URL, expectedFile, tempDir)
- // nolint:noctx
-	req := httptest.NewRequestWithContext(context.Background(),http.MethodPost, "/download", bytes.NewBufferString(body))
+	// nolint:noctx
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/download", bytes.NewBufferString(body))
 	rec := httptest.NewRecorder()
 
 	handleDownload(rec, req, "", svc)
@@ -331,7 +331,7 @@ func TestHandleDownload_EnqueueError_RecordsPreflightError(t *testing.T) {
 
 	// Use a URL with an invalid scheme so ProbeServer fails immediately.
 	body := `{"url": "badscheme://example.com/file.bin", "path": "/tmp", "skip_approval": true}` // nolint:noctx
-	req := httptest.NewRequestWithContext(context.Background(),http.MethodPost, "/download", bytes.NewBufferString(body))
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/download", bytes.NewBufferString(body))
 	rec := httptest.NewRecorder()
 
 	handleDownload(rec, req, "", svc)
@@ -395,7 +395,7 @@ func TestHandleDownload_PublishError_RecordsPreflightError(t *testing.T) {
 
 	outDir := t.TempDir()
 	body := fmt.Sprintf(`{"url": %q, "path": %q}`, "http://example.com/file.bin", outDir)
-	req := httptest.NewRequestWithContext(context.Background(),http.MethodPost, "/download", bytes.NewBufferString(body))
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/download", bytes.NewBufferString(body))
 	rec := httptest.NewRecorder()
 
 	handleDownload(rec, req, "", svc)

--- a/cmd/http_handler_test.go
+++ b/cmd/http_handler_test.go
@@ -167,20 +167,21 @@ func TestHandleDownload_PathResolution(t *testing.T) {
 					// If expectedPathSuffix is relative (like "relative"), we check if path ends with it.
 					// If expectedPathSuffix is absolute (like /tmp/.../absolute), we check if paths match.
 
-					if tt.request.RelativeToDefaultDir {
+					switch {
+					case tt.request.RelativeToDefaultDir:
 						expectedAbs := filepath.Join(defaultDownloadDir, tt.request.Path)
 						if cfg.OutputPath != expectedAbs {
 							t.Errorf("Expected path %s, got %s", expectedAbs, cfg.OutputPath)
 						}
-					} else if tt.request.Path == "" {
+					case tt.request.Path == "":
 						if cfg.OutputPath != defaultDownloadDir {
 							t.Errorf("Expected path %s, got %s", defaultDownloadDir, cfg.OutputPath)
 						}
-					} else if filepath.IsAbs(tt.request.Path) {
+					case filepath.IsAbs(tt.request.Path):
 						if cfg.OutputPath != tt.request.Path {
 							t.Errorf("Expected path %s, got %s", tt.request.Path, cfg.OutputPath)
 						}
-					} else {
+					default:
 						// Relative path without flag (Ensured Absolute CWD)
 						// Hard to test exactly without knowing CWD, but it should end with the relative path
 						if !strings.HasSuffix(cfg.OutputPath, tt.request.Path) {

--- a/cmd/http_handler_test.go
+++ b/cmd/http_handler_test.go
@@ -1,7 +1,10 @@
 package cmd
 
+// nolint:noctx
+
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -137,8 +140,8 @@ func TestHandleDownload_PathResolution(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			body, _ := json.Marshal(tt.request)
-			req := httptest.NewRequest("POST", "/download", bytes.NewBuffer(body))
+			body, _ := json.Marshal(tt.request) // nolint:noctx
+			req := httptest.NewRequestWithContext(context.Background(),"POST", "/download", bytes.NewBuffer(body))
 			w := httptest.NewRecorder()
 			svc := core.NewLocalDownloadService(GlobalPool)
 
@@ -275,8 +278,8 @@ func TestHandleDownload_SkipApprovalUsesLifecycleEnqueue(t *testing.T) {
 		"is_explicit_category": true,
 		"headers": {"Authorization": "Bearer test"}
 	}`, probeServer.URL, expectedFile, tempDir)
-
-	req := httptest.NewRequest(http.MethodPost, "/download", bytes.NewBufferString(body))
+ // nolint:noctx
+	req := httptest.NewRequestWithContext(context.Background(),http.MethodPost, "/download", bytes.NewBufferString(body))
 	rec := httptest.NewRecorder()
 
 	handleDownload(rec, req, "", svc)
@@ -327,8 +330,8 @@ func TestHandleDownload_EnqueueError_RecordsPreflightError(t *testing.T) {
 	})
 
 	// Use a URL with an invalid scheme so ProbeServer fails immediately.
-	body := `{"url": "badscheme://example.com/file.bin", "path": "/tmp", "skip_approval": true}`
-	req := httptest.NewRequest(http.MethodPost, "/download", bytes.NewBufferString(body))
+	body := `{"url": "badscheme://example.com/file.bin", "path": "/tmp", "skip_approval": true}` // nolint:noctx
+	req := httptest.NewRequestWithContext(context.Background(),http.MethodPost, "/download", bytes.NewBufferString(body))
 	rec := httptest.NewRecorder()
 
 	handleDownload(rec, req, "", svc)
@@ -392,7 +395,7 @@ func TestHandleDownload_PublishError_RecordsPreflightError(t *testing.T) {
 
 	outDir := t.TempDir()
 	body := fmt.Sprintf(`{"url": %q, "path": %q}`, "http://example.com/file.bin", outDir)
-	req := httptest.NewRequest(http.MethodPost, "/download", bytes.NewBufferString(body))
+	req := httptest.NewRequestWithContext(context.Background(),http.MethodPost, "/download", bytes.NewBufferString(body))
 	rec := httptest.NewRecorder()
 
 	handleDownload(rec, req, "", svc)

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -176,7 +176,7 @@ func showDownloadDetails(partialID string, jsonOutput bool, baseURL string, toke
 
 	// Try to get from running server first
 	if baseURL != "" {
-		path := fmt.Sprintf("/download?id=%s", url.QueryEscape(fullID))
+		path := "/download?id=" + url.QueryEscape(fullID)
 		resp, err := doAPIRequest(http.MethodGet, baseURL, token, path, nil)
 		if err != nil {
 			if strictRemote {

--- a/cmd/pause.go
+++ b/cmd/pause.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -20,7 +21,7 @@ var pauseCmd = &cobra.Command{
 		all, _ := cmd.Flags().GetBool("all")
 
 		if !all && len(args) == 0 {
-			return fmt.Errorf("provide a download ID or use --all")
+			return errors.New("provide a download ID or use --all")
 		}
 
 		if all {

--- a/cmd/refresh.go
+++ b/cmd/refresh.go
@@ -45,7 +45,7 @@ var refreshCmd = &cobra.Command{
 		}
 
 		// Send to running server
-		path := fmt.Sprintf("/update-url?id=%s", url.QueryEscape(id))
+		path := "/update-url?id=" + url.QueryEscape(id)
 		resp, err := doAPIRequest(http.MethodPut, baseURL, token, path, bytes.NewBuffer(jsonData))
 		if err != nil {
 			return fmt.Errorf("error connecting to server: %w", err)

--- a/cmd/resume.go
+++ b/cmd/resume.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -20,7 +21,7 @@ var resumeCmd = &cobra.Command{
 		all, _ := cmd.Flags().GetBool("all")
 
 		if !all && len(args) == 0 {
-			return fmt.Errorf("provide a download ID or use --all")
+			return errors.New("provide a download ID or use --all")
 		}
 
 		if all {

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -22,7 +23,7 @@ var rmCmd = &cobra.Command{
 		clean, _ := cmd.Flags().GetBool("clean")
 
 		if !clean && len(args) == 0 {
-			return fmt.Errorf("provide a download ID or use --clean")
+			return errors.New("provide a download ID or use --clean")
 		}
 
 		if clean {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -415,7 +415,7 @@ var rootCmd = &cobra.Command{
 	Long:          `Surge is a blazing fast TUI download manager built in Go for power users. Find more info here: https://github.com/SurgeDM/Surge`,
 	Version:       Version,
 	Args:          cobra.ArbitraryArgs,
-	SilenceErrors: true, //errors are printed in main.go this prevents double printing
+	SilenceErrors: true, // errors are printed in main.go; this prevents double printing
 	SilenceUsage:  true, // prevent usage text from being printed on every error
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -331,7 +332,7 @@ func maybeRunRemoteTUI(cmd *cobra.Command, args []string) (bool, error) {
 	}
 
 	if len(args) > 0 {
-		return false, fmt.Errorf("URLs cannot be passed when using --host. Use 'surge add <url>' after connecting")
+		return false, errors.New("URLs cannot be passed when using --host. Use 'surge add <url>' after connecting")
 	}
 
 	if err := connectAndRunTUI(cmd, hostTarget); err != nil {
@@ -347,7 +348,7 @@ func acquireRootInstanceLock() (func(), error) {
 	}
 
 	if !isMaster {
-		return nil, fmt.Errorf("surge is already running. Use 'surge add <url>' to add a download to the active instance")
+		return nil, errors.New("surge is already running. Use 'surge add <url>' to add a download to the active instance")
 	}
 
 	return func() {

--- a/cmd/root_downloads.go
+++ b/cmd/root_downloads.go
@@ -349,11 +349,12 @@ func resolveOutputDir(reqPath string, relativeToDefaultDir bool, defaultOutputDi
 		}
 		outPath = filepath.Join(baseDir, reqPath)
 	} else if outPath == "" {
-		if defaultOutputDir != "" {
+		switch {
+		case defaultOutputDir != "":
 			outPath = defaultOutputDir
-		} else if settings.General.DefaultDownloadDir != "" {
+		case settings.General.DefaultDownloadDir != "":
 			outPath = settings.General.DefaultDownloadDir
-		} else {
+		default:
 			outPath = "."
 		}
 	}

--- a/cmd/root_downloads.go
+++ b/cmd/root_downloads.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -112,24 +113,24 @@ func decodeAndValidateDownloadRequest(r *http.Request) (DownloadRequest, error) 
 		return req, fmt.Errorf("invalid json: %w", err)
 	}
 	if req.URL == "" {
-		return req, fmt.Errorf("url is required")
+		return req, errors.New("url is required")
 	}
 	if strings.Contains(req.Filename, "..") {
-		return req, fmt.Errorf("invalid filename")
+		return req, errors.New("invalid filename")
 	}
 	if strings.Contains(req.Filename, "/") || strings.Contains(req.Filename, "\\") {
-		return req, fmt.Errorf("invalid filename")
+		return req, errors.New("invalid filename")
 	}
 	if strings.Contains(req.Path, "..") {
-		return req, fmt.Errorf("invalid path")
+		return req, errors.New("invalid path")
 	}
 	if req.RelativeToDefaultDir && req.Path != "" {
 		if filepath.IsAbs(req.Path) {
-			return req, fmt.Errorf("invalid path")
+			return req, errors.New("invalid path")
 		}
 		cleanPath := filepath.Clean(req.Path)
 		if cleanPath == ".." || strings.HasPrefix(cleanPath, ".."+string(filepath.Separator)) {
-			return req, fmt.Errorf("invalid path")
+			return req, errors.New("invalid path")
 		}
 		req.Path = cleanPath
 	}
@@ -313,7 +314,7 @@ func processDownloads(urls []string, outputDir string, port int) int {
 		// CLI explicit arg means we do not auto-route when user provided an explicit output path.
 		isExplicit := isExplicitOutputPath(outPath, settings.General.DefaultDownloadDir)
 		if lifecycle == nil {
-			err := fmt.Errorf("lifecycle manager unavailable")
+			err := errors.New("lifecycle manager unavailable")
 			recordPreflightDownloadError(url, outPath, err)
 			publishSystemLog(fmt.Sprintf("Error adding %s: %v", url, err))
 			continue

--- a/cmd/root_http_server.go
+++ b/cmd/root_http_server.go
@@ -1,12 +1,15 @@
 package cmd
 
 import (
+	"context"
 	"crypto/subtle"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/SurgeDM/Surge/internal/config"
@@ -20,8 +23,9 @@ const serverBindHost = "0.0.0.0"
 // findAvailablePort tries ports starting from 'start' until one is available
 func findAvailablePort(start int) (int, net.Listener) {
 	bindHost := serverBindHost
+	var lc net.ListenConfig
 	for port := start; port < start+100; port++ {
-		ln, err := net.Listen("tcp", fmt.Sprintf("%s:%d", bindHost, port))
+		ln, err := lc.Listen(context.Background(), "tcp", fmt.Sprintf("%s:%d", bindHost, port))
 		if err == nil {
 			return port, ln
 		}
@@ -31,8 +35,9 @@ func findAvailablePort(start int) (int, net.Listener) {
 
 func bindServerListener(portFlag int) (int, net.Listener, error) {
 	bindHost := serverBindHost
+	var lc net.ListenConfig
 	if portFlag > 0 {
-		ln, err := net.Listen("tcp", fmt.Sprintf("%s:%d", bindHost, portFlag))
+		ln, err := lc.Listen(context.Background(), "tcp", fmt.Sprintf("%s:%d", bindHost, portFlag))
 		if err != nil {
 			return 0, nil, fmt.Errorf("could not bind to port %d: %w", portFlag, err)
 		}
@@ -40,7 +45,7 @@ func bindServerListener(portFlag int) (int, net.Listener, error) {
 	}
 	port, ln := findAvailablePort(1700)
 	if ln == nil {
-		return 0, nil, fmt.Errorf("could not find available port")
+		return 0, nil, errors.New("could not find available port")
 	}
 	return port, ln, nil
 }
@@ -53,7 +58,7 @@ func saveActivePort(port int) {
 	}
 
 	portFile := filepath.Join(config.GetRuntimeDir(), "port")
-	if err := os.WriteFile(portFile, []byte(fmt.Sprintf("%d", port)), 0o644); err != nil {
+	if err := os.WriteFile(portFile, []byte(strconv.Itoa(port)), 0o644); err != nil {
 		utils.Debug("Error writing port file: %v", err)
 	}
 	utils.Debug("HTTP server listening on port %d", port)

--- a/cmd/root_http_server.go
+++ b/cmd/root_http_server.go
@@ -102,7 +102,7 @@ func corsMiddleware(next http.Handler) http.Handler {
 		w.Header().Set("Access-Control-Allow-Private-Network", "true")
 
 		// Handle preflight requests
-		if r.Method == "OPTIONS" {
+		if r.Method == http.MethodOptions {
 			w.WriteHeader(http.StatusOK)
 			return
 		}
@@ -120,7 +120,7 @@ func authMiddleware(token string, next http.Handler) http.Handler {
 		}
 
 		// Allow OPTIONS for CORS preflight
-		if r.Method == "OPTIONS" {
+		if r.Method == http.MethodOptions {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	"os"
@@ -37,7 +38,7 @@ var serverStartCmd = &cobra.Command{
 		}
 
 		if !isMaster {
-			return fmt.Errorf("surge server is already running")
+			return errors.New("surge server is already running")
 		}
 		defer func() {
 			if err := ReleaseLock(); err != nil {
@@ -149,7 +150,7 @@ func savePID() {
 		return
 	}
 	pidFile := filepath.Join(config.GetRuntimeDir(), "pid")
-	if err := os.WriteFile(pidFile, []byte(fmt.Sprintf("%d", pid)), 0o644); err != nil {
+	if err := os.WriteFile(pidFile, []byte(strconv.Itoa(pid)), 0o644); err != nil {
 		utils.Debug("Error writing PID file: %v", err)
 	}
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -171,7 +171,7 @@ func readPID() int {
 	return pid
 }
 
-func startServerLogic(cmd *cobra.Command, args []string, portFlag int, batchFile string, outputDir string, exitWhenDone bool, noResume bool, tokenOverride string) error {
+func startServerLogic(_ *cobra.Command, args []string, portFlag int, batchFile string, outputDir string, exitWhenDone bool, noResume bool, tokenOverride string) error {
 	port, listener, err := bindServerListener(portFlag)
 	if err != nil {
 		return err

--- a/cmd/test_helpers_test.go
+++ b/cmd/test_helpers_test.go
@@ -7,7 +7,7 @@ import (
 
 func requireTCPListener(t *testing.T) {
 	t.Helper()
-	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	ln, err := net.Listen("tcp4", "127.0.0.1:0") // nolint:noctx
 	if err != nil {
 		t.Skipf("tcp listener unavailable: %v", err)
 		return

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -105,7 +106,7 @@ func resolveAPIConnection(requireServer bool) (string, string, error) {
 
 func doAPIRequest(method string, baseURL string, token string, path string, body io.Reader) (*http.Response, error) {
 	reqURL := fmt.Sprintf("%s%s", strings.TrimRight(baseURL, "/"), path)
-	req, err := http.NewRequest(method, reqURL, body)
+	req, err := http.NewRequestWithContext(context.Background(), method, reqURL, body)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -12,7 +12,7 @@ func TestResolveClientOutputPath(t *testing.T) {
 	originalHost := os.Getenv("SURGE_HOST")
 	originalGlobalHost := globalHost
 	defer func() {
-		os.Setenv("SURGE_HOST", originalHost)
+		_ = os.Setenv("SURGE_HOST", originalHost)
 		globalHost = originalGlobalHost
 	}()
 
@@ -31,7 +31,7 @@ func TestResolveClientOutputPath(t *testing.T) {
 		{
 			name: "Remote Host Set via Env - Pass Through Empty",
 			setupHost: func() {
-				os.Setenv("SURGE_HOST", "127.0.0.1:1234")
+				_ = os.Setenv("SURGE_HOST", "127.0.0.1:1234")
 				globalHost = ""
 			},
 			outputDir: "",
@@ -40,7 +40,7 @@ func TestResolveClientOutputPath(t *testing.T) {
 		{
 			name: "Remote Host Set via Global - Pass Through Exact",
 			setupHost: func() {
-				os.Setenv("SURGE_HOST", "")
+				_ = os.Setenv("SURGE_HOST", "")
 				globalHost = "127.0.0.1:1234"
 			},
 			outputDir: ".",
@@ -49,7 +49,7 @@ func TestResolveClientOutputPath(t *testing.T) {
 		{
 			name: "Local Execution - Empty Dir returns CWD",
 			setupHost: func() {
-				os.Setenv("SURGE_HOST", "")
+				_ = os.Setenv("SURGE_HOST", "")
 				globalHost = ""
 			},
 			outputDir: "",
@@ -58,7 +58,7 @@ func TestResolveClientOutputPath(t *testing.T) {
 		{
 			name: "Local Execution - Dot returns Absolute CWD",
 			setupHost: func() {
-				os.Setenv("SURGE_HOST", "")
+				_ = os.Setenv("SURGE_HOST", "")
 				globalHost = ""
 			},
 			outputDir: ".",
@@ -67,7 +67,7 @@ func TestResolveClientOutputPath(t *testing.T) {
 		{
 			name: "Local Execution - Relative Subdir returns Absolute",
 			setupHost: func() {
-				os.Setenv("SURGE_HOST", "")
+				_ = os.Setenv("SURGE_HOST", "")
 				globalHost = ""
 			},
 			outputDir: "downloads",

--- a/internal/core/local_service.go
+++ b/internal/core/local_service.go
@@ -384,11 +384,12 @@ func (s *LocalDownloadService) List() ([]types.DownloadStatus, error) {
 				status.Connections = int(connections)
 
 				// Update status based on state
-				if cfg.State.IsPausing() {
+				switch {
+				case cfg.State.IsPausing():
 					status.Status = "pausing"
-				} else if cfg.State.IsPaused() {
+				case cfg.State.IsPaused():
 					status.Status = "paused"
-				} else if cfg.State.Done.Load() {
+				case cfg.State.Done.Load():
 					status.Status = "completed"
 				}
 

--- a/internal/core/local_service.go
+++ b/internal/core/local_service.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -318,13 +319,13 @@ func (s *LocalDownloadService) StreamEvents(ctx context.Context) (<-chan interfa
 // Publish emits an event into the service's event stream.
 func (s *LocalDownloadService) Publish(msg interface{}) error {
 	if s.InputCh == nil {
-		return fmt.Errorf("input channel not initialized")
+		return errors.New("input channel not initialized")
 	}
 	select {
 	case s.InputCh <- msg:
 		return nil
 	case <-time.After(1 * time.Second):
-		return fmt.Errorf("event publish timeout")
+		return errors.New("event publish timeout")
 	}
 }
 
@@ -468,7 +469,7 @@ func (s *LocalDownloadService) AddWithID(url string, path string, filename strin
 
 func (s *LocalDownloadService) add(url string, path string, filename string, mirrors []string, headers map[string]string, requestedID string, isExplicitCategory bool, totalSize int64, supportsRange bool) (string, error) {
 	if s.Pool == nil {
-		return "", fmt.Errorf("worker pool not initialized")
+		return "", errors.New("worker pool not initialized")
 	}
 
 	s.settingsMu.RLock()
@@ -490,12 +491,12 @@ func (s *LocalDownloadService) add(url string, path string, filename string, mir
 		id = uuid.New().String()
 	}
 	if st := s.Pool.GetStatus(id); st != nil {
-		return "", fmt.Errorf("download id already exists")
+		return "", errors.New("download id already exists")
 	}
 	if entry, err := state.GetDownload(id); err != nil {
 		return "", fmt.Errorf("failed to query download state: %w", err)
 	} else if entry != nil {
-		return "", fmt.Errorf("download id already exists")
+		return "", errors.New("download id already exists")
 	}
 
 	state := types.NewProgressState(id, 0)
@@ -526,7 +527,7 @@ func (s *LocalDownloadService) Pause(id string) error {
 	if s.lifecycleHooks.Pause != nil {
 		return s.lifecycleHooks.Pause(id)
 	}
-	return fmt.Errorf("PauseFunc not initialized")
+	return errors.New("PauseFunc not initialized")
 }
 
 // Resume resumes a paused download.
@@ -534,7 +535,7 @@ func (s *LocalDownloadService) Resume(id string) error {
 	if s.lifecycleHooks.Resume != nil {
 		return s.lifecycleHooks.Resume(id)
 	}
-	return fmt.Errorf("ResumeFunc not initialized")
+	return errors.New("ResumeFunc not initialized")
 }
 
 // ResumeBatch resumes multiple paused downloads efficiently.
@@ -544,7 +545,7 @@ func (s *LocalDownloadService) ResumeBatch(ids []string) []error {
 	}
 	errs := make([]error, len(ids))
 	for i := range errs {
-		errs[i] = fmt.Errorf("ResumeBatchFunc not initialized")
+		errs[i] = errors.New("ResumeBatchFunc not initialized")
 	}
 	return errs
 }
@@ -562,7 +563,7 @@ func (s *LocalDownloadService) UpdateURL(id string, newURL string) error {
 	}
 	// Fallback: update pool in-memory only (no DB persistence)
 	if s.Pool == nil {
-		return fmt.Errorf("worker pool not initialized")
+		return errors.New("worker pool not initialized")
 	}
 	return s.Pool.UpdateURL(id, newURL)
 }
@@ -574,7 +575,7 @@ func (s *LocalDownloadService) Delete(id string) error {
 	}
 	// Fallback when lifecycle hooks not wired (e.g. tests)
 	if s.Pool == nil {
-		return fmt.Errorf("worker pool not initialized")
+		return errors.New("worker pool not initialized")
 	}
 	s.Pool.Cancel(id)
 	if entry, err := state.GetDownload(id); err == nil && entry != nil {
@@ -593,7 +594,7 @@ func (s *LocalDownloadService) Delete(id string) error {
 // GetStatus returns a status for a single download by id.
 func (s *LocalDownloadService) GetStatus(id string) (*types.DownloadStatus, error) {
 	if id == "" {
-		return nil, fmt.Errorf("missing id")
+		return nil, errors.New("missing id")
 	}
 
 	// 1. Check active pool
@@ -629,7 +630,7 @@ func (s *LocalDownloadService) GetStatus(id string) (*types.DownloadStatus, erro
 		return &status, nil
 	}
 
-	return nil, fmt.Errorf("download not found")
+	return nil, errors.New("download not found")
 }
 
 // History returns completed downloads

--- a/internal/core/local_service.go
+++ b/internal/core/local_service.go
@@ -18,8 +18,14 @@ import (
 	"github.com/google/uuid"
 )
 
+const (
+	statusCompleted = "completed"
+	statusPausing = "pausing"
+	statusPaused    = "paused"
+)
+
 func completedSpeedMBps(entry types.DownloadEntry) float64 {
-	if entry.Status != "completed" {
+	if entry.Status != statusCompleted {
 		return 0
 	}
 	if entry.AvgSpeed > 0 {
@@ -387,11 +393,11 @@ func (s *LocalDownloadService) List() ([]types.DownloadStatus, error) {
 				// Update status based on state
 				switch {
 				case cfg.State.IsPausing():
-					status.Status = "pausing"
+					status.Status = statusPausing
 				case cfg.State.IsPaused():
 					status.Status = "paused"
 				case cfg.State.Done.Load():
-					status.Status = "completed"
+					status.Status = statusCompleted
 				}
 
 				// Calculate speed from progress only while actively downloading.
@@ -432,7 +438,7 @@ func (s *LocalDownloadService) List() ([]types.DownloadStatus, error) {
 			var progress float64
 			if d.TotalSize > 0 {
 				progress = float64(d.Downloaded) * 100 / float64(d.TotalSize)
-			} else if d.Status == "completed" {
+			} else if d.Status == statusCompleted {
 				progress = 100.0
 			}
 
@@ -584,7 +590,7 @@ func (s *LocalDownloadService) Delete(id string) error {
 				DownloadID: id,
 				Filename:   entry.Filename,
 				DestPath:   entry.DestPath,
-				Completed:  entry.Status == "completed",
+				Completed:  entry.Status == statusCompleted,
 			}
 		}
 	}
@@ -611,7 +617,7 @@ func (s *LocalDownloadService) GetStatus(id string) (*types.DownloadStatus, erro
 		var progress float64
 		if entry.TotalSize > 0 {
 			progress = float64(entry.Downloaded) * 100 / float64(entry.TotalSize)
-		} else if entry.Status == "completed" {
+		} else if entry.Status == statusCompleted {
 			progress = 100.0
 		}
 

--- a/internal/core/local_service.go
+++ b/internal/core/local_service.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	statusCompleted = "completed"
-	statusPausing = "pausing"
+	statusPausing   = "pausing"
 	statusPaused    = "paused"
 )
 

--- a/internal/core/local_service_test.go
+++ b/internal/core/local_service_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/SurgeDM/Surge/internal/testutil"
 )
 
+const statusDownloading = "downloading"
+
 func TestLocalDownloadService_Delete_DBOnlyBroadcastsRemoved(t *testing.T) {
 	tempDir := t.TempDir()
 	state.CloseDB()
@@ -130,7 +132,7 @@ func TestLocalDownloadService_Delete_ActiveWithoutDB_RemovesPartialFile(t *testi
 	var runtimeDestPath string
 	for time.Now().Before(deadline) {
 		st, _ = svc.GetStatus(id)
-		if st != nil && st.DestPath != "" && st.Status == "downloading" {
+		if st != nil && st.DestPath != "" && st.Status == statusDownloading {
 			runtimeDestPath = st.DestPath
 			break
 		}
@@ -434,7 +436,7 @@ func TestLocalDownloadService_Shutdown_PersistsQueuedState(t *testing.T) {
 	for time.Now().Before(deadline) {
 		firstStatus, _ := svc.GetStatus(firstID)
 		secondStatus, _ := svc.GetStatus(secondID)
-		if firstStatus != nil && (firstStatus.Status == "downloading" || firstStatus.Status == "pausing") {
+		if firstStatus != nil && (firstStatus.Status == statusDownloading || firstStatus.Status == "pausing") {
 			seenFirstActive = true
 		}
 		if secondStatus != nil && secondStatus.Status == "queued" {
@@ -462,7 +464,7 @@ func TestLocalDownloadService_Shutdown_PersistsQueuedState(t *testing.T) {
 	if second == nil {
 		t.Fatal("expected queued download to be persisted on shutdown")
 	}
-	if second.Status != "queued" && second.Status != "paused" && second.Status != "completed" && second.Status != "downloading" {
+	if second.Status != "queued" && second.Status != "paused" && second.Status != "completed" && second.Status != statusDownloading {
 		t.Fatalf("status = %q, want queued/paused/completed/downloading", second.Status)
 	}
 }

--- a/internal/core/local_service_test.go
+++ b/internal/core/local_service_test.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -21,7 +20,7 @@ import (
 func TestLocalDownloadService_Delete_DBOnlyBroadcastsRemoved(t *testing.T) {
 	tempDir := t.TempDir()
 	state.CloseDB()
-	state.Configure(filepath.Join(tempDir, fmt.Sprintf("%s-surge.db", t.Name())))
+	state.Configure(filepath.Join(tempDir, t.Name()+"-surge.db"))
 	defer state.CloseDB()
 
 	ch := make(chan interface{}, 20)
@@ -98,7 +97,7 @@ func TestLocalDownloadService_Delete_DBOnlyBroadcastsRemoved(t *testing.T) {
 func TestLocalDownloadService_Delete_ActiveWithoutDB_RemovesPartialFile(t *testing.T) {
 	tempDir := t.TempDir()
 	state.CloseDB()
-	state.Configure(filepath.Join(tempDir, fmt.Sprintf("%s-surge.db", t.Name())))
+	state.Configure(filepath.Join(tempDir, t.Name()+"-surge.db"))
 	defer state.CloseDB()
 
 	ch := make(chan interface{}, 100)
@@ -293,7 +292,7 @@ func TestLocalDownloadService_AddWithID_UsesProvidedID(t *testing.T) {
 func TestLocalDownloadService_Shutdown_PersistsPausedState(t *testing.T) {
 	tempDir := t.TempDir()
 	state.CloseDB()
-	state.Configure(filepath.Join(tempDir, fmt.Sprintf("%s-surge.db", t.Name())))
+	state.Configure(filepath.Join(tempDir, t.Name()+"-surge.db"))
 	defer state.CloseDB()
 
 	ch := make(chan interface{}, 100)
@@ -397,7 +396,7 @@ func TestLocalDownloadService_Shutdown_PersistsPausedState(t *testing.T) {
 func TestLocalDownloadService_Shutdown_PersistsQueuedState(t *testing.T) {
 	tempDir := t.TempDir()
 	state.CloseDB()
-	state.Configure(filepath.Join(tempDir, fmt.Sprintf("%s-surge.db", t.Name())))
+	state.Configure(filepath.Join(tempDir, t.Name()+"-surge.db"))
 	defer state.CloseDB()
 
 	ch := make(chan interface{}, 200)
@@ -500,7 +499,7 @@ func TestLocalDownloadService_BatchProgress(t *testing.T) {
 	// Create temporary directory for downloads
 	tempDir := t.TempDir()
 	state.CloseDB()
-	state.Configure(filepath.Join(tempDir, fmt.Sprintf("%s-surge.db", t.Name())))
+	state.Configure(filepath.Join(tempDir, t.Name()+"-surge.db"))
 	defer state.CloseDB()
 
 	pool := download.NewWorkerPool(ch, 1)
@@ -543,7 +542,7 @@ func TestLocalDownloadService_BatchProgress(t *testing.T) {
 func TestLocalDownloadService_ResumeRejectedWhilePausing(t *testing.T) {
 	tempDir := t.TempDir()
 	state.CloseDB()
-	state.Configure(filepath.Join(tempDir, fmt.Sprintf("%s-surge.db", t.Name())))
+	state.Configure(filepath.Join(tempDir, t.Name()+"-surge.db"))
 	defer state.CloseDB()
 
 	ch := make(chan interface{}, 100)

--- a/internal/core/local_service_test.go
+++ b/internal/core/local_service_test.go
@@ -473,7 +473,7 @@ func TestLocalDownloadService_BatchProgress(t *testing.T) {
 	// Start a local test server
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// 1. Probe request (HEAD or GET with Range: bytes=0-0)
-		if r.Method == "HEAD" || r.Header.Get("Range") == "bytes=0-0" {
+		if r.Method == http.MethodHead || r.Header.Get("Range") == "bytes=0-0" {
 			w.Header().Set("Content-Length", "1000")
 			w.Header().Set("Accept-Ranges", "bytes")
 			w.WriteHeader(http.StatusOK)

--- a/internal/core/pause_resume_integration_test.go
+++ b/internal/core/pause_resume_integration_test.go
@@ -154,7 +154,7 @@ func TestIntegration_PauseResume_HotPath_Aggregates(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", rootDir)
 
 	state.CloseDB()
-	dbPath := filepath.Join(rootDir, fmt.Sprintf("%s-surge.db", t.Name()))
+	dbPath := filepath.Join(rootDir, t.Name()+"-surge.db")
 	state.Configure(dbPath)
 	defer state.CloseDB()
 
@@ -315,7 +315,7 @@ func TestIntegration_PauseResume_ColdPath_StateContinuity(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", rootDir)
 
 	state.CloseDB()
-	dbPath := filepath.Join(rootDir, fmt.Sprintf("%s-surge.db", t.Name()))
+	dbPath := filepath.Join(rootDir, t.Name()+"-surge.db")
 	state.Configure(dbPath)
 	defer state.CloseDB()
 
@@ -464,7 +464,7 @@ func TestIntegration_PauseResume_ResumeBatchRejectsPausing(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", rootDir)
 
 	state.CloseDB()
-	dbPath := filepath.Join(rootDir, fmt.Sprintf("%s-surge.db", t.Name()))
+	dbPath := filepath.Join(rootDir, t.Name()+"-surge.db")
 	state.Configure(dbPath)
 	defer state.CloseDB()
 
@@ -543,7 +543,7 @@ func TestIntegration_PauseResume_StatusFormulaInvariants(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", rootDir)
 
 	state.CloseDB()
-	dbPath := filepath.Join(rootDir, fmt.Sprintf("%s-surge.db", t.Name()))
+	dbPath := filepath.Join(rootDir, t.Name()+"-surge.db")
 	state.Configure(dbPath)
 	defer state.CloseDB()
 
@@ -640,7 +640,7 @@ func TestIntegration_PauseResume_ConcreteSnapshotDebugString(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", rootDir)
 
 	state.CloseDB()
-	dbPath := filepath.Join(rootDir, fmt.Sprintf("%s-surge.db", t.Name()))
+	dbPath := filepath.Join(rootDir, t.Name()+"-surge.db")
 	state.Configure(dbPath)
 	defer state.CloseDB()
 
@@ -717,7 +717,7 @@ func TestIntegration_PauseResumeBatch_ColdPath(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", rootDir)
 
 	state.CloseDB()
-	dbPath := filepath.Join(rootDir, fmt.Sprintf("%s-surge.db", t.Name()))
+	dbPath := filepath.Join(rootDir, t.Name()+"-surge.db")
 	state.Configure(dbPath)
 	defer state.CloseDB()
 

--- a/internal/core/remote_service.go
+++ b/internal/core/remote_service.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -247,7 +248,7 @@ func (s *RemoteDownloadService) StreamEvents(ctx context.Context) (<-chan interf
 // Publish emits an event into the service's event stream.
 // Remote services do not accept client-side event injection.
 func (s *RemoteDownloadService) Publish(msg interface{}) error {
-	return fmt.Errorf("publish not supported for remote service")
+	return errors.New("publish not supported for remote service")
 }
 
 func (s *RemoteDownloadService) streamWithReconnect(ctx context.Context, ch chan interface{}) {

--- a/internal/core/remote_service.go
+++ b/internal/core/remote_service.go
@@ -284,7 +284,7 @@ func (s *RemoteDownloadService) streamWithReconnect(ctx context.Context, ch chan
 }
 
 func (s *RemoteDownloadService) connectSSE(ctx context.Context, ch chan interface{}) error {
-	req, err := http.NewRequestWithContext(ctx, "GET", s.BaseURL+"/events", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.BaseURL+"/events", nil)
 	if err != nil {
 		return err
 	}
@@ -300,7 +300,7 @@ func (s *RemoteDownloadService) connectSSE(ctx context.Context, ch chan interfac
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("failed to connect to event stream: %s", resp.Status)
 	}
 

--- a/internal/download/manager.go
+++ b/internal/download/manager.go
@@ -88,8 +88,7 @@ func TUIDownload(ctx context.Context, cfg *types.DownloadConfig) error {
 	finalDestPath := filepath.Join(destPath, finalFilename)
 
 	// Local mirrors slice to avoid modifying config (race condition)
-	mirrors := make([]string, len(cfg.Mirrors))
-	copy(mirrors, cfg.Mirrors)
+	mirrors := append([]string(nil), cfg.Mirrors...)
 
 	// Check if this is a resume (explicitly marked by TUI)
 	var savedState *types.DownloadState
@@ -105,6 +104,11 @@ func TUIDownload(ctx context.Context, cfg *types.DownloadConfig) error {
 			existing := make(map[string]bool)
 			for _, m := range mirrors {
 				existing[m] = true
+			}
+			if len(mirrors) > 0 {
+				expandedMirrors := make([]string, len(mirrors), len(mirrors)+len(savedState.Mirrors))
+				copy(expandedMirrors, mirrors)
+				mirrors = expandedMirrors
 			}
 
 			// Add restored mirrors

--- a/internal/download/manager_test.go
+++ b/internal/download/manager_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -648,9 +649,11 @@ func TestUniqueFilePath_LongFilename(t *testing.T) {
 
 	// Create a file with a long name (within OS limits)
 	longName := ""
+	var longNameSb651 strings.Builder
 	for i := 0; i < 50; i++ {
-		longName += "a"
+		longNameSb651.WriteString("a")
 	}
+	longName += longNameSb651.String()
 	longName += ".txt"
 
 	existingFile := filepath.Join(tmpDir, longName)

--- a/internal/download/pool.go
+++ b/internal/download/pool.go
@@ -2,7 +2,7 @@ package download
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"path/filepath"
 	"sync"
 	"sync/atomic"
@@ -308,14 +308,14 @@ func (p *WorkerPool) UpdateURL(downloadID string, newURL string) error {
 
 	if qExists {
 		p.mu.Unlock()
-		return fmt.Errorf("cannot update URL for a queued download, please cancel or wait for it to start")
+		return errors.New("cannot update URL for a queued download, please cancel or wait for it to start")
 	}
 
 	if exists && ad != nil {
 		if ad.config.State != nil && !ad.config.State.IsPaused() {
 			if ad.running.Load() {
 				p.mu.Unlock()
-				return fmt.Errorf("download is currently active, please pause it before updating the URL")
+				return errors.New("download is currently active, please pause it before updating the URL")
 			}
 		}
 		ad.config.URL = newURL

--- a/internal/download/pool.go
+++ b/internal/download/pool.go
@@ -154,7 +154,7 @@ func (p *WorkerPool) GetAll() []types.DownloadConfig {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 
-	var configs []types.DownloadConfig
+	configs := make([]types.DownloadConfig, 0, len(p.downloads)+len(p.queued))
 	for _, ad := range p.downloads {
 		cfg := ad.config
 		syncConfigFromState(&cfg)
@@ -370,10 +370,11 @@ func (p *WorkerPool) worker() {
 			ad.config.State.SetPausing(false)
 		}
 
-		if isPaused {
+		switch {
+		case isPaused:
 			utils.Debug("WorkerPool: Download %s paused cleanly", cfg.ID)
 			// If paused, we keep it in downloads map for potential resume via ExtractPausedConfig
-		} else if err != nil {
+		case err != nil:
 			if cfg.State != nil {
 				cfg.State.SetError(err)
 			}
@@ -382,8 +383,7 @@ func (p *WorkerPool) worker() {
 			p.mu.Lock()
 			delete(p.downloads, cfg.ID)
 			p.mu.Unlock()
-
-		} else {
+		default:
 			// Only mark as done if not paused
 			if cfg.State != nil {
 				cfg.State.Done.Store(true)
@@ -451,11 +451,12 @@ func (p *WorkerPool) GetStatus(id string) *types.DownloadStatus {
 		status.DestPath = ad.config.DestPath
 	}
 
-	if ad.config.State.IsPausing() {
+	switch {
+	case ad.config.State.IsPausing():
 		status.Status = "pausing"
-	} else if ad.config.State.IsPaused() {
+	case ad.config.State.IsPaused():
 		status.Status = "paused"
-	} else if state.Done.Load() {
+	case state.Done.Load():
 		status.Status = "completed"
 	}
 

--- a/internal/download/resume_test.go
+++ b/internal/download/resume_test.go
@@ -122,7 +122,7 @@ func TestIntegration_PauseResume(t *testing.T) {
 	// Wait for download to return
 	select {
 	case err := <-errCh:
-		if err != nil && err != context.Canceled && !errors.Is(err, types.ErrPaused) {
+		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, types.ErrPaused) {
 			t.Logf("Download returned error: %v", err)
 		}
 	case <-time.After(15 * time.Second):

--- a/internal/engine/concurrent/downloader.go
+++ b/internal/engine/concurrent/downloader.go
@@ -3,6 +3,7 @@ package concurrent
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"math"
 	"net"
@@ -236,7 +237,7 @@ func (d *ConcurrentDownloader) newConcurrentClient(numConns int) *http.Client {
 		// Since these headers were explicitly provided by the browser for this download, we forward them.
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= 10 {
-				return fmt.Errorf("stopped after 10 redirects")
+				return errors.New("stopped after 10 redirects")
 			}
 			// Copy headers from original request to redirect request
 			if len(via) > 0 {
@@ -503,7 +504,7 @@ func (d *ConcurrentDownloader) Download(ctx context.Context, rawurl string, cand
 		go func(workerID int) {
 			defer wg.Done()
 			err := d.worker(downloadCtx, workerID, workerMirrors, outFile, queue, fileSize, client)
-			if err != nil && err != context.Canceled {
+			if err != nil && !errors.Is(err, context.Canceled) {
 				workerErrors <- err
 			}
 		}(i)

--- a/internal/engine/concurrent/proxy_test.go
+++ b/internal/engine/concurrent/proxy_test.go
@@ -29,7 +29,7 @@ func TestConcurrentDownloader_ProxySupport(t *testing.T) {
 		// For this test, the client will send an absolute URL to the proxy.
 
 		// Create request to target
-		req, err := http.NewRequestWithContext(context.Background(),r.Method, r.RequestURI, r.Body)
+		req, err := http.NewRequestWithContext(context.Background(), r.Method, r.RequestURI, r.Body)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/internal/engine/concurrent/proxy_test.go
+++ b/internal/engine/concurrent/proxy_test.go
@@ -29,7 +29,7 @@ func TestConcurrentDownloader_ProxySupport(t *testing.T) {
 		// For this test, the client will send an absolute URL to the proxy.
 
 		// Create request to target
-		req, err := http.NewRequest(r.Method, r.RequestURI, r.Body)
+		req, err := http.NewRequestWithContext(context.Background(),r.Method, r.RequestURI, r.Body)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/internal/engine/concurrent/worker.go
+++ b/internal/engine/concurrent/worker.go
@@ -2,6 +2,7 @@ package concurrent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -215,7 +216,7 @@ func (d *ConcurrentDownloader) downloadTask(ctx context.Context, rawurl string, 
 
 	// Handle rate limiting explicitly
 	if resp.StatusCode == http.StatusTooManyRequests {
-		return fmt.Errorf("rate limited (429)")
+		return errors.New("rate limited (429)")
 	}
 
 	// Validate status code
@@ -223,7 +224,7 @@ func (d *ConcurrentDownloader) downloadTask(ctx context.Context, rawurl string, 
 		// Valid only if we requested the full file
 		// If we wanted a partial range but got the whole file (200), that's an error because we can't handle the full stream at a non-zero offset
 		if task.Offset != 0 || task.Length != totalSize {
-			return fmt.Errorf("server indicated success (200) but ignored range request (expected 206)")
+			return errors.New("server indicated success (200) but ignored range request (expected 206)")
 		}
 	} else if resp.StatusCode != http.StatusPartialContent {
 		return fmt.Errorf("unexpected status: %d", resp.StatusCode)

--- a/internal/engine/single/downloader.go
+++ b/internal/engine/single/downloader.go
@@ -2,6 +2,7 @@ package single
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -64,7 +65,7 @@ func newSingleClient(runtime *types.RuntimeConfig, sd *SingleDownloader) *http.C
 		Transport: transport,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= 10 {
-				return fmt.Errorf("stopped after 10 redirects")
+				return errors.New("stopped after 10 redirects")
 			}
 			if len(via) > 0 {
 				utils.CopyRedirectHeaders(req, via[0])

--- a/internal/engine/single/downloader_test.go
+++ b/internal/engine/single/downloader_test.go
@@ -2,6 +2,7 @@ package single
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -424,7 +425,7 @@ func TestSingleDownloader_Download_Cancellation(t *testing.T) {
 	select {
 	case err := <-done:
 		// Accept context.Canceled or wrapped errors
-		if err != nil && err != context.Canceled && err.Error() != "context canceled" {
+		if err != nil && !errors.Is(err, context.Canceled) && err.Error() != "context canceled" {
 			t.Logf("Expected context.Canceled, got: %v", err)
 		}
 	case <-time.After(5 * time.Second):

--- a/internal/engine/state/db.go
+++ b/internal/engine/state/db.go
@@ -1,7 +1,9 @@
 package state
 
 import (
+	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log"
 	"sync"
@@ -32,7 +34,7 @@ func initDBLocked() error {
 	}
 
 	if !configured || dbPath == "" {
-		return fmt.Errorf("state database not configured: call state.Configure() first")
+		return errors.New("state database not configured: call state.Configure() first")
 	}
 
 	var err error
@@ -43,47 +45,47 @@ func initDBLocked() error {
 
 	// Enable WAL mode and busy_timeout for concurrent reader-writer access
 	// (required now that the processing layer's event worker writes from a goroutine)
-	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
+	if _, err := db.ExecContext(context.Background(), "PRAGMA journal_mode=WAL"); err != nil {
 		return fmt.Errorf("failed to set WAL mode: %w", err)
 	}
-	if _, err := db.Exec("PRAGMA busy_timeout=5000"); err != nil {
+	if _, err := db.ExecContext(context.Background(), "PRAGMA busy_timeout=5000"); err != nil {
 		return fmt.Errorf("failed to set busy_timeout: %w", err)
 	}
 
 	// Create tables
 	query := `
-	CREATE TABLE IF NOT EXISTS downloads (
-		id TEXT PRIMARY KEY,
-		url TEXT NOT NULL,
-		dest_path TEXT NOT NULL,
-		filename TEXT,
-		status TEXT,
-		total_size INTEGER,
-		downloaded INTEGER,
-		url_hash TEXT,
-		created_at INTEGER,
-		paused_at INTEGER,
-		completed_at INTEGER,
-		time_taken INTEGER,
-		mirrors TEXT,
-		chunk_bitmap BLOB,
-		actual_chunk_size INTEGER,
-		avg_speed REAL,
-		file_hash TEXT
-	);
+CREATE TABLE IF NOT EXISTS downloads (
+	id TEXT PRIMARY KEY,
+	url TEXT NOT NULL,
+	dest_path TEXT NOT NULL,
+	filename TEXT,
+	status TEXT,
+	total_size INTEGER,
+	downloaded INTEGER,
+	url_hash TEXT,
+	created_at INTEGER,
+	paused_at INTEGER,
+	completed_at INTEGER,
+	time_taken INTEGER,
+	mirrors TEXT,
+	chunk_bitmap BLOB,
+	actual_chunk_size INTEGER,
+	avg_speed REAL,
+	file_hash TEXT
+);
 
-	CREATE TABLE IF NOT EXISTS tasks (
-		id INTEGER PRIMARY KEY AUTOINCREMENT,
-		download_id TEXT,
-		offset INTEGER,
-		length INTEGER,
-		FOREIGN KEY(download_id) REFERENCES downloads(id) ON DELETE CASCADE
-	);
+CREATE TABLE IF NOT EXISTS tasks (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	download_id TEXT,
+	offset INTEGER,
+	length INTEGER,
+	FOREIGN KEY(download_id) REFERENCES downloads(id) ON DELETE CASCADE
+);
 
-	CREATE INDEX IF NOT EXISTS idx_tasks_download_id ON tasks(download_id);
-	`
+CREATE INDEX IF NOT EXISTS idx_tasks_download_id ON tasks(download_id);
+`
 
-	if _, err := db.Exec(query); err != nil {
+	if _, err := db.ExecContext(context.Background(), query); err != nil {
 		return fmt.Errorf("failed to create tables: %w", err)
 	}
 
@@ -102,7 +104,7 @@ func initDB() error {
 
 // ensureDownloadsSchema checks if required columns exist in the downloads table and adds them if missing.
 func ensureDownloadsSchema() error {
-	rows, err := db.Query("PRAGMA table_info(downloads)")
+	rows, err := db.QueryContext(context.Background(), "PRAGMA table_info(downloads)")
 	if err != nil {
 		return err
 	}
@@ -135,7 +137,7 @@ func ensureDownloadsSchema() error {
 	for _, col := range columnsToAdd {
 		if !existingColumns[col.name] {
 			alterQuery := fmt.Sprintf("ALTER TABLE downloads ADD COLUMN %s %s", col.name, col.def)
-			if _, err := db.Exec(alterQuery); err != nil {
+			if _, err := db.ExecContext(context.Background(), alterQuery); err != nil {
 				log.Printf("Failed to add column %s: %v", col.name, err)
 			}
 		}
@@ -182,10 +184,10 @@ func getDBHelper() *sql.DB {
 func withTx(fn func(*sql.Tx) error) error {
 	d := getDBHelper()
 	if d == nil {
-		return fmt.Errorf("database not initialized")
+		return errors.New("database not initialized")
 	}
 
-	tx, err := d.Begin()
+	tx, err := d.BeginTx(context.Background(), nil)
 	if err != nil {
 		return err
 	}

--- a/internal/engine/state/db.go
+++ b/internal/engine/state/db.go
@@ -104,7 +104,7 @@ func initDB() error {
 
 // ensureDownloadsSchema checks if required columns exist in the downloads table and adds them if missing.
 func ensureDownloadsSchema() error {
-	rows, err := db.QueryContext(context.Background(), "PRAGMA table_info(downloads)")
+	rows, err := db.QueryContext(context.Background(), "PRAGMA table_info(downloads)") // nolint:rowserrcheck
 	if err != nil {
 		return err
 	}

--- a/internal/engine/state/db_test.go
+++ b/internal/engine/state/db_test.go
@@ -59,11 +59,11 @@ func TestDBLifecycle(t *testing.T) {
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	_, err = tx.ExecContext(context.Background(),"SELECT * FROM downloads LIMIT 1")
+	_, err = tx.ExecContext(context.Background(), "SELECT * FROM downloads LIMIT 1")
 	if err != nil {
 		t.Errorf("Table 'downloads' check failed: %v", err)
 	}
-	_, err = tx.ExecContext(context.Background(),"SELECT * FROM tasks LIMIT 1")
+	_, err = tx.ExecContext(context.Background(), "SELECT * FROM tasks LIMIT 1")
 	if err != nil {
 		t.Errorf("Table 'tasks' check failed: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestWithTx_Commit(t *testing.T) {
 	defer CloseDB()
 
 	err := withTx(func(tx *sql.Tx) error {
-		_, err := tx.ExecContext(context.Background(),"INSERT INTO downloads (id, url, dest_path) VALUES (?, ?, ?)", "tx-test-1", "http://tx.com/1", "/tmp/1")
+		_, err := tx.ExecContext(context.Background(), "INSERT INTO downloads (id, url, dest_path) VALUES (?, ?, ?)", "tx-test-1", "http://tx.com/1", "/tmp/1")
 		return err
 	})
 	if err != nil {
@@ -85,7 +85,7 @@ func TestWithTx_Commit(t *testing.T) {
 	// Verify data persisted
 	d, _ := GetDB()
 	var url string
-	err = d.QueryRowContext(context.Background(),"SELECT url FROM downloads WHERE id = ?", "tx-test-1").Scan(&url)
+	err = d.QueryRowContext(context.Background(), "SELECT url FROM downloads WHERE id = ?", "tx-test-1").Scan(&url)
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -101,13 +101,13 @@ func TestWithTx_Rollback(t *testing.T) {
 
 	// Ensure DB is clean
 	d, _ := GetDB()
-	if _, err := d.ExecContext(context.Background(),"DELETE FROM downloads"); err != nil {
+	if _, err := d.ExecContext(context.Background(), "DELETE FROM downloads"); err != nil {
 		t.Fatal(err)
 	}
 
 	expectedErr := errors.New("intentional error")
 	err := withTx(func(tx *sql.Tx) error {
-		_, err := tx.ExecContext(context.Background(),"INSERT INTO downloads (id, url, dest_path) VALUES (?, ?, ?)", "tx-test-2", "http://tx.com/2", "/tmp/2")
+		_, err := tx.ExecContext(context.Background(), "INSERT INTO downloads (id, url, dest_path) VALUES (?, ?, ?)", "tx-test-2", "http://tx.com/2", "/tmp/2")
 		if err != nil {
 			return err
 		}
@@ -121,7 +121,7 @@ func TestWithTx_Rollback(t *testing.T) {
 
 	// Verify data NOT persisted
 	var count int
-	err = d.QueryRowContext(context.Background(),"SELECT count(*) FROM downloads WHERE id = ?", "tx-test-2").Scan(&count)
+	err = d.QueryRowContext(context.Background(), "SELECT count(*) FROM downloads WHERE id = ?", "tx-test-2").Scan(&count)
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -175,7 +175,7 @@ func TestInitDB_CreatesTasksDownloadIDIndex(t *testing.T) {
 	}
 
 	var indexName string
-	err = d.QueryRowContext(context.Background(),`
+	err = d.QueryRowContext(context.Background(), `
 		SELECT name
 		FROM sqlite_master
 		WHERE type = 'index'

--- a/internal/engine/state/db_test.go
+++ b/internal/engine/state/db_test.go
@@ -1,8 +1,9 @@
 package state
 
 import (
+	"context"
 	"database/sql"
-	"fmt"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -52,7 +53,7 @@ func TestDBLifecycle(t *testing.T) {
 	}
 
 	// Test tables exist
-	tx, err := d3.Begin()
+	tx, err := d3.BeginTx(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Failed to begin tx: %v", err)
 	}
@@ -104,7 +105,7 @@ func TestWithTx_Rollback(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedErr := fmt.Errorf("intentional error")
+	expectedErr := errors.New("intentional error")
 	err := withTx(func(tx *sql.Tx) error {
 		_, err := tx.Exec("INSERT INTO downloads (id, url, dest_path) VALUES (?, ?, ?)", "tx-test-2", "http://tx.com/2", "/tmp/2")
 		if err != nil {
@@ -114,7 +115,7 @@ func TestWithTx_Rollback(t *testing.T) {
 		return expectedErr
 	})
 
-	if err != expectedErr {
+	if !errors.Is(err, expectedErr) {
 		t.Fatalf("Expected error %v, got %v", expectedErr, err)
 	}
 

--- a/internal/engine/state/db_test.go
+++ b/internal/engine/state/db_test.go
@@ -59,11 +59,11 @@ func TestDBLifecycle(t *testing.T) {
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	_, err = tx.Exec("SELECT * FROM downloads LIMIT 1")
+	_, err = tx.ExecContext(context.Background(),"SELECT * FROM downloads LIMIT 1")
 	if err != nil {
 		t.Errorf("Table 'downloads' check failed: %v", err)
 	}
-	_, err = tx.Exec("SELECT * FROM tasks LIMIT 1")
+	_, err = tx.ExecContext(context.Background(),"SELECT * FROM tasks LIMIT 1")
 	if err != nil {
 		t.Errorf("Table 'tasks' check failed: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestWithTx_Commit(t *testing.T) {
 	defer CloseDB()
 
 	err := withTx(func(tx *sql.Tx) error {
-		_, err := tx.Exec("INSERT INTO downloads (id, url, dest_path) VALUES (?, ?, ?)", "tx-test-1", "http://tx.com/1", "/tmp/1")
+		_, err := tx.ExecContext(context.Background(),"INSERT INTO downloads (id, url, dest_path) VALUES (?, ?, ?)", "tx-test-1", "http://tx.com/1", "/tmp/1")
 		return err
 	})
 	if err != nil {
@@ -85,7 +85,7 @@ func TestWithTx_Commit(t *testing.T) {
 	// Verify data persisted
 	d, _ := GetDB()
 	var url string
-	err = d.QueryRow("SELECT url FROM downloads WHERE id = ?", "tx-test-1").Scan(&url)
+	err = d.QueryRowContext(context.Background(),"SELECT url FROM downloads WHERE id = ?", "tx-test-1").Scan(&url)
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -101,13 +101,13 @@ func TestWithTx_Rollback(t *testing.T) {
 
 	// Ensure DB is clean
 	d, _ := GetDB()
-	if _, err := d.Exec("DELETE FROM downloads"); err != nil {
+	if _, err := d.ExecContext(context.Background(),"DELETE FROM downloads"); err != nil {
 		t.Fatal(err)
 	}
 
 	expectedErr := errors.New("intentional error")
 	err := withTx(func(tx *sql.Tx) error {
-		_, err := tx.Exec("INSERT INTO downloads (id, url, dest_path) VALUES (?, ?, ?)", "tx-test-2", "http://tx.com/2", "/tmp/2")
+		_, err := tx.ExecContext(context.Background(),"INSERT INTO downloads (id, url, dest_path) VALUES (?, ?, ?)", "tx-test-2", "http://tx.com/2", "/tmp/2")
 		if err != nil {
 			return err
 		}
@@ -121,7 +121,7 @@ func TestWithTx_Rollback(t *testing.T) {
 
 	// Verify data NOT persisted
 	var count int
-	err = d.QueryRow("SELECT count(*) FROM downloads WHERE id = ?", "tx-test-2").Scan(&count)
+	err = d.QueryRowContext(context.Background(),"SELECT count(*) FROM downloads WHERE id = ?", "tx-test-2").Scan(&count)
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -175,7 +175,7 @@ func TestInitDB_CreatesTasksDownloadIDIndex(t *testing.T) {
 	}
 
 	var indexName string
-	err = d.QueryRow(`
+	err = d.QueryRowContext(context.Background(),`
 		SELECT name
 		FROM sqlite_master
 		WHERE type = 'index'

--- a/internal/engine/state/state.go
+++ b/internal/engine/state/state.go
@@ -317,6 +317,9 @@ func LoadState(url string, destPath string) (*types.DownloadState, error) {
 		}
 		state.Tasks = append(state.Tasks, t)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate tasks: %w", err)
+	}
 
 	return &state, nil
 }
@@ -415,6 +418,9 @@ func LoadMasterList() (*types.MasterList, error) {
 		}
 
 		list.Downloads = append(list.Downloads, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate downloads: %w", err)
 	}
 
 	return &list, nil
@@ -684,7 +690,7 @@ func LoadStates(ids []string) (map[string]*types.DownloadState, error) {
 		WHERE id IN (%s) AND status != 'completed'
 	`, inClause)
 
-	rows, err := db.QueryContext(context.Background(), query, args...)
+	rows, err := db.QueryContext(context.Background(), query, args...) // nolint:rowserrcheck
 	if err != nil {
 		return nil, fmt.Errorf("failed to query downloads batch: %w", err)
 	}
@@ -733,7 +739,7 @@ func LoadStates(ids []string) (map[string]*types.DownloadState, error) {
 
 	// 2. Load Tasks for all these downloads
 	taskQuery := fmt.Sprintf(`SELECT download_id, offset, length FROM tasks WHERE download_id IN (%s)`, inClause)
-	taskRows, err := db.QueryContext(context.Background(), taskQuery, args...)
+	taskRows, err := db.QueryContext(context.Background(), taskQuery, args...) // nolint:rowserrcheck
 	if err != nil {
 		return nil, fmt.Errorf("failed to query tasks batch: %w", err)
 	}
@@ -878,7 +884,11 @@ func ValidateIntegrity() (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("failed to query known download paths: %w", err)
 	}
-	defer allRows.Close()
+	defer func() {
+		if err := allRows.Close(); err != nil {
+			utils.Debug("Error closing rows: %v", err)
+		}
+	}()
 	for allRows.Next() {
 		var dest string
 		var status string

--- a/internal/engine/state/state.go
+++ b/internal/engine/state/state.go
@@ -1,10 +1,12 @@
 package state
 
 import (
+	"context"
 	"crypto/md5"
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -79,7 +81,7 @@ func SaveStateWithOptions(url string, destPath string, state *types.DownloadStat
 
 	return withTx(func(tx *sql.Tx) error {
 		// 1. Upsert into downloads table
-		_, err := tx.Exec(`
+		_, err := tx.ExecContext(context.Background(), `
 				INSERT INTO downloads (
 					id, url, dest_path, filename, status, total_size, downloaded, url_hash, created_at, paused_at, time_taken, mirrors, chunk_bitmap, actual_chunk_size, file_hash
 			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -104,7 +106,7 @@ func SaveStateWithOptions(url string, destPath string, state *types.DownloadStat
 
 		// 2. Refresh tasks
 		// First delete existing tasks for this download
-		if _, err := tx.Exec("DELETE FROM tasks WHERE download_id = ?", state.ID); err != nil {
+		if _, err := tx.ExecContext(context.Background(), "DELETE FROM tasks WHERE download_id = ?", state.ID); err != nil {
 			return fmt.Errorf("failed to delete old tasks: %w", err)
 		}
 
@@ -118,7 +120,7 @@ func SaveStateWithOptions(url string, destPath string, state *types.DownloadStat
 			// Prepare statement for full batches
 			placeholders := strings.Repeat("(?, ?, ?),", batchSize)
 			placeholders = placeholders[:len(placeholders)-1] // remove trailing comma
-			stmt, err := tx.Prepare("INSERT INTO tasks (download_id, offset, length) VALUES " + placeholders)
+			stmt, err := tx.PrepareContext(context.Background(), "INSERT INTO tasks (download_id, offset, length) VALUES "+placeholders)
 			if err != nil {
 				return fmt.Errorf("failed to prepare batch insert: %w", err)
 			}
@@ -141,7 +143,7 @@ func SaveStateWithOptions(url string, destPath string, state *types.DownloadStat
 						q.WriteString("(?, ?, ?)")
 						args = append(args, state.ID, task.Offset, task.Length)
 					}
-					if _, err := tx.Exec(q.String(), args...); err != nil {
+					if _, err := tx.ExecContext(context.Background(), q.String(), args...); err != nil {
 						return fmt.Errorf("failed to insert partial batch: %w", err)
 					}
 				} else {
@@ -151,7 +153,7 @@ func SaveStateWithOptions(url string, destPath string, state *types.DownloadStat
 					for _, task := range batch {
 						args = append(args, state.ID, task.Offset, task.Length)
 					}
-					if _, err := stmt.Exec(args...); err != nil {
+					if _, err := stmt.ExecContext(context.Background(), args...); err != nil {
 						return fmt.Errorf("failed to insert tasks batch: %w", err)
 					}
 				}
@@ -249,7 +251,7 @@ func LoadState(url string, destPath string) (*types.DownloadState, error) {
 
 	db := getDBHelper()
 	if db == nil {
-		return nil, fmt.Errorf("database not initialized")
+		return nil, errors.New("database not initialized")
 	}
 
 	var state types.DownloadState
@@ -257,7 +259,7 @@ func LoadState(url string, destPath string) (*types.DownloadState, error) {
 	var mirrors, fileHash sql.NullString                              // handle null mirrors/hash
 	var chunkBitmap []byte
 
-	row := db.QueryRow(`
+	row := db.QueryRowContext(context.Background(), `
 		SELECT id, url, dest_path, filename, total_size, downloaded, url_hash, created_at, paused_at, time_taken, mirrors, chunk_bitmap, actual_chunk_size, file_hash
 		FROM downloads 
 		WHERE url = ? AND dest_path = ? AND status != 'completed'
@@ -270,7 +272,7 @@ func LoadState(url string, destPath string) (*types.DownloadState, error) {
 		&createdAt, &pausedAt, &timeTaken, &mirrors, &chunkBitmap, &actualChunkSize, &fileHash,
 	)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			// Try finding without status constraint (just in case)
 			return nil, fmt.Errorf("state not found: %w", os.ErrNotExist) // mimic os.ErrNotExist for compatibility
 		}
@@ -298,7 +300,7 @@ func LoadState(url string, destPath string) (*types.DownloadState, error) {
 	}
 
 	// Load tasks
-	rows, err := db.Query("SELECT offset, length FROM tasks WHERE download_id = ?", state.ID)
+	rows, err := db.QueryContext(context.Background(), "SELECT offset, length FROM tasks WHERE download_id = ?", state.ID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query tasks: %w", err)
 	}
@@ -323,11 +325,11 @@ func LoadState(url string, destPath string) (*types.DownloadState, error) {
 func DeleteState(id string) error {
 	db := getDBHelper()
 	if db == nil {
-		return fmt.Errorf("database not initialized")
+		return errors.New("database not initialized")
 	}
 
 	if id == "" {
-		return fmt.Errorf("id cannot be empty")
+		return errors.New("id cannot be empty")
 	}
 
 	if err := removeDownloadAndTasks(id); err != nil {
@@ -341,14 +343,14 @@ func DeleteState(id string) error {
 func DeleteTasks(id string) error {
 	db := getDBHelper()
 	if db == nil {
-		return fmt.Errorf("database not initialized")
+		return errors.New("database not initialized")
 	}
 
 	if id == "" {
-		return fmt.Errorf("id cannot be empty")
+		return errors.New("id cannot be empty")
 	}
 
-	_, err := db.Exec("DELETE FROM tasks WHERE download_id = ?", id)
+	_, err := db.ExecContext(context.Background(), "DELETE FROM tasks WHERE download_id = ?", id)
 	if err != nil {
 		return fmt.Errorf("failed to delete tasks: %w", err)
 	}
@@ -366,7 +368,7 @@ func LoadMasterList() (*types.MasterList, error) {
 		return &types.MasterList{Downloads: []types.DownloadEntry{}}, nil
 	}
 
-	rows, err := db.Query(`
+	rows, err := db.QueryContext(context.Background(), `
 		SELECT id, url, dest_path, filename, status, total_size, downloaded, completed_at, time_taken, url_hash, mirrors, avg_speed 
 		FROM downloads
 	`)
@@ -431,7 +433,7 @@ func AddToMasterList(entry types.DownloadEntry) error {
 	}
 
 	return withTx(func(tx *sql.Tx) error {
-		_, err := tx.Exec(`
+		_, err := tx.ExecContext(context.Background(), `
 			INSERT INTO downloads (
 				id, url, dest_path, filename, status, total_size, downloaded, completed_at, time_taken, url_hash, mirrors, avg_speed
 			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -459,10 +461,10 @@ func AddToMasterList(entry types.DownloadEntry) error {
 func RemoveFromMasterList(id string) error {
 	db := getDBHelper()
 	if db == nil {
-		return fmt.Errorf("database not initialized")
+		return errors.New("database not initialized")
 	}
 
-	_, err := db.Exec("DELETE FROM downloads WHERE id = ?", id)
+	_, err := db.ExecContext(context.Background(), "DELETE FROM downloads WHERE id = ?", id)
 	return err
 }
 
@@ -478,7 +480,7 @@ func GetDownload(id string) (*types.DownloadEntry, error) {
 	var urlHash, filename, mirrors sql.NullString
 	var avgSpeed sql.NullFloat64
 
-	row := db.QueryRow(`
+	row := db.QueryRowContext(context.Background(), `
 		SELECT id, url, dest_path, filename, status, total_size, downloaded, completed_at, time_taken, url_hash, mirrors, avg_speed 
 		FROM downloads
 		WHERE id = ?
@@ -553,12 +555,12 @@ func LoadCompletedDownloads() ([]types.DownloadEntry, error) {
 func CheckDownloadExists(url string) (bool, error) {
 	db := getDBHelper()
 	if db == nil {
-		return false, fmt.Errorf("database not initialized")
+		return false, errors.New("database not initialized")
 	}
 
 	var count int
 	// Check for any status (active, paused, completed)
-	err := db.QueryRow("SELECT COUNT(*) FROM downloads WHERE url = ?", url).Scan(&count)
+	err := db.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM downloads WHERE url = ?", url).Scan(&count)
 	if err != nil {
 		return false, fmt.Errorf("failed to query download existence: %w", err)
 	}
@@ -570,10 +572,10 @@ func CheckDownloadExists(url string) (bool, error) {
 func UpdateStatus(id string, status string) error {
 	db := getDBHelper()
 	if db == nil {
-		return fmt.Errorf("database not initialized")
+		return errors.New("database not initialized")
 	}
 
-	result, err := db.Exec("UPDATE downloads SET status = ? WHERE id = ?", status, id)
+	result, err := db.ExecContext(context.Background(), "UPDATE downloads SET status = ? WHERE id = ?", status, id)
 	if err != nil {
 		return fmt.Errorf("failed to update status: %w", err)
 	}
@@ -590,12 +592,12 @@ func UpdateStatus(id string, status string) error {
 func UpdateURL(id string, newURL string) error {
 	db := getDBHelper()
 	if db == nil {
-		return fmt.Errorf("database not initialized")
+		return errors.New("database not initialized")
 	}
 
 	newHash := URLHash(newURL)
 
-	result, err := db.Exec("UPDATE downloads SET url = ?, url_hash = ? WHERE id = ?", newURL, newHash, id)
+	result, err := db.ExecContext(context.Background(), "UPDATE downloads SET url = ?, url_hash = ? WHERE id = ?", newURL, newHash, id)
 	if err != nil {
 		return fmt.Errorf("failed to update url: %w", err)
 	}
@@ -612,10 +614,10 @@ func UpdateURL(id string, newURL string) error {
 func PauseAllDownloads() error {
 	db := getDBHelper()
 	if db == nil {
-		return fmt.Errorf("database not initialized")
+		return errors.New("database not initialized")
 	}
 
-	_, err := db.Exec("UPDATE downloads SET status = 'paused' WHERE status != 'completed'")
+	_, err := db.ExecContext(context.Background(), "UPDATE downloads SET status = 'paused' WHERE status != 'completed'")
 	return err
 }
 
@@ -623,10 +625,10 @@ func PauseAllDownloads() error {
 func ResumeAllDownloads() error {
 	db := getDBHelper()
 	if db == nil {
-		return fmt.Errorf("database not initialized")
+		return errors.New("database not initialized")
 	}
 
-	_, err := db.Exec("UPDATE downloads SET status = 'queued' WHERE status = 'paused'")
+	_, err := db.ExecContext(context.Background(), "UPDATE downloads SET status = 'queued' WHERE status = 'paused'")
 	return err
 }
 
@@ -643,10 +645,10 @@ func ListAllDownloads() ([]types.DownloadEntry, error) {
 func RemoveCompletedDownloads() (int64, error) {
 	db := getDBHelper()
 	if db == nil {
-		return 0, fmt.Errorf("database not initialized")
+		return 0, errors.New("database not initialized")
 	}
 
-	result, err := db.Exec("DELETE FROM downloads WHERE status = 'completed'")
+	result, err := db.ExecContext(context.Background(), "DELETE FROM downloads WHERE status = 'completed'")
 	if err != nil {
 		return 0, fmt.Errorf("failed to remove completed downloads: %w", err)
 	}
@@ -663,7 +665,7 @@ func LoadStates(ids []string) (map[string]*types.DownloadState, error) {
 
 	db := getDBHelper()
 	if db == nil {
-		return nil, fmt.Errorf("database not initialized")
+		return nil, errors.New("database not initialized")
 	}
 
 	// Prepare IN clause placeholders
@@ -682,7 +684,7 @@ func LoadStates(ids []string) (map[string]*types.DownloadState, error) {
 		WHERE id IN (%s) AND status != 'completed'
 	`, inClause)
 
-	rows, err := db.Query(query, args...)
+	rows, err := db.QueryContext(context.Background(), query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query downloads batch: %w", err)
 	}
@@ -731,7 +733,7 @@ func LoadStates(ids []string) (map[string]*types.DownloadState, error) {
 
 	// 2. Load Tasks for all these downloads
 	taskQuery := fmt.Sprintf(`SELECT download_id, offset, length FROM tasks WHERE download_id IN (%s)`, inClause)
-	taskRows, err := db.Query(taskQuery, args...)
+	taskRows, err := db.QueryContext(context.Background(), taskQuery, args...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query tasks batch: %w", err)
 	}
@@ -773,10 +775,10 @@ func computeFileHash(path string) (string, error) {
 
 func removeDownloadAndTasks(id string) error {
 	return withTx(func(tx *sql.Tx) error {
-		if _, err := tx.Exec("DELETE FROM tasks WHERE download_id = ?", id); err != nil {
+		if _, err := tx.ExecContext(context.Background(), "DELETE FROM tasks WHERE download_id = ?", id); err != nil {
 			return fmt.Errorf("failed to delete tasks: %w", err)
 		}
-		if _, err := tx.Exec("DELETE FROM downloads WHERE id = ?", id); err != nil {
+		if _, err := tx.ExecContext(context.Background(), "DELETE FROM downloads WHERE id = ?", id); err != nil {
 			return fmt.Errorf("failed to delete download: %w", err)
 		}
 		return nil
@@ -792,10 +794,10 @@ func removeDownloadAndTasks(id string) error {
 func NormalizeStaleDownloads() (int, error) {
 	db := getDBHelper()
 	if db == nil {
-		return 0, fmt.Errorf("database not initialized")
+		return 0, errors.New("database not initialized")
 	}
 
-	result, err := db.Exec(`UPDATE downloads SET status = 'paused' WHERE status = 'downloading'`)
+	result, err := db.ExecContext(context.Background(), `UPDATE downloads SET status = 'paused' WHERE status = 'downloading'`)
 	if err != nil {
 		return 0, fmt.Errorf("failed to normalize stale downloads: %w", err)
 	}
@@ -810,11 +812,11 @@ func NormalizeStaleDownloads() (int, error) {
 func ValidateIntegrity() (int, error) {
 	db := getDBHelper()
 	if db == nil {
-		return 0, fmt.Errorf("database not initialized")
+		return 0, errors.New("database not initialized")
 	}
 
 	// Load all paused/queued downloads
-	rows, err := db.Query(`
+	rows, err := db.QueryContext(context.Background(), `
 		SELECT id, dest_path, file_hash, status, downloaded
 		FROM downloads
 		WHERE status IN ('paused', 'queued')
@@ -868,7 +870,7 @@ func ValidateIntegrity() (int, error) {
 	// Also include directories of all known downloads so we can clean orphan .surge
 	// files that no longer have corresponding DB entries.
 	// Keep .surge files for any non-completed entry (e.g. downloading after crash).
-	allRows, err := db.Query(`
+	allRows, err := db.QueryContext(context.Background(), `
 		SELECT dest_path, status
 		FROM downloads
 		WHERE dest_path IS NOT NULL AND dest_path != ''
@@ -876,11 +878,11 @@ func ValidateIntegrity() (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("failed to query known download paths: %w", err)
 	}
+	defer allRows.Close()
 	for allRows.Next() {
 		var dest string
 		var status string
 		if err := allRows.Scan(&dest, &status); err != nil {
-			_ = allRows.Close()
 			return 0, fmt.Errorf("failed to scan download path: %w", err)
 		}
 		candidateDirs[filepath.Dir(dest)] = struct{}{}
@@ -889,10 +891,8 @@ func ValidateIntegrity() (int, error) {
 		}
 	}
 	if err := allRows.Err(); err != nil {
-		_ = allRows.Close()
 		return 0, fmt.Errorf("failed to iterate download paths: %w", err)
 	}
-	_ = allRows.Close()
 
 	for _, e := range entries {
 		if e.status == "queued" && e.downloaded <= 0 {

--- a/internal/engine/state/state_test.go
+++ b/internal/engine/state/state_test.go
@@ -675,10 +675,8 @@ func TestMirrorsPersistence(t *testing.T) {
 
 	if len(loadedState.Mirrors) != 2 {
 		t.Errorf("Loaded mirrors count = %d, want 2", len(loadedState.Mirrors))
-	} else {
-		if loadedState.Mirrors[0] != mirrors[0] || loadedState.Mirrors[1] != mirrors[1] {
-			t.Errorf("Loaded mirrors mismatch: %v", loadedState.Mirrors)
-		}
+	} else if loadedState.Mirrors[0] != mirrors[0] || loadedState.Mirrors[1] != mirrors[1] {
+		t.Errorf("Loaded mirrors mismatch: %v", loadedState.Mirrors)
 	}
 
 	// 2. Test DownloadEntry (Master List / Completed)
@@ -708,10 +706,8 @@ func TestMirrorsPersistence(t *testing.T) {
 			foundVal = true
 			if len(e.Mirrors) != 2 {
 				t.Errorf("Entry mirrors count = %d, want 2", len(e.Mirrors))
-			} else {
-				if e.Mirrors[0] != mirrors[0] || e.Mirrors[1] != mirrors[1] {
-					t.Errorf("Entry mirrors mismatch: %v", e.Mirrors)
-				}
+			} else if e.Mirrors[0] != mirrors[0] || e.Mirrors[1] != mirrors[1] {
+				t.Errorf("Entry mirrors mismatch: %v", e.Mirrors)
 			}
 			break
 		}

--- a/internal/engine/state/state_test.go
+++ b/internal/engine/state/state_test.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"database/sql"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -269,11 +270,10 @@ func TestDeleteState(t *testing.T) {
 
 	// Verify it was deleted
 	_, err := LoadState(testURL, testDestPath)
-	switch err {
-	case nil:
+	if err == nil {
 		t.Error("LoadState should fail after DeleteState")
-	case sql.ErrNoRows:
-		// Acceptable error
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		t.Errorf("Expected sql.ErrNoRows, got %v", err)
 	}
 }
 

--- a/internal/engine/state/state_test.go
+++ b/internal/engine/state/state_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"os"
@@ -436,7 +437,7 @@ func TestUpdateStatus(t *testing.T) {
 		t.Fatalf("AddToMasterList failed: %v", err)
 	}
 	d := getDBHelper()
-	if _, err := d.Exec("INSERT INTO tasks (download_id, offset, length) VALUES (?, ?, ?)", entry.ID, 0, 100); err != nil {
+	if _, err := d.ExecContext(context.Background(),"INSERT INTO tasks (download_id, offset, length) VALUES (?, ?, ?)", entry.ID, 0, 100); err != nil {
 		t.Fatalf("failed to seed task row: %v", err)
 	}
 
@@ -765,7 +766,7 @@ func TestValidateIntegrity_MissingFile(t *testing.T) {
 
 	d := getDBHelper()
 	var taskCount int
-	if err := d.QueryRow("SELECT COUNT(*) FROM tasks WHERE download_id = ?", entry.ID).Scan(&taskCount); err != nil {
+	if err := d.QueryRowContext(context.Background(),"SELECT COUNT(*) FROM tasks WHERE download_id = ?", entry.ID).Scan(&taskCount); err != nil {
 		t.Fatalf("failed to count tasks: %v", err)
 	}
 	if taskCount != 0 {
@@ -806,7 +807,7 @@ func TestValidateIntegrity_ValidFile(t *testing.T) {
 
 	// Set file_hash directly in DB (simulating SaveState having computed it)
 	d := getDBHelper()
-	_, err = d.Exec("UPDATE downloads SET file_hash = ? WHERE id = ?", expectedHash, "integrity-valid")
+	_, err = d.ExecContext(context.Background(),"UPDATE downloads SET file_hash = ? WHERE id = ?", expectedHash, "integrity-valid")
 	if err != nil {
 		t.Fatalf("Failed to set file_hash: %v", err)
 	}
@@ -858,7 +859,7 @@ func TestValidateIntegrity_TamperedFile(t *testing.T) {
 
 	// Set a fake hash that won't match the file content
 	d := getDBHelper()
-	_, _ = d.Exec("UPDATE downloads SET file_hash = ? WHERE id = ?", "0000000000000000000000000000000000000000000000000000000000000000", "integrity-tampered")
+	_, _ = d.ExecContext(context.Background(),"UPDATE downloads SET file_hash = ? WHERE id = ?", "0000000000000000000000000000000000000000000000000000000000000000", "integrity-tampered")
 
 	// Run integrity check — hash mismatch, entry AND file should be removed
 	removed, err := ValidateIntegrity()

--- a/internal/engine/state/state_test.go
+++ b/internal/engine/state/state_test.go
@@ -2,7 +2,6 @@ package state
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"os"
 	"path/filepath"
@@ -273,8 +272,8 @@ func TestDeleteState(t *testing.T) {
 	_, err := LoadState(testURL, testDestPath)
 	if err == nil {
 		t.Error("LoadState should fail after DeleteState")
-	} else if !errors.Is(err, sql.ErrNoRows) {
-		t.Errorf("Expected sql.ErrNoRows, got %v", err)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("Expected os.ErrNotExist, got %v", err)
 	}
 }
 
@@ -437,7 +436,7 @@ func TestUpdateStatus(t *testing.T) {
 		t.Fatalf("AddToMasterList failed: %v", err)
 	}
 	d := getDBHelper()
-	if _, err := d.ExecContext(context.Background(),"INSERT INTO tasks (download_id, offset, length) VALUES (?, ?, ?)", entry.ID, 0, 100); err != nil {
+	if _, err := d.ExecContext(context.Background(), "INSERT INTO tasks (download_id, offset, length) VALUES (?, ?, ?)", entry.ID, 0, 100); err != nil {
 		t.Fatalf("failed to seed task row: %v", err)
 	}
 
@@ -766,7 +765,7 @@ func TestValidateIntegrity_MissingFile(t *testing.T) {
 
 	d := getDBHelper()
 	var taskCount int
-	if err := d.QueryRowContext(context.Background(),"SELECT COUNT(*) FROM tasks WHERE download_id = ?", entry.ID).Scan(&taskCount); err != nil {
+	if err := d.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM tasks WHERE download_id = ?", entry.ID).Scan(&taskCount); err != nil {
 		t.Fatalf("failed to count tasks: %v", err)
 	}
 	if taskCount != 0 {
@@ -807,7 +806,7 @@ func TestValidateIntegrity_ValidFile(t *testing.T) {
 
 	// Set file_hash directly in DB (simulating SaveState having computed it)
 	d := getDBHelper()
-	_, err = d.ExecContext(context.Background(),"UPDATE downloads SET file_hash = ? WHERE id = ?", expectedHash, "integrity-valid")
+	_, err = d.ExecContext(context.Background(), "UPDATE downloads SET file_hash = ? WHERE id = ?", expectedHash, "integrity-valid")
 	if err != nil {
 		t.Fatalf("Failed to set file_hash: %v", err)
 	}
@@ -859,7 +858,7 @@ func TestValidateIntegrity_TamperedFile(t *testing.T) {
 
 	// Set a fake hash that won't match the file content
 	d := getDBHelper()
-	_, _ = d.ExecContext(context.Background(),"UPDATE downloads SET file_hash = ? WHERE id = ?", "0000000000000000000000000000000000000000000000000000000000000000", "integrity-tampered")
+	_, _ = d.ExecContext(context.Background(), "UPDATE downloads SET file_hash = ? WHERE id = ?", "0000000000000000000000000000000000000000000000000000000000000000", "integrity-tampered")
 
 	// Run integrity check — hash mismatch, entry AND file should be removed
 	removed, err := ValidateIntegrity()

--- a/internal/engine/types/progress.go
+++ b/internal/engine/types/progress.go
@@ -289,7 +289,7 @@ func (ps *ProgressState) RestoreBitmap(bitmap []byte, actualChunkSize int64) {
 		return
 	}
 
-	//utils.Debug("RestoreBitmap: Len=%d, ChunkSize=%d", len(bitmap), actualChunkSize)
+	// utils.Debug("RestoreBitmap: Len=%d, ChunkSize=%d", len(bitmap), actualChunkSize)
 
 	ps.ChunkBitmap = bitmap
 	ps.ActualChunkSize = actualChunkSize
@@ -434,11 +434,9 @@ func (ps *ProgressState) UpdateChunkStatus(offset, length int64, status ChunkSta
 				ps.ChunkProgress[i] = chunkEnd - chunkStart // clamp
 				ps.setChunkState(i, ChunkCompleted)
 				// utils.Debug("Chunk %d completed (size=%d)", i, ps.ChunkProgress[i])
-			} else {
+			} else if ps.getChunkState(i) != ChunkCompleted {
 				// Partial progress -> Downloading
-				if ps.getChunkState(i) != ChunkCompleted {
-					ps.setChunkState(i, ChunkDownloading)
-				}
+				ps.setChunkState(i, ChunkDownloading)
 			}
 		case ChunkDownloading:
 			current := ps.getChunkState(i)
@@ -529,13 +527,14 @@ func (ps *ProgressState) RecalculateProgress(remainingTasks []Task) {
 		}
 		chunkSize := chunkEnd - chunkStart
 
-		if ps.ChunkProgress[i] >= chunkSize {
+		switch {
+		case ps.ChunkProgress[i] >= chunkSize:
 			ps.ChunkProgress[i] = chunkSize // clamp
 			ps.setChunkState(i, ChunkCompleted)
-		} else if ps.ChunkProgress[i] > 0 {
+		case ps.ChunkProgress[i] > 0:
 			// Even if saved bitmap said Pending, if we have bytes, it's actually partial
 			ps.setChunkState(i, ChunkDownloading)
-		} else {
+		default:
 			ps.ChunkProgress[i] = 0 // clamp
 			ps.setChunkState(i, ChunkPending)
 		}

--- a/internal/engine/types/progress_test.go
+++ b/internal/engine/types/progress_test.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 )
@@ -73,7 +74,7 @@ func TestProgressState_Error(t *testing.T) {
 	testErr := context.DeadlineExceeded
 	ps.SetError(testErr)
 
-	if err := ps.GetError(); err != testErr {
+	if err := ps.GetError(); !errors.Is(err, testErr) {
 		t.Errorf("GetError = %v, want %v", err, testErr)
 	}
 }

--- a/internal/processing/events.go
+++ b/internal/processing/events.go
@@ -47,7 +47,7 @@ func advanceRemainingTasks(tasks []types.Task, consumed int64) []types.Task {
 
 func finalizeCompletedFile(finalPath string) error {
 	if finalPath == "" {
-		return fmt.Errorf("missing destination path for completed download")
+		return errors.New("missing destination path for completed download")
 	}
 
 	surgePath := finalPath + types.IncompleteSuffix
@@ -248,7 +248,7 @@ func (mgr *LifecycleManager) StartEventWorker(ch <-chan interface{}) {
 					msg = err.Error()
 				}
 				if settings := mgr.GetSettings(); settings != nil && settings.General.DownloadCompleteNotification {
-					notify(fmt.Sprintf("Download failed: %s", filename), msg)
+					notify("Download failed: "+filename, msg)
 				}
 				break
 			}
@@ -280,7 +280,7 @@ func (mgr *LifecycleManager) StartEventWorker(ch <-chan interface{}) {
 					filename = m.DownloadID
 				}
 
-				title := fmt.Sprintf("Download Complete: %s", filename)
+				title := "Download Complete: " + filename
 
 				if m.Elapsed.Seconds() <= 0 {
 					notify(title, "Download complete!")
@@ -321,7 +321,7 @@ func (mgr *LifecycleManager) StartEventWorker(ch <-chan interface{}) {
 					msg = m.Err.Error()
 				}
 
-				notify(fmt.Sprintf("Download failed: %s", filename), msg)
+				notify("Download failed: "+filename, msg)
 			}
 
 		case events.DownloadRemovedMsg:

--- a/internal/processing/manager.go
+++ b/internal/processing/manager.go
@@ -169,7 +169,7 @@ type DownloadRequest struct {
 // Enqueue probes and reserves a stable destination before dispatching to the queue layer.
 func (mgr *LifecycleManager) Enqueue(ctx context.Context, req *DownloadRequest) (string, error) {
 	if mgr.addFunc == nil {
-		return "", fmt.Errorf("add function unavailable")
+		return "", errors.New("add function unavailable")
 	}
 
 	utils.Debug("Lifecycle: Enqueue %s", req.URL)
@@ -190,7 +190,7 @@ func (mgr *LifecycleManager) Enqueue(ctx context.Context, req *DownloadRequest) 
 // EnqueueWithID does the same lifecycle work as Enqueue while preserving a caller-owned id.
 func (mgr *LifecycleManager) EnqueueWithID(ctx context.Context, req *DownloadRequest, requestID string) (string, error) {
 	if mgr.addWithIDFunc == nil {
-		return "", fmt.Errorf("addWithID function unavailable")
+		return "", errors.New("addWithID function unavailable")
 	}
 
 	utils.Debug("Lifecycle: EnqueueWithID %s (%s)", req.URL, requestID)
@@ -212,10 +212,10 @@ func (mgr *LifecycleManager) EnqueueWithID(ctx context.Context, req *DownloadReq
 // download to the engine, so workers and lifecycle events agree on one stable destination.
 func (mgr *LifecycleManager) enqueueResolved(ctx context.Context, req *DownloadRequest, dispatch func(string, string, *ProbeResult) (string, error)) (string, error) {
 	if req.URL == "" {
-		return "", fmt.Errorf("URL is required")
+		return "", errors.New("URL is required")
 	}
 	if req.Path == "" {
-		return "", fmt.Errorf("destination path is required")
+		return "", errors.New("destination path is required")
 	}
 
 	settings := mgr.GetSettings()

--- a/internal/processing/manager_test.go
+++ b/internal/processing/manager_test.go
@@ -951,7 +951,7 @@ func TestLifecycleManager_UpdateURL_Success(t *testing.T) {
 func TestLifecycleManager_UpdateURL_HookError(t *testing.T) {
 	testutil.SetupStateDB(t)
 
-	expectedErr := fmt.Errorf("not in pausable state")
+	expectedErr := errors.New("not in pausable state")
 	mgr := newLifecycleManagerForTest()
 	mgr.SetEngineHooks(EngineHooks{
 		UpdateURL: func(id, newURL string) error { return expectedErr },

--- a/internal/processing/pause_resume.go
+++ b/internal/processing/pause_resume.go
@@ -1,6 +1,7 @@
 package processing
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -36,7 +37,7 @@ type EngineHooks struct {
 func (mgr *LifecycleManager) Pause(id string) error {
 	hooks := mgr.getEngineHooks()
 	if hooks.Pause == nil {
-		return fmt.Errorf("engine not initialized")
+		return errors.New("engine not initialized")
 	}
 
 	if hooks.Pause(id) {
@@ -57,7 +58,7 @@ func (mgr *LifecycleManager) Pause(id string) error {
 		return nil // Already stopped
 	}
 
-	return fmt.Errorf("download not found")
+	return errors.New("download not found")
 }
 
 // hydrateConfigFromDisk loads the latest persisted pause snapshot from disk
@@ -90,7 +91,7 @@ func (mgr *LifecycleManager) Resume(id string) error {
 	// Guard: still transitioning to paused
 	if hooks.GetStatus != nil {
 		if st := hooks.GetStatus(id); st != nil && st.Status == "pausing" {
-			return fmt.Errorf("download is still pausing, try again in a moment")
+			return errors.New("download is still pausing, try again in a moment")
 		}
 	}
 
@@ -115,11 +116,11 @@ func (mgr *LifecycleManager) Resume(id string) error {
 	// Cold path: download from a prior session (only in DB).
 	entry, err := state.GetDownload(id)
 	if err != nil || entry == nil {
-		return fmt.Errorf("download not found")
+		return errors.New("download not found")
 	}
 
 	if entry.Status == "completed" {
-		return fmt.Errorf("download already completed")
+		return errors.New("download already completed")
 	}
 
 	settings := mgr.GetSettings()
@@ -167,7 +168,7 @@ func (mgr *LifecycleManager) ResumeBatch(ids []string) []error {
 	for i, id := range ids {
 		if hooks.GetStatus != nil {
 			if st := hooks.GetStatus(id); st != nil && st.Status == "pausing" {
-				errs[i] = fmt.Errorf("download is still pausing, try again in a moment")
+				errs[i] = errors.New("download is still pausing, try again in a moment")
 				continue
 			}
 		}
@@ -213,7 +214,7 @@ func (mgr *LifecycleManager) ResumeBatch(ids []string) []error {
 		idx := coldIdx[id]
 		savedState, ok := states[id]
 		if !ok {
-			errs[idx] = fmt.Errorf("download not found or completed")
+			errs[idx] = errors.New("download not found or completed")
 			continue
 		}
 
@@ -268,7 +269,7 @@ func (mgr *LifecycleManager) Cancel(id string) error {
 	}
 
 	if !found {
-		return fmt.Errorf("download not found")
+		return errors.New("download not found")
 	}
 
 	// Emit removal event — event worker handles DB deletion and file cleanup.

--- a/internal/processing/pause_resume.go
+++ b/internal/processing/pause_resume.go
@@ -332,7 +332,8 @@ func buildResumeConfig(id, outputPath string, entry *types.DownloadEntry, savedS
 			dmState.SetSavedElapsed(time.Duration(savedState.Elapsed))
 		}
 		if len(savedState.Mirrors) > 0 {
-			var mirrors []types.MirrorStatus
+			mirrors := make([]types.MirrorStatus, 0, len(savedState.Mirrors))
+			mirrorURLs = make([]string, 0, len(savedState.Mirrors))
 			for _, u := range savedState.Mirrors {
 				mirrors = append(mirrors, types.MirrorStatus{URL: u, Active: true})
 				mirrorURLs = append(mirrorURLs, u)

--- a/internal/processing/probe.go
+++ b/internal/processing/probe.go
@@ -2,6 +2,7 @@ package processing
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -261,7 +262,7 @@ func getProbeClient(proxyURL string) *http.Client {
 		Transport: newProbeTransport(proxyURL),
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= 10 {
-				return fmt.Errorf("stopped after 10 redirects")
+				return errors.New("stopped after 10 redirects")
 			}
 			if len(via) > 0 {
 				copyProbeRedirectHeaders(req, via[0])
@@ -388,7 +389,7 @@ func ProbeMirrorsWithProxy(ctx context.Context, mirrors []string, proxyURL strin
 			} else {
 				outcome.valid = result.SupportsRange
 				if !result.SupportsRange {
-					outcome.err = fmt.Errorf("does not support ranges")
+					outcome.err = errors.New("does not support ranges")
 				}
 			}
 			results[idx] = outcome

--- a/internal/testutil/http_server.go
+++ b/internal/testutil/http_server.go
@@ -1,5 +1,7 @@
 package testutil
 
+// nolint:noctx
+
 import (
 	"net"
 	"net/http"
@@ -9,7 +11,7 @@ import (
 
 // NewHTTPServer starts an httptest server bound to IPv4 to avoid IPv6 listener issues in sandboxed environments.
 func NewHTTPServer(handler http.Handler) *httptest.Server {
-	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	ln, err := net.Listen("tcp4", "127.0.0.1:0") // nolint:noctx
 	if err != nil {
 		return httptest.NewServer(handler)
 	}
@@ -27,7 +29,7 @@ func NewHTTPServer(handler http.Handler) *httptest.Server {
 // NewHTTPServerT starts an httptest server bound to IPv4 and skips the test if binding fails.
 func NewHTTPServerT(t *testing.T, handler http.Handler) *httptest.Server {
 	t.Helper()
-	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	ln, err := net.Listen("tcp4", "127.0.0.1:0") // nolint:noctx
 	if err != nil {
 		t.Skipf("tcp4 listener unavailable: %v", err)
 		return nil

--- a/internal/testutil/mock_server.go
+++ b/internal/testutil/mock_server.go
@@ -3,6 +3,7 @@ package testutil
 
 import (
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -348,13 +349,13 @@ func (m *MockServer) setCommonHeaders(w http.ResponseWriter, start, end int64) {
 // Handles formats like "bytes=0-499" or "bytes=500-"
 func parseRange(rangeHeader string, fileSize int64) (int64, int64, error) {
 	if !strings.HasPrefix(rangeHeader, "bytes=") {
-		return 0, 0, fmt.Errorf("invalid range prefix")
+		return 0, 0, errors.New("invalid range prefix")
 	}
 
 	rangeSpec := strings.TrimPrefix(rangeHeader, "bytes=")
 	parts := strings.Split(rangeSpec, "-")
 	if len(parts) != 2 {
-		return 0, 0, fmt.Errorf("invalid range format")
+		return 0, 0, errors.New("invalid range format")
 	}
 
 	var start, end int64
@@ -387,7 +388,7 @@ func parseRange(rangeHeader string, fileSize int64) (int64, int64, error) {
 
 	// Validate
 	if start < 0 || end >= fileSize || start > end {
-		return 0, 0, fmt.Errorf("range out of bounds")
+		return 0, 0, errors.New("range out of bounds")
 	}
 
 	return start, end, nil

--- a/internal/testutil/mock_server_test.go
+++ b/internal/testutil/mock_server_test.go
@@ -1,5 +1,7 @@
 package testutil
 
+// nolint:noctx
+
 import (
 	"io"
 	"net/http"
@@ -16,7 +18,7 @@ func TestMockServer_BasicDownload(t *testing.T) {
 	defer server.Close()
 
 	// Full download
-	resp, err := http.Get(server.URL())
+	resp, err := http.Get(server.URL()) // nolint:noctx
 	if err != nil {
 		t.Fatalf("Failed to connect: %v", err)
 	}
@@ -53,7 +55,7 @@ func TestMockServer_RangeRequest(t *testing.T) {
 
 	// Range request for first 1024 bytes
 	client := &http.Client{}
-	req, _ := http.NewRequest("GET", server.URL(), nil)
+	req, _ := http.NewRequest("GET", server.URL(), nil) // nolint:noctx
 	req.Header.Set("Range", "bytes=0-1023")
 
 	resp, err := client.Do(req)
@@ -97,7 +99,7 @@ func TestMockServer_MultipleRangeRequests(t *testing.T) {
 			end = fileSize - 1
 		}
 
-		req, _ := http.NewRequest("GET", server.URL(), nil)
+		req, _ := http.NewRequest("GET", server.URL(), nil) // nolint:noctx
 		req.Header.Set("Range", "bytes="+formatRange(offset, end))
 
 		resp, err := client.Do(req)
@@ -135,7 +137,7 @@ func TestMockServer_HeadRequest(t *testing.T) {
 	defer server.Close()
 
 	client := &http.Client{}
-	req, _ := http.NewRequest("HEAD", server.URL(), nil)
+	req, _ := http.NewRequest("HEAD", server.URL(), nil) // nolint:noctx
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -165,7 +167,7 @@ func TestMockServer_NoRangeSupport(t *testing.T) {
 	defer server.Close()
 
 	client := &http.Client{}
-	req, _ := http.NewRequest("GET", server.URL(), nil)
+	req, _ := http.NewRequest("GET", server.URL(), nil) // nolint:noctx
 	req.Header.Set("Range", "bytes=0-511")
 
 	resp, err := client.Do(req)
@@ -194,21 +196,21 @@ func TestMockServer_FailOnNthRequest(t *testing.T) {
 	defer server.Close()
 
 	// First request should succeed
-	resp1, _ := http.Get(server.URL())
+	resp1, _ := http.Get(server.URL()) // nolint:noctx
 	if resp1.StatusCode != http.StatusOK {
 		t.Errorf("First request should succeed, got %d", resp1.StatusCode)
 	}
 	_ = resp1.Body.Close()
 
 	// Second request should fail
-	resp2, _ := http.Get(server.URL())
+	resp2, _ := http.Get(server.URL()) // nolint:noctx
 	if resp2.StatusCode != http.StatusInternalServerError {
 		t.Errorf("Second request should fail, got %d", resp2.StatusCode)
 	}
 	_ = resp2.Body.Close()
 
 	// Third request should succeed
-	resp3, _ := http.Get(server.URL())
+	resp3, _ := http.Get(server.URL()) // nolint:noctx
 	if resp3.StatusCode != http.StatusOK {
 		t.Errorf("Third request should succeed, got %d", resp3.StatusCode)
 	}
@@ -229,7 +231,7 @@ func TestMockServer_Latency(t *testing.T) {
 	defer server.Close()
 
 	start := time.Now()
-	resp, _ := http.Get(server.URL())
+	resp, _ := http.Get(server.URL()) // nolint:noctx
 	_ = resp.Body.Close()
 	elapsed := time.Since(start)
 
@@ -243,7 +245,7 @@ func TestMockServer_Reset(t *testing.T) {
 	defer server.Close()
 
 	// Make a request
-	resp, _ := http.Get(server.URL())
+	resp, _ := http.Get(server.URL()) // nolint:noctx
 	_ = resp.Body.Close()
 
 	if server.Stats().TotalRequests != 1 {
@@ -266,7 +268,7 @@ func TestStreamingMockServer_LargeFile(t *testing.T) {
 
 	// Just request a small range to verify it works
 	client := &http.Client{}
-	req, _ := http.NewRequest("GET", server.URL(), nil)
+	req, _ := http.NewRequest("GET", server.URL(), nil) // nolint:noctx
 	req.Header.Set("Range", "bytes=0-1023")
 
 	resp, err := client.Do(req)

--- a/internal/testutil/mock_server_test.go
+++ b/internal/testutil/mock_server_test.go
@@ -55,7 +55,7 @@ func TestMockServer_RangeRequest(t *testing.T) {
 
 	// Range request for first 1024 bytes
 	client := &http.Client{}
-	req, _ := http.NewRequest("GET", server.URL(), nil) // nolint:noctx
+	req, _ := http.NewRequest(http.MethodGet, server.URL(), nil) // nolint:noctx
 	req.Header.Set("Range", "bytes=0-1023")
 
 	resp, err := client.Do(req)
@@ -99,7 +99,7 @@ func TestMockServer_MultipleRangeRequests(t *testing.T) {
 			end = fileSize - 1
 		}
 
-		req, _ := http.NewRequest("GET", server.URL(), nil) // nolint:noctx
+		req, _ := http.NewRequest(http.MethodGet, server.URL(), nil) // nolint:noctx
 		req.Header.Set("Range", "bytes="+formatRange(offset, end))
 
 		resp, err := client.Do(req)
@@ -137,7 +137,7 @@ func TestMockServer_HeadRequest(t *testing.T) {
 	defer server.Close()
 
 	client := &http.Client{}
-	req, _ := http.NewRequest("HEAD", server.URL(), nil) // nolint:noctx
+	req, _ := http.NewRequest(http.MethodHead, server.URL(), nil) // nolint:noctx
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -167,7 +167,7 @@ func TestMockServer_NoRangeSupport(t *testing.T) {
 	defer server.Close()
 
 	client := &http.Client{}
-	req, _ := http.NewRequest("GET", server.URL(), nil) // nolint:noctx
+	req, _ := http.NewRequest(http.MethodGet, server.URL(), nil) // nolint:noctx
 	req.Header.Set("Range", "bytes=0-511")
 
 	resp, err := client.Do(req)
@@ -268,7 +268,7 @@ func TestStreamingMockServer_LargeFile(t *testing.T) {
 
 	// Just request a small range to verify it works
 	client := &http.Client{}
-	req, _ := http.NewRequest("GET", server.URL(), nil) // nolint:noctx
+	req, _ := http.NewRequest(http.MethodGet, server.URL(), nil) // nolint:noctx
 	req.Header.Set("Range", "bytes=0-1023")
 
 	resp, err := client.Do(req)

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"context"
 	"os/exec"
 	"runtime"
 
@@ -30,11 +31,11 @@ func openWithSystem(path string) error {
 	var cmd *exec.Cmd
 	switch runtime.GOOS {
 	case "darwin":
-		cmd = exec.Command("open", path)
+		cmd = exec.CommandContext(context.Background(), "open", path)
 	case "windows":
-		cmd = exec.Command("cmd", "/c", "start", "", path)
+		cmd = exec.CommandContext(context.Background(), "cmd", "/c", "start", "", path)
 	default: // linux and others
-		cmd = exec.Command("xdg-open", path)
+		cmd = exec.CommandContext(context.Background(), "xdg-open", path)
 	}
 	err := cmd.Start()
 	if err == nil {

--- a/internal/tui/components/box.go
+++ b/internal/tui/components/box.go
@@ -43,8 +43,9 @@ func RenderBtopBox(leftTitle, rightTitle string, content string, width, height i
 	borderStyler := lipgloss.NewStyle().Foreground(borderColor)
 	var topBorder string
 
+	switch {
 	// Case 1: Both Titles
-	if leftTitle != "" && rightTitle != "" {
+	case leftTitle != "" && rightTitle != "":
 		remainingWidth := innerWidth - leftTitleWidth - rightTitleWidth - 1 // 1 for the start dash
 		if remainingWidth < 1 {
 			remainingWidth = 1 // overflow mitigation (might break layout but prevents crash)
@@ -55,8 +56,7 @@ func RenderBtopBox(leftTitle, rightTitle string, content string, width, height i
 			borderStyler.Render(strings.Repeat(horizontal, remainingWidth)) +
 			rightTitle +
 			borderStyler.Render(topRight)
-
-	} else if leftTitle != "" {
+	case leftTitle != "":
 		// Case 2: Only Left Title
 		remainingWidth := innerWidth - leftTitleWidth - 1
 		if remainingWidth < 0 {
@@ -66,8 +66,7 @@ func RenderBtopBox(leftTitle, rightTitle string, content string, width, height i
 		topBorder = borderStyler.Render(topLeft+horizontal) +
 			leftTitle +
 			borderStyler.Render(strings.Repeat(horizontal, remainingWidth)+topRight)
-
-	} else if rightTitle != "" {
+	case rightTitle != "":
 		// Case 3: Only Right Title
 		remainingWidth := innerWidth - rightTitleWidth - 1
 		if remainingWidth < 0 {
@@ -77,8 +76,7 @@ func RenderBtopBox(leftTitle, rightTitle string, content string, width, height i
 		topBorder = borderStyler.Render(topLeft+strings.Repeat(horizontal, remainingWidth)) +
 			rightTitle +
 			borderStyler.Render(horizontal+topRight)
-
-	} else {
+	default:
 		// Case 4: No Title
 		topBorder = borderStyler.Render(topLeft + strings.Repeat(horizontal, innerWidth) + topRight)
 	}
@@ -106,7 +104,7 @@ func RenderBtopBox(leftTitle, rightTitle string, content string, width, height i
 		// Pad or truncate line to fit innerWidth
 		lineWidth := lipgloss.Width(line)
 		if lineWidth < innerWidth {
-			line = line + strings.Repeat(" ", innerWidth-lineWidth)
+			line += strings.Repeat(" ", innerWidth-lineWidth)
 		} else if lineWidth > innerWidth {
 			// Truncate (simplified - just take first innerWidth chars)
 			runes := []rune(line)

--- a/internal/tui/components/box.go
+++ b/internal/tui/components/box.go
@@ -45,7 +45,7 @@ func RenderBtopBox(leftTitle, rightTitle string, content string, width, height i
 
 	switch {
 	// Case 1: Both Titles
-	if leftTitle != "" && rightTitle != "" {
+	case leftTitle != "" && rightTitle != "":
 		remainingWidth := innerWidth - leftTitleWidth - rightTitleWidth - lipgloss.Width(horizontal)
 		if remainingWidth < 1 {
 			remainingWidth = 1 // overflow mitigation (might break layout but prevents crash)

--- a/internal/tui/components/chunkmap.go
+++ b/internal/tui/components/chunkmap.go
@@ -182,13 +182,14 @@ func (m ChunkMapModel) View() string {
 		}
 
 		// Determine Status
-		if allCompleted || (!hasApproximateProgress && downloadedInBlock >= blockSize) {
+		switch {
+		case allCompleted || (!hasApproximateProgress && downloadedInBlock >= blockSize):
 			visualChunks[i] = types.ChunkCompleted
-		} else if downloadedInBlock > 0 {
+		case downloadedInBlock > 0:
 			// If we have ANY bytes in this visual block, it is "Downloading" (or Paused Partial)
 			// This creates the "granular progress" we want.
 			visualChunks[i] = types.ChunkDownloading
-		} else {
+		default:
 			visualChunks[i] = types.ChunkPending
 		}
 	}

--- a/internal/tui/components/tab_bar.go
+++ b/internal/tui/components/tab_bar.go
@@ -16,7 +16,7 @@ type Tab struct {
 // Each tab is wrapped in a rounded border box for consistent styling
 // activeIndex specifies which tab is currently active (0-indexed)
 func RenderTabBar(tabs []Tab, activeIndex int, activeStyle, inactiveStyle lipgloss.Style) string {
-	var rendered []string
+	rendered := make([]string, 0, len(tabs))
 	for i, t := range tabs {
 		var label string
 		if t.Count >= 0 {
@@ -49,7 +49,7 @@ func RenderTabBar(tabs []Tab, activeIndex int, activeStyle, inactiveStyle lipglo
 // RenderNumberedTabBar renders tabs with number prefixes like "[1] General"
 // Each tab is wrapped in a rounded border box
 func RenderNumberedTabBar(tabs []Tab, activeIndex int, activeStyle, inactiveStyle lipgloss.Style) string {
-	var rendered []string
+	rendered := make([]string, 0, len(tabs))
 	for i, t := range tabs {
 		var label string
 		if t.Count >= 0 {

--- a/internal/tui/graph.go
+++ b/internal/tui/graph.go
@@ -44,12 +44,13 @@ func renderMultiLineGraph(data []float64, width, height int, maxVal float64, sta
 	for i := range rows {
 		rows[i] = make([]string, width)
 		for j := range rows[i] {
-			if i == height-1 {
+			switch {
+			case i == height-1:
 				// Bottom row: solid baseline
 				rows[i][j] = gridStyle.Render("─")
-			} else if i%2 == 0 {
+			case i%2 == 0:
 				rows[i][j] = gridStyle.Render("╌")
-			} else {
+			default:
 				rows[i][j] = " "
 			}
 		}
@@ -106,11 +107,12 @@ func renderMultiLineGraph(data []float64, width, height int, maxVal float64, sta
 					rowValue := totalSubBlocks - float64(y*8)
 
 					var charIndex int
-					if rowValue <= 0 {
+					switch {
+					case rowValue <= 0:
 						charIndex = 0 // Space
-					} else if rowValue >= 8 {
+					case rowValue >= 8:
 						charIndex = 7 // Full block (█)
-					} else {
+					default:
 						charIndex = int(rowValue) // Partial block
 					}
 

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -32,12 +32,13 @@ func (i DownloadItem) Description() string {
 
 	// Get styled status using the shared component
 	var styledStatus string
-	if d.pausing {
+	switch {
+	case d.pausing:
 		// Custom "Pausing..." style using existing colors
 		styledStatus = lipgloss.NewStyle().Foreground(colors.StatePaused).Render(i.spinnerView + " Pausing...")
-	} else if d.resuming {
+	case d.resuming:
 		styledStatus = lipgloss.NewStyle().Foreground(colors.StateDownloading).Render(i.spinnerView + " Resuming...")
-	} else {
+	default:
 		status := components.DetermineStatus(d.done, d.paused, d.err != nil, d.Speed, d.Downloaded)
 		styledStatus = status.RenderWithSpinner(i.spinnerView)
 	}
@@ -267,11 +268,12 @@ func (m *RootModel) UpdateListItems() {
 			for _, d := range m.downloads {
 				if d.ID == targetID {
 					var newTab int
-					if d.done {
+					switch {
+					case d.done:
 						newTab = TabDone
-					} else if d.Speed > 0 {
+					case d.Speed > 0:
 						newTab = TabActive
-					} else {
+					default:
 						newTab = TabQueued
 					}
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -440,7 +440,7 @@ func (m RootModel) Init() tea.Cmd {
 			errs := m.Service.ResumeBatch(resumeIDs)
 
 			// Dispatch individual messages for UI updates
-			var batch []tea.Cmd
+			batch := make([]tea.Cmd, 0, len(resumeIDs))
 			for i, id := range resumeIDs {
 				err := errs[i]
 				// Capture for closure

--- a/internal/tui/update_modals.go
+++ b/internal/tui/update_modals.go
@@ -127,9 +127,9 @@ func (m RootModel) updateURLUpdate(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		if newURL != "" {
 			if d := m.GetSelectedDownload(); d != nil {
 				if err := m.Service.UpdateURL(d.ID, newURL); err != nil {
-					m.addLogEntry(LogStyleError.Render(fmt.Sprintf("✖ Failed to update URL: %s", err.Error())))
+					m.addLogEntry(LogStyleError.Render("✖ Failed to update URL: " + err.Error()))
 				} else {
-					m.addLogEntry(LogStyleComplete.Render(fmt.Sprintf("✔ URL Updated: %s", d.Filename)))
+					m.addLogEntry(LogStyleComplete.Render("✔ URL Updated: " + d.Filename))
 					d.URL = newURL
 				}
 			}

--- a/internal/tui/update_settings.go
+++ b/internal/tui/update_settings.go
@@ -26,7 +26,7 @@ func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		if key.Matches(msg, m.keys.SettingsEditor.Confirm) {
 			currentCategory := categories[m.SettingsActiveTab]
 			settingKey := m.getCurrentSettingKey()
-			_ = m.setSettingValue(currentCategory, settingKey, m.SettingsInput.Value())
+			m.setSettingValue(currentCategory, settingKey, m.SettingsInput.Value())
 			m.SettingsIsEditing = false
 			m.SettingsInput.Blur()
 			return m, nil
@@ -126,7 +126,7 @@ func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 		currentCategory := categories[m.SettingsActiveTab]
 		if typ == "bool" {
-			_ = m.setSettingValue(currentCategory, settingKey, "")
+			m.setSettingValue(currentCategory, settingKey, "")
 		} else {
 			// Enter edit mode
 			m.SettingsIsEditing = true

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -208,8 +209,8 @@ func (m RootModel) View() tea.View {
 	if m.state == UpdateAvailableState && m.UpdateInfo != nil {
 		modal := components.ConfirmationModal{
 			Title:       "⬆ Update Available",
-			Message:     fmt.Sprintf("A new version of Surge is available: %s", m.UpdateInfo.LatestVersion),
-			Detail:      fmt.Sprintf("Current: %s", m.UpdateInfo.CurrentVersion),
+			Message:     "A new version of Surge is available: " + m.UpdateInfo.LatestVersion,
+			Detail:      "Current: " + m.UpdateInfo.CurrentVersion,
 			Keys:        m.keys.Update,
 			Help:        m.help,
 			BorderColor: colors.NeonCyan,
@@ -268,7 +269,7 @@ func (m RootModel) View() tea.View {
 	// Footer - keybindings on left, version on bottom-right
 	helpText := m.help.View(m.keys.Dashboard)
 	versionBlue := colors.ThemeColor("#005cc5", "#58a6ff")
-	versionText := lipgloss.NewStyle().Foreground(versionBlue).Render(fmt.Sprintf("v%s", m.CurrentVersion))
+	versionText := lipgloss.NewStyle().Foreground(versionBlue).Render("v" + m.CurrentVersion)
 	footerContentWidth := availableWidth
 	leftFooterWidth := footerContentWidth - lipgloss.Width(versionText)
 	if leftFooterWidth < 0 {
@@ -1032,7 +1033,7 @@ func renderFocusedDetails(d *DownloadModel, w int, spinnerView string) string {
 		if conns == 0 {
 			conns = 1 // Single-connection download (range requests not supported)
 		}
-		connStr := fmt.Sprintf("%d", conns)
+		connStr := strconv.Itoa(conns)
 		leftColItems = append(leftColItems, lipgloss.JoinHorizontal(lipgloss.Left, StatsLabelStyle.Width(7).Render("Conns:"), StatsValueStyle.Render(connStr)))
 	}
 	leftCol := lipgloss.JoinVertical(lipgloss.Left, leftColItems...)

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -580,7 +580,7 @@ func (m RootModel) View() tea.View {
 		maxSpeed = 1.0 // Default scale for empty graph
 	} else {
 		// Add headroom
-		maxSpeed = maxSpeed * 1.1
+		maxSpeed *= 1.1
 
 		if maxSpeed < 1.0 {
 			maxSpeed = 1.0
@@ -956,11 +956,12 @@ func renderFocusedDetails(d *DownloadModel, w int, spinnerView string) string {
 	// TUI owns elapsed time: compute from StartTime for active downloads,
 	// use frozen d.Elapsed for completed downloads.
 	var elapsed time.Duration
-	if d.done {
+	switch {
+	case d.done:
 		elapsed = d.Elapsed
-	} else if d.Elapsed > 0 {
+	case d.Elapsed > 0:
 		elapsed = d.Elapsed
-	} else if !d.StartTime.IsZero() {
+	case !d.StartTime.IsZero():
 		elapsed = time.Since(d.StartTime)
 	}
 
@@ -972,26 +973,28 @@ func renderFocusedDetails(d *DownloadModel, w int, spinnerView string) string {
 	}
 
 	// Speed & ETA
-	if d.done {
-		if elapsed.Seconds() >= 1 {
+	switch {
+	case d.done:
+		switch {
+		case elapsed.Seconds() >= 1:
 			avgSpeed := float64(d.Total) / float64(int(elapsed.Seconds()))
 			speedStr = fmt.Sprintf("%.2f MB/s (Avg)", avgSpeed/float64(config.MB))
-		} else if d.Speed > 0 {
+		case d.Speed > 0:
 			speedStr = fmt.Sprintf("%.2f MB/s (Avg)", d.Speed/float64(config.MB))
-		} else if elapsed.Seconds() > 0 {
+		case elapsed.Seconds() > 0:
 			avgSpeed := float64(d.Total) / elapsed.Seconds()
 			speedStr = fmt.Sprintf("%.2f MB/s (Avg)", avgSpeed/float64(config.MB))
-		} else {
+		default:
 			speedStr = "N/A"
 		}
 		etaStr = "Done"
-	} else if d.resuming {
+	case d.resuming:
 		speedStr = "Resuming..."
 		etaStr = "..."
-	} else if d.paused || d.Speed == 0 {
+	case d.paused || d.Speed == 0:
 		speedStr = "Paused"
 		etaStr = "∞"
-	} else {
+	default:
 		speedStr = fmt.Sprintf("%.2f MB/s", d.Speed/float64(config.MB))
 		if d.Total > 0 {
 			remaining := d.Total - d.Downloaded
@@ -1126,11 +1129,12 @@ func (m RootModel) calcTotalSpeed() float64 {
 func (m RootModel) ComputeViewStats() ViewStats {
 	var stats ViewStats
 	for _, d := range m.downloads {
-		if d.done {
+		switch {
+		case d.done:
 			stats.DownloadedCount++
-		} else if d.Speed > 0 {
+		case d.Speed > 0:
 			stats.ActiveCount++
-		} else {
+		default:
 			stats.QueuedCount++
 		}
 		stats.TotalDownloaded += d.Downloaded

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -854,12 +854,12 @@ func formatSettingValue(value interface{}, typ string) string {
 	case "int64":
 		if v, ok := value.(int64); ok {
 			// Just display the raw number - units handled by getSettingUnit
-			return fmt.Sprintf("%d", v)
+			return strconv.FormatInt(v, 10)
 		}
 	case "int":
 		v := reflect.ValueOf(value)
 		if v.Kind() == reflect.Int {
-			return fmt.Sprintf("%d", v.Int())
+			return strconv.FormatInt(v.Int(), 10)
 		}
 	case "float64":
 		if v, ok := value.(float64); ok {
@@ -881,7 +881,7 @@ func formatSettingValue(value interface{}, typ string) string {
 	v := reflect.ValueOf(value)
 	switch v.Kind() {
 	case reflect.Int, reflect.Int64:
-		return fmt.Sprintf("%d", v.Int())
+		return strconv.FormatInt(v.Int(), 10)
 	case reflect.Float64:
 		return fmt.Sprintf("%.2f", v.Float())
 	default:

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -556,24 +556,13 @@ func (m RootModel) getSettingsValues(category string) map[string]interface{} {
 
 // setSettingValue sets a setting value from string input
 func (m *RootModel) setSettingValue(category, key, value string) error {
-	metadata := config.GetSettingsMetadata()
-	metas := metadata[category]
-
-	var meta config.SettingMeta
-	for _, sm := range metas {
-		if sm.Key == key {
-			meta = sm
-			break
-		}
-	}
-
 	switch category {
 	case "General":
-		return m.setGeneralSetting(key, value, meta.Type)
+		return m.setGeneralSetting(key, value)
 	case "Network":
-		return m.setNetworkSetting(key, value, meta.Type)
+		return m.setNetworkSetting(key, value)
 	case "Performance":
-		return m.setPerformanceSetting(key, value, meta.Type)
+		return m.setPerformanceSetting(key, value)
 	case "Categories":
 		if key == "category_enabled" {
 			m.Settings.General.CategoryEnabled = !m.Settings.General.CategoryEnabled
@@ -598,7 +587,7 @@ func (m *RootModel) persistSettings() error {
 	return nil
 }
 
-func (m *RootModel) setGeneralSetting(key, value, typ string) error {
+func (m *RootModel) setGeneralSetting(key, value string) error {
 	switch key {
 	case "default_download_dir":
 		m.Settings.General.DefaultDownloadDir = value
@@ -650,7 +639,7 @@ func (m *RootModel) setGeneralSetting(key, value, typ string) error {
 	return nil
 }
 
-func (m *RootModel) setNetworkSetting(key, value, typ string) error {
+func (m *RootModel) setNetworkSetting(key, value string) error {
 	switch key {
 	case "max_connections_per_host":
 		if v, err := strconv.Atoi(value); err == nil {
@@ -693,7 +682,7 @@ func (m *RootModel) setNetworkSetting(key, value, typ string) error {
 	return nil
 }
 
-func (m *RootModel) setPerformanceSetting(key, value, typ string) error {
+func (m *RootModel) setPerformanceSetting(key, value string) error {
 	switch key {
 	case "max_task_retries":
 		if v, err := strconv.Atoi(value); err == nil {
@@ -959,8 +948,7 @@ func (m *RootModel) resetSettingToDefault(category, key string, defaults *config
 			m.Settings.Performance.SpeedEmaAlpha = defaults.Performance.SpeedEmaAlpha
 		}
 	case "Categories":
-		switch key {
-		case "category_enabled":
+		if key == "category_enabled" {
 			m.Settings.General.CategoryEnabled = defaults.General.CategoryEnabled
 		}
 	}

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -578,7 +578,7 @@ func (m RootModel) getSettingsValues(category string) map[string]interface{} {
 }
 
 // setSettingValue sets a setting value from string input
-func (m *RootModel) setSettingValue(category, key, value string) error {
+func (m *RootModel) setSettingValue(category, key, value string) {
 	val := reflect.ValueOf(m.Settings).Elem()
 	typ := val.Type()
 
@@ -598,7 +598,7 @@ func (m *RootModel) setSettingValue(category, key, value string) error {
 	}
 
 	if !foundCat || catVal.Kind() != reflect.Struct {
-		return nil
+		return
 	}
 
 	catTyp := catVal.Type()
@@ -616,7 +616,7 @@ func (m *RootModel) setSettingValue(category, key, value string) error {
 		if fieldKey == key {
 			targetField := catVal.Field(i)
 			if !targetField.CanSet() {
-				return nil
+				return
 			}
 
 			// Special logic for Theme to trigger app re-rendering internally
@@ -634,12 +634,12 @@ func (m *RootModel) setSettingValue(category, key, value string) error {
 					if v, err := strconv.Atoi(value); err == nil && v >= 0 && v <= 2 {
 						theme = v
 					} else {
-						return nil // Invalid
+						return // Invalid
 					}
 				}
 				targetField.Set(reflect.ValueOf(theme))
 				m.ApplyTheme(theme)
-				return nil
+				return
 			}
 
 			// Generic Parsing and Application
@@ -684,10 +684,9 @@ func (m *RootModel) setSettingValue(category, key, value string) error {
 				}
 			}
 
-			return nil
+			return
 		}
 	}
-	return nil
 }
 
 func (m *RootModel) persistSettings() error {
@@ -925,8 +924,7 @@ func (m *RootModel) resetSettingToDefault(category, key string, defaults *config
 			m.Settings.Performance.SpeedEmaAlpha = defaults.Performance.SpeedEmaAlpha
 		}
 	case "Categories":
-		switch key {
-		case "category_enabled":
+		if key == "category_enabled" {
 			m.Settings.Categories.CategoryEnabled = defaults.Categories.CategoryEnabled
 		}
 	}

--- a/internal/utils/debug_test.go
+++ b/internal/utils/debug_test.go
@@ -140,7 +140,7 @@ func TestCleanupLogs(t *testing.T) {
 
 	if len(entries) != 5 {
 		// For debugging failure
-		var names []string
+		names := make([]string, 0, len(entries))
 		for _, e := range entries {
 			names = append(names, e.Name())
 		}

--- a/internal/utils/open.go
+++ b/internal/utils/open.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -10,7 +12,7 @@ import (
 
 func OpenFile(path string) error {
 	if path == "" {
-		return fmt.Errorf("path is empty")
+		return errors.New("path is empty")
 	}
 
 	info, err := os.Stat(path)
@@ -27,7 +29,7 @@ func OpenFile(path string) error {
 
 func OpenContainingFolder(path string) error {
 	if path == "" {
-		return fmt.Errorf("path is empty")
+		return errors.New("path is empty")
 	}
 
 	targetPath := path
@@ -64,10 +66,10 @@ func openWithSystem(path string) error {
 func buildOpenCommand(path string) *exec.Cmd {
 	switch runtime.GOOS {
 	case "darwin":
-		return exec.Command("open", path)
+		return exec.CommandContext(context.Background(), "open", path)
 	case "windows":
-		return exec.Command("cmd", "/c", "start", "", path)
+		return exec.CommandContext(context.Background(), "cmd", "/c", "start", "", path)
 	default:
-		return exec.Command("xdg-open", path)
+		return exec.CommandContext(context.Background(), "xdg-open", path)
 	}
 }

--- a/internal/utils/url_reader.go
+++ b/internal/utils/url_reader.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -55,7 +56,7 @@ func ReadURLsFromFile(filepath string) ([]string, error) {
 		return nil, err
 	}
 	if len(urls) == 0 {
-		return nil, fmt.Errorf("no valid URLs found in file")
+		return nil, errors.New("no valid URLs found in file")
 	}
 	return urls, nil
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,6 +2,7 @@
 package version
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -46,7 +47,7 @@ func CheckForUpdate(currentVersion string) (*UpdateInfo, error) {
 		Timeout: RequestTimeout,
 	}
 
-	req, err := http.NewRequest("GET", GitHubAPIURL, nil)
+	req, err := http.NewRequestWithContext(context.Background(), "GET", GitHubAPIURL, nil)
 	if err != nil {
 		return nil, nil // Fail silently
 	}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -47,7 +47,7 @@ func CheckForUpdate(currentVersion string) (*UpdateInfo, error) {
 		Timeout: RequestTimeout,
 	}
 
-	req, err := http.NewRequestWithContext(context.Background(), "GET", GitHubAPIURL, nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, GitHubAPIURL, nil)
 	if err != nil {
 		return nil, nil // Fail silently
 	}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the golangci-lint configuration (migrating to the v2 schema with correctly-nested `linters.settings`) and fixes a broad sweep of lint violations across 63 files — including `errorlint`, `noctx`, `rowserrcheck`, and `bodyclose` findings. Most previously raised concerns are resolved, but one `errorlint` violation was missed: `GetDownload` in `internal/engine/state/state.go` still uses a bare `err == sql.ErrNoRows` comparison while its sibling `LoadState` was updated to `errors.Is` — this will be caught by the very linter rule this PR enables.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the one remaining errorlint violation in GetDownload.

A single P1 remains: GetDownload uses err == sql.ErrNoRows while the PR itself enables errorlint and updated the equivalent check in LoadState to errors.Is — making this a self-defeating omission that will fail CI. All other previously raised concerns (v2 config schema, switch/case compile error, os.ErrNotExist test assertion) are resolved.

internal/engine/state/state.go — GetDownload at line 499 needs the errorlint fix.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. Changes are confined to linter configuration and mechanical code-quality fixes (error wrapping, context propagation, resource-close guards); no new attack surface is introduced.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .golangci.yml | Linter settings now correctly nested under `linters.settings` (v2 schema); previously raised misconfiguration is resolved. |
| internal/engine/state/state.go | LoadState updated to errors.Is for sql.ErrNoRows, but GetDownload still uses a bare == comparison (line 499) — will fail the newly-enabled errorlint check. LoadStates also carries forward unresolved rowserrcheck nolint suppressions (flagged in a prior review thread). |
| internal/tui/components/box.go | Previously reported compile error (if inside switch) is now fixed; switch/case structure looks correct. |
| internal/engine/state/state_test.go | TestDeleteState now correctly asserts os.ErrNotExist rather than sql.ErrNoRows; prior test-assertion bug is resolved. |
| cmd/http_handler_test.go | Two misplaced nolint:noctx directives (lines 281, 333) were flagged in a prior thread; those specific nolint placements persist in the current state but are already tracked. |
| cmd/utils.go | HTTP method constants used, context-aware requests in place; no new issues found. |
| internal/processing/events.go | Event handling logic looks clean; no linter or logic issues found. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[golangci-lint v2 config] --> B[errorlint enabled]
    A --> C[rowserrcheck enabled]
    A --> D[noctx enabled]
    B --> E[LoadState: fixed ✅\nerrors.Is for sql.ErrNoRows]
    B --> F[GetDownload: missed ❌\nerr == sql.ErrNoRows]
    C --> G[LoadMasterList: fixed ✅\nrows.Err check added]
    C --> H[LoadStates: suppressed ⚠️\nnolint directive, no rows.Err]
    D --> I[doAPIRequest: fixed ✅\nNewRequestWithContext used]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/engine/state/state.go`, line 499 ([link](https://github.com/surgedm/surge/blob/34d1537d2a5d31d2cccda80b65957726c1813c6a/internal/engine/state/state.go#L499)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Direct `==` comparison bypasses `errorlint` which this PR enables**

   `GetDownload` uses `err == sql.ErrNoRows` while the sibling function `LoadState` (line 275, also changed in this PR) was updated to `errors.Is(err, sql.ErrNoRows)`. With `errorlint` now active in `.golangci.yml`, this line will be flagged on CI — making the linter config improvement self-defeating for this file. Wrap the value with a driver that returns a wrapped error and the check silently passes through, always taking the generic `fmt.Errorf` path.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/engine/state/state.go
   Line: 499

   Comment:
   **Direct `==` comparison bypasses `errorlint` which this PR enables**

   `GetDownload` uses `err == sql.ErrNoRows` while the sibling function `LoadState` (line 275, also changed in this PR) was updated to `errors.Is(err, sql.ErrNoRows)`. With `errorlint` now active in `.golangci.yml`, this line will be flagged on CI — making the linter config improvement self-defeating for this file. Wrap the value with a driver that returns a wrapped error and the check silently passes through, always taking the generic `fmt.Errorf` path.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/engine/state/state.go
Line: 499

Comment:
**Direct `==` comparison bypasses `errorlint` which this PR enables**

`GetDownload` uses `err == sql.ErrNoRows` while the sibling function `LoadState` (line 275, also changed in this PR) was updated to `errors.Is(err, sql.ErrNoRows)`. With `errorlint` now active in `.golangci.yml`, this line will be flagged on CI — making the linter config improvement self-defeating for this file. Wrap the value with a driver that returns a wrapped error and the check silently passes through, always taking the generic `fmt.Errorf` path.

```suggestion
		if errors.Is(err, sql.ErrNoRows) {
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["Merge remote-tracking branch &#39;refs/remot..."](https://github.com/surgedm/surge/commit/34d1537d2a5d31d2cccda80b65957726c1813c6a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27603693)</sub>

<!-- /greptile_comment -->