### PR TITLE
fix: implement filename truncation to 255 bytes and prioritize authoritative filename resolution over hints

### DIFF
--- a/internal/processing/probe.go
+++ b/internal/processing/probe.go
@@ -206,7 +206,13 @@ func ProbeServerWithProxy(ctx context.Context, rawurl string, filenameHint strin
 		name = "download.bin"
 	}
 
-	if filenameHint != "" {
+	// Prefer the name resolved from the response (Content-Disposition, magic
+	// bytes, etc.) because it is always more authoritative than a hint derived
+	// from the raw URL.  Only fall back to the hint when DetermineFilename
+	// could not do better than the generic "download.bin" placeholder.
+	if name != "" && name != "download.bin" {
+		result.Filename = name
+	} else if filenameHint != "" {
 		result.Filename = filenameHint
 	} else {
 		result.Filename = name

--- a/internal/utils/filename.go
+++ b/internal/utils/filename.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/h2non/filetype"
 	"github.com/vfaronov/httpheader"
@@ -154,6 +155,24 @@ func sanitizeFilename(name string) string {
 
 	if name == "" {
 		return "_"
+	}
+
+	// Truncate to 255 bytes (Linux/macOS/Windows fs limit), preserving extension.
+	const maxBytes = 255
+	if len(name) > maxBytes {
+		ext := filepath.Ext(name)
+		stem := strings.TrimSuffix(name, ext)
+		// Ensure ext itself fits; if the extension alone is absurdly long, drop it.
+		if len(ext) >= maxBytes {
+			ext = ""
+		}
+		allowedStem := maxBytes - len(ext)
+		// Trim stem by rune boundary so we don't split a multi-byte character.
+		for len(stem) > allowedStem {
+			_, size := utf8.DecodeLastRuneInString(stem)
+			stem = stem[:len(stem)-size]
+		}
+		name = stem + ext
 	}
 
 	return name


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds 255-byte filename truncation (with rune-boundary and extension preservation) to `sanitizeFilename`, and flips the resolution priority in `ProbeServerWithProxy` so that server-provided names from Content-Disposition or magic-byte sniffing now win over the URL-derived `filenameHint`, falling back to the hint only when `DetermineFilename` could not do better than `"download.bin"`.

All findings are P2: a redundant `name != ""` guard (dead code), a minor edge case where the truncated stem can end with a space or dot character, and missing unit tests for the new truncation logic and priority path.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are P2 style/quality suggestions with no blocking correctness issues.

Both changes are well-reasoned and logically correct. The priority inversion in probe.go is clearly intentional and the fallback chain is sound. The truncation in filename.go handles rune boundaries and extension preservation correctly. The three findings (dead `name != ""` guard, potential trailing space/dot on the truncated stem, missing truncation tests) are all non-blocking P2 improvements.

internal/utils/filename.go — truncation edge case and missing tests

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/processing/probe.go | Inverts filename priority so server-provided names (Content-Disposition, magic bytes) win over URL-derived hints; logic is correct but contains a redundant `name != ""` guard. |
| internal/utils/filename.go | Adds 255-byte truncation with rune-boundary preservation and extension retention; minor edge case where the trimmed stem can end with a space or dot, and no new tests cover the truncation path. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ProbeServerWithProxy called\nwith filenameHint] --> B[DetermineFilename\nContent-Disposition / query param\n/ URL path / magic bytes]
    B --> C{err != nil?}
    C -- yes --> D[name = download.bin]
    C -- no --> E[name = resolved filename\nor download.bin fallback]
    D --> F{name != empty\nAND name != download.bin?}
    E --> F
    F -- yes\nserver provided a real name --> G[result.Filename = name\nserver name wins]
    F -- no --> H{filenameHint != empty?}
    H -- yes --> I[result.Filename = filenameHint\nhint used as fallback]
    H -- no --> J[result.Filename = download.bin\ngeneric fallback]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/processing/probe.go
Line: 213

Comment:
**Redundant `name != ""` guard**

`name` can never be empty at this point: `DetermineFilename` always returns either a real filename or `"download.bin"` on success, and the error handler above unconditionally sets `name = "download.bin"` on failure. The `name != ""` check is dead code that adds noise without protection.

```suggestion
	if name != "download.bin" {
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/utils/filename.go
Line: 171-175

Comment:
**Truncated stem may end with `.` or ` `**

After the rune-boundary loop, the last character of `stem` could be a period or a space if that character happened to sit at the truncation boundary (e.g., original name `"a" * 250 + " " + "b" * 10 + ".pdf"` → truncated stem `"a" * 250 + " "`). This yields `"aaa… .pdf"` with an interior space, or `"aaa….pdf"` with a double-dot for stems ending in `.`. Both are technically valid on Linux/macOS, but the Windows filesystem silently strips a trailing dot from the full path component, which can produce unexpected results. A cheap fix:

```suggestion
		for len(stem) > allowedStem {
			_, size := utf8.DecodeLastRuneInString(stem)
			stem = stem[:len(stem)-size]
		}
		stem = strings.TrimRight(stem, ". ")
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/utils/filename.go
Line: 160-176

Comment:
**No tests cover the new 255-byte truncation path**

`TestSanitizeFilename` has no cases for filenames that exceed 255 bytes, and `probe_test.go` has no case where `filenameHint != ""` while the server returns a non-`"download.bin"` name (the scenario that exercises the new priority logic). Useful cases to add: exact 255-byte name (no truncation), 256-byte name (truncation by 1), extension-heavy name (long stem, short ext), multi-byte character straddling the boundary, and `ProbeServer` with a `filenameHint` and a real `Content-Disposition` header confirming the server name wins.

**Rule Used:** What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: implement filename truncation to 25..."](https://github.com/surgedm/surge/commit/3baac940da1f7b93af88c4ef3e9614f8616cde48) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28078364)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Rule used - What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))

<!-- /greptile_comment -->