### PR TITLE
refactor: centralize TUI layout logic and constants to standardize responsive dimensions

### DIFF
--- a/internal/tui/constants.go
+++ b/internal/tui/constants.go
@@ -36,7 +36,8 @@ const (
 	MinChunkMapVisibleH  = 18 // Min term height to show chunk map
 
 	// === Component Heights ===
-	HeaderHeightMax  = 11
+	ModalHeightPadding = 4  // Bottom fallback padding for modals to avoid clipping
+	HeaderHeightMax    = 11
 	HeaderHeightMin  = 3
 	FilePickerHeight = 12
 	CardHeight       = 2 // Compact rows for downloads list

--- a/internal/tui/constants.go
+++ b/internal/tui/constants.go
@@ -21,9 +21,9 @@ const (
 	MinTermHeight = 12
 	ShortTermHeightThreshold = 25 // Switch to compact header below this height
 
-	MinSettingsWidth  = 64
+	MinSettingsWidth  = 45
 	MaxSettingsWidth  = 130
-	MinSettingsHeight = 26
+	MinSettingsHeight = 12
 
 	MinRightColumnWidth = 50 // Hide right column if narrow
 	MinGraphStatsWidth  = 70 // Hide inline graph stats if narrow

--- a/internal/tui/constants.go
+++ b/internal/tui/constants.go
@@ -7,29 +7,64 @@ import (
 )
 
 const (
-	// Timeouts and Intervals
+	// === Timeouts and Intervals ===
 	TickInterval = 200 * time.Millisecond
-	// Input Dimensions
-	InputWidth = 40
 
-	// Layout Offsets and Padding
+	// === Layout Ratios ===
+	ListWidthRatio      = 0.6  // Dashboard: List takes 60% width
+	SettingsWidthRatio  = 0.72 // Modals: Settings/Category use 72% width
+	LogoWidthRatio      = 0.45 // Header: Logo takes 45% of left column
+	GraphTargetHeightRatio = 0.4  // Right Column: Graph target 40% height
+
+	// === Thresholds and Minimums ===
+	MinTermWidth  = 45
+	MinTermHeight = 12
+	ShortTermHeightThreshold = 25 // Switch to compact header below this height
+
+	MinSettingsWidth  = 64
+	MaxSettingsWidth  = 130
+	MinSettingsHeight = 26
+
+	MinRightColumnWidth = 50 // Hide right column if narrow
+	MinGraphStatsWidth  = 70 // Hide inline graph stats if narrow
+	MinLogoWidth        = 60 // Hide ASCII logo if narrow
+
+	MinGraphHeight       = 9
+	MinGraphHeightShort  = 5
+	MinListHeight        = 10
+	MinChunkMapHeight    = 4
+	MinChunkMapVisibleH  = 18 // Min term height to show chunk map
+
+	// === Component Heights ===
+	HeaderHeightMax  = 11
+	HeaderHeightMin  = 3
+	FilePickerHeight = 12
+	CardHeight       = 2 // Compact rows for downloads list
+
+	// === Padding and Offsets ===
+	DefaultPaddingX = 1
+	DefaultPaddingY = 0
+	PopupPaddingX   = 2
+	PopupPaddingY   = 1
+	PopupWidth      = 70 // Consistent width for small popup dialogs
+
 	HeaderWidthOffset      = 2
 	ProgressBarWidthOffset = 4
-	DefaultPaddingX        = 1
-	DefaultPaddingY        = 0
-	PopupPaddingY          = 1
-	PopupPaddingX          = 2
-	PopupWidth             = 70 // Consistent width for all popup dialogs
 
-	// Viewport layout
-	CardHeight       = 2  // Compact rows for cyberpunk theme
-	HeaderHeight     = 8  // Logo + Graph height
-	FilePickerHeight = 12 // Height for file picker display
+	// === Graph Configuration ===
+	GraphAxisWidth  = 10
+	GraphStatsWidth = 18
+	GraphHeadroom   = 1.1 // Scale max speed by 110% for visual headroom
 
-	// Channel Buffers - use consolidated constant from downloader
+	// === Input Dimensions ===
+	InputWidth        = 40
+	MinSettingsInputW = 8
+	MaxSettingsInputW = 48
+
+	// === Channel Buffers ===
 	ProgressChannelBuffer = types.ProgressChannelBuffer
 
-	// Units - use consolidated constants from downloader
+	// === Units ===
 	KB = types.KB
 	MB = types.MB
 	GB = types.GB

--- a/internal/tui/layout_helpers.go
+++ b/internal/tui/layout_helpers.go
@@ -1,0 +1,85 @@
+package tui
+
+// GetHeaderHeight returns the appropriate header height based on terminal height
+func GetHeaderHeight(termHeight int) int {
+	if termHeight < ShortTermHeightThreshold {
+		return HeaderHeightMin
+	}
+	return HeaderHeightMax
+}
+
+// GetMinGraphHeight returns the minimum graph height based on terminal height
+func GetMinGraphHeight(termHeight int) int {
+	if termHeight < ShortTermHeightThreshold {
+		return MinGraphHeightShort
+	}
+	return MinGraphHeight
+}
+
+// GetSettingsDimensions calculates dimensions for settings/category modals
+func GetSettingsDimensions(termWidth, termHeight int) (int, int) {
+	width := int(float64(termWidth) * SettingsWidthRatio)
+	if width < MinSettingsWidth {
+		width = MinSettingsWidth
+	}
+	if width > MaxSettingsWidth {
+		width = MaxSettingsWidth
+	}
+
+	maxWidth := termWidth - (WindowStyle.GetHorizontalFrameSize() * 2)
+	if maxWidth < 1 {
+		maxWidth = 1
+	}
+	if width > maxWidth {
+		width = maxWidth
+	}
+
+	height := MinSettingsHeight
+	maxHeight := termHeight - (WindowStyle.GetVerticalFrameSize() * 2) - 4 // fallback padding
+	if maxHeight < 1 {
+		maxHeight = 1
+	}
+	if height > maxHeight {
+		height = maxHeight
+	}
+
+	return width, height
+}
+
+// GetListWidth calculates the list width based on available width
+func GetListWidth(availableWidth int) int {
+	leftWidth := int(float64(availableWidth) * ListWidthRatio)
+	
+	// Determine right column viability
+	rightWidth := availableWidth - leftWidth
+	if rightWidth < MinRightColumnWidth {
+		return availableWidth
+	}
+	return leftWidth
+}
+
+// IsShortTerminal returns true if the terminal height is below the threshold
+func IsShortTerminal(height int) bool {
+	return height < ShortTermHeightThreshold
+}
+
+// GetGraphAreaDimensions calculates dimensions for the graph area
+func GetGraphAreaDimensions(rightWidth int, isStatsHidden bool) (int, int) {
+	axisWidth := GraphAxisWidth
+	
+	if isStatsHidden {
+		// No stats box — graph gets almost full width
+		graphAreaWidth := rightWidth - axisWidth - (BoxStyle.GetHorizontalFrameSize() * 5)
+		if graphAreaWidth < 10 {
+			graphAreaWidth = 10
+		}
+		return graphAreaWidth, axisWidth
+	}
+	
+	// Graph takes remaining width after stats box
+	graphAreaWidth := rightWidth - GraphStatsWidth - axisWidth - (BoxStyle.GetHorizontalFrameSize() * 3)
+	if graphAreaWidth < 10 {
+		graphAreaWidth = 10
+	}
+	return graphAreaWidth, axisWidth
+}

--- a/internal/tui/layout_helpers.go
+++ b/internal/tui/layout_helpers.go
@@ -86,3 +86,26 @@ func GetGraphAreaDimensions(rightWidth int, isStatsHidden bool) (int, int) {
 	}
 	return graphAreaWidth, axisWidth
 }
+
+// CalculateTwoColumnWidths calculates the distribution of widths for a two-column modal layout.
+func CalculateTwoColumnWidths(modalWidth, preferredLeft, minRight int) (int, int) {
+	horizontalPadding := ModalPaddingStyle.GetHorizontalFrameSize() * 2
+
+	leftWidth := preferredLeft
+	if modalWidth-leftWidth-horizontalPadding < minRight {
+		leftWidth = modalWidth - minRight - horizontalPadding
+	}
+	if leftWidth < 16 {
+		leftWidth = 16
+	}
+
+	rightWidth := modalWidth - leftWidth - horizontalPadding
+	if rightWidth < minRight {
+		rightWidth = minRight
+		if modalWidth-rightWidth-horizontalPadding > 16 {
+			leftWidth = modalWidth - rightWidth - horizontalPadding
+		}
+	}
+
+	return leftWidth, rightWidth
+}

--- a/internal/tui/layout_helpers.go
+++ b/internal/tui/layout_helpers.go
@@ -35,7 +35,7 @@ func GetSettingsDimensions(termWidth, termHeight int) (int, int) {
 	}
 
 	height := MinSettingsHeight
-	maxHeight := termHeight - (WindowStyle.GetVerticalFrameSize() * 2) - 4 // fallback padding
+	maxHeight := termHeight - (WindowStyle.GetVerticalFrameSize() * 2) - ModalHeightPadding
 	if maxHeight < 1 {
 		maxHeight = 1
 	}
@@ -68,7 +68,9 @@ func GetGraphAreaDimensions(rightWidth int, isStatsHidden bool) (int, int) {
 	axisWidth := GraphAxisWidth
 	
 	if isStatsHidden {
-		// No stats box — graph gets almost full width
+		// No stats box — graph gets almost full width.
+		// Higher buffer (* 5) accounts for extra padding needed when axis is on the far right
+		// to maintain visual balance with the outer container borders.
 		graphAreaWidth := rightWidth - axisWidth - (BoxStyle.GetHorizontalFrameSize() * 5)
 		if graphAreaWidth < 10 {
 			graphAreaWidth = 10
@@ -76,7 +78,8 @@ func GetGraphAreaDimensions(rightWidth int, isStatsHidden bool) (int, int) {
 		return graphAreaWidth, axisWidth
 	}
 	
-	// Graph takes remaining width after stats box
+	// Graph takes remaining width after stats box.
+	// Smaller buffer (* 3) as the stats box provides its own internal padding.
 	graphAreaWidth := rightWidth - GraphStatsWidth - axisWidth - (BoxStyle.GetHorizontalFrameSize() * 3)
 	if graphAreaWidth < 10 {
 		graphAreaWidth = 10

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -37,9 +37,9 @@ func init() {
 }
 
 func rebuildStyles() {
-	WindowStyle = lipgloss.NewStyle().Margin(0, 1)
+	WindowStyle = lipgloss.NewStyle().Margin(DefaultPaddingY, DefaultPaddingX)
 	BoxStyle = lipgloss.NewStyle().Border(lipgloss.RoundedBorder())
-	ModalPaddingStyle = lipgloss.NewStyle().Padding(1, 2)
+	ModalPaddingStyle = lipgloss.NewStyle().Padding(PopupPaddingY, PopupPaddingX)
 	LayoutGapStyle = lipgloss.NewStyle().MarginTop(1)
 
 	AppStyle = lipgloss.NewStyle().
@@ -49,7 +49,7 @@ func rebuildStyles() {
 	PaneStyle = lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(colors.Gray).
-		Padding(0, 1)
+		Padding(DefaultPaddingY, DefaultPaddingX)
 
 	ActivePaneStyle = PaneStyle.BorderForeground(colors.NeonPink)
 	LogoStyle = lipgloss.NewStyle().Foreground(colors.NeonPurple).Bold(true).MarginBottom(1)
@@ -59,13 +59,13 @@ func rebuildStyles() {
 
 	TitleStyle = lipgloss.NewStyle().Foreground(colors.NeonCyan).Bold(true).MarginBottom(1)
 	PaneTitleStyle = lipgloss.NewStyle().Foreground(colors.NeonCyan).Bold(true)
-	TabStyle = lipgloss.NewStyle().Foreground(colors.LightGray).Padding(0, 1)
+	TabStyle = lipgloss.NewStyle().Foreground(colors.LightGray).Padding(DefaultPaddingY, DefaultPaddingX)
 
 	ActiveTabStyle = lipgloss.NewStyle().
 		Foreground(colors.NeonPink).
 		Border(lipgloss.NormalBorder(), false, false, true, false).
 		BorderForeground(colors.NeonPink).
-		Padding(0, 1).
+		Padding(DefaultPaddingY, DefaultPaddingX).
 		Bold(true)
 
 	StatsLabelStyle = lipgloss.NewStyle().Foreground(colors.NeonCyan).Width(12)

--- a/internal/tui/update_category.go
+++ b/internal/tui/update_category.go
@@ -71,18 +71,7 @@ func (m *RootModel) updateCategoryInputWidthsForViewport() {
 
 	var targetWidth int
 	if modalWidth >= 76 {
-		leftWidth := 28
-		minRightWidth := 24
-
-		horizontalPadding := ModalPaddingStyle.GetHorizontalFrameSize() * 2
-
-		if modalWidth-leftWidth-horizontalPadding < minRightWidth {
-			leftWidth = modalWidth - minRightWidth - horizontalPadding
-		}
-		if leftWidth < 16 {
-			leftWidth = 16
-		}
-		rightWidth := modalWidth - leftWidth - horizontalPadding
+		_, rightWidth := CalculateTwoColumnWidths(modalWidth, 28, 24)
 		targetWidth = rightWidth - 10
 	} else {
 		targetWidth = modalWidth - 14

--- a/internal/tui/update_category.go
+++ b/internal/tui/update_category.go
@@ -67,7 +67,7 @@ func (m *RootModel) normalizeCategoryManagerSelection() {
 }
 
 func (m *RootModel) updateCategoryInputWidthsForViewport() {
-	modalWidth, _ := categoryModalDimensions(m.width, m.height)
+	modalWidth, _ := GetSettingsDimensions(m.width, m.height)
 
 	var targetWidth int
 	if modalWidth >= 76 {

--- a/internal/tui/update_category.go
+++ b/internal/tui/update_category.go
@@ -198,7 +198,7 @@ func (m RootModel) updateCategoryManager(msg tea.KeyPressMsg) (tea.Model, tea.Cm
 	// Not editing - handle navigation
 	if key.Matches(msg, m.keys.CategoryMgr.Close) {
 		_ = m.persistSettings()
-		m.state = DashboardState
+		m.state = SettingsState
 		return m, nil
 	}
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -402,8 +402,8 @@ func (m RootModel) View() tea.View {
 		// Sufficient space for everything
 		chunkMapHeight = chunkMapNeeded
 		if !showChunkMap {
-			// User wants 4:6 ratio for Graph:Details
-			targetGraphHeight := int(float64(availableHeight) * 0.4)
+			// User wants target ratio for Graph:Details
+			targetGraphHeight := int(float64(availableHeight) * GraphTargetHeightRatio)
 			targetDetailHeight := availableHeight - targetGraphHeight
 
 			// Ensure Graph meets minimum

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -15,11 +15,7 @@ import (
 	"charm.land/lipgloss/v2"
 )
 
-// Define the Layout Ratios
-const (
-	ListWidthRatio = 0.6 // List takes 60% width
-)
-
+// Viewport layout
 const maxUIDuration = 30 * 24 * time.Hour
 
 // formatDurationForUI formats a duration as a human-readable clock string.
@@ -74,8 +70,8 @@ func (m RootModel) View() tea.View {
 	}
 
 	// Terminal too small to render any meaningful layout
-	if m.width < 45 || m.height < 12 {
-		msg := lipgloss.NewStyle().Foreground(colors.NeonCyan).Render("Terminal too small (min: 45×12)")
+	if m.width < MinTermWidth || m.height < MinTermHeight {
+		msg := lipgloss.NewStyle().Foreground(colors.NeonCyan).Render(fmt.Sprintf("Terminal too small (min: %d×%d)", MinTermWidth, MinTermHeight))
 		return m.wrapView(lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, msg))
 	}
 
@@ -238,11 +234,11 @@ func (m RootModel) View() tea.View {
 	}
 
 	if m.state == HelpModalState {
-		modalW := 70
+		modalW := PopupWidth
 		if m.width < modalW {
 			modalW = m.width
 		}
-		modalH := 22
+		modalH := 22 // Height for keyboard shortcuts (TODO: calculate based on key count)
 		if m.height < modalH {
 			modalH = m.height
 		}
@@ -297,39 +293,30 @@ func (m RootModel) View() tea.View {
 	}
 
 	// Column Widths (or full-width when right column is hidden)
-	leftWidth := int(float64(availableWidth) * ListWidthRatio)
+	leftWidth := GetListWidth(availableWidth)
 	rightWidth := availableWidth - leftWidth
 	if rightWidth < 0 {
 		rightWidth = 0
 	}
 
 	// Determine right column viability thresholds
-	hideRightColumn := rightWidth < 50                    // too narrow for any right content
-	hideGraphStats := rightWidth >= 50 && rightWidth < 70 // enough for graph, not for inline stats
-	hideLogo := leftWidth < 60                            // not enough room for ASCII logo
+	hideRightColumn := rightWidth < MinRightColumnWidth
+	hideGraphStats := rightWidth >= MinRightColumnWidth && rightWidth < MinGraphStatsWidth
+	hideLogo := leftWidth < MinLogoWidth
 
 	if hideRightColumn {
 		leftWidth = availableWidth
 	}
 
-	// Short terminal: reduce header and graph minimums
-	shortTerminal := availableHeight < 25
-
 	// --- LEFT COLUMN HEIGHTS ---
-	headerHeight := 11
-	if shortTerminal {
-		headerHeight = 3 // server info bar only, skip logo
-	}
+	headerHeight := GetHeaderHeight(availableHeight)
 	listHeight := availableHeight - headerHeight
-	if listHeight < 10 {
-		listHeight = 10
+	if listHeight < MinListHeight {
+		listHeight = MinListHeight
 	}
 
 	// Short terminal: reduce minimum graph height
-	minGraphHeight := 9
-	if shortTerminal {
-		minGraphHeight = 5
-	}
+	minGraphHeight := GetMinGraphHeight(availableHeight)
 
 	// --- RIGHT COLUMN HEIGHTS ---
 	// Priority 1: Details (Fixed content + Padding)
@@ -385,7 +372,7 @@ func (m RootModel) View() tea.View {
 
 		hasChunks := len(bitmap) > 0 && bitmapWidth > 0
 
-		if !selected.done && hasChunks && availableHeight >= 18 {
+		if !selected.done && hasChunks && availableHeight >= MinChunkMapVisibleH {
 			showChunkMap = true
 		}
 	}
@@ -438,10 +425,10 @@ func (m RootModel) View() tea.View {
 		chunkMapHeight = remainingHeight - graphHeight
 
 		// If ChunkMap gets squeezed too much, we might need to squeeze Graph purely to survive
-		if chunkMapHeight < 4 {
+		if chunkMapHeight < MinChunkMapHeight {
 			// Check if we can start eating into Graph's minimum?
 			// Let's enforce a hard floor for ChunkMap
-			chunkMapHeight = 4
+			chunkMapHeight = MinChunkMapHeight
 			graphHeight = remainingHeight - chunkMapHeight
 			// If graphHeight becomes negative, the whole UI is too small,
 			// renderBtopBox will handle truncation, but visual will be broken.
@@ -469,7 +456,7 @@ func (m RootModel) View() tea.View {
 	downloaded := stats.DownloadedCount
 
 	// Logo takes ~45% of header width
-	logoWidth := int(float64(leftWidth) * 0.45)
+	logoWidth := int(float64(leftWidth) * LogoWidthRatio)
 	logWidth := leftWidth - logoWidth - BoxStyle.GetHorizontalFrameSize() // Rest for log box
 
 	if logoWidth < 4 {
@@ -580,7 +567,7 @@ func (m RootModel) View() tea.View {
 		maxSpeed = 1.0 // Default scale for empty graph
 	} else {
 		// Add headroom
-		maxSpeed = maxSpeed * 1.1
+		maxSpeed = maxSpeed * GraphHeadroom
 
 		if maxSpeed < 1.0 {
 			maxSpeed = 1.0
@@ -600,10 +587,9 @@ func (m RootModel) View() tea.View {
 	}
 
 	// Stats box width inside the Network Activity box
-	statsBoxWidth := 18
+	statsBoxWidth := GraphStatsWidth
 
 	// Graph width calculation: hide stats box when too narrow
-	axisWidth := 10
 	buildAxisLines := func(height int, axisStyle lipgloss.Style) []string {
 		label := func(v float64) string {
 			if v <= 0 {
@@ -652,10 +638,7 @@ func (m RootModel) View() tea.View {
 	var graphWithAxis string
 	if hideGraphStats {
 		// No stats box — graph gets almost full width
-		graphAreaWidth := rightWidth - axisWidth - (BoxStyle.GetHorizontalFrameSize() * 5)
-		if graphAreaWidth < 10 {
-			graphAreaWidth = 10
-		}
+		graphAreaWidth, axisWidth := GetGraphAreaDimensions(rightWidth, true)
 
 		graphVisual := renderMultiLineGraph(graphData, graphAreaWidth, graphContentHeight, maxSpeed, nil)
 
@@ -709,11 +692,7 @@ func (m RootModel) View() tea.View {
 		statsBox := statsBoxStyle.Render(statsContent)
 
 		// Graph takes remaining width after stats box
-		axisWidth := 10
-		graphAreaWidth := rightWidth - statsBoxWidth - axisWidth - (BoxStyle.GetHorizontalFrameSize() * 3)
-		if graphAreaWidth < 10 {
-			graphAreaWidth = 10
-		}
+		graphAreaWidth, axisWidth := GetGraphAreaDimensions(rightWidth, false)
 
 		graphVisual := renderMultiLineGraph(graphData, graphAreaWidth, graphContentHeight, maxSpeed, nil)
 

--- a/internal/tui/view_category.go
+++ b/internal/tui/view_category.go
@@ -270,25 +270,7 @@ func (m RootModel) renderCategoryEditView(innerWidth, rows int) string {
 }
 
 func (m RootModel) renderCategoryTwoColumn(cats []config.Category, cursor, modalWidth, bodyHeight int) string {
-	leftWidth := 28
-	minRightWidth := 24
-
-	horizontalPadding := ModalPaddingStyle.GetHorizontalFrameSize() * 2
-
-	if modalWidth-leftWidth-horizontalPadding < minRightWidth {
-		leftWidth = modalWidth - minRightWidth - horizontalPadding
-	}
-	if leftWidth < 16 {
-		leftWidth = 16
-	}
-
-	rightWidth := modalWidth - leftWidth - horizontalPadding
-	if rightWidth < minRightWidth {
-		rightWidth = minRightWidth
-		if modalWidth-rightWidth-horizontalPadding > 16 {
-			leftWidth = modalWidth - rightWidth - horizontalPadding
-		}
-	}
+	leftWidth, rightWidth := CalculateTwoColumnWidths(modalWidth, 28, 24)
 
 	if leftWidth < 14 || rightWidth < 16 {
 		return m.renderCategoryCompact(cats, cursor, modalWidth, bodyHeight)

--- a/internal/tui/view_category.go
+++ b/internal/tui/view_category.go
@@ -338,7 +338,7 @@ func (m RootModel) renderCategoryCompact(cats []config.Category, cursor, modalWi
 		listRows = 1
 	}
 
-	detailRows := bodyHeight - listRows - LayoutGapStyle.GetVerticalFrameSize()
+	detailRows := bodyHeight - listRows - 1 // -1 for the divider line
 	if detailRows < 1 {
 		detailRows = 1
 		listRows = bodyHeight - detailRows

--- a/internal/tui/view_category.go
+++ b/internal/tui/view_category.go
@@ -104,9 +104,7 @@ func (m RootModel) viewCategoryManager() string {
 	return m.renderModalWithOverlay(box)
 }
 
-func categoryModalDimensions(termWidth, termHeight int) (int, int) {
-	return GetSettingsDimensions(termWidth, termHeight)
-}
+
 
 func (m RootModel) renderCategoryHelp(width int) string {
 	if width < 1 {

--- a/internal/tui/view_category.go
+++ b/internal/tui/view_category.go
@@ -15,10 +15,10 @@ func (m RootModel) viewCategoryManager() string {
 		return ""
 	}
 
-	width, height := categoryModalDimensions(m.width, m.height)
-	if width < 40 || height < 10 {
+	width, height := GetSettingsDimensions(m.width, m.height)
+	if width < MinSettingsWidth || height < 10 { // Rendering floor for modals
 		content := lipgloss.NewStyle().
-			Padding(1, 2).
+			Padding(DefaultPaddingY, DefaultPaddingX*2).
 			Foreground(colors.LightGray).
 			Render("Terminal too small for category manager")
 		box := renderBtopBox(PaneTitleStyle.Render(" Category Manager "), "", content, width, height, colors.NeonPurple)
@@ -58,13 +58,13 @@ func (m RootModel) viewCategoryManager() string {
 	toggleLine := lipgloss.NewStyle().Foreground(colors.LightGray).Render("  Auto-Sort Downloads: ") +
 		toggleStyle.Render(enabledStr) +
 		lipgloss.NewStyle().Foreground(colors.Gray).Render("  (t to toggle)")
-	if width < 70 {
+	if width < MinGraphStatsWidth {
 		toggleLine = lipgloss.NewStyle().Foreground(colors.LightGray).Render("  Auto-Sort: ") +
 			toggleStyle.Render(enabledStr) +
 			lipgloss.NewStyle().Foreground(colors.Gray).Render("  (t)")
 	}
 
-	helpText := m.renderCategoryHelp(width - 6)
+	helpText := m.renderCategoryHelp(width - (ProgressBarWidthOffset + HeaderWidthOffset))
 	catCount := fmt.Sprintf("%d categories", len(cats))
 	infoLine := lipgloss.NewStyle().Foreground(colors.Gray).Render("  " + catCount)
 
@@ -105,32 +105,7 @@ func (m RootModel) viewCategoryManager() string {
 }
 
 func categoryModalDimensions(termWidth, termHeight int) (int, int) {
-	width := int(float64(termWidth) * 0.72)
-	if width < 64 {
-		width = 64
-	}
-	if width > 130 {
-		width = 130
-	}
-	height := 26
-
-	maxWidth := termWidth - (WindowStyle.GetHorizontalFrameSize() * 2)
-	if maxWidth < 1 {
-		maxWidth = 1
-	}
-	maxHeight := termHeight - (WindowStyle.GetVerticalFrameSize() * 2) - 4 // default fallback padding
-	if maxHeight < 1 {
-		maxHeight = 1
-	}
-
-	if width > maxWidth {
-		width = maxWidth
-	}
-	if height > maxHeight {
-		height = maxHeight
-	}
-
-	return width, height
+	return GetSettingsDimensions(termWidth, termHeight)
 }
 
 func (m RootModel) renderCategoryHelp(width int) string {
@@ -139,10 +114,10 @@ func (m RootModel) renderCategoryHelp(width int) string {
 	}
 
 	helpText := m.help.View(m.keys.CategoryMgr)
-	if width < 68 {
+	if width < MinGraphStatsWidth-2 {
 		helpText = "esc: save/close  enter: edit/save  del: remove"
 	}
-	if width < 48 {
+	if width < MinTermWidth+3 {
 		helpText = "esc close | enter edit | del rm"
 	}
 

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -363,25 +363,7 @@ func (m RootModel) renderSettingsDetailBlock(settingsMeta []config.SettingMeta, 
 }
 
 func (m RootModel) renderSettingsTwoColumn(settingsMeta []config.SettingMeta, selectedRow int, settingsValues map[string]interface{}, modalWidth, bodyHeight int) string {
-	leftWidth := 32
-	minRightWidth := 22
-
-	horizontalPadding := ModalPaddingStyle.GetHorizontalFrameSize() * 2
-
-	if modalWidth-leftWidth-horizontalPadding < minRightWidth {
-		leftWidth = modalWidth - minRightWidth - horizontalPadding
-	}
-	if leftWidth < 16 {
-		leftWidth = 16
-	}
-
-	rightWidth := modalWidth - leftWidth - horizontalPadding
-	if rightWidth < minRightWidth {
-		rightWidth = minRightWidth
-		if modalWidth-rightWidth-horizontalPadding > 16 {
-			leftWidth = modalWidth - rightWidth - horizontalPadding
-		}
-	}
+	leftWidth, rightWidth := CalculateTwoColumnWidths(modalWidth, 32, 22)
 
 	if leftWidth < 12 || rightWidth < 14 {
 		return m.renderSettingsCompact(settingsMeta, selectedRow, settingsValues, modalWidth, bodyHeight)
@@ -503,17 +485,7 @@ func (m *RootModel) updateSettingsInputWidthForViewport() {
 
 	var targetWidth int
 	if modalWidth >= 72 {
-		leftWidth := 32
-		minRightWidth := 22
-		horizontalPadding := ModalPaddingStyle.GetHorizontalFrameSize() * 2
-
-		if modalWidth-leftWidth-horizontalPadding < minRightWidth {
-			leftWidth = modalWidth - minRightWidth - horizontalPadding
-		}
-		if leftWidth < 16 {
-			leftWidth = 16
-		}
-		rightWidth := modalWidth - leftWidth - horizontalPadding
+		_, rightWidth := CalculateTwoColumnWidths(modalWidth, 32, 22)
 		targetWidth = rightWidth - 10
 	} else {
 		targetWidth = modalWidth - 16

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -107,9 +107,7 @@ func (m RootModel) viewSettings() string {
 	return m.renderModalWithOverlay(box)
 }
 
-func settingsModalDimensions(termWidth, termHeight int) (int, int) {
-	return GetSettingsDimensions(termWidth, termHeight)
-}
+
 
 func shortSettingsCategoryLabel(label string) string {
 	switch label {
@@ -501,7 +499,7 @@ func (m *RootModel) normalizeSettingsSelection() {
 }
 
 func (m *RootModel) updateSettingsInputWidthForViewport() {
-	modalWidth, _ := settingsModalDimensions(m.width, m.height)
+	modalWidth, _ := GetSettingsDimensions(m.width, m.height)
 
 	var targetWidth int
 	if modalWidth >= 72 {

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -420,7 +420,7 @@ func (m RootModel) renderSettingsCompact(settingsMeta []config.SettingMeta, sele
 		listRows = 1
 	}
 
-	detailRows := bodyHeight - listRows - LayoutGapStyle.GetVerticalFrameSize()
+	detailRows := bodyHeight - listRows - 1 // -1 for the divider line
 	if detailRows < 1 {
 		detailRows = 1
 		listRows = bodyHeight - detailRows

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -20,10 +20,10 @@ func (m RootModel) viewSettings() string {
 		return ""
 	}
 
-	width, height := settingsModalDimensions(m.width, m.height)
-	if width < 40 || height < 10 {
+	width, height := GetSettingsDimensions(m.width, m.height)
+	if width < MinSettingsWidth || height < 10 { // Special threshold for settings rendering floor
 		content := lipgloss.NewStyle().
-			Padding(1, 2).
+			Padding(DefaultPaddingY, DefaultPaddingX*2).
 			Foreground(colors.LightGray).
 			Render("Terminal too small for settings view")
 		box := renderBtopBox(PaneTitleStyle.Render(" Settings "), "", content, width, height, colors.NeonPurple)
@@ -69,8 +69,8 @@ func (m RootModel) viewSettings() string {
 	}
 
 	settingsValues := m.getSettingsValues(currentCategory)
-	tabBar := m.renderSettingsTabBar(categories, activeTab, width-6)
-	helpText := m.renderSettingsHelp(width - 6)
+	tabBar := m.renderSettingsTabBar(categories, activeTab, width-(ProgressBarWidthOffset+HeaderWidthOffset))
+	helpText := m.renderSettingsHelp(width - (ProgressBarWidthOffset + HeaderWidthOffset))
 
 	innerHeight := height - BoxStyle.GetVerticalFrameSize()
 	tabBarHeight := lipgloss.Height(tabBar)
@@ -108,32 +108,7 @@ func (m RootModel) viewSettings() string {
 }
 
 func settingsModalDimensions(termWidth, termHeight int) (int, int) {
-	width := int(float64(termWidth) * 0.72)
-	if width < 64 {
-		width = 64
-	}
-	if width > 130 {
-		width = 130
-	}
-	height := 26
-
-	maxWidth := termWidth - (WindowStyle.GetHorizontalFrameSize() * 2)
-	if maxWidth < 1 {
-		maxWidth = 1
-	}
-	maxHeight := termHeight - (WindowStyle.GetVerticalFrameSize() * 2) - 4 // fallback padding
-	if maxHeight < 1 {
-		maxHeight = 1
-	}
-
-	if width > maxWidth {
-		width = maxWidth
-	}
-	if height > maxHeight {
-		height = maxHeight
-	}
-
-	return width, height
+	return GetSettingsDimensions(termWidth, termHeight)
 }
 
 func shortSettingsCategoryLabel(label string) string {
@@ -546,11 +521,11 @@ func (m *RootModel) updateSettingsInputWidthForViewport() {
 		targetWidth = modalWidth - 16
 	}
 
-	if targetWidth < 8 {
-		targetWidth = 8
+	if targetWidth < MinSettingsInputW {
+		targetWidth = MinSettingsInputW
 	}
-	if targetWidth > 48 {
-		targetWidth = 48
+	if targetWidth > MaxSettingsInputW {
+		targetWidth = MaxSettingsInputW
 	}
 
 	m.SettingsInput.SetWidth(targetWidth)


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralizes TUI layout constants into `constants.go` and extracts responsive dimension helpers into `layout_helpers.go`, replacing scattered inline arithmetic in `view_category.go`, `view_settings.go`, and `update_category.go`. The refactor also replaces hardcoded style padding literals with named constants in `styles.go`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are P2 suggestions; no logic regressions introduced by the refactor

The refactor is purely extractive: constants and helpers carry identical values/logic from their inline origins, the navigation state fix (`SettingsState` instead of `DashboardState`) is straightforwardly correct, and callers guard against extreme edge cases. The only remaining gap is missing unit tests for the non-trivial branching in `CalculateTwoColumnWidths` and `GetGraphAreaDimensions`, which is a P2 best-practice concern and does not block merge.

internal/tui/layout_helpers.go — `CalculateTwoColumnWidths` and `GetGraphAreaDimensions` have branching logic without unit test coverage

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/tui/layout_helpers.go | New file centralizing layout dimension helpers; `CalculateTwoColumnWidths` has branching edge-case logic with no accompanying unit tests |
| internal/tui/constants.go | New file collecting all layout, threshold, and padding constants; values are identical to prior hardcoded literals — clean extraction |
| internal/tui/styles.go | Replaced hardcoded padding literals `(0, 1)` and `(1, 2)` with `DefaultPaddingY/X` and `PopupPaddingY/X`; functionally identical, improves consistency |
| internal/tui/update_category.go | Replaced inline two-column width arithmetic with `CalculateTwoColumnWidths`; also fixes navigation state to return to `SettingsState` instead of `DashboardState` |
| internal/tui/view_category.go | Now calls `GetSettingsDimensions` and `CalculateTwoColumnWidths` directly, removing the previously flagged pass-through wrapper |
| internal/tui/view_settings.go | Now calls `GetSettingsDimensions` and `CalculateTwoColumnWidths` directly; `updateSettingsInputWidthForViewport` mirrors the same pattern as the category equivalent |
| internal/tui/view.go | Adopts `GetListWidth`, `GetHeaderHeight`, and `GetGraphAreaDimensions` from the new helper module; no logic changes |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Window resize event] --> B[GetSettingsDimensions]
    B --> C{width within Min/Max bounds?}
    C -- clamp to range --> D[constrained width]
    D --> E{height fits terminal?}
    E -- clamp to maxHeight --> F[constrained height]
    F --> G{modalWidth >= threshold 72 settings / 76 category}
    G -- yes --> H[CalculateTwoColumnWidths]
    G -- no --> I[Compact single-column layout]
    H --> J{leftWidth >= 16?}
    J -- clamp to 16 --> K{rightWidth >= minRight?}
    J -- yes --> K
    K -- clamp + recalc left --> L[Two-column render]
    K -- yes --> L
    A2[Dashboard render] --> B2[GetListWidth]
    B2 --> C2{rightWidth >= MinRightColumnWidth?}
    C2 -- yes --> D2[Split list / detail]
    C2 -- no --> E2[Full-width list]
    A3[Graph render] --> B3[GetGraphAreaDimensions]
    B3 --> C3{isStatsHidden?}
    C3 -- yes --> D3[graphWidth = rightWidth - axis - frame x5]
    C3 -- no --> E3[graphWidth = rightWidth - stats - axis - frame x3]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/tui/view.go`, line 406 ([link](https://github.com/surgedm/surge/blob/53b9a18b1cf21886c198c4a13934fdd09ee2dcdc/internal/tui/view.go#L406)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`GraphTargetHeightRatio` constant unused at its only use-site**

   `GraphTargetHeightRatio = 0.4` was introduced in `constants.go` specifically for this calculation, but the raw literal `0.4` was left in place. The constant is never actually referenced anywhere, making it dead code and defeating the PR's stated goal.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/tui/view.go
   Line: 406

   Comment:
   **`GraphTargetHeightRatio` constant unused at its only use-site**

   `GraphTargetHeightRatio = 0.4` was introduced in `constants.go` specifically for this calculation, but the raw literal `0.4` was left in place. The constant is never actually referenced anywhere, making it dead code and defeating the PR's stated goal.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/tui/layout_helpers.go
Line: 91-111

Comment:
**New helpers lack unit tests**

`CalculateTwoColumnWidths` has three distinct branches (normal path, `leftWidth` floor at 16, and `rightWidth < minRight` recovery), and `GetGraphAreaDimensions` has two paths controlled by `isStatsHidden`. Neither has a test file. Edge inputs — e.g. `modalWidth` smaller than `preferredLeft + minRight + horizontalPadding` — can quietly return widths that sum beyond `modalWidth`, relying on callers to fall back to compact mode. Per the team's testing rule, edge cases and integration boundaries should have explicit coverage.

**Rule Used:** What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["refactor: reduce minimum settings window..."](https://github.com/surgedm/surge/commit/67a9322709abd1ade2fd486ebeafd025a804c4ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28045505)</sub>

<!-- /greptile_comment -->