### PR TITLE
add custom dns settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ uv.lock
 # analysis files
 speed_graph.png
 worker_speeds.png
-logs/
+*.log
 
 # Added by goreleaser init:
 dist/

--- a/cmd/root_downloads.go
+++ b/cmd/root_downloads.go
@@ -143,7 +143,7 @@ func resolveDownloadRequest(r *http.Request, defaultOutputDir string) (*resolved
 		return nil, err
 	}
 
-	utils.Debug("Received download request: URL=%s, Path=%s", req.URL, req.Path)
+	utils.Debug("Received download request: URL=%s, Path=%s, Headers=%v", req.URL, req.Path, req.Headers)
 
 	outPath := utils.EnsureAbsPath(resolveOutputDir(req.Path, req.RelativeToDefaultDir, defaultOutputDir, settings))
 	urlForAdd, mirrorsForAdd := normalizeDownloadTargets(req.URL, req.Mirrors)

--- a/extension-chrome/background.js
+++ b/extension-chrome/background.js
@@ -66,6 +66,47 @@ chrome.webRequest.onBeforeSendHeaders.addListener(
   ["requestHeaders", "extraHeaders"],
 );
 
+// === Redirect Chain Tracking ===
+// Maps original URL → final redirected URL so we can find captured headers
+// after a redirect chain (e.g. pixeldrain.com → cdn-1.pixeldrain.com)
+const redirectChains = new Map(); // Key: originalUrl, Value: { finalUrl, timestamp }
+const REDIRECT_EXPIRY_MS = 120000; // 2 minutes
+
+chrome.webRequest.onBeforeRedirect.addListener(
+  (details) => {
+    if (!details.url || !details.redirectUrl) return;
+
+    // Find the chain start (walk back through existing chains)
+    let originUrl = details.url;
+    for (const [original, data] of redirectChains) {
+      if (data.finalUrl === details.url) {
+        originUrl = original;
+        break;
+      }
+    }
+
+    redirectChains.set(originUrl, {
+      finalUrl: details.redirectUrl,
+      timestamp: Date.now(),
+    });
+
+    // Also capture headers for the redirect target if available
+    // (the onBeforeSendHeaders for the new request will fire separately,
+    // but we want to preserve the original headers too)
+
+    // Cleanup old chains
+    if (redirectChains.size > 500) {
+      const now = Date.now();
+      for (const [url, data] of redirectChains) {
+        if (now - data.timestamp > REDIRECT_EXPIRY_MS) {
+          redirectChains.delete(url);
+        }
+      }
+    }
+  },
+  { urls: ["<all_urls>"] },
+);
+
 function cleanupExpiredHeaders() {
   const now = Date.now();
   for (const [url, data] of capturedHeaders) {
@@ -86,6 +127,56 @@ function getCapturedHeaders(url) {
   }
 
   return data.headers;
+}
+
+// Resolve headers by walking the redirect chain.
+// Tries the exact URL first, then the final redirect target, then the original URL.
+function resolveHeadersForUrl(url) {
+  // Try direct match first
+  let headers = getCapturedHeaders(url);
+  if (headers) return headers;
+
+  // Try looking up this URL's redirect chain to find the final URL's headers
+  const chain = redirectChains.get(url);
+  if (chain) {
+    headers = getCapturedHeaders(chain.finalUrl);
+    if (headers) return headers;
+  }
+
+  // Try reverse: maybe 'url' is a final URL, find the original
+  for (const [original, data] of redirectChains) {
+    if (data.finalUrl === url) {
+      headers = getCapturedHeaders(original);
+      if (headers) return headers;
+    }
+  }
+
+  return null;
+}
+
+// Resolve the best download URL by checking for redirect chains.
+// Returns the final URL if a redirect was tracked, otherwise the original.
+function resolveDownloadUrl(url) {
+  const chain = redirectChains.get(url);
+  if (chain && Date.now() - chain.timestamp < REDIRECT_EXPIRY_MS) {
+    return chain.finalUrl;
+  }
+  return url;
+}
+
+// Read cookies for a URL directly from the browser's cookie store.
+// This is more reliable than onBeforeSendHeaders for download requests,
+// which Chrome routes through the download manager without exposing headers
+// to extensions via webRequest.
+async function getCookiesAsHeader(url) {
+  try {
+    const cookies = await chrome.cookies.getAll({ url });
+    if (!cookies || cookies.length === 0) return null;
+    return cookies.map((c) => `${c.name}=${c.value}`).join("; ");
+  } catch (e) {
+    console.log("[Surge] Failed to read cookies:", e.message);
+    return null;
+  }
 }
 
 async function loadAuthToken() {
@@ -435,11 +526,20 @@ async function sendToSurge(url, filename, absolutePath) {
       body.path = absolutePath;
     }
 
-    // Include captured headers for authenticated downloads
-    const headers = getCapturedHeaders(url);
-    if (headers) {
-      body.headers = headers;
-      console.log("[Surge] Forwarding captured headers to Surge");
+    // Build headers to forward to Surge.
+    // Primary: read cookies directly from browser storage (reliable for downloads).
+    // Fallback: use any headers captured via onBeforeSendHeaders.
+    const cookieString = await getCookiesAsHeader(url);
+    const capturedHdrs = resolveHeadersForUrl(url);
+
+    if (cookieString || capturedHdrs) {
+      const merged = Object.assign({}, capturedHdrs || {});
+      if (cookieString) {
+        // Cookies from the store take precedence over captured headers
+        merged["Cookie"] = cookieString;
+      }
+      body.headers = merged;
+      console.log("[Surge] Forwarding headers to Surge (cookie:", !!cookieString, "captured:", !!capturedHdrs, ")");
     }
 
     const auth = await authHeaders();
@@ -591,8 +691,13 @@ function isFreshDownload(downloadItem) {
 }
 
 function shouldSkipUrl(url) {
-  // Skip blob and data URLs
+  // Skip blob and data URLs - these exist only in browser memory and cannot
+  // be forwarded to an external downloader
   if (url.startsWith("blob:") || url.startsWith("data:")) {
+    console.log(
+      "[Surge] Skipping blob/data URL (browser-memory-only, cannot be forwarded):",
+      url.substring(0, 80),
+    );
     return true;
   }
 
@@ -642,69 +747,149 @@ function extractPathInfo(downloadItem) {
 }
 
 // === Download Interception ===
+// Uses onDeterminingFilename instead of onCreated to guarantee:
+// 1. Filename is fully resolved (Content-Disposition parsed)
+// 2. finalUrl is available (post-redirect)
+// 3. Download is paused, giving us time to intercept cleanly
 
 const processedIds = new Set();
 
-chrome.downloads.onCreated.addListener(async (downloadItem) => {
-  // Prevent duplicate events for the same download ID
-  if (processedIds.has(downloadItem.id)) {
-    return;
-  }
-
-  console.log(
-    "[Surge] Download created:",
-    downloadItem.url,
-    "filename:",
-    downloadItem.filename,
-    "state:",
-    downloadItem.state,
-  );
-
-  // Quick checks that can be done immediately
-  const enabled = await isInterceptEnabled();
-  if (!enabled) {
-    console.log("[Surge] Interception disabled");
-    return;
-  }
-
-  if (shouldSkipUrl(downloadItem.url)) {
-    console.log("[Surge] Skipping URL type");
-    return;
-  }
-
-  if (!isFreshDownload(downloadItem)) {
-    console.log("[Surge] Ignoring historical download");
-    return;
-  }
-
-  processedIds.add(downloadItem.id);
-  setTimeout(() => processedIds.delete(downloadItem.id), 120000);
-
-  await handleDownloadIntercept(downloadItem);
+// Must be registered synchronously at top level for MV3 service workers
+chrome.downloads.onDeterminingFilename.addListener((downloadItem, suggest) => {
+  // Return true to indicate we will call suggest() asynchronously
+  handleDeterminingFilename(downloadItem, suggest);
+  return true;
 });
 
-async function handleDownloadIntercept(downloadItem) {
-  // Check for duplicates (async - checks both time-based and Surge's download list)
-  if (await isDuplicateDownload(downloadItem.url)) {
-    // Cancel the browser download
+async function handleDeterminingFilename(downloadItem, suggest) {
+  // Default: let browser proceed normally with whatever filename it resolved
+  const allowBrowserDownload = () => {
     try {
-      await chrome.downloads.cancel(downloadItem.id);
-      await chrome.downloads.erase({ id: downloadItem.id });
+      suggest();
     } catch (e) {
-      console.log("[Surge] Error canceling duplicate:", e);
+      // suggest() may throw if download was already cancelled
+    }
+  };
+
+  try {
+    // Prevent duplicate events for the same download ID
+    if (processedIds.has(downloadItem.id)) {
+      allowBrowserDownload();
+      return;
     }
 
+    const enabled = await isInterceptEnabled();
+    if (!enabled) {
+      console.log("[Surge] Interception disabled");
+      allowBrowserDownload();
+      return;
+    }
+
+    // Use finalUrl (post-redirect) if available, otherwise fall back to url
+    const url = downloadItem.finalUrl || downloadItem.url;
+
+    if (shouldSkipUrl(url)) {
+      allowBrowserDownload();
+      return;
+    }
+
+    if (!isFreshDownload(downloadItem)) {
+      console.log("[Surge] Ignoring historical download");
+      allowBrowserDownload();
+      return;
+    }
+
+    // Fast pre-check using cached connection status to avoid a slow port scan
+    // in the critical window before cancel(). If we know Surge is offline, bail.
+    if (!isConnected) {
+      const healthy = await checkSurgeHealth();
+      if (!healthy) {
+        console.log("[Surge] Server not running, allowing browser download");
+        allowBrowserDownload();
+        return;
+      }
+    }
+
+    processedIds.add(downloadItem.id);
+    setTimeout(() => processedIds.delete(downloadItem.id), 120000);
+
+    // At this point, downloadItem.filename is the FINAL resolved filename
+    // from Content-Disposition or URL, already parsed by Chrome.
+    // This is the key advantage over onCreated.
+    const filename = downloadItem.filename || "";
+
+    console.log("[Surge] onDeterminingFilename:", {
+      url,
+      originalUrl: downloadItem.url,
+      filename,
+      mime: downloadItem.mime,
+    });
+
+    // Cancel the browser download NOW while it is still paused by onDeterminingFilename.
+    // Must happen BEFORE any slow async operation to avoid the
+    // "Download must be in progress" race condition.
+    const cancelOk = await new Promise((resolve) => {
+      chrome.downloads.cancel(downloadItem.id, () => {
+        const err = chrome.runtime.lastError;
+        if (err) {
+          console.log("[Surge] Could not cancel download (already ended?):", err.message);
+          resolve(false);
+        } else {
+          resolve(true);
+        }
+      });
+    });
+
+    // Release the filename determination lock regardless — must always be called.
+    allowBrowserDownload();
+
+    if (!cancelOk) {
+      // Download already ended before we could take it — nothing more to do.
+      processedIds.delete(downloadItem.id);
+      return;
+    }
+
+    await new Promise((resolve) => {
+      chrome.downloads.erase({ id: downloadItem.id }, () => {
+        const err = chrome.runtime.lastError; // read to clear warning
+        resolve();
+      });
+    });
+
+    // Now confirm Surge is still reachable (cancel is done, timing no longer matters).
+    const surgeRunning = await checkSurgeHealth();
+    if (!surgeRunning) {
+      console.log("[Surge] Server went offline after cancel — download lost");
+      chrome.notifications.create({
+        type: "basic",
+        iconUrl: "icons/icon48.png",
+        title: "Surge",
+        message: "Download intercepted but Surge is not running. Please restart Surge and try again.",
+      });
+      return;
+    }
+
+    // Hand off to Surge with the correct filename and resolved headers
+    await handleInterceptedDownload(url, downloadItem, filename);
+  } catch (error) {
+    console.error("[Surge] onDeterminingFilename error:", error);
+    allowBrowserDownload();
+  }
+}
+
+async function handleInterceptedDownload(url, downloadItem, filename) {
+  // Check for duplicates
+  if (await isDuplicateDownload(url)) {
     // Store pending duplicate and prompt user
     const pendingId = `dup_${++pendingDuplicateCounter}`;
-    const { filename, directory } = extractPathInfo(downloadItem);
     const displayName =
-      filename || downloadItem.url.split("/").pop() || "Unknown file";
+      filename || url.split("/").pop() || "Unknown file";
 
     pendingDuplicates.set(pendingId, {
       downloadItem,
       filename,
       directory: "",
-      url: downloadItem.url,
+      url: url,
       timestamp: Date.now(),
     });
 
@@ -719,52 +904,20 @@ async function handleDownloadIntercept(downloadItem) {
     // Update badge
     updateBadge();
 
-    // Try to open popup and send prompt (might fail if no user gesture)
-    try {
-      await chrome.action.openPopup();
-    } catch (e) {
-      console.log(
-        "[Surge] openPopup failed (might be open or no user gesture):",
-        e,
-      );
-    }
-
-    // Send message to popup
-    chrome.runtime
-      .sendMessage({
-        type: "promptDuplicate",
-        id: pendingId,
-        filename: displayName,
-      })
-      .catch((e) => {
-        // Popup might not be open, that's ok - duplicate will timeout
-        console.log("[Surge] Sending promptDuplicate failed:", e);
-      });
+    // Notify user via standard notification instead of popup (openPopup requires user gesture in MV3)
+    chrome.notifications.create({
+      type: "basic",
+      iconUrl: "icons/icon48.png",
+      title: "Surge / Duplicate",
+      message: `Already downloading: ${displayName}`,
+    });
 
     return;
   }
 
-  // Check if Surge is running
-  const surgeRunning = await checkSurgeHealth();
-  if (!surgeRunning) {
-    console.log("[Surge] Server not running, using browser download");
-    return; // Let browser continue - download is already in progress
-  }
-
-  const { filename } = extractPathInfo(downloadItem);
-
-  console.log(
-    "[Surge] Extracted path info - filename:",
-    filename,
-    "directory: (forced default)",
-  );
-
-  // Cancel browser download and send to Surge
+  // Send to Surge
   try {
-    await chrome.downloads.cancel(downloadItem.id);
-    await chrome.downloads.erase({ id: downloadItem.id });
-
-    const result = await sendToSurge(downloadItem.url, filename, "");
+    const result = await sendToSurge(url, filename, "");
 
     if (result.success) {
       if (result.data && result.data.status === "pending_approval") {
@@ -772,7 +925,7 @@ async function handleDownloadIntercept(downloadItem) {
           type: "basic",
           iconUrl: "icons/icon48.png",
           title: "Surge - Confirmation Required",
-          message: `Click to confirm download: ${filename || downloadItem.url.split("/").pop()}`,
+          message: `Click to confirm download: ${filename || url.split("/").pop()}`,
           requireInteraction: true,
         });
         return; // Don't auto-open popup for pending interactions
@@ -783,7 +936,7 @@ async function handleDownloadIntercept(downloadItem) {
         type: "basic",
         iconUrl: "icons/icon48.png",
         title: "Surge",
-        message: `Download started: ${filename || downloadItem.url.split("/").pop()}`,
+        message: `Download started: ${filename || url.split("/").pop()}`,
       });
 
       // Auto-open the popup to show download progress
@@ -803,7 +956,7 @@ async function handleDownloadIntercept(downloadItem) {
       });
     }
   } catch (error) {
-    console.error("[Surge] Failed to intercept download:", error);
+    console.error("[Surge] Failed to send download to Surge:", error);
   }
 }
 

--- a/extension-chrome/background.js
+++ b/extension-chrome/background.js
@@ -848,7 +848,7 @@ async function handleDeterminingFilename(downloadItem, suggest) {
 
     await new Promise((resolve) => {
       chrome.downloads.erase({ id: downloadItem.id }, () => {
-        const err = chrome.runtime.lastError; // read to clear warning
+        chrome.runtime.lastError; // read to clear warning
         resolve();
       });
     });

--- a/extension-chrome/background.js
+++ b/extension-chrome/background.js
@@ -90,9 +90,6 @@ chrome.webRequest.onBeforeRedirect.addListener(
       timestamp: Date.now(),
     });
 
-    // Also capture headers for the redirect target if available
-    // (the onBeforeSendHeaders for the new request will fire separately,
-    // but we want to preserve the original headers too)
 
     // Cleanup old chains
     if (redirectChains.size > 500) {

--- a/extension-chrome/background.js
+++ b/extension-chrome/background.js
@@ -848,7 +848,10 @@ async function handleDeterminingFilename(downloadItem, suggest) {
 
     await new Promise((resolve) => {
       chrome.downloads.erase({ id: downloadItem.id }, () => {
-        chrome.runtime.lastError; // read to clear warning
+        const err = chrome.runtime.lastError;
+        if (err) {
+          // Intentionally ignored: erase may fail if item is already gone.
+        }
         resolve();
       });
     });

--- a/extension-chrome/manifest.json
+++ b/extension-chrome/manifest.json
@@ -3,7 +3,7 @@
   "name": "Surge Download Manager",
   "version": "1.6.8",
   "description": "High-performance download acceleration with live progress tracking. Intercepts downloads and accelerates them using Surge's multi-connection engine.",
-  "permissions": ["downloads", "storage", "notifications", "webRequest"],
+  "permissions": ["downloads", "cookies", "storage", "notifications", "webRequest"],
   "host_permissions": ["http://127.0.0.1/*", "<all_urls>"],
   "background": {
     "service_worker": "background.js"

--- a/extension-firefox/background.js
+++ b/extension-firefox/background.js
@@ -66,6 +66,43 @@ browser.webRequest.onBeforeSendHeaders.addListener(
   ["requestHeaders"]
 );
 
+// === Redirect Chain Tracking ===
+// Maps original URL → final redirected URL so we can find captured headers
+// after a redirect chain (e.g. pixeldrain.com → cdn-1.pixeldrain.com)
+const redirectChains = new Map(); // Key: originalUrl, Value: { finalUrl, timestamp }
+const REDIRECT_EXPIRY_MS = 120000; // 2 minutes
+
+browser.webRequest.onBeforeRedirect.addListener(
+  (details) => {
+    if (!details.url || !details.redirectUrl) return;
+
+    // Find the chain start (walk back through existing chains)
+    let originUrl = details.url;
+    for (const [original, data] of redirectChains) {
+      if (data.finalUrl === details.url) {
+        originUrl = original;
+        break;
+      }
+    }
+
+    redirectChains.set(originUrl, {
+      finalUrl: details.redirectUrl,
+      timestamp: Date.now(),
+    });
+
+    // Cleanup old chains
+    if (redirectChains.size > 500) {
+      const now = Date.now();
+      for (const [url, data] of redirectChains) {
+        if (now - data.timestamp > REDIRECT_EXPIRY_MS) {
+          redirectChains.delete(url);
+        }
+      }
+    }
+  },
+  { urls: ["<all_urls>"] },
+);
+
 function cleanupExpiredHeaders() {
   const now = Date.now();
   for (const [url, data] of capturedHeaders) {
@@ -86,6 +123,54 @@ function getCapturedHeaders(url) {
   }
   
   return data.headers;
+}
+
+// Resolve headers by walking the redirect chain.
+// Tries the exact URL first, then the final redirect target, then the original URL.
+function resolveHeadersForUrl(url) {
+  // Try direct match first
+  let headers = getCapturedHeaders(url);
+  if (headers) return headers;
+
+  // Try looking up this URL's redirect chain to find the final URL's headers
+  const chain = redirectChains.get(url);
+  if (chain) {
+    headers = getCapturedHeaders(chain.finalUrl);
+    if (headers) return headers;
+  }
+
+  // Try reverse: maybe 'url' is a final URL, find the original
+  for (const [original, data] of redirectChains) {
+    if (data.finalUrl === url) {
+      headers = getCapturedHeaders(original);
+      if (headers) return headers;
+    }
+  }
+
+  return null;
+}
+
+// Resolve the best download URL by checking for redirect chains.
+// Returns the final URL if a redirect was tracked, otherwise the original.
+function resolveDownloadUrl(url) {
+  const chain = redirectChains.get(url);
+  if (chain && Date.now() - chain.timestamp < REDIRECT_EXPIRY_MS) {
+    return chain.finalUrl;
+  }
+  return url;
+}
+
+// Read cookies for a URL directly from the browser's cookie store.
+// This is more reliable than onBeforeSendHeaders for download requests.
+async function getCookiesAsHeader(url) {
+  try {
+    const cookies = await browser.cookies.getAll({ url });
+    if (!cookies || cookies.length === 0) return null;
+    return cookies.map((c) => `${c.name}=${c.value}`).join("; ");
+  } catch (e) {
+    console.log("[Surge] Failed to read cookies:", e.message);
+    return null;
+  }
 }
 
 async function loadAuthToken() {
@@ -451,11 +536,20 @@ async function sendToSurge(url, filename, absolutePath) {
       body.path = absolutePath;
     }
 
-    // Include captured headers for authenticated downloads
-    const headers = getCapturedHeaders(url);
-    if (headers) {
-      body.headers = headers;
-      console.log('[Surge] Forwarding captured headers to Surge');
+    // Build headers to forward to Surge.
+    // Primary: read cookies directly from browser storage (reliable for downloads).
+    // Fallback: use any headers captured via onBeforeSendHeaders.
+    const cookieString = await getCookiesAsHeader(url);
+    const capturedHdrs = resolveHeadersForUrl(url);
+
+    if (cookieString || capturedHdrs) {
+      const merged = Object.assign({}, capturedHdrs || {});
+      if (cookieString) {
+        // Cookies from the store take precedence over captured headers
+        merged["Cookie"] = cookieString;
+      }
+      body.headers = merged;
+      console.log("[Surge] Forwarding headers to Surge (cookie:", !!cookieString, "captured:", !!capturedHdrs, ")");
     }
 
     const auth = await authHeaders();
@@ -595,7 +689,13 @@ function isFreshDownload(downloadItem) {
 }
 
 function shouldSkipUrl(url) {
+  // Skip blob and data URLs - these exist only in browser memory and cannot
+  // be forwarded to an external downloader
   if (url.startsWith('blob:') || url.startsWith('data:')) {
+    console.log(
+      '[Surge] Skipping blob/data URL (browser-memory-only, cannot be forwarded):',
+      url.substring(0, 80),
+    );
     return true;
   }
   
@@ -633,6 +733,40 @@ function extractPathInfo(downloadItem) {
   return { filename, directory };
 }
 
+// Firefox does not support onDeterminingFilename, so we must resolve
+// the filename from onCreated which may fire before Chrome finishes parsing
+// Content-Disposition. This polls downloads.search() as a fallback.
+async function resolveFilename(downloadItem) {
+  // If filename is already available and looks valid, use it
+  if (downloadItem.filename) {
+    const { filename } = extractPathInfo(downloadItem);
+    if (filename && !filename.includes('?')) return filename;
+  }
+
+  // Poll for the resolved filename (Firefox populates it slightly after onCreated)
+  for (let i = 0; i < 5; i++) {
+    await new Promise(r => setTimeout(r, 100));
+    try {
+      const [item] = await browser.downloads.search({ id: downloadItem.id });
+      if (item && item.filename) {
+        const { filename } = extractPathInfo(item);
+        if (filename && !filename.includes('?')) return filename;
+      }
+    } catch (e) {
+      // Download may have been cancelled/erased
+      break;
+    }
+  }
+
+  // Last resort: extract from URL path
+  try {
+    const urlObj = new URL(downloadItem.url);
+    return decodeURIComponent(urlObj.pathname.split('/').pop() || '');
+  } catch {
+    return downloadItem.url.split('/').pop() || '';
+  }
+}
+
 // === Download Interception ===
 
 const processedIds = new Set();
@@ -667,8 +801,11 @@ browser.downloads.onCreated.addListener(async (downloadItem) => {
 });
 
 async function handleDownloadIntercept(downloadItem) {
-  // Check for duplicates (async - checks both time-based and Surge's download list)
-  if (await isDuplicateDownload(downloadItem.url)) {
+  // Resolve the best URL (follow redirect chain if available)
+  const url = resolveDownloadUrl(downloadItem.url);
+
+  // Check for duplicates (async - checks Surge's download list)
+  if (await isDuplicateDownload(url)) {
     // Cancel the browser download
     try {
       await browser.downloads.cancel(downloadItem.id);
@@ -677,16 +814,18 @@ async function handleDownloadIntercept(downloadItem) {
       console.log('[Surge] Error canceling duplicate:', e);
     }
     
+    // Resolve filename (may need polling since Firefox lacks onDeterminingFilename)
+    const filename = await resolveFilename(downloadItem);
+    const displayName = filename || url.split('/').pop() || 'Unknown file';
+    
     // Store pending duplicate and prompt user
     const pendingId = `dup_${++pendingDuplicateCounter}`;
-    const { filename, directory } = extractPathInfo(downloadItem);
-    const displayName = filename || downloadItem.url.split('/').pop() || 'Unknown file';
     
     pendingDuplicates.set(pendingId, {
       downloadItem,
       filename,
-      directory,
-      url: downloadItem.url,
+      directory: '',
+      url: url,
       timestamp: Date.now()
     });
     
@@ -701,20 +840,11 @@ async function handleDownloadIntercept(downloadItem) {
     // Update badge
     updateBadge();
 
-    // Try to open popup and send prompt
-    try {
-      await browser.action.openPopup();
-    } catch (e) {
-      // Popup may already be open
-    }
-    
-    // Send message to popup
-    browser.runtime.sendMessage({
-      type: 'promptDuplicate',
-      id: pendingId,
-      filename: displayName
-    }).catch(() => {
-      // Popup might not be open, that's ok - duplicate will timeout
+    browser.notifications.create({
+      type: 'basic',
+      iconUrl: 'icons/icon48.png',
+      title: 'Surge / Duplicate',
+      message: `Already downloading: ${displayName}`,
     });
     
     return;
@@ -725,16 +855,23 @@ async function handleDownloadIntercept(downloadItem) {
     return; // Let browser continue - download is already in progress
   }
 
-  const { filename, directory } = extractPathInfo(downloadItem);
+  // Resolve filename (may need polling since Firefox lacks onDeterminingFilename)
+  const filename = await resolveFilename(downloadItem);
+
+  console.log('[Surge] Resolved download info:', {
+    url,
+    originalUrl: downloadItem.url,
+    filename,
+  });
 
   try {
     await browser.downloads.cancel(downloadItem.id);
     await browser.downloads.erase({ id: downloadItem.id });
 
     const result = await sendToSurge(
-      downloadItem.url,
+      url,
       filename,
-      directory
+      ''
     );
 
     if (result.success) {
@@ -742,7 +879,7 @@ async function handleDownloadIntercept(downloadItem) {
         type: 'basic',
         iconUrl: 'icons/icon48.png',
         title: 'Surge',
-        message: `Download started: ${filename || downloadItem.url.split('/').pop()}`,
+        message: `Download started: ${filename || url.split('/').pop()}`,
       });
       
       // Auto-open the popup to show download progress

--- a/extension-firefox/manifest.json
+++ b/extension-firefox/manifest.json
@@ -5,6 +5,7 @@
   "description": "High-performance download acceleration with live progress tracking. Intercepts downloads and accelerates them using Surge's multi-connection engine.",
   "permissions": [
     "downloads",
+    "cookies",
     "storage",
     "notifications",
     "webRequest"

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -51,6 +51,7 @@ type NetworkSettings struct {
 	MaxConcurrentDownloads int    `json:"max_concurrent_downloads" ui_label:"Max Concurrent Downloads" ui_desc:"Maximum number of downloads running at once (1-10). Requires restart."`
 	UserAgent              string `json:"user_agent" ui_label:"User Agent" ui_desc:"Custom User-Agent string for HTTP requests. Leave empty for default."`
 	ProxyURL               string `json:"proxy_url" ui_label:"Proxy URL" ui_desc:"HTTP/HTTPS proxy URL (e.g. http://127.0.0.1:1700). Leave empty to use system default."`
+	CustomDNS              string `json:"custom_dns" ui_label:"Custom DNS Server" ui_desc:"Set custom DNS (e.g., 1.1.1.1:53, 94.140.14.14:53). Leave empty for system."`
 	SequentialDownload     bool   `json:"sequential_download" ui_label:"Sequential Download" ui_desc:"Download pieces in order (Streaming Mode). May be slower."`
 	MinChunkSize           int64  `json:"min_chunk_size" ui_label:"Min Chunk Size" ui_desc:"Minimum download chunk size in MB (e.g., 2)."`
 	WorkerBufferSize       int    `json:"worker_buffer_size" ui_label:"Worker Buffer Size" ui_desc:"I/O buffer size per worker in KB (e.g., 512)."`
@@ -197,6 +198,8 @@ func DefaultSettings() *Settings {
 			MaxConnectionsPerHost:  32,
 			MaxConcurrentDownloads: 3,
 			UserAgent:              "", // Empty means use default UA
+			ProxyURL:               "",
+			CustomDNS:              "",
 			SequentialDownload:     false,
 			MinChunkSize:           2 * MB,
 			WorkerBufferSize:       512 * KB,
@@ -271,6 +274,7 @@ type RuntimeConfig struct {
 	MaxConnectionsPerHost int
 	UserAgent             string
 	ProxyURL              string
+	CustomDNS             string
 	SequentialDownload    bool
 	MinChunkSize          int64
 	WorkerBufferSize      int
@@ -287,6 +291,7 @@ func (s *Settings) ToRuntimeConfig() *RuntimeConfig {
 		MaxConnectionsPerHost: s.Network.MaxConnectionsPerHost,
 		UserAgent:             s.Network.UserAgent,
 		ProxyURL:              s.Network.ProxyURL,
+		CustomDNS:             s.Network.CustomDNS,
 		SequentialDownload:    s.Network.SequentialDownload,
 		MinChunkSize:          s.Network.MinChunkSize,
 		WorkerBufferSize:      s.Network.WorkerBufferSize,

--- a/internal/download/manager.go
+++ b/internal/download/manager.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/engine/concurrent"
 	"github.com/SurgeDM/Surge/internal/engine/events"
 	"github.com/SurgeDM/Surge/internal/engine/single"
@@ -160,7 +161,11 @@ func TUIDownload(ctx context.Context, cfg *types.DownloadConfig) error {
 			utils.Debug("Probing %d mirrors", len(mirrors))
 			// Always check primary + mirrors to ensure we are using the best set
 			allToCheck := append([]string{cfg.URL}, mirrors...)
-			valid, errs := processing.ProbeMirrorsWithProxy(ctx, allToCheck, cfg.Runtime.ProxyURL)
+			runCfg := &config.RuntimeConfig{
+				ProxyURL:  cfg.Runtime.ProxyURL,
+				CustomDNS: cfg.Runtime.CustomDNS,
+			}
+			valid, errs := processing.ProbeMirrorsWithProxy(ctx, allToCheck, runCfg)
 
 			// Log errors
 			for u, e := range errs {

--- a/internal/engine/concurrent/downloader.go
+++ b/internal/engine/concurrent/downloader.go
@@ -221,13 +221,15 @@ func (d *ConcurrentDownloader) newConcurrentClient(numConns int) *http.Client {
 		DisableCompression: true,  // Files are usually already compressed
 		ForceAttemptHTTP2:  false, // FORCE HTTP/1.1 for multiple TCP connections
 		TLSNextProto:       make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
-
-		// Dial settings for TCP reliability
-		DialContext: (&net.Dialer{
-			Timeout:   types.DialTimeout,
-			KeepAlive: types.KeepAliveDuration,
-		}).DialContext,
 	}
+
+	dialer := &net.Dialer{
+		Timeout:   types.DialTimeout,
+		KeepAlive: types.KeepAliveDuration,
+	}
+
+	utils.ConfigureDialer(dialer, d.Runtime.CustomDNS)
+	transport.DialContext = dialer.DialContext
 
 	return &http.Client{
 		Transport: transport,

--- a/internal/engine/single/downloader.go
+++ b/internal/engine/single/downloader.go
@@ -30,6 +30,7 @@ type SingleDownloader struct {
 type singleTransportKey struct {
 	proxyURL string
 	maxConns int
+	customDNS string
 }
 
 var singleTransportCache sync.Map // map[singleTransportKey]*http.Transport
@@ -83,8 +84,9 @@ func newSingleClient(runtime *types.RuntimeConfig, sd *SingleDownloader) *http.C
 
 func getSharedSingleTransport(runtime *types.RuntimeConfig) *http.Transport {
 	key := singleTransportKey{
-		proxyURL: runtime.ProxyURL,
-		maxConns: runtime.GetMaxConnectionsPerHost(),
+		proxyURL:  runtime.ProxyURL,
+		maxConns:  runtime.GetMaxConnectionsPerHost(),
+		customDNS: runtime.CustomDNS,
 	}
 
 	if cached, ok := singleTransportCache.Load(key); ok {
@@ -106,6 +108,13 @@ func newSingleTransport(runtime *types.RuntimeConfig) *http.Transport {
 		}
 	}
 
+	dialer := &net.Dialer{
+		Timeout:   types.DialTimeout,
+		KeepAlive: types.KeepAliveDuration,
+	}
+
+	utils.ConfigureDialer(dialer, runtime.CustomDNS)
+
 	return &http.Transport{
 		MaxIdleConns:        types.DefaultMaxIdleConns,
 		MaxIdleConnsPerHost: runtime.GetMaxConnectionsPerHost(),
@@ -118,10 +127,7 @@ func newSingleTransport(runtime *types.RuntimeConfig) *http.Transport {
 		ExpectContinueTimeout: types.DefaultExpectContinueTimeout,
 
 		DisableCompression: true,
-		DialContext: (&net.Dialer{
-			Timeout:   types.DialTimeout,
-			KeepAlive: types.KeepAliveDuration,
-		}).DialContext,
+		DialContext:        dialer.DialContext,
 	}
 }
 

--- a/internal/engine/single/downloader.go
+++ b/internal/engine/single/downloader.go
@@ -28,8 +28,8 @@ type SingleDownloader struct {
 }
 
 type singleTransportKey struct {
-	proxyURL string
-	maxConns int
+	proxyURL  string
+	maxConns  int
 	customDNS string
 }
 

--- a/internal/engine/types/config.go
+++ b/internal/engine/types/config.go
@@ -71,6 +71,7 @@ type RuntimeConfig struct {
 	MaxConnectionsPerHost int
 	UserAgent             string
 	ProxyURL              string
+	CustomDNS             string
 	SequentialDownload    bool
 	MinChunkSize          int64
 

--- a/internal/engine/types/config_convert.go
+++ b/internal/engine/types/config_convert.go
@@ -8,6 +8,7 @@ func ConvertRuntimeConfig(rc *config.RuntimeConfig) *RuntimeConfig {
 		MaxConnectionsPerHost: rc.MaxConnectionsPerHost,
 		UserAgent:             rc.UserAgent,
 		ProxyURL:              rc.ProxyURL,
+		CustomDNS:             rc.CustomDNS,
 		SequentialDownload:    rc.SequentialDownload,
 		MinChunkSize:          rc.MinChunkSize,
 		WorkerBufferSize:      rc.WorkerBufferSize,

--- a/internal/processing/manager.go
+++ b/internal/processing/manager.go
@@ -220,7 +220,7 @@ func (mgr *LifecycleManager) enqueueResolved(ctx context.Context, req *DownloadR
 
 	settings := mgr.GetSettings()
 
-	probe, err := ProbeServerWithProxy(ctx, req.URL, req.Filename, req.Headers, settings.Network.ProxyURL)
+	probe, err := ProbeServerWithProxy(ctx, req.URL, req.Filename, req.Headers, settings.ToRuntimeConfig())
 	if err != nil {
 		utils.Debug("Lifecycle: Probe failed: %v\n", err)
 		return "", fmt.Errorf("probe failed: %w", err)

--- a/internal/processing/probe.go
+++ b/internal/processing/probe.go
@@ -303,6 +303,11 @@ func newProbeTransport(proxyURL string) *http.Transport {
 		}
 	}
 
+	dialer := &net.Dialer{
+		Timeout:   types.DialTimeout,
+		KeepAlive: types.KeepAliveDuration,
+	}
+
 	return &http.Transport{
 		Proxy:                 proxyFunc,
 		MaxIdleConns:          types.DefaultMaxIdleConns,
@@ -311,10 +316,15 @@ func newProbeTransport(proxyURL string) *http.Transport {
 		TLSHandshakeTimeout:   types.DefaultTLSHandshakeTimeout,
 		ResponseHeaderTimeout: types.DefaultResponseHeaderTimeout,
 		ExpectContinueTimeout: types.DefaultExpectContinueTimeout,
-		DialContext: (&net.Dialer{
-			Timeout:   types.DialTimeout,
-			KeepAlive: types.KeepAliveDuration,
-		}).DialContext,
+		// Use tcp4 to prefer IPv4 when connecting to CDN hosts.
+		// Some CDN nodes resolve to IPv6 addresses that are unreachable
+		// on networks that have IPv6 assigned but no working IPv6 path.
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			if network == "tcp" {
+				network = "tcp4"
+			}
+			return dialer.DialContext(ctx, network, addr)
+		},
 	}
 }
 

--- a/internal/processing/probe.go
+++ b/internal/processing/probe.go
@@ -255,7 +255,8 @@ func getProbeClient(runCfg *config.RuntimeConfig) *http.Client {
 
 	key := ""
 	if runCfg != nil {
-		key = runCfg.ProxyURL + "|" + runCfg.CustomDNS
+		// Quote values to prevent ambiguity when one value contains the separator
+		key = fmt.Sprintf("%q|%q", runCfg.ProxyURL, runCfg.CustomDNS)
 	}
 
 	if cached, ok := probeClients[key]; ok {

--- a/internal/processing/probe.go
+++ b/internal/processing/probe.go
@@ -40,22 +40,22 @@ type ProbeResult struct {
 // probeHeadersContextKey is used to pass custom headers to the HTTP client's CheckRedirect function
 type probeHeadersContextKey struct{}
 
-func resolveProxyURL() string {
+func resolveRuntimeConfig() *config.RuntimeConfig {
 	settings, err := config.LoadSettings()
 	if err != nil {
 		settings = config.DefaultSettings()
 	}
 	if settings != nil {
-		return settings.Network.ProxyURL
+		return settings.ToRuntimeConfig()
 	}
-	return ""
+	return nil
 }
 
 // ProbeServer is the convenience entry point for callers that do not already
 // hold a settings snapshot; it reloads persisted settings so probe traffic can
 // honor the saved proxy configuration.
 func ProbeServer(ctx context.Context, rawurl string, filenameHint string, headers map[string]string) (*ProbeResult, error) {
-	return ProbeServerWithProxy(ctx, rawurl, filenameHint, headers, resolveProxyURL())
+	return ProbeServerWithProxy(ctx, rawurl, filenameHint, headers, resolveRuntimeConfig())
 }
 
 var (
@@ -77,7 +77,7 @@ func getProbeHostLock(rawurl string) *sync.Mutex {
 // ProbeServerWithProxy is the hot-path variant for callers that already know
 // the effective proxy and want probe traffic to match the eventual download path
 // without re-reading settings from disk.
-func ProbeServerWithProxy(ctx context.Context, rawurl string, filenameHint string, headers map[string]string, proxyURL string) (*ProbeResult, error) {
+func ProbeServerWithProxy(ctx context.Context, rawurl string, filenameHint string, headers map[string]string, runCfg *config.RuntimeConfig) (*ProbeResult, error) {
 	utils.Debug("Probing server: %s", rawurl)
 
 	// Embed custom headers in context so CheckRedirect can use them
@@ -87,7 +87,7 @@ func ProbeServerWithProxy(ctx context.Context, rawurl string, filenameHint strin
 
 	var resp *http.Response
 
-	client := getProbeClient(proxyURL)
+	client := getProbeClient(runCfg)
 
 	// Sequentialize probes to the same host to prevent rate limiting (e.g., Google Drive)
 	hostLock := getProbeHostLock(rawurl)
@@ -249,16 +249,21 @@ func applyProbeHeaders(req *http.Request, headers map[string]string, includeRang
 	}
 }
 
-func getProbeClient(proxyURL string) *http.Client {
+func getProbeClient(runCfg *config.RuntimeConfig) *http.Client {
 	probeClientsMu.Lock()
 	defer probeClientsMu.Unlock()
 
-	if cached, ok := probeClients[proxyURL]; ok {
+	key := ""
+	if runCfg != nil {
+		key = runCfg.ProxyURL + "|" + runCfg.CustomDNS
+	}
+
+	if cached, ok := probeClients[key]; ok {
 		return cached
 	}
 
 	client := &http.Client{
-		Transport: newProbeTransport(proxyURL),
+		Transport: newProbeTransport(runCfg),
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= 10 {
 				return fmt.Errorf("stopped after 10 redirects")
@@ -288,18 +293,22 @@ func getProbeClient(proxyURL string) *http.Client {
 		}
 	}
 
-	probeClients[proxyURL] = client
-	probeClientOrder = append(probeClientOrder, proxyURL)
+	probeClients[key] = client
+	probeClientOrder = append(probeClientOrder, key)
 	return client
 }
 
-func newProbeTransport(proxyURL string) *http.Transport {
+func newProbeTransport(runCfg *config.RuntimeConfig) *http.Transport {
 	proxyFunc := http.ProxyFromEnvironment
-	if strings.TrimSpace(proxyURL) != "" {
-		if parsedURL, err := neturl.Parse(proxyURL); err == nil {
-			proxyFunc = http.ProxyURL(parsedURL)
-		} else {
-			utils.Debug("Invalid probe proxy URL %s: %v", proxyURL, err)
+	var customDNS string
+	if runCfg != nil {
+		customDNS = runCfg.CustomDNS
+		if strings.TrimSpace(runCfg.ProxyURL) != "" {
+			if parsedURL, err := neturl.Parse(runCfg.ProxyURL); err == nil {
+				proxyFunc = http.ProxyURL(parsedURL)
+			} else {
+				utils.Debug("Invalid probe proxy URL %s: %v", runCfg.ProxyURL, err)
+			}
 		}
 	}
 
@@ -307,6 +316,8 @@ func newProbeTransport(proxyURL string) *http.Transport {
 		Timeout:   types.DialTimeout,
 		KeepAlive: types.KeepAliveDuration,
 	}
+
+	utils.ConfigureDialer(dialer, customDNS)
 
 	return &http.Transport{
 		Proxy:                 proxyFunc,
@@ -361,11 +372,11 @@ func sameProbeRedirectOrigin(a, b *neturl.URL) bool {
 // ProbeMirrors is the convenience wrapper for callers that need mirror probing
 // to honor the saved proxy setting but do not already hold a live settings snapshot.
 func ProbeMirrors(ctx context.Context, mirrors []string) (valid []string, errs map[string]error) {
-	return ProbeMirrorsWithProxy(ctx, mirrors, resolveProxyURL())
+	return ProbeMirrorsWithProxy(ctx, mirrors, resolveRuntimeConfig())
 }
 
 // ProbeMirrorsWithProxy preserves caller order so mirror priority remains stable.
-func ProbeMirrorsWithProxy(ctx context.Context, mirrors []string, proxyURL string) (valid []string, errs map[string]error) {
+func ProbeMirrorsWithProxy(ctx context.Context, mirrors []string, runCfg *config.RuntimeConfig) (valid []string, errs map[string]error) {
 	candidates := orderedUniqueMirrors(mirrors)
 	utils.Debug("Probing %d mirrors...", len(candidates))
 
@@ -390,7 +401,7 @@ func ProbeMirrorsWithProxy(ctx context.Context, mirrors []string, proxyURL strin
 			probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 			defer cancel()
 
-			result, err := ProbeServerWithProxy(probeCtx, target, "", nil, proxyURL)
+			result, err := ProbeServerWithProxy(probeCtx, target, "", nil, runCfg)
 
 			outcome := mirrorProbeResult{}
 			if err != nil {

--- a/internal/processing/probe_test.go
+++ b/internal/processing/probe_test.go
@@ -77,7 +77,7 @@ func TestProbeMirrors_PreservesCallerOrderAfterDedupe(t *testing.T) {
 		fast.URL,
 		slow.URL,
 		invalid.URL,
-	}, "")
+	}, nil)
 
 	want := []string{slow.URL, fast.URL}
 	if len(valid) != len(want) {
@@ -116,7 +116,7 @@ func TestProbeServer_ReadsBodyBeforeContextCancel(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	result, err := processing.ProbeServerWithProxy(ctx, server.URL, "", nil, "")
+	result, err := processing.ProbeServerWithProxy(ctx, server.URL, "", nil, nil)
 	if err != nil {
 		t.Fatalf("ProbeServerWithProxy() failed: %v", err)
 	}

--- a/internal/utils/dns.go
+++ b/internal/utils/dns.go
@@ -15,17 +15,20 @@ func ConfigureDialer(dialer *net.Dialer, customAddr string) {
 	}
 
 	// Ensure there is a port in the address. If not, default to 53.
-	if _, _, err := net.SplitHostPort(customAddr); err != nil {
-		if strings.Contains(err.Error(), "missing port in address") {
-			customAddr = net.JoinHostPort(customAddr, "53")
-		}
+	host, port, err := net.SplitHostPort(customAddr)
+	if err != nil {
+		host = customAddr
+		port = "53"
 	}
+	customAddr = net.JoinHostPort(host, port)
 
 	dialer.Resolver = &net.Resolver{
 		PreferGo: true,
 		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
-			// Always route to the custom nameserver, ignoring the system address
-			return dialer.DialContext(ctx, "udp", customAddr)
+			// Use a clean dialer with no custom resolver to avoid recursive resolution
+			// when customAddr is a hostname rather than a literal IP.
+			d := net.Dialer{Timeout: dialer.Timeout}
+			return d.DialContext(ctx, "udp", customAddr)
 		},
 	}
 }

--- a/internal/utils/dns.go
+++ b/internal/utils/dns.go
@@ -1,0 +1,31 @@
+package utils
+
+import (
+	"context"
+	"net"
+	"strings"
+)
+
+// ConfigureDialer modifies the provided net.Dialer to route all DNS lookups
+// through the specified custom DNS server address.
+// customAddr should include the port, e.g., "1.1.1.1:53".
+func ConfigureDialer(dialer *net.Dialer, customAddr string) {
+	if strings.TrimSpace(customAddr) == "" {
+		return
+	}
+
+	// Ensure there is a port in the address. If not, default to 53.
+	if _, _, err := net.SplitHostPort(customAddr); err != nil {
+		if strings.Contains(err.Error(), "missing port in address") {
+			customAddr = net.JoinHostPort(customAddr, "53")
+		}
+	}
+
+	dialer.Resolver = &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			// Always route to the custom nameserver, ignoring the system address
+			return dialer.DialContext(ctx, "udp", customAddr)
+		},
+	}
+}


### PR DESCRIPTION
- **feat: include request headers in download debug logs**
- **refactor: enhance download interception with redirect tracking, cookie-based authentication, and improved filename resolution for Firefox**
- **feat: add custom DNS server configuration support and utility for dialer resolution**
- **feat: custom dns settings**

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds custom DNS server configuration (plumbed through the Go download engine via `ConfigureDialer`), enhances both browser extensions with redirect chain tracking and cookie-based authentication, and improves Firefox filename resolution via polling. The Go-side changes are clean: the `dns.go` utility correctly uses a separate inner dialer to avoid recursive resolution, and the probe client cache key was fixed to use quoted values to prevent separator collision.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the single finding is a P2 edge case in the Firefox duplicate-download notification path that falls back gracefully.

All P0/P1 concerns from previous review rounds are addressed (recursive DNS fixed, cache key collision fixed). The only remaining finding is a P2: filename polling in Firefox's duplicate path fires after erase, but the fallback to URL-based extraction means functionality is not broken, just slightly degraded for an uncommon code path.

extension-firefox/background.js — resolveFilename ordering in duplicate handler

<details open><summary><h3>Vulnerabilities</h3></summary>

- Cookie forwarding logs only the boolean presence of cookies (`!!cookieString`), not the actual values — no accidental secret exposure in logs.
- `getCookiesAsHeader` reads from the browser's own cookie store (scoped to the URL) and forwards to a locally-running Surge instance, which is the intended trust boundary.
- No security concerns identified in the Go DNS utility or config plumbing.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/utils/dns.go | New DNS utility that configures a net.Dialer with a custom resolver; uses a clean inner dialer to avoid recursive resolution; correctly falls back to port 53 when missing. |
| internal/processing/probe.go | Adds CustomDNS support to probe transport; cache key now uses fmt.Sprintf quoting to avoid separator collision; ConfigureDialer wired into newProbeTransport cleanly. |
| extension-firefox/background.js | Adds redirect chain tracking, cookie-based auth, and Firefox-specific filename polling; minor issue: resolveFilename is called after download erase in the duplicate path, defeating the polling. |
| extension-chrome/background.js | Adds redirect chain tracking and cookie-based auth for Chrome; Chrome uses onDeterminingFilename so filename is already resolved before cancel/erase — no ordering issue. |
| internal/config/settings.go | Adds CustomDNS field to NetworkSettings and RuntimeConfig; DefaultSettings initialises ProxyURL and CustomDNS to empty strings; conversion propagated correctly. |
| internal/download/manager.go | ProbeMirrorsWithProxy call updated to pass a RuntimeConfig struct carrying both ProxyURL and CustomDNS instead of a bare string. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant B as Browser (FF/Chrome)
    participant EXT as Extension BG Script
    participant RC as redirectChains Map
    participant CS as Cookie Store
    participant S as Surge Server
    participant DNS as Custom DNS

    B->>EXT: onBeforeRedirect(url → finalUrl)
    EXT->>RC: set(originUrl, {finalUrl, ts})

    B->>EXT: onCreated / onDeterminingFilename
    EXT->>RC: resolveDownloadUrl(originalUrl)
    RC-->>EXT: finalUrl
    EXT->>CS: getCookiesAsHeader(finalUrl)
    CS-->>EXT: cookieString
    EXT->>S: POST /download {url: finalUrl, headers: {Cookie: ...}}
    S->>DNS: resolve host via CustomDNS (if configured)
    DNS-->>S: IP
    S-->>EXT: {success: true}
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: extension-firefox/background.js
Line: 811-818

Comment:
**`resolveFilename` called after download erase**

The download is cancelled and erased (lines 811–813) before `resolveFilename` is invoked on line 818. The polling loop inside `resolveFilename` calls `browser.downloads.search({ id: downloadItem.id })`, which returns an empty result once the item is erased, so the polling always falls through to the URL-based last-resort extraction — potentially giving a less accurate display name in the duplicate notification. Move the `resolveFilename` call before the cancel/erase block:

```suggestion
    // Resolve filename before erasing so polling can still find the item
    const filename = await resolveFilename(downloadItem);

    // Cancel the browser download
    try {
      await browser.downloads.cancel(downloadItem.id);
      await browser.downloads.erase({ id: downloadItem.id });
    } catch (e) {
      console.log('[Surge] Error canceling duplicate:', e);
    }
    
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Potential fix for pull request finding &#39;..."](https://github.com/surgedm/surge/commit/045fda58162d41fcfa8908a8bf0b51de4753c43b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27826887)</sub>

<!-- /greptile_comment -->