### PR TITLE
refactor: update active download criteria to account for paused, pausing, and resuming states

### DIFF
--- a/internal/tui/constants.go
+++ b/internal/tui/constants.go
@@ -21,9 +21,10 @@ const (
 	MinTermHeight = 12
 	ShortTermHeightThreshold = 25 // Switch to compact header below this height
 
-	MinSettingsWidth  = 45
+	MinSettingsWidth  = 64
 	MaxSettingsWidth  = 130
 	MinSettingsHeight = 12
+	DefaultSettingsHeight = 26
 
 	MinRightColumnWidth = 50 // Hide right column if narrow
 	MinGraphStatsWidth  = 70 // Hide inline graph stats if narrow

--- a/internal/tui/filtering_test.go
+++ b/internal/tui/filtering_test.go
@@ -69,6 +69,22 @@ func TestTabFiltering(t *testing.T) {
 			expectedCount: 0,
 		},
 		{
+			name:      "Active Tab excludes pausing downloads",
+			activeTab: TabActive,
+			downloads: []*DownloadModel{
+				{ID: "1", Speed: 1024, done: false, pausing: true},
+			},
+			expectedCount: 0,
+		},
+		{
+			name:      "Queued Tab includes pausing downloads",
+			activeTab: TabQueued,
+			downloads: []*DownloadModel{
+				{ID: "1", Speed: 1024, done: false, pausing: true},
+			},
+			expectedCount: 1,
+		},
+		{
 			name:      "Done Tab shows completed downloads",
 			activeTab: TabDone,
 			downloads: []*DownloadModel{

--- a/internal/tui/filtering_test.go
+++ b/internal/tui/filtering_test.go
@@ -1,0 +1,130 @@
+package tui
+
+import (
+	"testing"
+)
+
+func TestTabFiltering(t *testing.T) {
+	tests := []struct {
+		name          string
+		activeTab     int
+		downloads     []*DownloadModel
+		expectedCount int
+	}{
+		{
+			name:      "Active Tab shows non-paused with speed",
+			activeTab: TabActive,
+			downloads: []*DownloadModel{
+				{ID: "1", Speed: 1024, done: false, paused: false},
+				{ID: "2", Speed: 0, done: false, paused: true},
+			},
+			expectedCount: 1,
+		},
+		{
+			name:      "Active Tab shows non-paused with connections",
+			activeTab: TabActive,
+			downloads: []*DownloadModel{
+				{ID: "1", Speed: 0, Connections: 1, done: false, paused: false},
+			},
+			expectedCount: 1,
+		},
+		{
+			name:      "Active Tab shows resuming downloads",
+			activeTab: TabActive,
+			downloads: []*DownloadModel{
+				{ID: "1", Speed: 0, done: false, paused: false, resuming: true},
+			},
+			expectedCount: 1,
+		},
+		{
+			name:      "Active Tab excludes paused even with speed",
+			activeTab: TabActive,
+			downloads: []*DownloadModel{
+				{ID: "1", Speed: 1024, done: false, paused: true},
+			},
+			expectedCount: 0,
+		},
+		{
+			name:      "Queued Tab includes paused downloads",
+			activeTab: TabQueued,
+			downloads: []*DownloadModel{
+				{ID: "1", Speed: 0, done: false, paused: true},
+			},
+			expectedCount: 1,
+		},
+		{
+			name:      "Queued Tab includes downloads with 0 speed and 0 connections",
+			activeTab: TabQueued,
+			downloads: []*DownloadModel{
+				{ID: "1", Speed: 0, Connections: 0, done: false, paused: false},
+			},
+			expectedCount: 1,
+		},
+		{
+			name:      "Queued Tab excludes truly active downloads",
+			activeTab: TabQueued,
+			downloads: []*DownloadModel{
+				{ID: "1", Speed: 1024, done: false, paused: false},
+			},
+			expectedCount: 0,
+		},
+		{
+			name:      "Done Tab shows completed downloads",
+			activeTab: TabDone,
+			downloads: []*DownloadModel{
+				{ID: "1", done: true},
+				{ID: "2", done: false},
+			},
+			expectedCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := RootModel{
+				activeTab: tt.activeTab,
+				downloads: tt.downloads,
+			}
+			filtered := m.getFilteredDownloads()
+			if len(filtered) != tt.expectedCount {
+				t.Errorf("getFilteredDownloads() length = %v, want %v", len(filtered), tt.expectedCount)
+			}
+		})
+	}
+}
+
+func TestComputeViewStatsConsistency(t *testing.T) {
+	downloads := []*DownloadModel{
+		{ID: "active-speed", Speed: 1024, done: false, paused: false},
+		{ID: "active-conns", Speed: 0, Connections: 1, done: false, paused: false},
+		{ID: "active-resuming", Speed: 0, done: false, paused: false, resuming: true},
+		{ID: "paused", Speed: 0, done: false, paused: true},
+		{ID: "pausing", Speed: 1024, done: false, pausing: true},
+		{ID: "queued", Speed: 0, Connections: 0, done: false},
+		{ID: "done", done: true},
+	}
+
+	m := RootModel{
+		downloads: downloads,
+	}
+
+	stats := m.ComputeViewStats()
+
+	// Verify Active Tab
+	m.activeTab = TabActive
+	if stats.ActiveCount != len(m.getFilteredDownloads()) {
+		t.Errorf("ActiveCount (%d) does not match getFilteredDownloads (%d)", stats.ActiveCount, len(m.getFilteredDownloads()))
+	}
+
+	// Verify Queued Tab
+	m.activeTab = TabQueued
+	if stats.QueuedCount != len(m.getFilteredDownloads()) {
+		t.Errorf("QueuedCount (%d) does not match getFilteredDownloads (%d)", stats.QueuedCount, len(m.getFilteredDownloads()))
+	}
+
+	// Verify Done Tab
+	m.activeTab = TabDone
+	if stats.DownloadedCount != len(m.getFilteredDownloads()) {
+		t.Errorf("DownloadedCount (%d) does not match getFilteredDownloads (%d)", stats.DownloadedCount, len(m.getFilteredDownloads()))
+	}
+}

--- a/internal/tui/layout_helpers.go
+++ b/internal/tui/layout_helpers.go
@@ -34,7 +34,7 @@ func GetSettingsDimensions(termWidth, termHeight int) (int, int) {
 		width = maxWidth
 	}
 
-	height := MinSettingsHeight
+	height := DefaultSettingsHeight
 	maxHeight := termHeight - (WindowStyle.GetVerticalFrameSize() * 2) - ModalHeightPadding
 	if maxHeight < 1 {
 		maxHeight = 1

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -268,7 +268,7 @@ func (m *RootModel) UpdateListItems() {
 					var newTab int
 					if d.done {
 						newTab = TabDone
-					} else if d.Speed > 0 {
+					} else if !d.paused && !d.pausing && (d.Speed > 0 || d.Connections > 0 || d.resuming) {
 						newTab = TabActive
 					} else {
 						newTab = TabQueued

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -479,11 +479,13 @@ func (m RootModel) getFilteredDownloads() []*DownloadModel {
 		// Apply tab filter first
 		switch m.activeTab {
 		case TabQueued:
-			if d.done || d.Speed > 0 {
+			// Queued includes paused downloads and anything not currently active or done
+			if d.done || (!d.paused && !d.pausing && (d.Speed > 0 || d.Connections > 0 || d.resuming)) {
 				continue
 			}
 		case TabActive:
-			if d.done || (d.Speed == 0 && d.Connections == 0) {
+			// Active excludes paused downloads and anything without current activity
+			if d.done || d.paused || d.pausing || (d.Speed == 0 && d.Connections == 0 && !d.resuming) {
 				continue
 			}
 		case TabDone:

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -1107,7 +1107,7 @@ func (m RootModel) ComputeViewStats() ViewStats {
 	for _, d := range m.downloads {
 		if d.done {
 			stats.DownloadedCount++
-		} else if d.Speed > 0 {
+		} else if !d.paused && !d.pausing && (d.Speed > 0 || d.Connections > 0 || d.resuming) {
 			stats.ActiveCount++
 		} else {
 			stats.QueuedCount++

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -236,7 +236,7 @@ func TestView_SettingsResizeSequenceKeepsSelectedVisible(t *testing.T) {
 	sequence := []struct{ width, height int }{
 		{120, 35},
 		{76, 18},
-		{58, 16},
+		{80, 24},
 		{100, 30},
 	}
 
@@ -281,7 +281,7 @@ func TestView_CategoryManagerNoLineExceedsTerminalWidth(t *testing.T) {
 		{120, 35},
 		{92, 24},
 		{72, 18},
-		{58, 16},
+		{80, 24},
 		{50, 14},
 	}
 
@@ -314,7 +314,7 @@ func TestView_CategoryManagerResizeSequenceKeepsSelectedVisible(t *testing.T) {
 	sequence := []struct{ width, height int }{
 		{120, 35},
 		{76, 18},
-		{58, 16},
+		{80, 24},
 		{100, 30},
 	}
 


### PR DESCRIPTION
Close #329

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the TUI's active download criteria to correctly account for `pausing`, `paused`, and `resuming` states. Downloads in the `pausing` state now correctly appear in the Queued tab (not Active), with consistent logic applied across `getFilteredDownloads()`, `ComputeViewStats()`, `UpdateListItems()`, and the detail-view `isActive` check. Tests are added in `filtering_test.go` covering both the new `pausing` state and consistency between tab counts and the filter function.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all filtering, stat-counting, and tab-assignment logic is mutually consistent and backed by targeted tests.

No P0 or P1 issues found. The single P2 finding (`calcTotalSpeed` briefly counting a pausing download's speed) is a transient UX glitch that resolves as soon as the download fully stops. All changed code paths are consistent with each other and well-covered by the new tests.

internal/tui/view.go — `calcTotalSpeed` (minor, P2 only)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/tui/model.go | Core change: `getFilteredDownloads()` updated to exclude `pausing` downloads from Active and include them in Queued; logic is consistent with `ComputeViewStats` and `UpdateListItems`. |
| internal/tui/view.go | `ComputeViewStats` and `isActive` detail-view check correctly exclude `pausing`; however `calcTotalSpeed` still includes speed from pausing downloads, creating a brief inconsistency between the network graph and the Active tab. |
| internal/tui/list.go | `UpdateListItems` tab-assignment logic updated to include `!d.pausing` condition, consistent with `getFilteredDownloads`. |
| internal/tui/filtering_test.go | New test file with `TestTabFiltering` (including `pausing` cases) and `TestComputeViewStatsConsistency` validating count-filter agreement across all tabs. |
| internal/tui/view_test.go | Updated to test `getDownloadStatus` for `pausing` and `resuming` states; existing layout/rendering tests unchanged. |
| internal/tui/constants.go | Layout constants file; no functional changes related to this PR's state-filtering refactor. |
| internal/tui/layout_helpers.go | Layout helper functions; no changes related to the download-state filtering refactor. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[DownloadModel] --> B{d.done?}
    B -- yes --> DONE[TabDone / DownloadedCount]
    B -- no --> C{d.paused OR d.pausing?}
    C -- yes --> QUEUED[TabQueued / QueuedCount]
    C -- no --> D{Speed > 0 OR Connections > 0 OR resuming?}
    D -- yes --> ACTIVE[TabActive / ActiveCount]
    D -- no --> QUEUED
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/tui/view.go
Line: 1093-1103

Comment:
**`calcTotalSpeed` includes speed from `pausing` downloads**

Now that `pausing` downloads are moved to the Queued tab, a user can see the Active tab show 0 items while the network graph and header speed still register a non-zero value (from the in-flight `pausing` download). Before this PR, the download stayed in Active, so the inconsistency didn't arise. Adding a `!d.pausing` guard makes the graph consistent with the tab view:

```suggestion
func (m RootModel) calcTotalSpeed() float64 {
	total := 0.0
	for _, d := range m.downloads {
		// Skip completed and transitioning-to-pause downloads
		if d.done || d.pausing {
			continue
		}
		total += d.Speed
	}
	return total / float64(config.MB)
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: update settings layout constants an..."](https://github.com/surgedm/surge/commit/62906c76ae2acfb369239c121938b8b74c0181b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28053585)</sub>

<!-- /greptile_comment -->