### PR TITLE
feat: add LiveSpeedGraph setting to toggle between EMA smoothing and raw speed data

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -63,6 +63,7 @@ Surge follows OS conventions for storing its files. Below is a breakdown of ever
 | `clipboard_monitor`    | bool   | Watch the system clipboard for URLs and prompt to download them.                                   | `true`  |
 | `theme`                | int    | UI Theme (0=Adaptive, 1=Light, 2=Dark).                                                            | `0`     |
 | `log_retention_count`  | int    | Number of recent log files to keep.                                                                | `5`     |
+| `live_speed_graph`     | bool   | Use live speed for graph instead of EMA smoothed speed.                                            | `false` |
 
 ### Connection Settings
 

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -31,6 +31,7 @@ type GeneralSettings struct {
 	ClipboardMonitor  bool `json:"clipboard_monitor" ui_label:"Clipboard Monitor" ui_desc:"Watch clipboard for URLs and prompt to download them."`
 	Theme             int  `json:"theme" ui_label:"App Theme" ui_desc:"UI Theme (System, Light, Dark)."`
 	LogRetentionCount int  `json:"log_retention_count" ui_label:"Log Retention Count" ui_desc:"Number of recent log files to keep."`
+	LiveSpeedGraph    bool `json:"live_speed_graph" ui_label:"Live Speed Graph" ui_desc:"Use live speed for graph instead of EMA smoothed speed."`
 }
 
 const (
@@ -193,6 +194,7 @@ func DefaultSettings() *Settings {
 			ClipboardMonitor:  true,
 			Theme:             ThemeAdaptive,
 			LogRetentionCount: 5,
+			LiveSpeedGraph:    false,
 		},
 		Network: NetworkSettings{
 			MaxConnectionsPerHost:  32,

--- a/internal/tui/components/box.go
+++ b/internal/tui/components/box.go
@@ -84,16 +84,16 @@ func RenderBtopBox(leftTitle, rightTitle string, content string, width, height i
 	}
 
 	// Build bottom border: ╰───────────────────╯
-	bottomBorder := lipgloss.NewStyle().Foreground(borderColor).Render(
+	bottomBorder := borderStyler.Render(
 		bottomLeft + strings.Repeat(horizontal, innerWidth) + bottomRight,
 	)
-
-	// Style for vertical borders
-	borderStyle := lipgloss.NewStyle().Foreground(borderColor)
 
 	// Wrap content lines with vertical borders
 	contentLines := strings.Split(content, "\n")
 	innerHeight := height - 2 // Account for top and bottom borders
+
+	// Style for truncation
+	truncStyle := lipgloss.NewStyle().MaxWidth(innerWidth)
 
 	var wrappedLines []string
 	for i := 0; i < innerHeight; i++ {
@@ -108,9 +108,9 @@ func RenderBtopBox(leftTitle, rightTitle string, content string, width, height i
 		if lineWidth < innerWidth {
 			line = line + strings.Repeat(" ", innerWidth-lineWidth)
 		} else if lineWidth > innerWidth {
-			line = lipgloss.NewStyle().MaxWidth(innerWidth).Render(line)
+			line = truncStyle.Render(line)
 		}
-		wrappedLines = append(wrappedLines, borderStyle.Render(vertical)+line+borderStyle.Render(vertical))
+		wrappedLines = append(wrappedLines, borderStyler.Render(vertical)+line+borderStyler.Render(vertical))
 	}
 
 	return lipgloss.JoinVertical(lipgloss.Left, topBorder, strings.Join(wrappedLines, "\n"), bottomBorder)

--- a/internal/tui/components/box.go
+++ b/internal/tui/components/box.go
@@ -108,11 +108,7 @@ func RenderBtopBox(leftTitle, rightTitle string, content string, width, height i
 		if lineWidth < innerWidth {
 			line = line + strings.Repeat(" ", innerWidth-lineWidth)
 		} else if lineWidth > innerWidth {
-			// Truncate (simplified - just take first innerWidth chars)
-			runes := []rune(line)
-			if len(runes) > innerWidth {
-				line = string(runes[:innerWidth])
-			}
+			line = lipgloss.NewStyle().MaxWidth(innerWidth).Render(line)
 		}
 		wrappedLines = append(wrappedLines, borderStyle.Render(vertical)+line+borderStyle.Render(vertical))
 	}

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -142,20 +142,19 @@ func (d downloadDelegate) Render(w io.Writer, m list.Model, index int, listItem 
 		prefix = d.prefixNormal
 	}
 
-	// Truncate title if needed
-	width := m.Width() - 6
-	if width < 20 {
-		width = 20
+	// Truncate title and description if needed
+	// m.Width() is the available space for the list item
+	availableWidth := m.Width() - 4 // Account for prefix and some padding
+	if availableWidth < 10 {
+		availableWidth = 10
 	}
-	title := i.Title()
-	maxTitleWidth := width - 10
-	if len(title) > maxTitleWidth {
-		title = title[:maxTitleWidth-3] + "..."
-	}
+
+	title := truncateString(i.Title(), availableWidth)
+	description := truncateString(i.Description(), availableWidth)
 
 	// Render lines
 	line1 := prefix + titleStyle.Render(title)
-	line2 := prefix + descStyle.Render(i.Description())
+	line2 := prefix + descStyle.Render(description)
 
 	_, _ = fmt.Fprintf(w, "%s\n%s", line1, line2)
 }

--- a/internal/tui/process.go
+++ b/internal/tui/process.go
@@ -56,7 +56,9 @@ func (m *RootModel) processProgressMsg(msg events.ProgressMsg) {
 		totalSpeed := m.calcTotalSpeed()
 		// EMA smooth against previous graph point for visual continuity
 		var smoothed float64
-		if len(m.SpeedHistory) > 0 {
+		if m.Settings != nil && m.Settings.General.LiveSpeedGraph {
+			smoothed = totalSpeed
+		} else if len(m.SpeedHistory) > 0 {
 			prev := m.SpeedHistory[len(m.SpeedHistory)-1]
 			const graphAlpha = 0.3 // Graph smoothing factor
 			smoothed = graphAlpha*totalSpeed + (1-graphAlpha)*prev

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -931,9 +931,9 @@ func renderFocusedDetails(d *DownloadModel, w int, spinnerView string) string {
 	}
 
 	fileInfoContent := lipgloss.JoinVertical(lipgloss.Left,
-		lipgloss.JoinHorizontal(lipgloss.Left, StatsLabelStyle.Render("File: "), StatsValueStyle.Render(truncateString(displayFilename, contentWidth-8))),
-		lipgloss.JoinHorizontal(lipgloss.Left, StatsLabelStyle.Render("Path: "), StatsValueStyle.Render(truncateString(displayPath, contentWidth-8))),
-		lipgloss.JoinHorizontal(lipgloss.Left, StatsLabelStyle.Render("ID:   "), lipgloss.NewStyle().Foreground(colors.LightGray).Render(d.ID)),
+		lipgloss.JoinHorizontal(lipgloss.Left, StatsLabelStyle.Render("File: "), StatsValueStyle.Render(truncateString(displayFilename, contentWidth-12))),
+		lipgloss.JoinHorizontal(lipgloss.Left, StatsLabelStyle.Render("Path: "), StatsValueStyle.Render(truncateString(displayPath, contentWidth-12))),
+		lipgloss.JoinHorizontal(lipgloss.Left, StatsLabelStyle.Render("ID:   "), lipgloss.NewStyle().Foreground(colors.LightGray).Render(truncateString(d.ID, contentWidth-12))),
 	)
 	fileSection := sectionStyle.Render(fileInfoContent)
 
@@ -1142,11 +1142,13 @@ func truncateString(s string, i int) string {
 	if i <= 0 {
 		return ""
 	}
-	runes := []rune(s)
-	if len(runes) > i {
-		return string(runes[:i]) + "..."
+	if lipgloss.Width(s) <= i {
+		return s
 	}
-	return s
+	if i <= 1 {
+		return "…"
+	}
+	return lipgloss.NewStyle().MaxWidth(i-1).Render(s) + "…"
 }
 
 func renderTabs(activeTab, activeCount, queuedCount, doneCount int) string {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `LiveSpeedGraph` boolean setting that lets users toggle between raw speed and EMA-smoothed speed in the speed graph. It also ships a collection of related UI quality improvements: `truncateString` is rewritten to use `lipgloss.Width`/`MaxWidth` for correct Unicode terminal-width handling, the label-offset in the focused details panel is corrected from `-8` to `-12` (matching `StatsLabelStyle.Width(12)`), description lines in the download list are now truncated, and `d.ID` receives truncation it was previously missing.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the feature logic is correct and the accompanying UI fixes are improvements over the previous behavior.

All findings are P2 style suggestions. The core LiveSpeedGraph toggle is implemented correctly, the EMA fallback path is preserved, and the truncation refactor fixes real Unicode-width and overflow bugs.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| docs/SETTINGS.md | Adds `live_speed_graph` boolean entry to the settings table with accurate description and correct default (`false`). |
| internal/config/settings.go | Adds `LiveSpeedGraph bool` field to `GeneralSettings` with JSON tag, UI labels, and a `false` default — straightforward and clean. |
| internal/tui/process.go | Correctly gates between raw-speed and EMA paths; nil guard on Settings is appropriate and the first-point fallback (`else smoothed = totalSpeed`) is preserved for EMA mode. |
| internal/tui/view.go | Refactors `truncateString` to use `lipgloss.Width`/`MaxWidth` for proper Unicode terminal-width handling; corrects the label-offset from -8 to -12 (matching `StatsLabelStyle.Width(12)`) and adds `d.ID` truncation. |
| internal/tui/list.go | Extends truncation to description (previously untruncated); adjusts available-width offset to -4 and delegates to the improved `truncateString`. |
| internal/tui/components/box.go | Replaces custom rune-slice truncation with lipgloss `MaxWidth` and hoists the style out of the loop; minor "what" comment on the hoisted style variable. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[processProgressMsg] --> B{GraphUpdateInterval elapsed?}
    B -- No --> Z[Skip graph update]
    B -- Yes --> C[calcTotalSpeed]
    C --> D{Settings != nil &&\nLiveSpeedGraph?}
    D -- Yes --> E[smoothed = totalSpeed\n raw speed]
    D -- No --> F{len SpeedHistory > 0?}
    F -- Yes --> G[EMA: α·speed + 1-α·prev\nα = 0.3]
    F -- No --> H[smoothed = totalSpeed\n first-point fallback]
    E --> I[Append to SpeedHistory]
    G --> I
    H --> I
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/tui/process.go`, line 54-58 ([link](https://github.com/surgedm/surge/blob/09f3edeede505f16ef921da75caebfea82e47e97/internal/tui/process.go#L54-L58)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Outdated "EMA smoothing" comment**

   The outer comment on line 54 still reads "Update speed graph history with EMA smoothing for smooth transitions", but EMA is now only applied when `LiveSpeedGraph` is `false`. The comment describes a conditional behaviour as if it were unconditional, and it explains *what* happens rather than *why* the two modes exist.

   **Rule Used:** What: Comments must explain *why* code exists, not... ([source](https://app.greptile.com/review/custom-context?memory=4e45ef13-32c2-4753-8060-a44ef767144d))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: internal/tui/process.go
   Line: 54-58
   
   Comment:
   **Outdated "EMA smoothing" comment**
   
   The outer comment on line 54 still reads "Update speed graph history with EMA smoothing for smooth transitions", but EMA is now only applied when `LiveSpeedGraph` is `false`. The comment describes a conditional behaviour as if it were unconditional, and it explains *what* happens rather than *why* the two modes exist.
   
   
   
   **Rule Used:** What: Comments must explain *why* code exists, not... ([source](https://app.greptile.com/review/custom-context?memory=4e45ef13-32c2-4753-8060-a44ef767144d))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/tui/components/box.go
Line: 95-96

Comment:
**"What" comment instead of "why"**

`// Style for truncation` restates what `truncStyle` is without explaining the intent. Per the project's comment guidelines, comments should explain *why* — in this case, why the style is hoisted outside the loop (to avoid allocating a new `lipgloss.Style` on every iteration).

```suggestion
	// Reused across iterations to avoid per-line style allocations
	truncStyle := lipgloss.NewStyle().MaxWidth(innerWidth)
```

**Rule Used:** What: Comments must explain *why* code exists, not... ([source](https://app.greptile.com/review/custom-context?memory=4e45ef13-32c2-4753-8060-a44ef767144d))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor: optimize box content truncatio..."](https://github.com/surgedm/surge/commit/fecfca914bd43bc1ec944c4fcb3cba32d8b41f32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28027635)</sub>

<!-- /greptile_comment -->