### PR TITLE
refactor: make tui size dynamic and make settings modular

### DIFF
--- a/cmd/root_lifecycle_test.go
+++ b/cmd/root_lifecycle_test.go
@@ -237,8 +237,8 @@ func TestProcessDownloads_RoutesBinFilesToCustomCategory(t *testing.T) {
 	customDir := filepath.Join(t.TempDir(), "bin-artifacts")
 	settings := config.DefaultSettings()
 	settings.General.DefaultDownloadDir = defaultDir
-	settings.General.CategoryEnabled = true
-	settings.General.Categories = append(settings.General.Categories, config.Category{
+	settings.Categories.CategoryEnabled = true
+	settings.Categories.Categories = append(settings.Categories.Categories, config.Category{
 		Name:    "Binary",
 		Pattern: `(?i)\.bin$`,
 		Path:    customDir,
@@ -323,7 +323,7 @@ func TestProcessDownloads_UsesLatestSavedCategorySettings(t *testing.T) {
 	defaultDir := t.TempDir()
 	initial := config.DefaultSettings()
 	initial.General.DefaultDownloadDir = defaultDir
-	initial.General.CategoryEnabled = false
+	initial.Categories.CategoryEnabled = false
 	if err := config.SaveSettings(initial); err != nil {
 		t.Fatalf("SaveSettings(initial) failed: %v", err)
 	}
@@ -338,8 +338,8 @@ func TestProcessDownloads_UsesLatestSavedCategorySettings(t *testing.T) {
 	customDir := filepath.Join(t.TempDir(), "bin-updated")
 	updated := config.DefaultSettings()
 	updated.General.DefaultDownloadDir = defaultDir
-	updated.General.CategoryEnabled = true
-	updated.General.Categories = []config.Category{
+	updated.Categories.CategoryEnabled = true
+	updated.Categories.Categories = []config.Category{
 		{
 			Name:    "Binary",
 			Pattern: `(?i)\.bin$`,

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -11,7 +11,7 @@ from the `settings.json` file located in the application data directory:
 - **macOS:** `~/Library/Application Support/surge/settings.json`
 - **Linux:** `~/.config/surge/settings.json`
 
-The `settings.json` file expects a nested structure divided into `general`, `network`, and `performance` categories. For example:
+The `settings.json` file expects a nested structure divided into `general`, `network`, `performance`, and `categories` sections. For example:
 
 ```json
 {
@@ -24,6 +24,9 @@ The `settings.json` file expects a nested structure divided into `general`, `net
   },
   "performance": {
     "max_task_retries": 5
+  },
+  "categories": {
+    "category_enabled": true
   }
 }
 ```
@@ -82,3 +85,9 @@ Surge follows OS conventions for storing its files. Below is a breakdown of ever
 | `slow_worker_grace_period` | duration | Time to wait before checking a worker's speed (e.g., `5s`).                  | `5s`    |
 | `stall_timeout`            | duration | Restart workers that haven't received data for this duration (e.g., `3s`).   | `3s`    |
 | `speed_ema_alpha`          | float    | Exponential moving average smoothing factor for speed calculation (0.0-1.0). | `0.3`   |
+
+### Category Settings
+
+| Key                    | Type   | Description                                                                                              | Default |
+| :--------------------- | :----- | :------------------------------------------------------------------------------------------------------- | :------ |
+| `category_enabled`     | bool   | Enable automatic sorting of downloads into subfolders based on file type categories.                     | `false` |

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"time"
 
 	"github.com/SurgeDM/Surge/internal/utils"
@@ -11,26 +12,25 @@ import (
 
 // Settings holds all user-configurable application settings organized by category.
 type Settings struct {
-	General     GeneralSettings     `json:"general"`
-	Network     NetworkSettings     `json:"network"`
-	Performance PerformanceSettings `json:"performance"`
+	General     GeneralSettings     `json:"general" ui_label:"General"`
+	Network     NetworkSettings     `json:"network" ui_label:"Network"`
+	Performance PerformanceSettings `json:"performance" ui_label:"Performance"`
+	Categories  CategorySettings    `json:"categories" ui_label:"Categories"`
 }
 
 // GeneralSettings contains application behavior settings.
 type GeneralSettings struct {
-	DefaultDownloadDir           string     `json:"default_download_dir"`
-	WarnOnDuplicate              bool       `json:"warn_on_duplicate"`
-	DownloadCompleteNotification bool       `json:"download_complete_notification"`
-	AllowRemoteOpenActions       bool       `json:"allow_remote_open_actions"`
-	ExtensionPrompt              bool       `json:"extension_prompt"`
-	AutoResume                   bool       `json:"auto_resume"`
-	SkipUpdateCheck              bool       `json:"skip_update_check"`
-	CategoryEnabled              bool       `json:"category_enabled"`
-	Categories                   []Category `json:"categories"`
+	DefaultDownloadDir           string `json:"default_download_dir" ui_label:"Default Download Dir" ui_desc:"Default directory for new downloads. Leave empty to use current directory."`
+	WarnOnDuplicate              bool   `json:"warn_on_duplicate" ui_label:"Warn on Duplicate" ui_desc:"Show warning when adding a download that already exists."`
+	DownloadCompleteNotification bool   `json:"download_complete_notification" ui_label:"Download Complete Notification" ui_desc:"Show system notification when a download finishes."`
+	AllowRemoteOpenActions       bool   `json:"allow_remote_open_actions" ui_label:"Allow Remote Open Actions" ui_desc:"Allow /open-file and /open-folder API calls from non-loopback clients. Disabled by default for security."`
+	ExtensionPrompt              bool   `json:"extension_prompt" ui_label:"Extension Prompt" ui_desc:"Prompt for confirmation when adding downloads via browser extension."`
+	AutoResume                   bool   `json:"auto_resume" ui_label:"Auto Resume" ui_desc:"Automatically resume paused downloads on startup."`
+	SkipUpdateCheck              bool   `json:"skip_update_check" ui_label:"Skip Update Check" ui_desc:"Disable automatic check for new versions on startup."`
 
-	ClipboardMonitor  bool `json:"clipboard_monitor"`
-	Theme             int  `json:"theme"`
-	LogRetentionCount int  `json:"log_retention_count"`
+	ClipboardMonitor  bool `json:"clipboard_monitor" ui_label:"Clipboard Monitor" ui_desc:"Watch clipboard for URLs and prompt to download them."`
+	Theme             int  `json:"theme" ui_label:"App Theme" ui_desc:"UI Theme (System, Light, Dark)."`
+	LogRetentionCount int  `json:"log_retention_count" ui_label:"Log Retention Count" ui_desc:"Number of recent log files to keep."`
 }
 
 const (
@@ -39,24 +39,30 @@ const (
 	ThemeDark     = 2
 )
 
+// CategorySettings holds options specifically for categorizing files.
+type CategorySettings struct {
+	CategoryEnabled bool       `json:"category_enabled" ui_label:"Manage Categories" ui_desc:"Sort downloads into subfolders by file type. Press Enter to open Category Manager."`
+	Categories      []Category `json:"categories" ui_ignored:"true"`
+}
+
 // NetworkSettings contains network connection parameters.
 type NetworkSettings struct {
-	MaxConnectionsPerHost  int    `json:"max_connections_per_host"`
-	MaxConcurrentDownloads int    `json:"max_concurrent_downloads"`
-	UserAgent              string `json:"user_agent"`
-	ProxyURL               string `json:"proxy_url"`
-	SequentialDownload     bool   `json:"sequential_download"`
-	MinChunkSize           int64  `json:"min_chunk_size"`
-	WorkerBufferSize       int    `json:"worker_buffer_size"`
+	MaxConnectionsPerHost  int    `json:"max_connections_per_host" ui_label:"Max Connections/Host" ui_desc:"Maximum concurrent connections per host (1-64)."`
+	MaxConcurrentDownloads int    `json:"max_concurrent_downloads" ui_label:"Max Concurrent Downloads" ui_desc:"Maximum number of downloads running at once (1-10). Requires restart."`
+	UserAgent              string `json:"user_agent" ui_label:"User Agent" ui_desc:"Custom User-Agent string for HTTP requests. Leave empty for default."`
+	ProxyURL               string `json:"proxy_url" ui_label:"Proxy URL" ui_desc:"HTTP/HTTPS proxy URL (e.g. http://127.0.0.1:1700). Leave empty to use system default."`
+	SequentialDownload     bool   `json:"sequential_download" ui_label:"Sequential Download" ui_desc:"Download pieces in order (Streaming Mode). May be slower."`
+	MinChunkSize           int64  `json:"min_chunk_size" ui_label:"Min Chunk Size" ui_desc:"Minimum download chunk size in MB (e.g., 2)."`
+	WorkerBufferSize       int    `json:"worker_buffer_size" ui_label:"Worker Buffer Size" ui_desc:"I/O buffer size per worker in KB (e.g., 512)."`
 }
 
 // PerformanceSettings contains performance tuning parameters.
 type PerformanceSettings struct {
-	MaxTaskRetries        int           `json:"max_task_retries"`
-	SlowWorkerThreshold   float64       `json:"slow_worker_threshold"`
-	SlowWorkerGracePeriod time.Duration `json:"slow_worker_grace_period"`
-	StallTimeout          time.Duration `json:"stall_timeout"`
-	SpeedEmaAlpha         float64       `json:"speed_ema_alpha"`
+	MaxTaskRetries        int           `json:"max_task_retries" ui_label:"Max Task Retries" ui_desc:"Number of times to retry a failed chunk before giving up."`
+	SlowWorkerThreshold   float64       `json:"slow_worker_threshold" ui_label:"Slow Worker Threshold" ui_desc:"Restart workers slower than this fraction of mean speed (0.0-1.0)."`
+	SlowWorkerGracePeriod time.Duration `json:"slow_worker_grace_period" ui_label:"Slow Worker Grace" ui_desc:"Grace period before checking worker speed (e.g., 5s)."`
+	StallTimeout          time.Duration `json:"stall_timeout" ui_label:"Stall Timeout" ui_desc:"Restart workers with no data for this duration (e.g., 5s)."`
+	SpeedEmaAlpha         float64       `json:"speed_ema_alpha" ui_label:"Speed EMA Alpha" ui_desc:"Exponential moving average smoothing factor (0.0-1.0)."`
 }
 
 // SettingMeta provides metadata for a single setting (for UI rendering).
@@ -69,45 +75,99 @@ type SettingMeta struct {
 
 // GetSettingsMetadata returns metadata for all settings organized by category.
 func GetSettingsMetadata() map[string][]SettingMeta {
-	return map[string][]SettingMeta{
-		"General": {
-			{Key: "default_download_dir", Label: "Default Download Dir", Description: "Default directory for new downloads. Leave empty to use current directory.", Type: "string"},
-			{Key: "download_complete_notification", Label: "Download Complete Notification", Description: "Show system notification when a download finishes.", Type: "bool"},
-			{Key: "allow_remote_open_actions", Label: "Allow Remote Open Actions", Description: "Allow /open-file and /open-folder API calls from non-loopback clients. Disabled by default for security.", Type: "bool"},
-			{Key: "warn_on_duplicate", Label: "Warn on Duplicate", Description: "Show warning when adding a download that already exists.", Type: "bool"},
-			{Key: "extension_prompt", Label: "Extension Prompt", Description: "Prompt for confirmation when adding downloads via browser extension.", Type: "bool"},
-			{Key: "auto_resume", Label: "Auto Resume", Description: "Automatically resume paused downloads on startup.", Type: "bool"},
-			{Key: "skip_update_check", Label: "Skip Update Check", Description: "Disable automatic check for new versions on startup.", Type: "bool"},
+	meta := make(map[string][]SettingMeta)
+	t := reflect.TypeOf(Settings{})
 
-			{Key: "clipboard_monitor", Label: "Clipboard Monitor", Description: "Watch clipboard for URLs and prompt to download them.", Type: "bool"},
-			{Key: "theme", Label: "App Theme", Description: "UI Theme (System, Light, Dark).", Type: "int"},
-			{Key: "log_retention_count", Label: "Log Retention Count", Description: "Number of recent log files to keep.", Type: "int"},
-		},
-		"Categories": {
-			{Key: "category_enabled", Label: "Manage Categories", Description: "Sort downloads into subfolders by file type. Press Enter to open Category Manager.", Type: "bool"},
-		},
-		"Network": {
-			{Key: "max_connections_per_host", Label: "Max Connections/Host", Description: "Maximum concurrent connections per host (1-64).", Type: "int"},
-			{Key: "max_concurrent_downloads", Label: "Max Concurrent Downloads", Description: "Maximum number of downloads running at once (1-10). Requires restart.", Type: "int"},
-			{Key: "user_agent", Label: "User Agent", Description: "Custom User-Agent string for HTTP requests. Leave empty for default.", Type: "string"},
-			{Key: "proxy_url", Label: "Proxy URL", Description: "HTTP/HTTPS proxy URL (e.g. http://127.0.0.1:1700). Leave empty to use system default.", Type: "string"},
-			{Key: "sequential_download", Label: "Sequential Download", Description: "Download pieces in order (Streaming Mode). May be slower.", Type: "bool"},
-			{Key: "min_chunk_size", Label: "Min Chunk Size", Description: "Minimum download chunk size in MB (e.g., 2).", Type: "int64"},
-			{Key: "worker_buffer_size", Label: "Worker Buffer Size", Description: "I/O buffer size per worker in KB (e.g., 512).", Type: "int"},
-		},
-		"Performance": {
-			{Key: "max_task_retries", Label: "Max Task Retries", Description: "Number of times to retry a failed chunk before giving up.", Type: "int"},
-			{Key: "slow_worker_threshold", Label: "Slow Worker Threshold", Description: "Restart workers slower than this fraction of mean speed (0.0-1.0).", Type: "float64"},
-			{Key: "slow_worker_grace_period", Label: "Slow Worker Grace", Description: "Grace period before checking worker speed (e.g., 5s).", Type: "duration"},
-			{Key: "stall_timeout", Label: "Stall Timeout", Description: "Restart workers with no data for this duration (e.g., 5s).", Type: "duration"},
-			{Key: "speed_ema_alpha", Label: "Speed EMA Alpha", Description: "Exponential moving average smoothing factor (0.0-1.0).", Type: "float64"},
-		},
+	for i := 0; i < t.NumField(); i++ {
+		catField := t.Field(i)
+		catLabel := catField.Tag.Get("ui_label")
+		if catLabel == "" {
+			catLabel = catField.Name
+		}
+
+		var catMetas []SettingMeta
+		catType := catField.Type
+		if catType.Kind() == reflect.Struct {
+			for j := 0; j < catType.NumField(); j++ {
+				settingField := catType.Field(j)
+				if settingField.Tag.Get("ui_ignored") == "true" {
+					continue
+				}
+
+				key := settingField.Tag.Get("json")
+				if key == "" {
+					key = settingField.Name
+				}
+
+				label := settingField.Tag.Get("ui_label")
+				if label == "" {
+					label = settingField.Name
+				}
+
+				desc := settingField.Tag.Get("ui_desc")
+
+				// Determine implicit Type
+				typStr := "string"
+				switch settingField.Type.Kind() {
+				case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32:
+					typStr = "int"
+				case reflect.Int64:
+					if settingField.Type.String() == "time.Duration" {
+						typStr = "duration"
+					} else {
+						typStr = "int64"
+					}
+				case reflect.Bool:
+					typStr = "bool"
+				case reflect.Float32, reflect.Float64:
+					typStr = "float64"
+				}
+
+				catMetas = append(catMetas, SettingMeta{
+					Key:         key,
+					Label:       label,
+					Description: desc,
+					Type:        typStr,
+				})
+			}
+		}
+		// Only output categories that have editable GUI parameters
+		if len(catMetas) > 0 {
+			meta[catLabel] = catMetas
+		}
 	}
+	return meta
 }
 
 // CategoryOrder returns the order of categories for UI tabs.
 func CategoryOrder() []string {
-	return []string{"General", "Network", "Performance", "Categories"}
+	var order []string
+	t := reflect.TypeOf(Settings{})
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		label := field.Tag.Get("ui_label")
+		if label == "" {
+			label = field.Name
+		}
+		
+		// Ensure category has UI elements before creating a tab!
+		catType := field.Type
+		hasUIElements := false
+		if catType.Kind() == reflect.Struct {
+			for j := 0; j < catType.NumField(); j++ {
+				if catType.Field(j).Tag.Get("ui_ignored") != "true" {
+					hasUIElements = true
+					break
+				}
+			}
+		}
+		
+		// Only tabulate categories with active inputs
+		if hasUIElements {
+			order = append(order, label)
+		}
+	}
+	return order
 }
 
 const (
@@ -128,8 +188,6 @@ func DefaultSettings() *Settings {
 			AllowRemoteOpenActions:       false,
 			ExtensionPrompt:              false,
 			AutoResume:                   false,
-			CategoryEnabled:              false,
-			Categories:                   DefaultCategories(),
 
 			ClipboardMonitor:  true,
 			Theme:             ThemeAdaptive,
@@ -149,6 +207,10 @@ func DefaultSettings() *Settings {
 			SlowWorkerGracePeriod: 5 * time.Second,
 			StallTimeout:          3 * time.Second,
 			SpeedEmaAlpha:         0.3,
+		},
+		Categories: CategorySettings{
+			CategoryEnabled: false,
+			Categories:      DefaultCategories(),
 		},
 	}
 }

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -149,7 +149,7 @@ func CategoryOrder() []string {
 		if label == "" {
 			label = field.Name
 		}
-		
+
 		// Ensure category has UI elements before creating a tab!
 		catType := field.Type
 		hasUIElements := false
@@ -161,7 +161,7 @@ func CategoryOrder() []string {
 				}
 			}
 		}
-		
+
 		// Only tabulate categories with active inputs
 		if hasUIElements {
 			order = append(order, label)

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -578,7 +578,7 @@ func TestSaveAndLoadSettings_PreservesEmptyCategories(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
 	settings := DefaultSettings()
-	settings.General.Categories = []Category{}
+	settings.Categories.Categories = []Category{}
 
 	if err := SaveSettings(settings); err != nil {
 		t.Fatalf("SaveSettings failed: %v", err)
@@ -597,11 +597,11 @@ func TestSaveAndLoadSettings_PreservesEmptyCategories(t *testing.T) {
 		t.Fatalf("LoadSettings failed: %v", err)
 	}
 
-	if loaded.General.Categories == nil {
+	if loaded.Categories.Categories == nil {
 		t.Fatal("expected categories slice to be non-nil after load")
 	}
-	if len(loaded.General.Categories) != 0 {
-		t.Fatalf("expected zero categories after reload, got %d", len(loaded.General.Categories))
+	if len(loaded.Categories.Categories) != 0 {
+		t.Fatalf("expected zero categories after reload, got %d", len(loaded.Categories.Categories))
 	}
 }
 

--- a/internal/processing/file_utils.go
+++ b/internal/processing/file_utils.go
@@ -135,11 +135,11 @@ func GetUniqueFilename(dir, filename string, isNameActive func(string, string) b
 // GetCategoryPath applies category routing only while the caller is still using
 // the default destination, so explicit user paths are left untouched.
 func GetCategoryPath(filename, defaultDir string, settings *config.Settings) (string, error) {
-	if settings == nil || !settings.General.CategoryEnabled || filename == "" {
+	if settings == nil || !settings.Categories.CategoryEnabled || filename == "" {
 		return defaultDir, nil
 	}
 
-	cat, err := config.GetCategoryForFile(filename, settings.General.Categories)
+	cat, err := config.GetCategoryForFile(filename, settings.Categories.Categories)
 	if err != nil {
 		return defaultDir, fmt.Errorf("category match error for %s: %w", filename, err)
 	}
@@ -171,7 +171,7 @@ func ResolveDestination(url, candidateFilename, defaultDir string, routeToCatego
 	filename := getBaseFilename(url, candidateFilename, probe)
 
 	destPath := defaultDir
-	if routeToCategory && settings != nil && settings.General.CategoryEnabled && filename != "" {
+	if routeToCategory && settings != nil && settings.Categories.CategoryEnabled && filename != "" {
 		var err error
 		destPath, err = GetCategoryPath(filename, defaultDir, settings)
 		if err != nil {

--- a/internal/processing/file_utils_test.go
+++ b/internal/processing/file_utils_test.go
@@ -100,8 +100,8 @@ func TestGetCategoryPath(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	settings := config.DefaultSettings()
-	settings.General.CategoryEnabled = true
-	settings.General.Categories = []config.Category{
+	settings.Categories.CategoryEnabled = true
+	settings.Categories.Categories = []config.Category{
 		{
 			Name:    "Images",
 			Pattern: "\\.(jpg|png)$",
@@ -129,7 +129,7 @@ func TestGetCategoryPath(t *testing.T) {
 	}
 
 	// Disabled
-	settings.General.CategoryEnabled = false
+	settings.Categories.CategoryEnabled = false
 	path, err = processing.GetCategoryPath("test.jpg", tmpDir, settings)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -140,8 +140,8 @@ func TestGetCategoryPath(t *testing.T) {
 
 	// No side effects: routing should not create the directory before reservation.
 	missingDir := filepath.Join(tmpDir, "missing")
-	settings.General.CategoryEnabled = true
-	settings.General.Categories = []config.Category{
+	settings.Categories.CategoryEnabled = true
+	settings.Categories.Categories = []config.Category{
 		{
 			Name:    "Programs",
 			Pattern: `(?i)\.bin$`,
@@ -162,7 +162,7 @@ func TestGetCategoryPath(t *testing.T) {
 
 func TestResolveDestination_Priority(t *testing.T) {
 	settings := config.DefaultSettings()
-	settings.General.CategoryEnabled = false
+	settings.Categories.CategoryEnabled = false
 	defaultDir := "/downloads"
 
 	// 1. User defined beats all
@@ -192,7 +192,7 @@ func TestResolveDestination_Priority(t *testing.T) {
 
 func TestResolveDestination_ErrorsWhenUniqueNameExhausted(t *testing.T) {
 	settings := config.DefaultSettings()
-	settings.General.CategoryEnabled = false
+	settings.Categories.CategoryEnabled = false
 
 	overflowActive := func(dir, name string) bool {
 		if name == "overflow.bin" {

--- a/internal/processing/manager_test.go
+++ b/internal/processing/manager_test.go
@@ -35,7 +35,7 @@ func newProbeTestServer(t *testing.T, size int64) *httptest.Server {
 
 func newLifecycleManagerForTest() *LifecycleManager {
 	settings := config.DefaultSettings()
-	settings.General.CategoryEnabled = false
+	settings.Categories.CategoryEnabled = false
 	return &LifecycleManager{settings: settings, settingsRefreshedAt: time.Now()}
 }
 
@@ -403,7 +403,7 @@ func TestLifecycleManager_GetSettings_RefreshesFromDiskAfterTTL(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 
 	initial := config.DefaultSettings()
-	initial.General.CategoryEnabled = false
+	initial.Categories.CategoryEnabled = false
 	if err := config.SaveSettings(initial); err != nil {
 		t.Fatalf("SaveSettings(initial) failed: %v", err)
 	}
@@ -411,7 +411,7 @@ func TestLifecycleManager_GetSettings_RefreshesFromDiskAfterTTL(t *testing.T) {
 	mgr := NewLifecycleManager(nil, nil)
 
 	updated := config.DefaultSettings()
-	updated.General.CategoryEnabled = true
+	updated.Categories.CategoryEnabled = true
 	if err := config.SaveSettings(updated); err != nil {
 		t.Fatalf("SaveSettings(updated) failed: %v", err)
 	}
@@ -423,7 +423,7 @@ func TestLifecycleManager_GetSettings_RefreshesFromDiskAfterTTL(t *testing.T) {
 	settingsRefreshTTL = 0
 
 	settings := mgr.GetSettings()
-	if !settings.General.CategoryEnabled {
+	if !settings.Categories.CategoryEnabled {
 		t.Fatal("expected GetSettings to pick up saved settings after TTL expiry")
 	}
 }

--- a/internal/tui/category_regressions_test.go
+++ b/internal/tui/category_regressions_test.go
@@ -31,9 +31,9 @@ func TestStartDownload_RoutesDefaultPathWithURLDerivedFilename(t *testing.T) {
 	imageDir := filepath.Join(rootDir, "images")
 
 	settings := config.DefaultSettings()
-	settings.General.CategoryEnabled = true
+	settings.Categories.CategoryEnabled = true
 	settings.General.DefaultDownloadDir = rootDir
-	settings.General.Categories = []config.Category{
+	settings.Categories.Categories = []config.Category{
 		{Name: "Images", Pattern: `(?i)\.(jpg|jpeg|png)$`, Path: imageDir},
 	}
 
@@ -53,10 +53,10 @@ func TestUpdate_InputSubmit_BlankPathUsesDefaultPathRouting(t *testing.T) {
 	musicDir := filepath.Join(rootDir, "music")
 
 	settings := config.DefaultSettings()
-	settings.General.CategoryEnabled = true
+	settings.Categories.CategoryEnabled = true
 	settings.General.WarnOnDuplicate = false
 	settings.General.DefaultDownloadDir = rootDir
-	settings.General.Categories = []config.Category{
+	settings.Categories.Categories = []config.Category{
 		{Name: "Music", Pattern: `(?i)\.(mp3|flac)$`, Path: musicDir},
 	}
 
@@ -83,9 +83,9 @@ func TestUpdate_DuplicateContinuePreservesDefaultPathRouting(t *testing.T) {
 	videoDir := filepath.Join(rootDir, "videos")
 
 	settings := config.DefaultSettings()
-	settings.General.CategoryEnabled = true
+	settings.Categories.CategoryEnabled = true
 	settings.General.DefaultDownloadDir = rootDir
-	settings.General.Categories = []config.Category{
+	settings.Categories.Categories = []config.Category{
 		{Name: "Videos", Pattern: `(?i)\.mp4$`, Path: videoDir},
 	}
 
@@ -112,10 +112,10 @@ func TestUpdate_ExtensionConfirmBlankPathUsesDefaultPathRouting(t *testing.T) {
 	docDir := filepath.Join(rootDir, "docs")
 
 	settings := config.DefaultSettings()
-	settings.General.CategoryEnabled = true
+	settings.Categories.CategoryEnabled = true
 	settings.General.WarnOnDuplicate = false
 	settings.General.DefaultDownloadDir = rootDir
-	settings.General.Categories = []config.Category{
+	settings.Categories.Categories = []config.Category{
 		{Name: "Documents", Pattern: `(?i)\.pdf$`, Path: docDir},
 	}
 
@@ -138,7 +138,7 @@ func TestUpdate_ExtensionConfirmBlankPathUsesDefaultPathRouting(t *testing.T) {
 
 func TestUpdate_CategoryManagerEscRemovesNewPlaceholder(t *testing.T) {
 	settings := config.DefaultSettings()
-	settings.General.Categories = []config.Category{
+	settings.Categories.Categories = []config.Category{
 		{Name: "Existing", Pattern: `(?i)\.txt$`, Path: "docs"},
 		{Name: "New Category"},
 	}
@@ -164,15 +164,15 @@ func TestUpdate_CategoryManagerEscRemovesNewPlaceholder(t *testing.T) {
 	if m2.catMgrIsNew {
 		t.Fatal("expected catMgrIsNew to be cleared")
 	}
-	if got, want := len(m2.Settings.General.Categories), 1; got != want {
+	if got, want := len(m2.Settings.Categories.Categories), 1; got != want {
 		t.Fatalf("category count = %d, want %d", got, want)
 	}
 }
 
 func TestGetFilteredDownloads_AppliesCategoryFilter(t *testing.T) {
 	settings := config.DefaultSettings()
-	settings.General.CategoryEnabled = true
-	settings.General.Categories = []config.Category{
+	settings.Categories.CategoryEnabled = true
+	settings.Categories.Categories = []config.Category{
 		{Name: "Videos", Pattern: `(?i)\.mp4$`},
 		{Name: "Documents", Pattern: `(?i)\.pdf$`},
 	}

--- a/internal/tui/components/box.go
+++ b/internal/tui/components/box.go
@@ -45,7 +45,7 @@ func RenderBtopBox(leftTitle, rightTitle string, content string, width, height i
 
 	// Case 1: Both Titles
 	if leftTitle != "" && rightTitle != "" {
-		remainingWidth := innerWidth - leftTitleWidth - rightTitleWidth - 1 // 1 for the start dash
+		remainingWidth := innerWidth - leftTitleWidth - rightTitleWidth - lipgloss.Width(horizontal)
 		if remainingWidth < 1 {
 			remainingWidth = 1 // overflow mitigation (might break layout but prevents crash)
 		}
@@ -58,7 +58,7 @@ func RenderBtopBox(leftTitle, rightTitle string, content string, width, height i
 
 	} else if leftTitle != "" {
 		// Case 2: Only Left Title
-		remainingWidth := innerWidth - leftTitleWidth - 1
+		remainingWidth := innerWidth - leftTitleWidth - lipgloss.Width(horizontal)
 		if remainingWidth < 0 {
 			remainingWidth = 0
 		}
@@ -69,7 +69,7 @@ func RenderBtopBox(leftTitle, rightTitle string, content string, width, height i
 
 	} else if rightTitle != "" {
 		// Case 3: Only Right Title
-		remainingWidth := innerWidth - rightTitleWidth - 1
+		remainingWidth := innerWidth - rightTitleWidth - lipgloss.Width(horizontal)
 		if remainingWidth < 0 {
 			remainingWidth = 0
 		}

--- a/internal/tui/components/confirmation_modal.go
+++ b/internal/tui/components/confirmation_modal.go
@@ -54,8 +54,12 @@ func (m ConfirmationModal) RenderWithBtopBox(
 	renderBox func(leftTitle, rightTitle, content string, width, height int, borderColor color.Color) string,
 	titleStyle lipgloss.Style,
 ) string {
-	innerWidth := m.Width - 4 // Account for borders
-	innerHeight := m.Height - 2
+	boxFrameX := lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).GetHorizontalFrameSize()
+	paddingX := lipgloss.NewStyle().Padding(0, 1).GetHorizontalFrameSize()
+	innerWidth := m.Width - boxFrameX - paddingX
+
+	boxFrameY := lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).GetVerticalFrameSize()
+	innerHeight := m.Height - boxFrameY
 
 	// Get content without help
 	mainContent := m.view()
@@ -72,7 +76,8 @@ func (m ConfirmationModal) RenderWithBtopBox(
 	helpHeight := lipgloss.Height(helpText)
 
 	// Space above content to vertically center the main content in remaining space
-	remainingHeight := innerHeight - helpHeight - 1 // -1 for spacing before help
+	spacingStyle := lipgloss.NewStyle().MarginBottom(1)
+	remainingHeight := innerHeight - helpHeight - spacingStyle.GetVerticalFrameSize()
 	topPadding := (remainingHeight - mainContentHeight) / 2
 	if topPadding < 0 {
 		topPadding = 0
@@ -109,7 +114,7 @@ func (m ConfirmationModal) Centered(width, height int) string {
 		BorderForeground(m.BorderColor).
 		Padding(1, 4)
 
-	innerWidth := m.Width - 10 // Account for borders and padding
+	innerWidth := m.Width - boxStyle.GetHorizontalFrameSize()
 
 	// Get content without help
 	mainContent := m.view()

--- a/internal/tui/components/help_modal.go
+++ b/internal/tui/components/help_modal.go
@@ -23,7 +23,9 @@ func (m HelpModal) RenderWithBtopBox(
 	renderBox func(leftTitle, rightTitle, content string, width, height int, borderColor color.Color) string,
 	titleStyle lipgloss.Style,
 ) string {
-	innerWidth := m.Width - 4
+	boxFrameX := lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).GetHorizontalFrameSize()
+	paddingX := lipgloss.NewStyle().Padding(0, 1).GetHorizontalFrameSize()
+	innerWidth := m.Width - boxFrameX - paddingX
 
 	// Render the full help view from the keybindings
 	helpText := m.Help.FullHelpView(m.HelpKeys.FullHelp())
@@ -34,7 +36,8 @@ func (m HelpModal) RenderWithBtopBox(
 		Align(lipgloss.Center).
 		Render(helpText)
 
-	innerHeight := m.Height - 2
+	boxFrameY := lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).GetVerticalFrameSize()
+	innerHeight := m.Height - boxFrameY
 	contentHeight := lipgloss.Height(helpContent)
 	topPadding := (innerHeight - contentHeight) / 2
 	if topPadding < 0 {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -490,7 +490,7 @@ func (m RootModel) getFilteredDownloads() []*DownloadModel {
 		}
 
 		// Apply dashboard category filter.
-		if m.categoryFilter != "" && m.Settings != nil && m.Settings.General.CategoryEnabled {
+		if m.categoryFilter != "" && m.Settings != nil && m.Settings.Categories.CategoryEnabled {
 			if !m.matchesCategoryFilter(d) {
 				continue
 			}
@@ -526,7 +526,7 @@ func (m RootModel) matchesCategoryFilter(d *DownloadModel) bool {
 		filename = processing.InferFilenameFromURL(d.URL)
 	}
 
-	cat, err := config.GetCategoryForFile(filename, m.Settings.General.Categories)
+	cat, err := config.GetCategoryForFile(filename, m.Settings.Categories.Categories)
 	if filter == "Uncategorized" {
 		return err != nil || cat == nil
 	}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -25,6 +25,10 @@ var (
 	LogStyleComplete lipgloss.Style
 	LogStyleError    lipgloss.Style
 	LogStylePaused   lipgloss.Style
+	WindowStyle      lipgloss.Style
+	BoxStyle         lipgloss.Style
+	ModalPaddingStyle lipgloss.Style
+	LayoutGapStyle   lipgloss.Style
 )
 
 func init() {
@@ -33,6 +37,11 @@ func init() {
 }
 
 func rebuildStyles() {
+	WindowStyle = lipgloss.NewStyle().Margin(0, 1)
+	BoxStyle = lipgloss.NewStyle().Border(lipgloss.RoundedBorder())
+	ModalPaddingStyle = lipgloss.NewStyle().Padding(1, 2)
+	LayoutGapStyle = lipgloss.NewStyle().MarginTop(1)
+
 	AppStyle = lipgloss.NewStyle().
 		Background(lipgloss.Color("0")).
 		Foreground(colors.White)

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -8,27 +8,27 @@ import (
 
 // === Layout Styles ===
 var (
-	AppStyle         lipgloss.Style
-	PaneStyle        lipgloss.Style
-	ActivePaneStyle  lipgloss.Style
-	LogoStyle        lipgloss.Style
-	GraphStyle       lipgloss.Style
-	ListStyle        lipgloss.Style
-	DetailStyle      lipgloss.Style
-	TitleStyle       lipgloss.Style
-	PaneTitleStyle   lipgloss.Style
-	TabStyle         lipgloss.Style
-	ActiveTabStyle   lipgloss.Style
-	StatsLabelStyle  lipgloss.Style
-	StatsValueStyle  lipgloss.Style
-	LogStyleStarted  lipgloss.Style
-	LogStyleComplete lipgloss.Style
-	LogStyleError    lipgloss.Style
-	LogStylePaused   lipgloss.Style
-	WindowStyle      lipgloss.Style
-	BoxStyle         lipgloss.Style
+	AppStyle          lipgloss.Style
+	PaneStyle         lipgloss.Style
+	ActivePaneStyle   lipgloss.Style
+	LogoStyle         lipgloss.Style
+	GraphStyle        lipgloss.Style
+	ListStyle         lipgloss.Style
+	DetailStyle       lipgloss.Style
+	TitleStyle        lipgloss.Style
+	PaneTitleStyle    lipgloss.Style
+	TabStyle          lipgloss.Style
+	ActiveTabStyle    lipgloss.Style
+	StatsLabelStyle   lipgloss.Style
+	StatsValueStyle   lipgloss.Style
+	LogStyleStarted   lipgloss.Style
+	LogStyleComplete  lipgloss.Style
+	LogStyleError     lipgloss.Style
+	LogStylePaused    lipgloss.Style
+	WindowStyle       lipgloss.Style
+	BoxStyle          lipgloss.Style
 	ModalPaddingStyle lipgloss.Style
-	LayoutGapStyle   lipgloss.Style
+	LayoutGapStyle    lipgloss.Style
 )
 
 func init() {

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -93,7 +93,7 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// View() handles the actual dynamic layout math; we supply available bounds.
 		listInnerPadding := lipgloss.NewStyle().Padding(1, 2)
 		availableWidth := msg.Width - WindowStyle.GetHorizontalFrameSize() - BoxStyle.GetHorizontalFrameSize()
-		
+
 		// Give bubbles/list roughly the right dimensions for word-wrapping, exact styling is handled in view.
 		approxHeaderHeight := 11
 		approxTabBarHeight := 2

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -4,6 +4,8 @@ import (
 	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/utils"
 
+	"charm.land/lipgloss/v2"
+
 	tea "charm.land/bubbletea/v2"
 )
 
@@ -88,18 +90,14 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 
-		// Calculate list dimensions
-		// List goes in bottom-left pane — use full width; View() handles the actual box sizing
-		availableWidth := msg.Width - 4
-
-		// Calculate list height (total height - header row - margins)
-		topHeight := 9
-		bottomHeight := msg.Height - topHeight - 5
-		if bottomHeight < 10 {
-			bottomHeight = 10
-		}
-
-		m.list.SetSize(availableWidth-2, bottomHeight-4)
+		// View() handles the actual dynamic layout math; we supply available bounds.
+		listInnerPadding := lipgloss.NewStyle().Padding(1, 2)
+		availableWidth := msg.Width - WindowStyle.GetHorizontalFrameSize() - BoxStyle.GetHorizontalFrameSize()
+		
+		// Give bubbles/list roughly the right dimensions for word-wrapping, exact styling is handled in view.
+		approxHeaderHeight := 11
+		approxTabBarHeight := 2
+		m.list.SetSize(availableWidth-listInnerPadding.GetHorizontalFrameSize(), msg.Height-approxHeaderHeight-approxTabBarHeight-BoxStyle.GetVerticalFrameSize())
 
 		// Update list based on active tab
 		m.UpdateListItems()

--- a/internal/tui/update_category.go
+++ b/internal/tui/update_category.go
@@ -73,9 +73,9 @@ func (m *RootModel) updateCategoryInputWidthsForViewport() {
 	if modalWidth >= 76 {
 		leftWidth := 28
 		minRightWidth := 24
-		
+
 		horizontalPadding := ModalPaddingStyle.GetHorizontalFrameSize() * 2
-		
+
 		if modalWidth-leftWidth-horizontalPadding < minRightWidth {
 			leftWidth = modalWidth - minRightWidth - horizontalPadding
 		}

--- a/internal/tui/update_category.go
+++ b/internal/tui/update_category.go
@@ -73,13 +73,16 @@ func (m *RootModel) updateCategoryInputWidthsForViewport() {
 	if modalWidth >= 76 {
 		leftWidth := 28
 		minRightWidth := 24
-		if modalWidth-leftWidth-8 < minRightWidth {
-			leftWidth = modalWidth - minRightWidth - 8
+		
+		horizontalPadding := ModalPaddingStyle.GetHorizontalFrameSize() * 2
+		
+		if modalWidth-leftWidth-horizontalPadding < minRightWidth {
+			leftWidth = modalWidth - minRightWidth - horizontalPadding
 		}
 		if leftWidth < 16 {
 			leftWidth = 16
 		}
-		rightWidth := modalWidth - leftWidth - 8
+		rightWidth := modalWidth - leftWidth - horizontalPadding
 		targetWidth = rightWidth - 10
 	} else {
 		targetWidth = modalWidth - 14

--- a/internal/tui/update_category.go
+++ b/internal/tui/update_category.go
@@ -13,8 +13,8 @@ import (
 
 func (m *RootModel) catMgrBeginAdd() {
 	newCat := config.Category{Name: "New Category"}
-	m.Settings.General.Categories = append(m.Settings.General.Categories, newCat)
-	m.catMgrCursor = len(m.Settings.General.Categories) - 1
+	m.Settings.Categories.Categories = append(m.Settings.Categories.Categories, newCat)
+	m.catMgrCursor = len(m.Settings.Categories.Categories) - 1
 	m.catMgrIsNew = true
 	m.catMgrEditing = true
 	m.catMgrEditField = 0
@@ -37,7 +37,7 @@ func (m *RootModel) normalizeCategoryManagerSelection() {
 		return
 	}
 
-	cats := m.Settings.General.Categories
+	cats := m.Settings.Categories.Categories
 	maxCursor := len(cats)
 	if m.catMgrEditing {
 		if len(cats) == 0 {
@@ -102,7 +102,7 @@ func (m *RootModel) updateCategoryInputWidthsForViewport() {
 
 func (m RootModel) updateCategoryManager(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	m.normalizeCategoryManagerSelection()
-	cats := m.Settings.General.Categories
+	cats := m.Settings.Categories.Categories
 
 	// Handle editing mode
 	if m.catMgrEditing {
@@ -113,10 +113,10 @@ func (m RootModel) updateCategoryManager(msg tea.KeyPressMsg) (tea.Model, tea.Cm
 			m.blurAllCatInputs()
 
 			// If was adding new, remove the placeholder
-			if wasNew && m.catMgrCursor < len(m.Settings.General.Categories) {
-				m.Settings.General.Categories = append(
-					m.Settings.General.Categories[:m.catMgrCursor],
-					m.Settings.General.Categories[m.catMgrCursor+1:]...,
+			if wasNew && m.catMgrCursor < len(m.Settings.Categories.Categories) {
+				m.Settings.Categories.Categories = append(
+					m.Settings.Categories.Categories[:m.catMgrCursor],
+					m.Settings.Categories.Categories[m.catMgrCursor+1:]...,
 				)
 				if m.catMgrCursor > 0 {
 					m.catMgrCursor--
@@ -148,7 +148,7 @@ func (m RootModel) updateCategoryManager(msg tea.KeyPressMsg) (tea.Model, tea.Cm
 		}
 		if key.Matches(msg, m.keys.CategoryMgr.Edit) {
 			// Save edits
-			if m.catMgrCursor < 0 || m.catMgrCursor >= len(m.Settings.General.Categories) {
+			if m.catMgrCursor < 0 || m.catMgrCursor >= len(m.Settings.Categories.Categories) {
 				m.addLogEntry(LogStyleError.Render("✖ Invalid category selection"))
 				return m, nil
 			}
@@ -175,7 +175,7 @@ func (m RootModel) updateCategoryManager(msg tea.KeyPressMsg) (tea.Model, tea.Cm
 				return m, nil
 			}
 
-			target := &m.Settings.General.Categories[m.catMgrCursor]
+			target := &m.Settings.Categories.Categories[m.catMgrCursor]
 			target.Name = name
 			target.Description = description
 			target.Pattern = pattern
@@ -216,17 +216,17 @@ func (m RootModel) updateCategoryManager(msg tea.KeyPressMsg) (tea.Model, tea.Cm
 	}
 
 	if key.Matches(msg, m.keys.CategoryMgr.Toggle) {
-		m.Settings.General.CategoryEnabled = !m.Settings.General.CategoryEnabled
+		m.Settings.Categories.CategoryEnabled = !m.Settings.Categories.CategoryEnabled
 		return m, nil
 	}
 
 	if key.Matches(msg, m.keys.CategoryMgr.Delete) {
 		if m.catMgrCursor < len(cats) {
-			m.Settings.General.Categories = append(
-				m.Settings.General.Categories[:m.catMgrCursor],
-				m.Settings.General.Categories[m.catMgrCursor+1:]...,
+			m.Settings.Categories.Categories = append(
+				m.Settings.Categories.Categories[:m.catMgrCursor],
+				m.Settings.Categories.Categories[m.catMgrCursor+1:]...,
 			)
-			if m.catMgrCursor >= len(m.Settings.General.Categories) && m.catMgrCursor > 0 {
+			if m.catMgrCursor >= len(m.Settings.Categories.Categories) && m.catMgrCursor > 0 {
 				m.catMgrCursor--
 			}
 		}

--- a/internal/tui/update_dashboard.go
+++ b/internal/tui/update_dashboard.go
@@ -217,7 +217,7 @@ func (m RootModel) updateDashboard(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 
 	if key.Matches(msg, m.keys.Dashboard.CategoryFilter) {
-		if !m.Settings.General.CategoryEnabled || len(m.Settings.General.Categories) == 0 {
+		if !m.Settings.Categories.CategoryEnabled || len(m.Settings.Categories.Categories) == 0 {
 			if m.categoryFilter != "" {
 				m.categoryFilter = ""
 				m.addLogEntry(LogStyleStarted.Render("📂 Filter: All"))
@@ -227,7 +227,7 @@ func (m RootModel) updateDashboard(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.addLogEntry(LogStyleError.Render("✖ Enable categories in Settings first"))
 			return m, nil
 		}
-		names := config.CategoryNames(m.Settings.General.Categories)
+		names := config.CategoryNames(m.Settings.Categories.Categories)
 		cycle := append([]string{""}, names...)
 		cycle = append(cycle, "Uncategorized")
 		current := 0

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -1047,7 +1047,7 @@ func TestUpdate_CategoryManagerNotEditingPasteIsIgnored(t *testing.T) {
 
 func TestUpdate_WindowSizeNormalizesCategoryManagerSelection(t *testing.T) {
 	settings := config.DefaultSettings()
-	settings.General.Categories = []config.Category{
+	settings.Categories.Categories = []config.Category{
 		{Name: "Docs", Pattern: `(?i)\\.txt$`, Path: "docs"},
 	}
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -260,7 +260,7 @@ func (m RootModel) View() tea.View {
 
 	// === MAIN DASHBOARD LAYOUT ===
 
-	availableWidth := m.width - 2
+	availableWidth := m.width - WindowStyle.GetHorizontalFrameSize()
 	if availableWidth < 0 {
 		availableWidth = 0
 	}
@@ -340,7 +340,7 @@ func (m RootModel) View() tea.View {
 	var detailContent string
 	selected := m.GetSelectedDownload()
 
-	detailWidth := rightWidth - 4
+	detailWidth := rightWidth - PaneStyle.GetHorizontalFrameSize()
 	if detailWidth < 0 {
 		detailWidth = 0
 	}
@@ -354,7 +354,7 @@ func (m RootModel) View() tea.View {
 	}
 
 	// Exact height from content + borders
-	detailHeight := lipgloss.Height(detailContent) + 2
+	detailHeight := lipgloss.Height(detailContent) + BoxStyle.GetVerticalFrameSize()
 
 	// Calculate Available Height for Rest
 	remainingHeight := availableHeight - detailHeight
@@ -391,16 +391,16 @@ func (m RootModel) View() tea.View {
 	}
 
 	if showChunkMap {
-		// chunkMapWidth = rightWidth - 4 (box border) - 2 (inner padding) = rightWidth - 6
-		// Calculate available height for chunk map (remaining height minus graph minimum 9)
-		availableChunkHeight := remainingHeight - minGraphHeight - 4 // -minGraphHeight for graph floor, -4 for borders/padding
+		// Calculate available height for chunk map
+		chunkMapPadding := lipgloss.NewStyle().Padding(0, 2)
+		availableChunkHeight := remainingHeight - minGraphHeight - BoxStyle.GetVerticalFrameSize() - LayoutGapStyle.GetVerticalFrameSize() - LayoutGapStyle.GetVerticalFrameSize()
 		if availableChunkHeight < 1 {
 			availableChunkHeight = 1
 		}
-		contentLines := components.CalculateHeight(bitmapWidth, rightWidth-6, availableChunkHeight)
+		contentLines := components.CalculateHeight(bitmapWidth, rightWidth-BoxStyle.GetHorizontalFrameSize()-chunkMapPadding.GetHorizontalFrameSize(), availableChunkHeight)
 		if contentLines > 0 {
-			// +2 for top/bottom borders
-			chunkMapNeeded = contentLines + 2
+			// top/bottom borders
+			chunkMapNeeded = contentLines + BoxStyle.GetVerticalFrameSize()
 		} else {
 			// Minimum for message "Chunk visualization not available"
 			chunkMapNeeded = 6
@@ -470,7 +470,7 @@ func (m RootModel) View() tea.View {
 
 	// Logo takes ~45% of header width
 	logoWidth := int(float64(leftWidth) * 0.45)
-	logWidth := leftWidth - logoWidth - 2 // Rest for log box
+	logWidth := leftWidth - logoWidth - BoxStyle.GetHorizontalFrameSize() // Rest for log box
 
 	if logoWidth < 4 {
 		logoWidth = 4 // Minimum for server box content
@@ -494,7 +494,7 @@ func (m RootModel) View() tea.View {
 		statusLine = lipgloss.NewStyle().Foreground(colors.NeonCyan).Bold(true).Render(" Serving at " + serverAddr)
 	}
 
-	serverContentWidth := logoWidth - 4
+	serverContentWidth := logoWidth - (BoxStyle.GetHorizontalFrameSize() * 2)
 	if serverContentWidth < 0 {
 		serverContentWidth = 0
 	}
@@ -531,11 +531,11 @@ func (m RootModel) View() tea.View {
 	}
 
 	// Render log viewport
-	vpWidth := logWidth - 4
+	vpWidth := logWidth - (BoxStyle.GetHorizontalFrameSize() * 2)
 	if vpWidth < 0 {
 		vpWidth = 0
 	}
-	vpHeight := headerHeight - 4
+	vpHeight := headerHeight - (BoxStyle.GetVerticalFrameSize() * 2)
 	if vpHeight < 1 {
 		vpHeight = 1
 	}
@@ -594,8 +594,7 @@ func (m RootModel) View() tea.View {
 	}
 
 	// Calculate Available Height for the Graph
-	// graphHeight - Borders (2) - title area (1) - top/bottom padding (2)
-	graphContentHeight := graphHeight - 5
+	graphContentHeight := graphHeight - BoxStyle.GetVerticalFrameSize() - LayoutGapStyle.GetVerticalFrameSize() - 2 // remaining padding
 	if graphContentHeight < 3 {
 		graphContentHeight = 3
 	}
@@ -653,7 +652,7 @@ func (m RootModel) View() tea.View {
 	var graphWithAxis string
 	if hideGraphStats {
 		// No stats box — graph gets almost full width
-		graphAreaWidth := rightWidth - axisWidth - 10
+		graphAreaWidth := rightWidth - axisWidth - (BoxStyle.GetHorizontalFrameSize() * 5)
 		if graphAreaWidth < 10 {
 			graphAreaWidth = 10
 		}
@@ -711,7 +710,7 @@ func (m RootModel) View() tea.View {
 
 		// Graph takes remaining width after stats box
 		axisWidth := 10
-		graphAreaWidth := rightWidth - statsBoxWidth - axisWidth - 6 // borders + spacing
+		graphAreaWidth := rightWidth - statsBoxWidth - axisWidth - (BoxStyle.GetHorizontalFrameSize() * 3)
 		if graphAreaWidth < 10 {
 			graphAreaWidth = 10
 		}
@@ -771,9 +770,9 @@ func (m RootModel) View() tea.View {
 	// Render the bubbles list or centered empty message
 	var listContent string
 	if len(m.list.Items()) == 0 {
-		listContentHeight := listHeight - 6
+		listContentHeight := listHeight - BoxStyle.GetVerticalFrameSize() - ModalPaddingStyle.GetVerticalFrameSize()
 
-		listContentWidth := leftWidth - 8
+		listContentWidth := leftWidth - (BoxStyle.GetHorizontalFrameSize() * 4)
 		if listContentWidth < 0 {
 			listContentWidth = 0
 		}
@@ -787,7 +786,7 @@ func (m RootModel) View() tea.View {
 		}
 	} else {
 		// ensure list fills the height
-		m.list.SetHeight(listHeight - 4) // adjust for padding/tabs
+		m.list.SetHeight(listHeight - BoxStyle.GetVerticalFrameSize() - ModalPaddingStyle.GetVerticalFrameSize()) // adjust for padding/tabs
 		listContent = m.list.View()
 	}
 
@@ -822,18 +821,19 @@ func (m RootModel) View() tea.View {
 			if targetRows > 5 {
 				targetRows = 5 // Maximum 5 rows for compact look
 			}
-			chunkMapWidth := rightWidth - 6
+			chunkMapPadding := lipgloss.NewStyle().Padding(0, 2)
+			chunkMapWidth := rightWidth - BoxStyle.GetHorizontalFrameSize() - chunkMapPadding.GetHorizontalFrameSize()
 			if chunkMapWidth < 4 {
 				chunkMapWidth = 4
 			}
 			chunkMap := components.NewChunkMapModel(bitmap, bitmapWidth, chunkMapWidth, targetRows, selected.paused, totalSize, chunkSize, chunkProgress)
-			chunkContent = lipgloss.NewStyle().Padding(0, 2).Render(chunkMap.View()) // No bottom padding
+			chunkContent = chunkMapPadding.Render(chunkMap.View()) // No bottom padding
 
 			// If no chunks (not initialized or small file), show message
 			if bitmapWidth == 0 {
 				msg := "Chunk visualization not available"
 
-				placeholderWidth := rightWidth - 4
+				placeholderWidth := rightWidth - BoxStyle.GetHorizontalFrameSize()
 				if placeholderWidth < 0 {
 					placeholderWidth = 0
 				}

--- a/internal/tui/view_category.go
+++ b/internal/tui/view_category.go
@@ -25,7 +25,7 @@ func (m RootModel) viewCategoryManager() string {
 		return m.renderModalWithOverlay(box)
 	}
 
-	cats := m.Settings.General.Categories
+	cats := m.Settings.Categories.Categories
 	cursor := m.catMgrCursor
 	if m.catMgrEditing {
 		if len(cats) == 0 {
@@ -50,7 +50,7 @@ func (m RootModel) viewCategoryManager() string {
 	// === TOGGLE BAR ===
 	enabledStr := "OFF"
 	enabledColor := colors.Gray
-	if m.Settings.General.CategoryEnabled {
+	if m.Settings.Categories.CategoryEnabled {
 		enabledStr = "ON"
 		enabledColor = colors.StateDownloading
 	}

--- a/internal/tui/view_category.go
+++ b/internal/tui/view_category.go
@@ -68,11 +68,11 @@ func (m RootModel) viewCategoryManager() string {
 	catCount := fmt.Sprintf("%d categories", len(cats))
 	infoLine := lipgloss.NewStyle().Foreground(colors.Gray).Render("  " + catCount)
 
-	innerHeight := height - 2
+	innerHeight := height - BoxStyle.GetVerticalFrameSize()
 	toggleBarHeight := lipgloss.Height(toggleLine)
 	infoHeight := lipgloss.Height(infoLine)
 	helpHeight := lipgloss.Height(helpText)
-	bodyHeight := innerHeight - toggleBarHeight - infoHeight - helpHeight - 1
+	bodyHeight := innerHeight - toggleBarHeight - infoHeight - helpHeight - LayoutGapStyle.GetVerticalFrameSize()
 	if bodyHeight < 3 {
 		bodyHeight = 3
 	}
@@ -85,7 +85,7 @@ func (m RootModel) viewCategoryManager() string {
 	}
 
 	contentHeight := lipgloss.Height(content)
-	usedHeight := toggleBarHeight + infoHeight + 1 + contentHeight + helpHeight
+	usedHeight := toggleBarHeight + infoHeight + LayoutGapStyle.GetVerticalFrameSize() + contentHeight + helpHeight
 	paddingLines := innerHeight - usedHeight
 	if paddingLines < 0 {
 		paddingLines = 0
@@ -114,11 +114,11 @@ func categoryModalDimensions(termWidth, termHeight int) (int, int) {
 	}
 	height := 26
 
-	maxWidth := termWidth - 4
+	maxWidth := termWidth - (WindowStyle.GetHorizontalFrameSize() * 2)
 	if maxWidth < 1 {
 		maxWidth = 1
 	}
-	maxHeight := termHeight - 4
+	maxHeight := termHeight - (WindowStyle.GetVerticalFrameSize() * 2) - 4 // default fallback padding
 	if maxHeight < 1 {
 		maxHeight = 1
 	}
@@ -299,18 +299,21 @@ func (m RootModel) renderCategoryEditView(innerWidth, rows int) string {
 func (m RootModel) renderCategoryTwoColumn(cats []config.Category, cursor, modalWidth, bodyHeight int) string {
 	leftWidth := 28
 	minRightWidth := 24
-	if modalWidth-leftWidth-8 < minRightWidth {
-		leftWidth = modalWidth - minRightWidth - 8
+	
+	horizontalPadding := ModalPaddingStyle.GetHorizontalFrameSize() * 2
+	
+	if modalWidth-leftWidth-horizontalPadding < minRightWidth {
+		leftWidth = modalWidth - minRightWidth - horizontalPadding
 	}
 	if leftWidth < 16 {
 		leftWidth = 16
 	}
 
-	rightWidth := modalWidth - leftWidth - 8
+	rightWidth := modalWidth - leftWidth - horizontalPadding
 	if rightWidth < minRightWidth {
 		rightWidth = minRightWidth
-		if modalWidth-rightWidth-8 > 16 {
-			leftWidth = modalWidth - rightWidth - 8
+		if modalWidth-rightWidth-horizontalPadding > 16 {
+			leftWidth = modalWidth - rightWidth - horizontalPadding
 		}
 	}
 
@@ -318,38 +321,40 @@ func (m RootModel) renderCategoryTwoColumn(cats []config.Category, cursor, modal
 		return m.renderCategoryCompact(cats, cursor, modalWidth, bodyHeight)
 	}
 
-	listRows := bodyHeight - 4
-	if listRows < 1 {
-		listRows = 1
-	}
-	listContent := renderCategoryListViewport(cats, cursor, m.catMgrEditing, listRows, leftWidth-4)
-	listBox := lipgloss.NewStyle().
+	listBoxStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(colors.Gray).
 		Width(leftWidth).
-		Padding(1, 1).
-		Render(listContent)
+		Padding(1, 1)
+
+	listRows := bodyHeight - listBoxStyle.GetVerticalFrameSize()
+	if listRows < 1 {
+		listRows = 1
+	}
+	listContent := renderCategoryListViewport(cats, cursor, m.catMgrEditing, listRows, leftWidth-listBoxStyle.GetHorizontalFrameSize())
+	listBox := listBoxStyle.Render(listContent)
 
 	if m.catMgrEditing {
 		m.updateCategoryInputWidthsForViewport()
 	}
 
-	rightRows := bodyHeight - 2
+	rightBoxStyle := lipgloss.NewStyle().
+		Width(rightWidth).
+		Padding(1, 2)
+
+	rightRows := bodyHeight - rightBoxStyle.GetVerticalFrameSize()
 	if rightRows < 1 {
 		rightRows = 1
 	}
 
 	var rightContent string
 	if m.catMgrEditing {
-		rightContent = m.renderCategoryEditView(rightWidth-4, rightRows)
+		rightContent = m.renderCategoryEditView(rightWidth-rightBoxStyle.GetHorizontalFrameSize(), rightRows)
 	} else {
-		rightContent = m.renderCategoryDetailView(cats, cursor, rightWidth-4, rightRows)
+		rightContent = m.renderCategoryDetailView(cats, cursor, rightWidth-rightBoxStyle.GetHorizontalFrameSize(), rightRows)
 	}
 
-	rightBox := lipgloss.NewStyle().
-		Width(rightWidth).
-		Padding(1, 2).
-		Render(rightContent)
+	rightBox := rightBoxStyle.Render(rightContent)
 
 	dividerHeight := max(lipgloss.Height(listBox), lipgloss.Height(rightBox))
 	if dividerHeight < 1 {
@@ -360,11 +365,11 @@ func (m RootModel) renderCategoryTwoColumn(cats []config.Category, cursor, modal
 		Render(strings.Repeat("│\n", dividerHeight-1) + "│")
 
 	content := lipgloss.JoinHorizontal(lipgloss.Top, listBox, divider, rightBox)
-	return formatSettingsBlock(content, modalWidth-2, bodyHeight)
+	return formatSettingsBlock(content, modalWidth-BoxStyle.GetHorizontalFrameSize(), bodyHeight)
 }
 
 func (m RootModel) renderCategoryCompact(cats []config.Category, cursor, modalWidth, bodyHeight int) string {
-	innerWidth := modalWidth - 2
+	innerWidth := modalWidth - BoxStyle.GetHorizontalFrameSize()
 	if innerWidth < 1 {
 		innerWidth = 1
 	}
@@ -378,7 +383,7 @@ func (m RootModel) renderCategoryCompact(cats []config.Category, cursor, modalWi
 		listRows = 1
 	}
 
-	detailRows := bodyHeight - listRows - 1
+	detailRows := bodyHeight - listRows - LayoutGapStyle.GetVerticalFrameSize()
 	if detailRows < 1 {
 		detailRows = 1
 		listRows = bodyHeight - detailRows

--- a/internal/tui/view_category.go
+++ b/internal/tui/view_category.go
@@ -299,9 +299,9 @@ func (m RootModel) renderCategoryEditView(innerWidth, rows int) string {
 func (m RootModel) renderCategoryTwoColumn(cats []config.Category, cursor, modalWidth, bodyHeight int) string {
 	leftWidth := 28
 	minRightWidth := 24
-	
+
 	horizontalPadding := ModalPaddingStyle.GetHorizontalFrameSize() * 2
-	
+
 	if modalWidth-leftWidth-horizontalPadding < minRightWidth {
 		leftWidth = modalWidth - minRightWidth - horizontalPadding
 	}

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -292,7 +292,7 @@ func renderSettingsListViewport(settingsMeta []config.SettingMeta, selectedRow, 
 		if maxLabelLen < 0 {
 			maxLabelLen = 0
 		}
-		
+
 		// Truncate to avoid line wrapping which breaks parent height constraints
 		if len(label) > maxLabelLen {
 			if maxLabelLen > 3 {
@@ -368,9 +368,9 @@ func (m RootModel) renderSettingsDetailBlock(settingsMeta []config.SettingMeta, 
 func (m RootModel) renderSettingsTwoColumn(settingsMeta []config.SettingMeta, selectedRow int, settingsValues map[string]interface{}, modalWidth, bodyHeight int) string {
 	leftWidth := 32
 	minRightWidth := 22
-	
+
 	horizontalPadding := ModalPaddingStyle.GetHorizontalFrameSize() * 2
-	
+
 	if modalWidth-leftWidth-horizontalPadding < minRightWidth {
 		leftWidth = modalWidth - minRightWidth - horizontalPadding
 	}
@@ -511,7 +511,7 @@ func (m *RootModel) updateSettingsInputWidthForViewport() {
 		leftWidth := 32
 		minRightWidth := 22
 		horizontalPadding := ModalPaddingStyle.GetHorizontalFrameSize() * 2
-		
+
 		if modalWidth-leftWidth-horizontalPadding < minRightWidth {
 			leftWidth = modalWidth - minRightWidth - horizontalPadding
 		}

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -287,7 +287,22 @@ func renderSettingsListViewport(settingsMeta []config.SettingMeta, selectedRow, 
 			}
 		}
 
-		lines = append(lines, style.Width(innerWidth).MaxWidth(innerWidth).Render(prefix+meta.Label))
+		label := meta.Label
+		maxLabelLen := innerWidth - len(prefix)
+		if maxLabelLen < 0 {
+			maxLabelLen = 0
+		}
+		
+		// Truncate to avoid line wrapping which breaks parent height constraints
+		if len(label) > maxLabelLen {
+			if maxLabelLen > 3 {
+				label = label[:maxLabelLen-3] + "..."
+			} else {
+				label = label[:maxLabelLen]
+			}
+		}
+
+		lines = append(lines, style.Width(innerWidth).MaxWidth(innerWidth).Render(prefix+label))
 	}
 
 	return strings.Join(lines, "\n")

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -523,37 +523,42 @@ func (m *RootModel) updateSettingsInputWidthForViewport() {
 func (m RootModel) getSettingsValues(category string) map[string]interface{} {
 	values := make(map[string]interface{})
 
-	switch category {
-	case "General":
-		values["default_download_dir"] = m.Settings.General.DefaultDownloadDir
-		values["warn_on_duplicate"] = m.Settings.General.WarnOnDuplicate
-		values["download_complete_notification"] = m.Settings.General.DownloadCompleteNotification
-		values["allow_remote_open_actions"] = m.Settings.General.AllowRemoteOpenActions
-		values["extension_prompt"] = m.Settings.General.ExtensionPrompt
-		values["auto_resume"] = m.Settings.General.AutoResume
-		values["skip_update_check"] = m.Settings.General.SkipUpdateCheck
+	val := reflect.ValueOf(m.Settings).Elem()
+	typ := val.Type()
 
-		values["clipboard_monitor"] = m.Settings.General.ClipboardMonitor
-		values["theme"] = m.Settings.General.Theme
-		values["log_retention_count"] = m.Settings.General.LogRetentionCount
+	var catVal reflect.Value
+	var found bool
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		label := field.Tag.Get("ui_label")
+		if label == "" {
+			label = field.Name
+		}
+		if label == category {
+			catVal = val.Field(i)
+			found = true
+			break
+		}
+	}
 
-	case "Network":
-		values["max_connections_per_host"] = m.Settings.Network.MaxConnectionsPerHost
+	if !found {
+		return values
+	}
 
-		values["max_concurrent_downloads"] = m.Settings.Network.MaxConcurrentDownloads
-		values["user_agent"] = m.Settings.Network.UserAgent
-		values["proxy_url"] = m.Settings.Network.ProxyURL
-		values["sequential_download"] = m.Settings.Network.SequentialDownload
-		values["min_chunk_size"] = m.Settings.Network.MinChunkSize
-		values["worker_buffer_size"] = m.Settings.Network.WorkerBufferSize
-	case "Performance":
-		values["max_task_retries"] = m.Settings.Performance.MaxTaskRetries
-		values["slow_worker_threshold"] = m.Settings.Performance.SlowWorkerThreshold
-		values["slow_worker_grace_period"] = m.Settings.Performance.SlowWorkerGracePeriod
-		values["stall_timeout"] = m.Settings.Performance.StallTimeout
-		values["speed_ema_alpha"] = m.Settings.Performance.SpeedEmaAlpha
-	case "Categories":
-		values["category_enabled"] = m.Settings.General.CategoryEnabled
+	if catVal.Kind() == reflect.Struct {
+		catTyp := catVal.Type()
+		for i := 0; i < catTyp.NumField(); i++ {
+			field := catTyp.Field(i)
+			if field.Tag.Get("ui_ignored") == "true" {
+				continue
+			}
+
+			key := field.Tag.Get("json")
+			if key == "" {
+				key = field.Name
+			}
+			values[key] = catVal.Field(i).Interface()
+		}
 	}
 
 	return values
@@ -561,30 +566,114 @@ func (m RootModel) getSettingsValues(category string) map[string]interface{} {
 
 // setSettingValue sets a setting value from string input
 func (m *RootModel) setSettingValue(category, key, value string) error {
-	metadata := config.GetSettingsMetadata()
-	metas := metadata[category]
+	val := reflect.ValueOf(m.Settings).Elem()
+	typ := val.Type()
 
-	var meta config.SettingMeta
-	for _, sm := range metas {
-		if sm.Key == key {
-			meta = sm
+	var catVal reflect.Value
+	var foundCat bool
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		label := field.Tag.Get("ui_label")
+		if label == "" {
+			label = field.Name
+		}
+		if label == category {
+			catVal = val.Field(i)
+			foundCat = true
 			break
 		}
 	}
 
-	switch category {
-	case "General":
-		return m.setGeneralSetting(key, value, meta.Type)
-	case "Network":
-		return m.setNetworkSetting(key, value, meta.Type)
-	case "Performance":
-		return m.setPerformanceSetting(key, value, meta.Type)
-	case "Categories":
-		if key == "category_enabled" {
-			m.Settings.General.CategoryEnabled = !m.Settings.General.CategoryEnabled
-		}
+	if !foundCat || catVal.Kind() != reflect.Struct {
+		return nil
 	}
 
+	catTyp := catVal.Type()
+	for i := 0; i < catTyp.NumField(); i++ {
+		field := catTyp.Field(i)
+		if field.Tag.Get("ui_ignored") == "true" {
+			continue
+		}
+
+		fieldKey := field.Tag.Get("json")
+		if fieldKey == "" {
+			fieldKey = field.Name
+		}
+
+		if fieldKey == key {
+			targetField := catVal.Field(i)
+			if !targetField.CanSet() {
+				return nil
+			}
+
+			// Special logic for Theme to trigger app re-rendering internally
+			if key == "theme" {
+				var theme int
+				valLower := strings.ToLower(value)
+				switch valLower {
+				case "system", "adaptive", "0":
+					theme = config.ThemeAdaptive
+				case "light", "1":
+					theme = config.ThemeLight
+				case "dark", "2":
+					theme = config.ThemeDark
+				default:
+					if v, err := strconv.Atoi(value); err == nil && v >= 0 && v <= 2 {
+						theme = v
+					} else {
+						return nil // Invalid
+					}
+				}
+				targetField.Set(reflect.ValueOf(theme))
+				m.ApplyTheme(theme)
+				return nil
+			}
+
+			// Generic Parsing and Application
+			switch targetField.Kind() {
+			case reflect.Bool:
+				// Typically toggled unless explicitly typed out
+				if value == "" {
+					targetField.SetBool(!targetField.Bool())
+				} else {
+					b, _ := strconv.ParseBool(value)
+					targetField.SetBool(b)
+				}
+			case reflect.String:
+				targetField.SetString(value)
+			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32:
+				if v, err := strconv.Atoi(value); err == nil {
+					targetField.SetInt(int64(v))
+				}
+			case reflect.Int64:
+				if targetField.Type().String() == "time.Duration" {
+					if _, err := strconv.ParseFloat(value, 64); err == nil {
+						value += "s"
+					}
+					if v, err := time.ParseDuration(value); err == nil {
+						targetField.Set(reflect.ValueOf(v))
+					}
+				} else {
+					// Handle KB/MB scaling gracefully if specified
+					if key == "min_chunk_size" {
+						if v, err := strconv.ParseFloat(value, 64); err == nil {
+							targetField.SetInt(int64(v * float64(config.MB)))
+						}
+					} else {
+						if v, err := strconv.ParseInt(value, 10, 64); err == nil {
+							targetField.SetInt(v)
+						}
+					}
+				}
+			case reflect.Float32, reflect.Float64:
+				if v, err := strconv.ParseFloat(value, 64); err == nil {
+					targetField.SetFloat(v)
+				}
+			}
+
+			return nil
+		}
+	}
 	return nil
 }
 
@@ -599,147 +688,6 @@ func (m *RootModel) persistSettings() error {
 	}
 	if m.Orchestrator != nil {
 		m.Orchestrator.ApplySettings(m.Settings)
-	}
-	return nil
-}
-
-func (m *RootModel) setGeneralSetting(key, value, typ string) error {
-	switch key {
-	case "default_download_dir":
-		m.Settings.General.DefaultDownloadDir = value
-	case "warn_on_duplicate":
-		m.Settings.General.WarnOnDuplicate = !m.Settings.General.WarnOnDuplicate
-	case "allow_remote_open_actions":
-		m.Settings.General.AllowRemoteOpenActions = !m.Settings.General.AllowRemoteOpenActions
-	case "extension_prompt":
-		m.Settings.General.ExtensionPrompt = !m.Settings.General.ExtensionPrompt
-	case "auto_resume":
-		m.Settings.General.AutoResume = !m.Settings.General.AutoResume
-	case "skip_update_check":
-		m.Settings.General.SkipUpdateCheck = !m.Settings.General.SkipUpdateCheck
-	case "clipboard_monitor":
-		m.Settings.General.ClipboardMonitor = !m.Settings.General.ClipboardMonitor
-
-	case "theme":
-		var theme int
-		valLower := strings.ToLower(value)
-		switch valLower {
-		case "system", "adaptive", "0":
-			theme = config.ThemeAdaptive
-		case "light", "1":
-			theme = config.ThemeLight
-		case "dark", "2":
-			theme = config.ThemeDark
-		default:
-			// Try parsing as int fallback
-			if v, err := strconv.Atoi(value); err == nil {
-				if v >= 0 && v <= 2 {
-					theme = v
-				} else {
-					return nil // Invalid range
-				}
-			} else {
-				return nil // Invalid value
-			}
-		}
-		m.Settings.General.Theme = theme
-		m.ApplyTheme(theme)
-	case "log_retention_count":
-		if v, err := strconv.Atoi(value); err == nil {
-			if v < 0 {
-				v = 0 // Minimum valid value
-			}
-			m.Settings.General.LogRetentionCount = v
-		}
-	}
-	return nil
-}
-
-func (m *RootModel) setNetworkSetting(key, value, typ string) error {
-	switch key {
-	case "max_connections_per_host":
-		if v, err := strconv.Atoi(value); err == nil {
-			m.Settings.Network.MaxConnectionsPerHost = v
-		}
-
-	case "max_concurrent_downloads":
-		if v, err := strconv.Atoi(value); err == nil {
-			if v < 1 {
-				v = 1
-			} else if v > 10 {
-				v = 10
-			}
-			m.Settings.Network.MaxConcurrentDownloads = v
-		}
-	case "user_agent":
-		m.Settings.Network.UserAgent = value
-	case "proxy_url":
-		m.Settings.Network.ProxyURL = value
-	case "sequential_download":
-		// Toggle logic handled by generic bool toggle in Update, but just in case
-		if value == "" {
-			m.Settings.Network.SequentialDownload = !m.Settings.Network.SequentialDownload
-		} else {
-			// For programmatic setting if ever needed
-			b, _ := strconv.ParseBool(value)
-			m.Settings.Network.SequentialDownload = b
-		}
-	case "min_chunk_size":
-		// Parse as MB and convert to bytes
-		if v, err := strconv.ParseFloat(value, 64); err == nil {
-			m.Settings.Network.MinChunkSize = int64(v * float64(config.MB))
-		}
-	case "worker_buffer_size":
-		// Keep buffer in KB
-		if v, err := strconv.ParseFloat(value, 64); err == nil {
-			m.Settings.Network.WorkerBufferSize = int(v * float64(config.KB))
-		}
-	}
-	return nil
-}
-
-func (m *RootModel) setPerformanceSetting(key, value, typ string) error {
-	switch key {
-	case "max_task_retries":
-		if v, err := strconv.Atoi(value); err == nil {
-			m.Settings.Performance.MaxTaskRetries = v
-		}
-	case "slow_worker_threshold":
-		if v, err := strconv.ParseFloat(value, 64); err == nil {
-			// Clamp to valid range 0.0-1.0
-			if v < 0.0 {
-				v = 0.0
-			} else if v > 1.0 {
-				v = 1.0
-			}
-			m.Settings.Performance.SlowWorkerThreshold = v
-		}
-	case "slow_worker_grace_period":
-		// Check if it's just a number, if so add "s"
-		if _, err := strconv.ParseFloat(value, 64); err == nil {
-			value += "s"
-		}
-		if v, err := time.ParseDuration(value); err == nil {
-			m.Settings.Performance.SlowWorkerGracePeriod = v
-		}
-	case "stall_timeout":
-		// Check if it's just a number, if so add "s"
-		if _, err := strconv.ParseFloat(value, 64); err == nil {
-			value += "s"
-		}
-		if v, err := time.ParseDuration(value); err == nil {
-			m.Settings.Performance.StallTimeout = v
-		}
-	case "speed_ema_alpha":
-		if v, err := strconv.ParseFloat(value, 64); err == nil {
-			// Clamp to valid range 0.0-1.0
-			if v < 0.0 {
-				v = 0.0
-			} else if v > 1.0 {
-				v = 1.0
-			}
-			m.Settings.Performance.SpeedEmaAlpha = v
-		}
 	}
 	return nil
 }
@@ -966,7 +914,7 @@ func (m *RootModel) resetSettingToDefault(category, key string, defaults *config
 	case "Categories":
 		switch key {
 		case "category_enabled":
-			m.Settings.General.CategoryEnabled = defaults.General.CategoryEnabled
+			m.Settings.Categories.CategoryEnabled = defaults.Categories.CategoryEnabled
 		}
 	}
 }

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -406,15 +406,13 @@ func (m RootModel) renderSettingsTwoColumn(settingsMeta []config.SettingMeta, se
 		m.updateSettingsInputWidthForViewport()
 	}
 
-	rightRows := bodyHeight - 2
+	rightBoxStyle := lipgloss.NewStyle().Width(rightWidth).Padding(1, 2)
+	rightRows := bodyHeight - rightBoxStyle.GetVerticalFrameSize()
 	if rightRows < 1 {
 		rightRows = 1
 	}
-	rightContent := m.renderSettingsDetailBlock(settingsMeta, selectedRow, settingsValues, rightWidth-4, rightRows)
-	rightBox := lipgloss.NewStyle().
-		Width(rightWidth).
-		Padding(1, 2).
-		Render(rightContent)
+	rightContent := m.renderSettingsDetailBlock(settingsMeta, selectedRow, settingsValues, rightWidth-rightBoxStyle.GetHorizontalFrameSize(), rightRows)
+	rightBox := rightBoxStyle.Render(rightContent)
 
 	dividerHeight := max(lipgloss.Height(listBox), lipgloss.Height(rightBox))
 	if dividerHeight < 1 {

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -72,10 +72,10 @@ func (m RootModel) viewSettings() string {
 	tabBar := m.renderSettingsTabBar(categories, activeTab, width-6)
 	helpText := m.renderSettingsHelp(width - 6)
 
-	innerHeight := height - 2
+	innerHeight := height - BoxStyle.GetVerticalFrameSize()
 	tabBarHeight := lipgloss.Height(tabBar)
 	helpHeight := lipgloss.Height(helpText)
-	bodyHeight := innerHeight - tabBarHeight - helpHeight - 2 // one line gap above body and help
+	bodyHeight := innerHeight - tabBarHeight - helpHeight - (LayoutGapStyle.GetVerticalFrameSize() * 2) // one line gap above body and help
 	if bodyHeight < 3 {
 		bodyHeight = 3
 	}
@@ -88,7 +88,7 @@ func (m RootModel) viewSettings() string {
 	}
 
 	contentHeight := lipgloss.Height(content)
-	usedHeight := tabBarHeight + 1 + contentHeight + 1 + helpHeight
+	usedHeight := tabBarHeight + LayoutGapStyle.GetVerticalFrameSize() + contentHeight + LayoutGapStyle.GetVerticalFrameSize() + helpHeight
 	paddingLines := innerHeight - usedHeight
 	if paddingLines < 0 {
 		paddingLines = 0
@@ -117,11 +117,11 @@ func settingsModalDimensions(termWidth, termHeight int) (int, int) {
 	}
 	height := 24
 
-	maxWidth := termWidth - 4
+	maxWidth := termWidth - (WindowStyle.GetHorizontalFrameSize() * 2)
 	if maxWidth < 1 {
 		maxWidth = 1
 	}
-	maxHeight := termHeight - 4
+	maxHeight := termHeight - (WindowStyle.GetVerticalFrameSize() * 2) - 4 // fallback padding
 	if maxHeight < 1 {
 		maxHeight = 1
 	}
@@ -353,18 +353,21 @@ func (m RootModel) renderSettingsDetailBlock(settingsMeta []config.SettingMeta, 
 func (m RootModel) renderSettingsTwoColumn(settingsMeta []config.SettingMeta, selectedRow int, settingsValues map[string]interface{}, modalWidth, bodyHeight int) string {
 	leftWidth := 32
 	minRightWidth := 22
-	if modalWidth-leftWidth-8 < minRightWidth {
-		leftWidth = modalWidth - minRightWidth - 8
+	
+	horizontalPadding := ModalPaddingStyle.GetHorizontalFrameSize() * 2
+	
+	if modalWidth-leftWidth-horizontalPadding < minRightWidth {
+		leftWidth = modalWidth - minRightWidth - horizontalPadding
 	}
 	if leftWidth < 16 {
 		leftWidth = 16
 	}
 
-	rightWidth := modalWidth - leftWidth - 8
+	rightWidth := modalWidth - leftWidth - horizontalPadding
 	if rightWidth < minRightWidth {
 		rightWidth = minRightWidth
-		if modalWidth-rightWidth-8 > 16 {
-			leftWidth = modalWidth - rightWidth - 8
+		if modalWidth-rightWidth-horizontalPadding > 16 {
+			leftWidth = modalWidth - rightWidth - horizontalPadding
 		}
 	}
 
@@ -372,11 +375,11 @@ func (m RootModel) renderSettingsTwoColumn(settingsMeta []config.SettingMeta, se
 		return m.renderSettingsCompact(settingsMeta, selectedRow, settingsValues, modalWidth, bodyHeight)
 	}
 
-	listRows := bodyHeight - 4
+	listRows := bodyHeight - (BoxStyle.GetVerticalFrameSize() * 2)
 	if listRows < 1 {
 		listRows = 1
 	}
-	listContent := renderSettingsListViewport(settingsMeta, selectedRow, listRows, leftWidth-4)
+	listContent := renderSettingsListViewport(settingsMeta, selectedRow, listRows, leftWidth-(BoxStyle.GetHorizontalFrameSize()*2))
 	listBox := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(colors.Gray).
@@ -407,11 +410,11 @@ func (m RootModel) renderSettingsTwoColumn(settingsMeta []config.SettingMeta, se
 		Render(strings.Repeat("│\n", dividerHeight-1) + "│")
 
 	content := lipgloss.JoinHorizontal(lipgloss.Top, listBox, divider, rightBox)
-	return formatSettingsBlock(content, modalWidth-2, bodyHeight)
+	return formatSettingsBlock(content, modalWidth-BoxStyle.GetHorizontalFrameSize(), bodyHeight)
 }
 
 func (m RootModel) renderSettingsCompact(settingsMeta []config.SettingMeta, selectedRow int, settingsValues map[string]interface{}, modalWidth, bodyHeight int) string {
-	innerWidth := modalWidth - 2
+	innerWidth := modalWidth - BoxStyle.GetHorizontalFrameSize()
 	if innerWidth < 1 {
 		innerWidth = 1
 	}
@@ -425,7 +428,7 @@ func (m RootModel) renderSettingsCompact(settingsMeta []config.SettingMeta, sele
 		listRows = 1
 	}
 
-	detailRows := bodyHeight - listRows - 1
+	detailRows := bodyHeight - listRows - LayoutGapStyle.GetVerticalFrameSize()
 	if detailRows < 1 {
 		detailRows = 1
 		listRows = bodyHeight - detailRows
@@ -492,13 +495,15 @@ func (m *RootModel) updateSettingsInputWidthForViewport() {
 	if modalWidth >= 72 {
 		leftWidth := 32
 		minRightWidth := 22
-		if modalWidth-leftWidth-8 < minRightWidth {
-			leftWidth = modalWidth - minRightWidth - 8
+		horizontalPadding := ModalPaddingStyle.GetHorizontalFrameSize() * 2
+		
+		if modalWidth-leftWidth-horizontalPadding < minRightWidth {
+			leftWidth = modalWidth - minRightWidth - horizontalPadding
 		}
 		if leftWidth < 16 {
 			leftWidth = 16
 		}
-		rightWidth := modalWidth - leftWidth - 8
+		rightWidth := modalWidth - leftWidth - horizontalPadding
 		targetWidth = rightWidth - 10
 	} else {
 		targetWidth = modalWidth - 16

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -299,12 +299,12 @@ func TestView_CategoryManagerNoLineExceedsTerminalWidth(t *testing.T) {
 
 func TestView_CategoryManagerResizeSequenceKeepsSelectedVisible(t *testing.T) {
 	settings := config.DefaultSettings()
-	if len(settings.General.Categories) == 0 {
+	if len(settings.Categories.Categories) == 0 {
 		t.Fatal("expected default categories")
 	}
 
-	selectedCursor := len(settings.General.Categories) - 1
-	selectedLabel := settings.General.Categories[selectedCursor].Name
+	selectedCursor := len(settings.Categories.Categories) - 1
+	selectedLabel := settings.Categories.Categories[selectedCursor].Name
 
 	m := InitialRootModel(1701, "test-version", nil, processing.NewLifecycleManager(nil, nil), false)
 	m.state = CategoryManagerState


### PR DESCRIPTION
- **refactor: centralize TUI layout calculations using dynamic lipgloss frame size helpers**
- **refactor: move category-related settings into a dedicated Categories struct within Settings**
- **fix: truncate long labels in settings view to prevent layout breakage**

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the TUI to replace magic numeric offsets with `lipgloss` frame-size helpers for dynamic layout calculations, and splits category-related settings (`CategoryEnabled`, `Categories`) out of `GeneralSettings` into a new top-level `CategorySettings` struct. It also adds label truncation to the settings list view to prevent layout overflow.

- **Breaking settings migration**: Moving `CategoryEnabled`/`Categories` from JSON key `"general"` to a new top-level key `"categories"` means any existing `settings.json` that had category sorting enabled will silently reset to defaults (`CategoryEnabled = false`, `Categories = DefaultCategories()`) on next launch — no migration path is provided.
- The label-truncation fix in `view_settings.go` uses `len()` (byte count) rather than `lipgloss.Width()` (display columns) for prefix and label measurement, causing the selected-row label to truncate slightly earlier than necessary.

<h3>Confidence Score: 4/5</h3>

Safe to merge with awareness of the settings migration break; the layout refactor and struct split are otherwise correct.

One P1 finding: moving CategorySettings to a new JSON top-level key with no migration silently drops existing users' category configuration on upgrade. All other changes (lipgloss frame-size helpers, label truncation) are functionally equivalent to what they replace and are well-tested.

internal/config/settings.go — backward-incompatible JSON key change with no migration path

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. The refactor touches only UI layout, settings struct organization, and JSON serialization — no authentication, network, or input-validation paths are changed.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/config/settings.go | Introduces CategorySettings struct split from GeneralSettings; backward-incompatible JSON key change silently drops existing user category config on upgrade |
| internal/tui/view_settings.go | New label truncation uses byte-length comparisons instead of display-width; all current labels are ASCII so no crash today, but selected-row prefix byte/rune mismatch causes premature truncation |
| internal/tui/components/box.go | Replaces magic literal -1 with lipgloss.Width(horizontal) in remaining-width calculations; semantically equivalent and more self-documenting |
| internal/tui/components/confirmation_modal.go | Replaces magic offsets (-4, -2, -10, -1) with lipgloss frame-size helpers; all values are equivalent to the originals |
| internal/processing/file_utils.go | Updated to reference settings.Categories instead of settings.General for CategoryEnabled/Categories; logic is unchanged |
| internal/config/settings_test.go | Adds tests for CategoryOrder count (4), empty-categories round-trip, and metadata coverage; thorough coverage of new CategorySettings struct |
| docs/SETTINGS.md | Documents the new top-level categories section with category_enabled; accurate and consistent with the new struct layout |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[settings.json on disk] -->|LoadSettings| B{Top-level key present?}
    B -->|Old format: general.category_enabled| C[GeneralSettings - field removed, silently ignored]
    B -->|New format: categories.category_enabled| D[CategorySettings.CategoryEnabled OK]
    C --> E[CategorySettings falls back to defaults, CategoryEnabled=false]
    D --> F[Category routing works correctly]
    E -->|User impact| G[Category sorting silently disabled, Custom categories lost]

    subgraph NewStruct[Refactored Settings Struct]
        H[Settings]
        H --> I[GeneralSettings - json: general]
        H --> J[NetworkSettings - json: network]
        H --> K[PerformanceSettings - json: performance]
        H --> L[CategorySettings NEW - json: categories]
        L --> M[CategoryEnabled bool]
        L --> N[Categories slice]
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `internal/config/settings.go`, line 223-243 ([link](https://github.com/surgedm/surge/blob/b961496240ff5b30a80b10db7344ccedbbbec5d4/internal/config/settings.go#L223-L243)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Silent data loss for users with existing category settings**

   Moving `category_enabled` and `categories` from the `"general"` JSON key to a new top-level `"categories"` key is a breaking schema change. `LoadSettings()` initialises from `DefaultSettings()` (which resets `CategoryEnabled` to `false` and `Categories` to `DefaultCategories()`) and then unmarshals the stored JSON on top. Any existing file that contains `"general": {"category_enabled": true, "categories": [...]}` will have no `"categories"` top-level key, so the unmarshal leaves those fields at their defaults — silently discarding the user's configuration.

   A one-time migration in `LoadSettings()` would prevent data loss, for example:

   ```go
   // After unmarshaling, migrate legacy general.category_enabled / general.categories
   type legacySettings struct {
       General struct {
           CategoryEnabled bool       `json:"category_enabled"`
           Categories      []Category `json:"categories"`
       } `json:"general"`
   }
   var legacy legacySettings
   if json.Unmarshal(data, &legacy) == nil && (legacy.General.CategoryEnabled || len(legacy.General.Categories) > 0) {
       settings.Categories.CategoryEnabled = legacy.General.CategoryEnabled
       if len(legacy.General.Categories) > 0 {
           settings.Categories.Categories = legacy.General.Categories
       }
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/config/settings.go
   Line: 223-243

   Comment:
   **Silent data loss for users with existing category settings**

   Moving `category_enabled` and `categories` from the `"general"` JSON key to a new top-level `"categories"` key is a breaking schema change. `LoadSettings()` initialises from `DefaultSettings()` (which resets `CategoryEnabled` to `false` and `Categories` to `DefaultCategories()`) and then unmarshals the stored JSON on top. Any existing file that contains `"general": {"category_enabled": true, "categories": [...]}` will have no `"categories"` top-level key, so the unmarshal leaves those fields at their defaults — silently discarding the user's configuration.

   A one-time migration in `LoadSettings()` would prevent data loss, for example:

   ```go
   // After unmarshaling, migrate legacy general.category_enabled / general.categories
   type legacySettings struct {
       General struct {
           CategoryEnabled bool       `json:"category_enabled"`
           Categories      []Category `json:"categories"`
       } `json:"general"`
   }
   var legacy legacySettings
   if json.Unmarshal(data, &legacy) == nil && (legacy.General.CategoryEnabled || len(legacy.General.Categories) > 0) {
       settings.Categories.CategoryEnabled = legacy.General.CategoryEnabled
       if len(legacy.General.Categories) > 0 {
           settings.Categories.Categories = legacy.General.Categories
       }
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `docs/SETTINGS.md`, line 14-29 ([link](https://github.com/surgedm/surge/blob/b961496240ff5b30a80b10db7344ccedbbbec5d4/docs/SETTINGS.md#L14-L29)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`docs/SETTINGS.md` not updated for new `categories` section**

   The documented example JSON still shows only `general`, `network`, and `performance`. After this PR, category settings live under a top-level `"categories"` key and the guide omits that section entirely, leaving users with no reference for the new structure.

   The example should be updated to:

   ```json
   {
     "general": { ... },
     "network": { ... },
     "performance": { ... },
     "categories": {
       "category_enabled": true
     }
   }
   ```

   A new **Category Settings** table should also be added documenting `category_enabled` (the only user-editable key in that section).

   **Context Used:** docs/SETTINGS.md ([source](https://app.greptile.com/review/custom-context?memory=c9c02a40-4d2f-4e1b-8b2c-d98b2c265e1f))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: docs/SETTINGS.md
   Line: 14-29
   
   Comment:
   **`docs/SETTINGS.md` not updated for new `categories` section**
   
   The documented example JSON still shows only `general`, `network`, and `performance`. After this PR, category settings live under a top-level `"categories"` key and the guide omits that section entirely, leaving users with no reference for the new structure.
   
   The example should be updated to:
   
   ```json
   {
     "general": { ... },
     "network": { ... },
     "performance": { ... },
     "categories": {
       "category_enabled": true
     }
   }
   ```
   
   A new **Category Settings** table should also be added documenting `category_enabled` (the only user-editable key in that section).
   
   **Context Used:** docs/SETTINGS.md ([source](https://app.greptile.com/review/custom-context?memory=c9c02a40-4d2f-4e1b-8b2c-d98b2c265e1f))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

3. `internal/tui/view_settings.go`, line 393-413 ([link](https://github.com/surgedm/surge/blob/b961496240ff5b30a80b10db7344ccedbbbec5d4/internal/tui/view_settings.go#L393-L413)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Remaining hardcoded layout constants inconsistent with PR goals**

   `renderSettingsTwoColumn` still hardcodes two offsets that were explicitly the target of this refactor:

   - `rightRows := bodyHeight - 2` — the `rightBox` style is `Padding(1, 2)` (vertical frame = 2), so this should use the style's `GetVerticalFrameSize()`.
   - `rightContent := m.renderSettingsDetailBlock(..., rightWidth-4, ...)` — the same `Padding(1, 2)` gives a horizontal frame of 4, so `GetHorizontalFrameSize()` would be clearer.

   Suggested approach:

   ```go
   rightBoxStyle := lipgloss.NewStyle().Width(rightWidth).Padding(1, 2)
   rightRows := bodyHeight - rightBoxStyle.GetVerticalFrameSize()
   if rightRows < 1 {
       rightRows = 1
   }
   rightContent := m.renderSettingsDetailBlock(
       settingsMeta, selectedRow, settingsValues,
       rightWidth-rightBoxStyle.GetHorizontalFrameSize(), rightRows)
   rightBox := rightBoxStyle.Render(rightContent)
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/tui/view_settings.go
   Line: 393-413

   Comment:
   **Remaining hardcoded layout constants inconsistent with PR goals**

   `renderSettingsTwoColumn` still hardcodes two offsets that were explicitly the target of this refactor:

   - `rightRows := bodyHeight - 2` — the `rightBox` style is `Padding(1, 2)` (vertical frame = 2), so this should use the style's `GetVerticalFrameSize()`.
   - `rightContent := m.renderSettingsDetailBlock(..., rightWidth-4, ...)` — the same `Padding(1, 2)` gives a horizontal frame of 4, so `GetHorizontalFrameSize()` would be clearer.

   Suggested approach:

   ```go
   rightBoxStyle := lipgloss.NewStyle().Width(rightWidth).Padding(1, 2)
   rightRows := bodyHeight - rightBoxStyle.GetVerticalFrameSize()
   if rightRows < 1 {
       rightRows = 1
   }
   rightContent := m.renderSettingsDetailBlock(
       settingsMeta, selectedRow, settingsValues,
       rightWidth-rightBoxStyle.GetHorizontalFrameSize(), rightRows)
   rightBox := rightBoxStyle.Render(rightContent)
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/config/settings.go
Line: 43-46

Comment:
**Breaking backward compatibility — silent settings loss on upgrade**

Moving `CategoryEnabled` and `Categories` from `GeneralSettings` (JSON key `"general"`) to a new top-level `CategorySettings` (JSON key `"categories"`) breaks backward compatibility with every existing `settings.json`. On the next launch the Go JSON decoder ignores the old `"general"."category_enabled"` and `"general"."categories"` fields, and because there is no `"categories"` top-level key in the old file, `CategorySettings` falls back to its defaults: `CategoryEnabled = false` and `Categories = DefaultCategories()`.

Users who had category sorting enabled and custom categories defined will silently:
1. Have category routing disabled.
2. Lose all custom category rules, replaced by the defaults.

Consider adding a one-time migration in `LoadSettings` that reads the old field locations and promotes them to the new structure before the first save, similar to what many apps do with a schema-version field.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/tui/view_settings.go
Line: 291-305

Comment:
**Byte length used where display width is needed**

`len(prefix)` counts bytes, not terminal columns. The selected-row prefix `"▸ "` is `"▸"` (U+25B8, 3 bytes in UTF-8) + `" "` = 4 bytes but only 2 display columns, so `maxLabelLen` ends up 2 columns narrower than it should be — causing the label to truncate slightly earlier than necessary for the focused row.

Likewise, `len(label)` and `label[:maxLabelLen-3]` use byte indexing; if a future label contained a multibyte character at the cut point this would panic or produce garbled output.

```suggestion
		maxLabelLen := innerWidth - lipgloss.Width(prefix)
		if maxLabelLen < 0 {
			maxLabelLen = 0
		}

		// Truncate to avoid line wrapping which breaks parent height constraints
		if lipgloss.Width(label) > maxLabelLen {
			runes := []rune(label)
			if maxLabelLen > 3 {
				label = string(runes[:maxLabelLen-3]) + "..."
			} else {
				label = string(runes[:maxLabelLen])
			}
		}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["style: fix some inconsistent hardcoded v..."](https://github.com/surgedm/surge/commit/ff8212e595e6a456e72e999801e546b4d370bc2a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27766282)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->