### PR TITLE
Update Windows installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Surge is available on multiple platforms. Choose the method that works best for 
 | **Prebuilt Binary**          | [Download from Releases](https://github.com/SurgeDM/Surge/releases/latest) | Easiest method. Just download and run.       |
 | **Arch Linux (AUR)**         | `yay -S surge`                                                                 | Managed via AUR.                             |
 | **macOS / Linux (Homebrew)** | `brew install SurgeDM/tap/surge`                                      | Recommended for Mac/Linux users.             |
-| **Windows**         | `winget install SurgeDM.surge`<br />or<br />`scoop install surge` | Recommended for Windows users.               |
+| **Windows**         | `winget install surge-downloader.surge`<br />or<br />`scoop install surge` | Recommended for Windows users.               |
 | **Dockerfile**               | [See instructions](#4-server-mode-with-docker-compose)                              | Run Surge in server mode with Docker Compose |
 | **Go Install**               | `go install github.com/SurgeDM/Surge@latest`                          | Requires Go 1.25+                           |
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the Windows `winget` install command in the installation table from `winget install SurgeDM.surge` to `winget install surge-downloader.surge`. The new package identifier is confirmed correct per the official winget package registry (`winstall.app`) and the project's own published documentation.

- The `brew install SurgeDM/tap/surge` command and `go install github.com/SurgeDM/Surge@latest` still reference the old `SurgeDM` organization, which may also be outdated given the project appears to have migrated to the `surge-downloader` namespace. These are not introduced by this PR but may be worth a follow-up.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the winget package ID change is verified correct and no logic or code is affected.

Single-line documentation fix with the new package identifier confirmed against the official winget registry and project docs. The only finding is a P2 suggestion to also update other lingering `SurgeDM` references in the same file.

README.md — other `SurgeDM` references (brew tap, Go install URL) may warrant a follow-up update.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Corrects the Windows winget package ID from `SurgeDM.surge` to `surge-downloader.surge`; change is accurate per the official winget registry. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Windows User] --> B{Choose installer}
    B --> C[winget]
    B --> D[scoop]
    C --> E["winget install surge-downloader.surge\n(updated from SurgeDM.surge)"]
    D --> F["scoop install surge\n(unchanged)"]
    E --> G[Surge installed ✓]
    F --> G
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: README.md
Line: 67

Comment:
**Other `SurgeDM` references may also be outdated**

The brew tap (`brew install SurgeDM/tap/surge`) and Go install path (`go install github.com/SurgeDM/Surge@latest`) still use the old `SurgeDM` namespace. The upstream GitHub repo now lives under `surge-downloader`, and the official docs show `brew install surge-downloader/tap/surge`. If the Homebrew tap has been renamed, the brew command would silently fail for users. Consider updating these in the same pass.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Update Windows installation instructions..."](https://github.com/surgedm/surge/commit/cf5f07b79b3e77c544089ac3509379f94cf776fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28096643)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->