### PR TITLE
feat: add Extension settings category with auth token copying and browser integration support

### DIFF
--- a/cmd/connect_test.go
+++ b/cmd/connect_test.go
@@ -81,7 +81,7 @@ func TestNewRemoteRootModel_UsesNilOrchestrator(t *testing.T) {
 func TestNewRemoteRootModel_DownloadRequestUsesServiceAdd(t *testing.T) {
 	service := &fakeRemoteDownloadService{}
 	m := newRemoteRootModel(1700, service, "example.com")
-	m.Settings.General.ExtensionPrompt = false
+	m.Settings.Extension.ExtensionPrompt = false
 	m.Settings.General.WarnOnDuplicate = false
 
 	updated, cmd := m.Update(events.DownloadRequestMsg{

--- a/cmd/http_handler_test.go
+++ b/cmd/http_handler_test.go
@@ -72,6 +72,7 @@ func TestHandleDownload_PathResolution(t *testing.T) {
 	// Create a temporary settings file
 	settings := config.DefaultSettings()
 	settings.General.DefaultDownloadDir = defaultDownloadDir
+	settings.Extension.ExtensionPrompt = false
 
 	if err := config.SaveSettings(settings); err != nil {
 		t.Fatal(err)
@@ -376,7 +377,7 @@ func TestHandleDownload_PublishError_RecordsPreflightError(t *testing.T) {
 	t.Cleanup(func() { serverProgram = origServerProgram })
 
 	settings := config.DefaultSettings()
-	settings.General.ExtensionPrompt = true
+	settings.Extension.ExtensionPrompt = true
 	settings.General.WarnOnDuplicate = false
 	if err := config.SaveSettings(settings); err != nil {
 		t.Fatalf("SaveSettings failed: %v", err)

--- a/cmd/root_downloads.go
+++ b/cmd/root_downloads.go
@@ -197,7 +197,7 @@ func maybeRequireDownloadApproval(w http.ResponseWriter, service core.DownloadSe
 		return false
 	}
 
-	shouldPrompt := resolved.settings.General.ExtensionPrompt || (resolved.settings.General.WarnOnDuplicate && resolved.isDuplicate)
+	shouldPrompt := resolved.settings.Extension.ExtensionPrompt || (resolved.settings.General.WarnOnDuplicate && resolved.isDuplicate)
 	if !shouldPrompt {
 		return false
 	}

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -12,7 +12,9 @@ func TestResolveClientOutputPath(t *testing.T) {
 	originalHost := os.Getenv("SURGE_HOST")
 	originalGlobalHost := globalHost
 	defer func() {
-		os.Setenv("SURGE_HOST", originalHost)
+		if err := os.Setenv("SURGE_HOST", originalHost); err != nil {
+			t.Errorf("failed to restore environment variable: %v", err)
+		}
 		globalHost = originalGlobalHost
 	}()
 
@@ -31,7 +33,9 @@ func TestResolveClientOutputPath(t *testing.T) {
 		{
 			name: "Remote Host Set via Env - Pass Through Empty",
 			setupHost: func() {
-				os.Setenv("SURGE_HOST", "127.0.0.1:1234")
+				if err := os.Setenv("SURGE_HOST", "127.0.0.1:1234"); err != nil {
+					t.Fatalf("failed to set environment variable: %v", err)
+				}
 				globalHost = ""
 			},
 			outputDir: "",
@@ -40,7 +44,9 @@ func TestResolveClientOutputPath(t *testing.T) {
 		{
 			name: "Remote Host Set via Global - Pass Through Exact",
 			setupHost: func() {
-				os.Setenv("SURGE_HOST", "")
+				if err := os.Setenv("SURGE_HOST", ""); err != nil {
+					t.Fatalf("failed to set environment variable: %v", err)
+				}
 				globalHost = "127.0.0.1:1234"
 			},
 			outputDir: ".",
@@ -49,7 +55,9 @@ func TestResolveClientOutputPath(t *testing.T) {
 		{
 			name: "Local Execution - Empty Dir returns CWD",
 			setupHost: func() {
-				os.Setenv("SURGE_HOST", "")
+				if err := os.Setenv("SURGE_HOST", ""); err != nil {
+					t.Fatalf("failed to set environment variable: %v", err)
+				}
 				globalHost = ""
 			},
 			outputDir: "",
@@ -58,7 +66,9 @@ func TestResolveClientOutputPath(t *testing.T) {
 		{
 			name: "Local Execution - Dot returns Absolute CWD",
 			setupHost: func() {
-				os.Setenv("SURGE_HOST", "")
+				if err := os.Setenv("SURGE_HOST", ""); err != nil {
+					t.Fatalf("failed to set environment variable: %v", err)
+				}
 				globalHost = ""
 			},
 			outputDir: ".",
@@ -67,7 +77,9 @@ func TestResolveClientOutputPath(t *testing.T) {
 		{
 			name: "Local Execution - Relative Subdir returns Absolute",
 			setupHost: func() {
-				os.Setenv("SURGE_HOST", "")
+				if err := os.Setenv("SURGE_HOST", ""); err != nil {
+					t.Fatalf("failed to set environment variable: %v", err)
+				}
 				globalHost = ""
 			},
 			outputDir: "downloads",

--- a/extension-chrome/manifest.json
+++ b/extension-chrome/manifest.json
@@ -1,10 +1,19 @@
 {
   "manifest_version": 3,
   "name": "Surge Download Manager",
-  "version": "1.6.8",
+  "version": "1.8.0",
   "description": "High-performance download acceleration with live progress tracking. Intercepts downloads and accelerates them using Surge's multi-connection engine.",
-  "permissions": ["downloads", "cookies", "storage", "notifications", "webRequest"],
-  "host_permissions": ["http://127.0.0.1/*", "<all_urls>"],
+  "permissions": [
+    "downloads",
+    "cookies",
+    "storage",
+    "notifications",
+    "webRequest"
+  ],
+  "host_permissions": [
+    "http://127.0.0.1/*",
+    "<all_urls>"
+  ],
   "background": {
     "service_worker": "background.js"
   },

--- a/extension-firefox/manifest.json
+++ b/extension-firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Surge Download Manager",
-  "version": "1.6.8",
+  "version": "1.8.0",
   "description": "High-performance download acceleration with live progress tracking. Intercepts downloads and accelerates them using Surge's multi-connection engine.",
   "permissions": [
     "downloads",

--- a/internal/clipboard/utils.go
+++ b/internal/clipboard/utils.go
@@ -1,0 +1,18 @@
+package clipboard
+
+import (
+	"github.com/atotto/clipboard"
+)
+
+var clipboardReadAll = clipboard.ReadAll
+var clipboardWriteAll = clipboard.WriteAll
+
+// Read returns the current text content of the system clipboard.
+func Read() (string, error) {
+	return clipboardReadAll()
+}
+
+// Write copies the given text to the system clipboard.
+func Write(text string) error {
+	return clipboardWriteAll(text)
+}

--- a/internal/clipboard/validator.go
+++ b/internal/clipboard/validator.go
@@ -3,11 +3,7 @@ package clipboard
 import (
 	"net/url"
 	"strings"
-
-	"github.com/atotto/clipboard"
 )
-
-var clipboardReadAll = clipboard.ReadAll
 
 type Validator struct {
 	allowedSchemes map[string]bool
@@ -41,7 +37,7 @@ func (v *Validator) ExtractURL(text string) string {
 }
 
 func ReadURL() string {
-	text, err := clipboardReadAll()
+	text, err := Read()
 	if err != nil {
 		return ""
 	}

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -16,6 +16,7 @@ type Settings struct {
 	Network     NetworkSettings     `json:"network" ui_label:"Network"`
 	Performance PerformanceSettings `json:"performance" ui_label:"Performance"`
 	Categories  CategorySettings    `json:"categories" ui_label:"Categories"`
+	Extension   ExtensionSettings   `json:"extension" ui_label:"Extension"`
 }
 
 // GeneralSettings contains application behavior settings.
@@ -24,7 +25,6 @@ type GeneralSettings struct {
 	WarnOnDuplicate              bool   `json:"warn_on_duplicate" ui_label:"Warn on Duplicate" ui_desc:"Show warning when adding a download that already exists."`
 	DownloadCompleteNotification bool   `json:"download_complete_notification" ui_label:"Download Complete Notification" ui_desc:"Show system notification when a download finishes."`
 	AllowRemoteOpenActions       bool   `json:"allow_remote_open_actions" ui_label:"Allow Remote Open Actions" ui_desc:"Allow /open-file and /open-folder API calls from non-loopback clients. Disabled by default for security."`
-	ExtensionPrompt              bool   `json:"extension_prompt" ui_label:"Extension Prompt" ui_desc:"Prompt for confirmation when adding downloads via browser extension."`
 	AutoResume                   bool   `json:"auto_resume" ui_label:"Auto Resume" ui_desc:"Automatically resume paused downloads on startup."`
 	SkipUpdateCheck              bool   `json:"skip_update_check" ui_label:"Skip Update Check" ui_desc:"Disable automatic check for new versions on startup."`
 
@@ -44,6 +44,15 @@ const (
 type CategorySettings struct {
 	CategoryEnabled bool       `json:"category_enabled" ui_label:"Manage Categories" ui_desc:"Sort downloads into subfolders by file type. Press Enter to open Category Manager."`
 	Categories      []Category `json:"categories" ui_ignored:"true"`
+}
+
+// ExtensionSettings contains settings for the browser extension.
+type ExtensionSettings struct {
+	ExtensionPrompt     bool   `json:"extension_prompt" ui_label:"Extension Prompt" ui_desc:"Prompt for confirmation when adding downloads via browser extension."`
+	ChromeExtensionURL  string `json:"chrome_extension_url" ui_label:"Get Chrome Extension" ui_type:"link" ui_desc:"Open the Surge Chrome extension page."`
+	FirefoxExtensionURL string `json:"firefox_extension_url" ui_label:"Get Firefox Extension" ui_type:"link" ui_desc:"Open the Surge Firefox extension page."`
+	AuthToken           string `json:"auth_token" ui_label:"Auth Token" ui_type:"auth_token" ui_desc:"Your authentication token. Use this to connect the Browser Extension to Surge."`
+	InstructionsURL     string `json:"instructions_url" ui_label:"Setup Instructions" ui_type:"link" ui_desc:"View detailed instructions on how to set up the Surge browser extension."`
 }
 
 // NetworkSettings contains network connection parameters.
@@ -73,7 +82,7 @@ type SettingMeta struct {
 	Key         string // JSON key name
 	Label       string // Human-readable label
 	Description string // Help text displayed in right pane
-	Type        string // "string", "int", "int64", "bool", "duration", "float64"
+	Type        string // "string", "int", "int64", "bool", "duration", "float64", "auth_token", "link"
 }
 
 // GetSettingsMetadata returns metadata for all settings organized by category.
@@ -110,8 +119,10 @@ func GetSettingsMetadata() map[string][]SettingMeta {
 				desc := settingField.Tag.Get("ui_desc")
 
 				// Determine implicit Type
-				typStr := "string"
-				switch settingField.Type.Kind() {
+				typStr := settingField.Tag.Get("ui_type")
+				if typStr == "" {
+					typStr = "string"
+					switch settingField.Type.Kind() {
 				case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32:
 					typStr = "int"
 				case reflect.Int64:
@@ -124,6 +135,7 @@ func GetSettingsMetadata() map[string][]SettingMeta {
 					typStr = "bool"
 				case reflect.Float32, reflect.Float64:
 					typStr = "float64"
+				}
 				}
 
 				catMetas = append(catMetas, SettingMeta{
@@ -189,7 +201,6 @@ func DefaultSettings() *Settings {
 			WarnOnDuplicate:              true,
 			DownloadCompleteNotification: true,
 			AllowRemoteOpenActions:       false,
-			ExtensionPrompt:              false,
 			AutoResume:                   false,
 
 			ClipboardMonitor:  true,
@@ -218,6 +229,13 @@ func DefaultSettings() *Settings {
 		Categories: CategorySettings{
 			CategoryEnabled: false,
 			Categories:      DefaultCategories(),
+		},
+		Extension: ExtensionSettings{
+			ExtensionPrompt:     true,
+			ChromeExtensionURL:  "https://github.com/SurgeDM/Surge/releases/latest",
+			FirefoxExtensionURL: "https://addons.mozilla.org/en-US/firefox/addon/surge/",
+			AuthToken:           "", // Handled specially in TUI
+			InstructionsURL:     "https://github.com/SurgeDM/Surge#browser-extension",
 		},
 	}
 }

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -51,7 +51,7 @@ type ExtensionSettings struct {
 	ExtensionPrompt     bool   `json:"extension_prompt" ui_label:"Extension Prompt" ui_desc:"Prompt for confirmation when adding downloads via browser extension."`
 	ChromeExtensionURL  string `json:"chrome_extension_url" ui_label:"Get Chrome Extension" ui_type:"link" ui_desc:"Open the Surge Chrome extension page."`
 	FirefoxExtensionURL string `json:"firefox_extension_url" ui_label:"Get Firefox Extension" ui_type:"link" ui_desc:"Open the Surge Firefox extension page."`
-	AuthToken           string `json:"auth_token" ui_label:"Auth Token" ui_type:"auth_token" ui_desc:"Your authentication token. Use this to connect the Browser Extension to Surge."`
+	AuthToken           string `json:"-" ui_label:"Auth Token" ui_type:"auth_token" ui_desc:"Your authentication token. Use this to connect the Browser Extension to Surge."`
 	InstructionsURL     string `json:"instructions_url" ui_label:"Setup Instructions" ui_type:"link" ui_desc:"View detailed instructions on how to set up the Surge browser extension."`
 }
 
@@ -123,19 +123,19 @@ func GetSettingsMetadata() map[string][]SettingMeta {
 				if typStr == "" {
 					typStr = "string"
 					switch settingField.Type.Kind() {
-				case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32:
-					typStr = "int"
-				case reflect.Int64:
-					if settingField.Type.String() == "time.Duration" {
-						typStr = "duration"
-					} else {
-						typStr = "int64"
+					case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32:
+						typStr = "int"
+					case reflect.Int64:
+						if settingField.Type.String() == "time.Duration" {
+							typStr = "duration"
+						} else {
+							typStr = "int64"
+						}
+					case reflect.Bool:
+						typStr = "bool"
+					case reflect.Float32, reflect.Float64:
+						typStr = "float64"
 					}
-				case reflect.Bool:
-					typStr = "bool"
-				case reflect.Float32, reflect.Float64:
-					typStr = "float64"
-				}
 				}
 
 				catMetas = append(catMetas, SettingMeta{

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -28,9 +28,6 @@ func TestDefaultSettings(t *testing.T) {
 		if !settings.General.WarnOnDuplicate {
 			t.Error("WarnOnDuplicate should be true by default")
 		}
-		if settings.General.ExtensionPrompt {
-			t.Error("ExtensionPrompt should be false by default")
-		}
 		if settings.General.AllowRemoteOpenActions {
 			t.Error("AllowRemoteOpenActions should be false by default")
 		}
@@ -81,6 +78,22 @@ func TestDefaultSettings(t *testing.T) {
 		}
 		if settings.Performance.SpeedEmaAlpha < 0 || settings.Performance.SpeedEmaAlpha > 1 {
 			t.Errorf("SpeedEmaAlpha should be between 0 and 1, got: %f", settings.Performance.SpeedEmaAlpha)
+		}
+	})
+
+	// Verify Extension settings
+	t.Run("ExtensionSettings", func(t *testing.T) {
+		if !settings.Extension.ExtensionPrompt {
+			t.Error("ExtensionPrompt should be true by default in its new home")
+		}
+		if settings.Extension.ChromeExtensionURL == "" {
+			t.Error("ChromeExtensionURL should not be empty")
+		}
+		if settings.Extension.FirefoxExtensionURL == "" {
+			t.Error("FirefoxExtensionURL should not be empty")
+		}
+		if settings.Extension.InstructionsURL == "" {
+			t.Error("InstructionsURL should not be empty")
 		}
 	})
 }
@@ -137,8 +150,10 @@ func TestSaveAndLoadSettings(t *testing.T) {
 		General: GeneralSettings{
 			DefaultDownloadDir: tmpDir,
 			WarnOnDuplicate:    false,
-			ExtensionPrompt:    true,
 			AutoResume:         true,
+		},
+		Extension: ExtensionSettings{
+			ExtensionPrompt: true,
 		},
 		Network: NetworkSettings{
 			MaxConnectionsPerHost:  16,
@@ -187,7 +202,7 @@ func TestSaveAndLoadSettings(t *testing.T) {
 	if loaded.General.WarnOnDuplicate != original.General.WarnOnDuplicate {
 		t.Error("WarnOnDuplicate mismatch")
 	}
-	if loaded.General.ExtensionPrompt != original.General.ExtensionPrompt {
+	if loaded.Extension.ExtensionPrompt != original.Extension.ExtensionPrompt {
 		t.Error("ExtensionPrompt mismatch")
 	}
 	if loaded.Network.MaxConcurrentDownloads != original.Network.MaxConcurrentDownloads {
@@ -437,6 +452,7 @@ func TestGetSettingsMetadata(t *testing.T) {
 			validTypes := map[string]bool{
 				"string": true, "int": true, "int64": true,
 				"bool": true, "duration": true, "float64": true,
+				"auth_token": true, "link": true,
 			}
 			if !validTypes[setting.Type] {
 				t.Errorf("Category %s, key %s: Invalid type %q", category, setting.Key, setting.Type)
@@ -453,7 +469,7 @@ func TestCategoryOrder(t *testing.T) {
 	}
 
 	// Should have all expected categories
-	expectedCount := 4 // General, Network, Performance, Categories
+	expectedCount := 5 // General, Network, Performance, Categories, Extension
 	if len(order) != expectedCount {
 		t.Errorf("Expected %d categories, got %d", expectedCount, len(order))
 	}
@@ -612,8 +628,10 @@ func TestSaveAndLoadSettings_RoundTrip(t *testing.T) {
 		General: GeneralSettings{
 			DefaultDownloadDir: "/test/path",
 			WarnOnDuplicate:    false,
-			ExtensionPrompt:    true,
 			AutoResume:         true,
+		},
+		Extension: ExtensionSettings{
+			ExtensionPrompt: true,
 		},
 		Network: NetworkSettings{
 			MaxConnectionsPerHost: 64,
@@ -647,7 +665,7 @@ func TestSaveAndLoadSettings_RoundTrip(t *testing.T) {
 	if loaded.General.WarnOnDuplicate != original.General.WarnOnDuplicate {
 		t.Error("WarnOnDuplicate mismatch")
 	}
-	if loaded.General.ExtensionPrompt != original.General.ExtensionPrompt {
+	if loaded.Extension.ExtensionPrompt != original.Extension.ExtensionPrompt {
 		t.Error("ExtensionPrompt mismatch")
 	}
 

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -89,6 +89,7 @@ type SettingsKeyMap struct {
 	Tab2    key.Binding
 	Tab3    key.Binding
 	Tab4    key.Binding
+	Tab5    key.Binding
 	NextTab key.Binding
 	PrevTab key.Binding
 	Browse  key.Binding
@@ -331,15 +332,19 @@ var Keys = KeyMap{
 		),
 		Tab2: key.NewBinding(
 			key.WithKeys("2"),
-			key.WithHelp("2", "connections"),
+			key.WithHelp("2", "network"),
 		),
 		Tab3: key.NewBinding(
 			key.WithKeys("3"),
-			key.WithHelp("3", "chunks"),
+			key.WithHelp("3", "performance"),
 		),
 		Tab4: key.NewBinding(
 			key.WithKeys("4"),
-			key.WithHelp("4", "performance"),
+			key.WithHelp("4", "categories"),
+		),
+		Tab5: key.NewBinding(
+			key.WithKeys("5"),
+			key.WithHelp("5", "extension"),
 		),
 		NextTab: key.NewBinding(
 			key.WithKeys("right"),
@@ -494,7 +499,7 @@ func (k SettingsKeyMap) ShortHelp() []key.Binding {
 
 func (k SettingsKeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
-		{k.Tab1, k.Tab2, k.Tab3, k.Tab4},
+		{k.Tab1, k.Tab2, k.Tab3, k.Tab4, k.Tab5},
 		{k.PrevTab, k.NextTab, k.Up, k.Down, k.Edit, k.Reset, k.Browse, k.Close},
 	}
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -130,7 +130,6 @@ type RootModel struct {
 	SettingsFileBrowsing  bool             // Whether browsing for a directory
 	ExtensionFileBrowsing bool             // Whether browsing for extension prompt path
 	ExtensionTokenCopied  bool             // Flash message for "Token Copied!"
-	ExtensionTokenCopyTimer time.Time       // Timer for fading flash message
 
 	// Selection persistence
 	SelectedDownloadID string // ID of the currently selected download

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -129,6 +129,8 @@ type RootModel struct {
 	SettingsInput         textinput.Model  // Input for editing string/int values
 	SettingsFileBrowsing  bool             // Whether browsing for a directory
 	ExtensionFileBrowsing bool             // Whether browsing for extension prompt path
+	ExtensionTokenCopied  bool             // Flash message for "Token Copied!"
+	ExtensionTokenCopyTimer time.Time       // Timer for fading flash message
 
 	// Selection persistence
 	SelectedDownloadID string // ID of the currently selected download
@@ -390,6 +392,8 @@ func InitialRootModel(serverPort int, currentVersion string, service core.Downlo
 		cancelEnqueue:         cancelEnqueue,
 		spinner:               s,
 	}
+
+	InitAuthToken() // Cache auth token for TUI to avoid per-frame disk I/O
 
 	m.refreshThemeCaches()
 

--- a/internal/tui/token.go
+++ b/internal/tui/token.go
@@ -1,0 +1,26 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/SurgeDM/Surge/internal/config"
+)
+
+var authTokenCache string
+
+// InitAuthToken reads the authentication token from disk and caches it in memory.
+// This is called once at startup to avoid re-reading from disk on every frame layout.
+func InitAuthToken() {
+	stateTokenFile := filepath.Join(config.GetStateDir(), "token")
+	data, err := os.ReadFile(stateTokenFile)
+	if err == nil {
+		authTokenCache = strings.TrimSpace(string(data))
+	}
+}
+
+// GetAuthToken returns the cached authentication token.
+func GetAuthToken() string {
+	return authTokenCache
+}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -107,6 +107,10 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Notification tick is still used but logs don't expire
 		return m, nil
 
+	case extensionTokenFlashFadeMsg:
+		m.ExtensionTokenCopied = false
+		return m, nil
+
 	case UpdateCheckResultMsg:
 		if msg.Info != nil && msg.Info.UpdateAvailable {
 			m.UpdateInfo = msg.Info

--- a/internal/tui/update_events.go
+++ b/internal/tui/update_events.go
@@ -122,7 +122,7 @@ func (m RootModel) updateEvents(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
-		if m.Settings.General.ExtensionPrompt {
+		if m.Settings != nil && m.Settings.Extension.ExtensionPrompt {
 			m.pendingURL = msg.URL
 			m.pendingMirrors = msg.Mirrors
 			m.pendingHeaders = msg.Headers

--- a/internal/tui/update_settings.go
+++ b/internal/tui/update_settings.go
@@ -1,10 +1,16 @@
 package tui
 
 import (
+	"time"
+
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
+	"github.com/SurgeDM/Surge/internal/clipboard"
 	"github.com/SurgeDM/Surge/internal/config"
+	"github.com/SurgeDM/Surge/internal/utils"
 )
+
+type extensionTokenFlashFadeMsg struct{}
 
 func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	m.normalizeSettingsSelection()
@@ -45,7 +51,13 @@ func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.state = DashboardState
 		return m, nil
 	}
-	tabBindings := []key.Binding{m.keys.Settings.Tab1, m.keys.Settings.Tab2, m.keys.Settings.Tab3, m.keys.Settings.Tab4}
+	tabBindings := []key.Binding{
+		m.keys.Settings.Tab1,
+		m.keys.Settings.Tab2,
+		m.keys.Settings.Tab3,
+		m.keys.Settings.Tab4,
+		m.keys.Settings.Tab5,
+	}
 	for i, binding := range tabBindings {
 		if key.Matches(msg, binding) {
 			if categoryCount > i {
@@ -123,6 +135,29 @@ func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 		// Toggle bool or enter edit mode for other types
 		typ := m.getCurrentSettingType()
+
+		// Special actions for custom types
+		if typ == "auth_token" {
+			token := GetAuthToken()
+			if token != "" {
+				_ = clipboard.Write(token)
+				m.ExtensionTokenCopied = true
+				m.ExtensionTokenCopyTimer = time.Now()
+				return m, tea.Tick(2*time.Second, func(t time.Time) tea.Msg {
+					return extensionTokenFlashFadeMsg{}
+				})
+			}
+			return m, nil
+		}
+
+		if typ == "link" {
+			currentCategory := categories[m.SettingsActiveTab]
+			values := m.getSettingsValues(currentCategory)
+			if url, ok := values[settingKey].(string); ok && url != "" {
+				_ = utils.OpenBrowser(url)
+			}
+			return m, nil
+		}
 
 		currentCategory := categories[m.SettingsActiveTab]
 		if typ == "bool" {

--- a/internal/tui/update_settings.go
+++ b/internal/tui/update_settings.go
@@ -142,7 +142,6 @@ func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			if token != "" {
 				_ = clipboard.Write(token)
 				m.ExtensionTokenCopied = true
-				m.ExtensionTokenCopyTimer = time.Now()
 				return m, tea.Tick(2*time.Second, func(t time.Time) tea.Msg {
 					return extensionTokenFlashFadeMsg{}
 				})

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -356,7 +356,7 @@ func TestUpdate_DownloadRequestMsg(t *testing.T) {
 	}
 
 	// 1. Test Extension Prompt Enabled
-	m.Settings.General.ExtensionPrompt = true
+	m.Settings.Extension.ExtensionPrompt = true
 	m.Settings.General.WarnOnDuplicate = true
 
 	msg := events.DownloadRequestMsg{
@@ -382,7 +382,7 @@ func TestUpdate_DownloadRequestMsg(t *testing.T) {
 	}
 
 	// 2. Test Duplicate Warning (when prompt disabled but duplicate exists)
-	m.Settings.General.ExtensionPrompt = false
+	m.Settings.Extension.ExtensionPrompt = false
 	m.Settings.General.WarnOnDuplicate = true
 
 	// Add existing download
@@ -399,7 +399,7 @@ func TestUpdate_DownloadRequestMsg(t *testing.T) {
 	}
 
 	// 3. Test No Prompt (Direct Download)
-	m.Settings.General.ExtensionPrompt = false
+	m.Settings.Extension.ExtensionPrompt = false
 	m.Settings.General.WarnOnDuplicate = true
 	m.downloads = nil // Clear downloads
 

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -108,14 +108,14 @@ func (m RootModel) viewSettings() string {
 }
 
 func settingsModalDimensions(termWidth, termHeight int) (int, int) {
-	width := int(float64(termWidth) * 0.68)
+	width := int(float64(termWidth) * 0.72)
 	if width < 64 {
 		width = 64
 	}
-	if width > 120 {
-		width = 120
+	if width > 130 {
+		width = 130
 	}
-	height := 24
+	height := 26
 
 	maxWidth := termWidth - (WindowStyle.GetHorizontalFrameSize() * 2)
 	if maxWidth < 1 {

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -146,6 +146,8 @@ func shortSettingsCategoryLabel(label string) string {
 		return "Perf"
 	case "Categories":
 		return "Cats"
+	case "Extension":
+		return "Ext"
 	default:
 		return label
 	}
@@ -328,15 +330,33 @@ func (m RootModel) renderSettingsDetailBlock(settingsMeta []config.SettingMeta, 
 	if m.SettingsIsEditing {
 		valueStr = m.SettingsInput.View() + unitStyle.Render(unit)
 	} else {
-		valueStr = formatSettingValueForEdit(value, meta.Type, meta.Key) + unitStyle.Render(unit)
-		if meta.Key == "max_global_connections" {
-			valueStr += " (Ignored)"
+		if meta.Type == "auth_token" {
+			token := GetAuthToken()
+			if token == "" {
+				valueStr = lipgloss.NewStyle().Foreground(colors.Gray).Render("(Not generated yet)")
+			} else {
+				if m.ExtensionTokenCopied {
+					valueStr = lipgloss.NewStyle().Foreground(colors.StateDownloading).Bold(true).Render("Copied!")
+				} else {
+					valueStr = token[:8] + "..." + token[len(token)-8:] + lipgloss.NewStyle().Foreground(colors.Gray).Render(" [Enter to Copy]")
+				}
+			}
+		} else if meta.Type == "link" {
+			valueStr = lipgloss.NewStyle().Foreground(colors.NeonCyan).Render("Open [Enter]")
+		} else {
+			valueStr = formatSettingValueForEdit(value, meta.Type, meta.Key) + unitStyle.Render(unit)
+			if meta.Key == "max_global_connections" {
+				valueStr += " (Ignored)"
+			}
 		}
 	}
 
 	valueLabel := "Value: "
 	if meta.Key == "default_download_dir" && !m.SettingsIsEditing {
 		valueLabel = "[Tab] Browse: "
+	}
+	if meta.Type == "link" {
+		valueLabel = "Action: "
 	}
 
 	valueLabelStyle := lipgloss.NewStyle().Foreground(colors.NeonCyan).Bold(true)
@@ -842,7 +862,7 @@ func formatSettingValue(value interface{}, typ string) string {
 		if v, ok := value.(float64); ok {
 			return fmt.Sprintf("%.2f", v)
 		}
-	case "string":
+	case "string", "link":
 		if s, ok := value.(string); ok {
 			if s == "" {
 				return "(default)"
@@ -852,6 +872,8 @@ func formatSettingValue(value interface{}, typ string) string {
 			}
 			return s
 		}
+	case "auth_token":
+		return "********"
 	}
 
 	// Fallback using reflection for numeric types
@@ -877,8 +899,6 @@ func (m *RootModel) resetSettingToDefault(category, key string, defaults *config
 			m.Settings.General.WarnOnDuplicate = defaults.General.WarnOnDuplicate
 		case "download_complete_notification":
 			m.Settings.General.DownloadCompleteNotification = defaults.General.DownloadCompleteNotification
-		case "extension_prompt":
-			m.Settings.General.ExtensionPrompt = defaults.General.ExtensionPrompt
 		case "auto_resume":
 			m.Settings.General.AutoResume = defaults.General.AutoResume
 		case "skip_update_check":
@@ -928,6 +948,11 @@ func (m *RootModel) resetSettingToDefault(category, key string, defaults *config
 		switch key {
 		case "category_enabled":
 			m.Settings.Categories.CategoryEnabled = defaults.Categories.CategoryEnabled
+		}
+	case "Extension":
+		switch key {
+		case "extension_prompt":
+			m.Settings.Extension.ExtensionPrompt = defaults.Extension.ExtensionPrompt
 		}
 	}
 }

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -338,7 +338,11 @@ func (m RootModel) renderSettingsDetailBlock(settingsMeta []config.SettingMeta, 
 				if m.ExtensionTokenCopied {
 					valueStr = lipgloss.NewStyle().Foreground(colors.StateDownloading).Bold(true).Render("Copied!")
 				} else {
-					valueStr = token[:8] + "..." + token[len(token)-8:] + lipgloss.NewStyle().Foreground(colors.Gray).Render(" [Enter to Copy]")
+					displayToken := token
+					if len(token) > 16 {
+						displayToken = token[:8] + "..." + token[len(token)-8:]
+					}
+					valueStr = displayToken + lipgloss.NewStyle().Foreground(colors.Gray).Render(" [Enter to Copy]")
 				}
 			}
 		} else if meta.Type == "link" {

--- a/internal/utils/open.go
+++ b/internal/utils/open.go
@@ -71,3 +71,11 @@ func buildOpenCommand(path string) *exec.Cmd {
 		return exec.Command("xdg-open", path)
 	}
 }
+
+// OpenBrowser opens a URL in the system's default web browser.
+func OpenBrowser(url string) error {
+	if url == "" {
+		return fmt.Errorf("url is empty")
+	}
+	return openWithSystem(url)
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new **Extension** settings tab to the TUI, moving `ExtensionPrompt` from General into a dedicated `ExtensionSettings` struct, and adding auth-token display/copy-to-clipboard and browser-extension installation links. The `AuthToken` field is deliberately excluded from JSON serialization via `json:"-"` and is read from the state file via `InitAuthToken()` at startup.

The three commits address the previous round's feedback (removed dead `ExtensionTokenCopyTimer`, fixed JSON exclusion of the auth token, and corrected the `ExtensionPrompt` field location). Overall the feature is well-structured and handles the main user flows correctly.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all remaining findings are P2 style/quality suggestions that do not block correct runtime behaviour.

The three previous round findings have all been addressed: AuthToken is now json:"-", ExtensionTokenCopyTimer has been removed, and ExtensionPrompt has been relocated correctly. The two remaining issues (the "-" key produced by json:"-" in metadata, and missing unit tests for new TUI actions) are non-breaking quality improvements.

internal/config/settings.go (json:"-" key extraction) and internal/tui/view_settings.go (same pattern in getSettingsValues at line 593)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/config/settings.go | Adds ExtensionSettings struct; AuthToken uses json:"-" to fix the previous serialization issue, but this causes GetSettingsMetadata/getSettingsValues to store the field under key "-" instead of a meaningful name. |
| internal/tui/token.go | New file: simple startup-time token cache that reads from the state file once to avoid per-frame disk I/O. Implementation is clean and purposeful. |
| internal/tui/update_settings.go | Adds auth_token copy and link-open handling; imports are all used; flash-fade timer is correctly wired up. No missing edge-case guards for the new code paths. |
| internal/tui/view_settings.go | Extended rendering for auth_token and link types; truncation guard for token display now uses len(token) > 16, safely covering any realistic token length. |
| internal/tui/update_test.go | Correctly updates ExtensionPrompt references to Settings.Extension; no new tests added for the auth_token copy, link-open, or flash-fade behaviors introduced in this PR. |
| internal/tui/model.go | Adds ExtensionTokenCopied flash-state field and calls InitAuthToken() at startup; clean and correct. |
| internal/utils/open.go | Adds OpenBrowser as a thin wrapper over the existing openWithSystem; correct empty-string guard, consistent with the existing OpenFile pattern. |
| internal/tui/keys.go | Adds Tab5 key binding for the Extension tab; FullHelp slice updated accordingly. |
| extension-chrome/manifest.json | Version bump to 1.8.0; permissions and structure unchanged. |
| extension-firefox/manifest.json | Version bump to 1.8.0; CSP and gecko settings unchanged. |
| internal/config/settings_test.go | Good coverage of new ExtensionSettings defaults and round-trip serialization; validates ExtensionPrompt, ChromeExtensionURL, FirefoxExtensionURL, InstructionsURL. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([User presses Enter on Extension tab]) --> B{getCurrentSettingType}
    B -->|auth_token| C[GetAuthToken from cache]
    C --> D{token empty?}
    D -->|yes| E[return nil, no-op]
    D -->|no| F[clipboard.Write token]
    F --> G[ExtensionTokenCopied = true]
    G --> H[tea.Tick 2s → extensionTokenFlashFadeMsg]
    H --> I[ExtensionTokenCopied = false\nUI returns to truncated token display]
    B -->|link| J[getSettingsValues for category]
    J --> K[utils.OpenBrowser url]
    B -->|bool| L[toggle value via setSettingValue]
    B -->|string/int/etc| M[enter edit mode\nSettingsIsEditing = true]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/tui/update_test.go
Line: 356-410

Comment:
**Missing tests for new auth_token and link behaviours**

The PR adds three new code paths in `updateSettings` — auth_token copy-to-clipboard + flash, `extensionTokenFlashFadeMsg` reset of `ExtensionTokenCopied`, and link-open via `OpenBrowser` — but none of them are exercised in the test suite. Per the project's testing rule, edge cases and integration points between components should be covered.

Suggested additions:
- `TestUpdate_ExtensionTokenCopy`: set a non-empty `authTokenCache`, send an `Edit` keypress on the auth_token row, assert `ExtensionTokenCopied == true` and that a `tea.Cmd` is returned.
- `TestUpdate_ExtensionTokenFlashFade`: send `extensionTokenFlashFadeMsg`, assert `ExtensionTokenCopied == false`.
- `TestUpdate_LinkOpen`: send an `Edit` keypress on a `link`-type row, assert `OpenBrowser` was invoked with the expected URL.

**Rule Used:** What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/config/settings.go
Line: 109-114

Comment:
**Reflect tag extraction produces `"-"` as the metadata key for `AuthToken`**

`reflect.StructTag.Get("json")` on a field marked to be skipped during serialization returns the literal hyphen character, not an empty string. The `if key == ""` guard on line 113 never fires for `AuthToken`, so both `GetSettingsMetadata()` and `getSettingsValues()` store that field under key `"-"`.

Today this is non-breaking because every auth_token code path branches on `meta.Type` before touching the key. However, any future key-based switch in the Extension category would need to match `"-"` rather than the intuitive `"auth_token"`. Adding `|| key == "-"` to the empty-string guard (and the equivalent check in `getSettingsValues` in `view_settings.go`) would make the key meaningful and consistent with the rest of the settings metadata.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["style: increase settings modal width and..."](https://github.com/surgedm/surge/commit/28cd97b990cebb9fda31273e19537462bd461a85) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28041366)</sub>

<!-- /greptile_comment -->