### PR TITLE
fix(docker): Windows paths not being converted into linux while being run in WSL

### DIFF
--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -72,7 +72,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=${{ steps.surge-version.outputs.version }}
-            type=raw,value=latest,enable=${{ inputs.tag_as_latest }}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' || inputs.tag_as_latest == true }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -52,6 +52,19 @@ jobs:
           fi
           echo "version=$SURGE_VERSION" >> $GITHUB_OUTPUT
 
+      - name: Decide latest tag behavior
+        id: latest-tag
+        run: |
+          ENABLE_LATEST=false
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            if [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              ENABLE_LATEST=true
+            fi
+          elif [[ "${{ inputs.tag_as_latest }}" == "true" ]]; then
+            ENABLE_LATEST=true
+          fi
+          echo "enable=$ENABLE_LATEST" >> $GITHUB_OUTPUT
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -72,7 +85,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=${{ steps.surge-version.outputs.version }}
-            type=raw,value=latest,enable=${{ github.event_name == 'push' || inputs.tag_as_latest == true }}
+            type=raw,value=latest,enable=${{ steps.latest-tag.outputs.enable }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -1,6 +1,9 @@
 name: Build and Push Docker Images
 
 on:
+  push:
+    tags:
+      - "v*"
   workflow_dispatch:
     inputs:
       surge_version:
@@ -39,6 +42,9 @@ jobs:
           if [ -n "${{ inputs.surge_version }}" ]; then
             SURGE_VERSION="${{ inputs.surge_version }}"
             echo "Using manually specified version: $SURGE_VERSION"
+          elif [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            SURGE_VERSION="${GITHUB_REF_NAME#v}"
+            echo "Using tag version: $SURGE_VERSION"
           else
             echo "Fetching latest Surge release..."
             SURGE_VERSION=$(curl -s https://api.github.com/repos/SurgeDM/Surge/releases/latest | jq -r .tag_name | sed 's/^v//')

--- a/cmd/http_handler_test.go
+++ b/cmd/http_handler_test.go
@@ -162,6 +162,16 @@ func TestHandleDownload_PathResolution(t *testing.T) {
 			expectedPathSuffix:   filepath.Join(filepath.Base(defaultDownloadDir), "surge-repro"),
 			expectedPathAbsolute: true,
 		},
+		{
+			name: "Unmatched Windows Path Falls Back To Default Dir",
+			request: DownloadRequest{
+				URL:                  "http://example.com/file9",
+				Path:                 "E:/Torrents/complete",
+				RelativeToDefaultDir: true,
+			},
+			expectedPathSuffix:   filepath.Base(defaultDownloadDir),
+			expectedPathAbsolute: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -205,6 +215,10 @@ func TestHandleDownload_PathResolution(t *testing.T) {
 						}
 						if cfg.OutputPath != expectedAbs {
 							t.Errorf("Expected Windows client path to map to %s, got %s", expectedAbs, cfg.OutputPath)
+						}
+					} else if tt.request.RelativeToDefaultDir && strings.HasPrefix(tt.request.Path, "E:/") {
+						if cfg.OutputPath != defaultDownloadDir {
+							t.Errorf("Expected unmatched Windows path to fall back to %s, got %s", defaultDownloadDir, cfg.OutputPath)
 						}
 					} else if tt.request.RelativeToDefaultDir {
 						expectedAbs := filepath.Join(defaultDownloadDir, tt.request.Path)

--- a/cmd/http_handler_test.go
+++ b/cmd/http_handler_test.go
@@ -134,6 +134,34 @@ func TestHandleDownload_PathResolution(t *testing.T) {
 			expectedPathSuffix:   filepath.Base(defaultDownloadDir), // Should be just the default dir
 			expectedPathAbsolute: true,
 		},
+		{
+			name: "Windows Download Root Maps To Default Dir",
+			request: DownloadRequest{
+				URL:  "http://example.com/file6",
+				Path: "C:/Users/me/Downloads",
+			},
+			expectedPathSuffix:   filepath.Base(defaultDownloadDir),
+			expectedPathAbsolute: true,
+		},
+		{
+			name: "Windows Nested Path Maps Under Default Dir",
+			request: DownloadRequest{
+				URL:  "http://example.com/file7",
+				Path: "C:/Users/me/Downloads/surge-repro",
+			},
+			expectedPathSuffix:   filepath.Join(filepath.Base(defaultDownloadDir), "surge-repro"),
+			expectedPathAbsolute: true,
+		},
+		{
+			name: "Windows Nested Path Relative Flag Maps Under Default Dir",
+			request: DownloadRequest{
+				URL:                  "http://example.com/file8",
+				Path:                 "C:/Users/me/Downloads/surge-repro",
+				RelativeToDefaultDir: true,
+			},
+			expectedPathSuffix:   filepath.Join(filepath.Base(defaultDownloadDir), "surge-repro"),
+			expectedPathAbsolute: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -168,7 +196,17 @@ func TestHandleDownload_PathResolution(t *testing.T) {
 					// If expectedPathSuffix is relative (like "relative"), we check if path ends with it.
 					// If expectedPathSuffix is absolute (like /tmp/.../absolute), we check if paths match.
 
-					if tt.request.RelativeToDefaultDir {
+					if strings.HasPrefix(tt.request.Path, "C:/Users/me/Downloads") {
+						rel := strings.TrimPrefix(tt.request.Path, "C:/Users/me/Downloads")
+						rel = strings.TrimPrefix(rel, "/")
+						expectedAbs := defaultDownloadDir
+						if rel != "" {
+							expectedAbs = filepath.Join(defaultDownloadDir, filepath.FromSlash(rel))
+						}
+						if cfg.OutputPath != expectedAbs {
+							t.Errorf("Expected Windows client path to map to %s, got %s", expectedAbs, cfg.OutputPath)
+						}
+					} else if tt.request.RelativeToDefaultDir {
 						expectedAbs := filepath.Join(defaultDownloadDir, tt.request.Path)
 						if cfg.OutputPath != expectedAbs {
 							t.Errorf("Expected path %s, got %s", expectedAbs, cfg.OutputPath)

--- a/cmd/http_handler_test.go
+++ b/cmd/http_handler_test.go
@@ -204,6 +204,48 @@ func TestHandleDownload_PathResolution(t *testing.T) {
 	}
 }
 
+func TestShouldFallbackUnmappedWindowsPath(t *testing.T) {
+	tests := []struct {
+		name                 string
+		relativeToDefaultDir bool
+		hostOS               string
+		want                 bool
+	}{
+		{
+			name:                 "relative request falls back on windows",
+			relativeToDefaultDir: true,
+			hostOS:               "windows",
+			want:                 true,
+		},
+		{
+			name:                 "relative request falls back on linux",
+			relativeToDefaultDir: true,
+			hostOS:               "linux",
+			want:                 true,
+		},
+		{
+			name:                 "explicit request does not fall back on windows",
+			relativeToDefaultDir: false,
+			hostOS:               "windows",
+			want:                 false,
+		},
+		{
+			name:                 "explicit request falls back on linux",
+			relativeToDefaultDir: false,
+			hostOS:               "linux",
+			want:                 true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldFallbackUnmappedWindowsPath(tt.relativeToDefaultDir, tt.hostOS); got != tt.want {
+				t.Fatalf("shouldFallbackUnmappedWindowsPath(%v, %q) = %v, want %v", tt.relativeToDefaultDir, tt.hostOS, got, tt.want)
+			}
+		})
+	}
+}
+
 func mustGetwd(t *testing.T) string {
 	t.Helper()
 	wd, err := os.Getwd()

--- a/cmd/http_handler_test.go
+++ b/cmd/http_handler_test.go
@@ -82,10 +82,9 @@ func TestHandleDownload_PathResolution(t *testing.T) {
 	GlobalPool = download.NewWorkerPool(nil, 1)
 
 	tests := []struct {
-		name                 string
-		request              DownloadRequest
-		expectedPathSuffix   string
-		expectedPathAbsolute bool
+		name               string
+		request            DownloadRequest
+		expectedOutputPath string
 	}{
 		{
 			name: "Absolute Path (Explicit)",
@@ -93,8 +92,7 @@ func TestHandleDownload_PathResolution(t *testing.T) {
 				URL:  "http://example.com/file1",
 				Path: filepath.Join(tempDir, "absolute"),
 			},
-			expectedPathSuffix:   "absolute",
-			expectedPathAbsolute: true,
+			expectedOutputPath: filepath.Join(tempDir, "absolute"),
 		},
 		{
 			name: "Relative Path (No Flag)",
@@ -102,8 +100,7 @@ func TestHandleDownload_PathResolution(t *testing.T) {
 				URL:  "http://example.com/file2",
 				Path: "relative",
 			},
-			expectedPathSuffix:   "relative",
-			expectedPathAbsolute: true,
+			expectedOutputPath: filepath.Join(mustGetwd(t), "relative"),
 		},
 		{
 			name: "Relative to Default Dir",
@@ -112,8 +109,7 @@ func TestHandleDownload_PathResolution(t *testing.T) {
 				Path:                 "subdir",
 				RelativeToDefaultDir: true,
 			},
-			expectedPathSuffix:   filepath.Join(filepath.Base(defaultDownloadDir), "subdir"),
-			expectedPathAbsolute: true,
+			expectedOutputPath: filepath.Join(defaultDownloadDir, "subdir"),
 		},
 		{
 			name: "Nested Relative to Default Dir",
@@ -122,8 +118,7 @@ func TestHandleDownload_PathResolution(t *testing.T) {
 				Path:                 "nested/deep",
 				RelativeToDefaultDir: true,
 			},
-			expectedPathSuffix:   filepath.Join(filepath.Base(defaultDownloadDir), "nested", "deep"),
-			expectedPathAbsolute: true,
+			expectedOutputPath: filepath.Join(defaultDownloadDir, "nested", "deep"),
 		},
 		{
 			name: "Empty Path (Default)",
@@ -131,8 +126,7 @@ func TestHandleDownload_PathResolution(t *testing.T) {
 				URL:  "http://example.com/file5",
 				Path: "",
 			},
-			expectedPathSuffix:   filepath.Base(defaultDownloadDir), // Should be just the default dir
-			expectedPathAbsolute: true,
+			expectedOutputPath: defaultDownloadDir,
 		},
 		{
 			name: "Windows Download Root Maps To Default Dir",
@@ -140,8 +134,7 @@ func TestHandleDownload_PathResolution(t *testing.T) {
 				URL:  "http://example.com/file6",
 				Path: "C:/Users/me/Downloads",
 			},
-			expectedPathSuffix:   filepath.Base(defaultDownloadDir),
-			expectedPathAbsolute: true,
+			expectedOutputPath: defaultDownloadDir,
 		},
 		{
 			name: "Windows Nested Path Maps Under Default Dir",
@@ -149,8 +142,7 @@ func TestHandleDownload_PathResolution(t *testing.T) {
 				URL:  "http://example.com/file7",
 				Path: "C:/Users/me/Downloads/surge-repro",
 			},
-			expectedPathSuffix:   filepath.Join(filepath.Base(defaultDownloadDir), "surge-repro"),
-			expectedPathAbsolute: true,
+			expectedOutputPath: filepath.Join(defaultDownloadDir, "surge-repro"),
 		},
 		{
 			name: "Windows Nested Path Relative Flag Maps Under Default Dir",
@@ -159,8 +151,7 @@ func TestHandleDownload_PathResolution(t *testing.T) {
 				Path:                 "C:/Users/me/Downloads/surge-repro",
 				RelativeToDefaultDir: true,
 			},
-			expectedPathSuffix:   filepath.Join(filepath.Base(defaultDownloadDir), "surge-repro"),
-			expectedPathAbsolute: true,
+			expectedOutputPath: filepath.Join(defaultDownloadDir, "surge-repro"),
 		},
 		{
 			name: "Unmatched Windows Path Falls Back To Default Dir",
@@ -169,8 +160,7 @@ func TestHandleDownload_PathResolution(t *testing.T) {
 				Path:                 "E:/Torrents/complete",
 				RelativeToDefaultDir: true,
 			},
-			expectedPathSuffix:   filepath.Base(defaultDownloadDir),
-			expectedPathAbsolute: true,
+			expectedOutputPath: defaultDownloadDir,
 		},
 	}
 
@@ -197,48 +187,12 @@ func TestHandleDownload_PathResolution(t *testing.T) {
 					found = true
 					t.Logf("OutputPath for %s: %s", tt.name, cfg.OutputPath)
 
-					if !filepath.IsAbs(cfg.OutputPath) && tt.expectedPathAbsolute {
+					if !filepath.IsAbs(cfg.OutputPath) {
 						t.Errorf("Expected absolute path, got %s", cfg.OutputPath)
 					}
 
-					// Verify suffix
-					// NOTE: cfg.OutputPath is absolute path.
-					// If expectedPathSuffix is relative (like "relative"), we check if path ends with it.
-					// If expectedPathSuffix is absolute (like /tmp/.../absolute), we check if paths match.
-
-					if strings.HasPrefix(tt.request.Path, "C:/Users/me/Downloads") {
-						rel := strings.TrimPrefix(tt.request.Path, "C:/Users/me/Downloads")
-						rel = strings.TrimPrefix(rel, "/")
-						expectedAbs := defaultDownloadDir
-						if rel != "" {
-							expectedAbs = filepath.Join(defaultDownloadDir, filepath.FromSlash(rel))
-						}
-						if cfg.OutputPath != expectedAbs {
-							t.Errorf("Expected Windows client path to map to %s, got %s", expectedAbs, cfg.OutputPath)
-						}
-					} else if tt.request.RelativeToDefaultDir && strings.HasPrefix(tt.request.Path, "E:/") {
-						if cfg.OutputPath != defaultDownloadDir {
-							t.Errorf("Expected unmatched Windows path to fall back to %s, got %s", defaultDownloadDir, cfg.OutputPath)
-						}
-					} else if tt.request.RelativeToDefaultDir {
-						expectedAbs := filepath.Join(defaultDownloadDir, tt.request.Path)
-						if cfg.OutputPath != expectedAbs {
-							t.Errorf("Expected path %s, got %s", expectedAbs, cfg.OutputPath)
-						}
-					} else if tt.request.Path == "" {
-						if cfg.OutputPath != defaultDownloadDir {
-							t.Errorf("Expected path %s, got %s", defaultDownloadDir, cfg.OutputPath)
-						}
-					} else if filepath.IsAbs(tt.request.Path) {
-						if cfg.OutputPath != tt.request.Path {
-							t.Errorf("Expected path %s, got %s", tt.request.Path, cfg.OutputPath)
-						}
-					} else {
-						// Relative path without flag (Ensured Absolute CWD)
-						// Hard to test exactly without knowing CWD, but it should end with the relative path
-						if !strings.HasSuffix(cfg.OutputPath, tt.request.Path) {
-							t.Errorf("Expected suffix %s, got %s", tt.request.Path, cfg.OutputPath)
-						}
+					if cfg.OutputPath != tt.expectedOutputPath {
+						t.Errorf("Expected path %s, got %s", tt.expectedOutputPath, cfg.OutputPath)
 					}
 					break
 				}
@@ -248,6 +202,15 @@ func TestHandleDownload_PathResolution(t *testing.T) {
 			}
 		})
 	}
+}
+
+func mustGetwd(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd failed: %v", err)
+	}
+	return wd
 }
 
 func TestHandleDownload_SkipApprovalUsesLifecycleEnqueue(t *testing.T) {

--- a/cmd/root_downloads.go
+++ b/cmd/root_downloads.go
@@ -124,7 +124,9 @@ func decodeAndValidateDownloadRequest(r *http.Request) (DownloadRequest, error) 
 		return req, fmt.Errorf("invalid path")
 	}
 	if req.RelativeToDefaultDir && req.Path != "" {
-		if filepath.IsAbs(req.Path) {
+		// Linux filepath.IsAbs does not recognize Windows drive paths, so those
+		// are normalized later against the daemon's default download directory.
+		if filepath.IsAbs(req.Path) && !utils.IsWindowsAbsPath(req.Path) {
 			return req, fmt.Errorf("invalid path")
 		}
 		cleanPath := filepath.Clean(req.Path)
@@ -339,6 +341,10 @@ func processDownloads(urls []string, outputDir string, port int) int {
 func resolveOutputDir(reqPath string, relativeToDefaultDir bool, defaultOutputDir string, settings *config.Settings) string {
 	outPath := reqPath
 
+	if mapped := mapClientWindowsPath(reqPath, relativeToDefaultDir, defaultOutputDir, settings); mapped != "" {
+		return mapped
+	}
+
 	if relativeToDefaultDir && reqPath != "" {
 		baseDir := settings.General.DefaultDownloadDir
 		if baseDir == "" {
@@ -359,4 +365,32 @@ func resolveOutputDir(reqPath string, relativeToDefaultDir bool, defaultOutputDi
 	}
 
 	return outPath
+}
+
+func mapClientWindowsPath(reqPath string, relativeToDefaultDir bool, defaultOutputDir string, settings *config.Settings) string {
+	reqPath = strings.TrimSpace(reqPath)
+	if reqPath == "" || !utils.IsWindowsAbsPath(reqPath) {
+		return ""
+	}
+
+	baseDir := "."
+	if relativeToDefaultDir {
+		if settings != nil && strings.TrimSpace(settings.General.DefaultDownloadDir) != "" {
+			baseDir = settings.General.DefaultDownloadDir
+		} else if strings.TrimSpace(defaultOutputDir) != "" {
+			baseDir = defaultOutputDir
+		}
+	} else {
+		if strings.TrimSpace(defaultOutputDir) != "" {
+			baseDir = defaultOutputDir
+		} else if settings != nil && strings.TrimSpace(settings.General.DefaultDownloadDir) != "" {
+			baseDir = settings.General.DefaultDownloadDir
+		}
+	}
+
+	if mapped, ok := utils.MapWindowsPathToDefaultDir(reqPath, baseDir); ok {
+		return mapped
+	}
+
+	return ""
 }

--- a/cmd/root_downloads.go
+++ b/cmd/root_downloads.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync/atomic"
 
@@ -392,7 +393,7 @@ func mapClientWindowsPath(reqPath string, relativeToDefaultDir bool, defaultOutp
 		return mapped
 	}
 
-	if !relativeToDefaultDir {
+	if !shouldFallbackUnmappedWindowsPath(relativeToDefaultDir, runtime.GOOS) {
 		return ""
 	}
 
@@ -401,4 +402,8 @@ func mapClientWindowsPath(reqPath string, relativeToDefaultDir bool, defaultOutp
 	// rooted at baseDir instead of letting a bogus "E:/..." path turn into
 	// a Linux-relative path via EnsureAbsPath.
 	return filepath.Clean(baseDir)
+}
+
+func shouldFallbackUnmappedWindowsPath(relativeToDefaultDir bool, hostOS string) bool {
+	return relativeToDefaultDir || hostOS != "windows"
 }

--- a/cmd/root_downloads.go
+++ b/cmd/root_downloads.go
@@ -392,5 +392,13 @@ func mapClientWindowsPath(reqPath string, relativeToDefaultDir bool, defaultOutp
 		return mapped
 	}
 
-	return ""
+	if !relativeToDefaultDir {
+		return ""
+	}
+
+	// If we positively identified a Windows absolute path but could not
+	// project it onto the server-side default directory, keep the download
+	// rooted at baseDir instead of letting a bogus "E:/..." path turn into
+	// a Linux-relative path via EnsureAbsPath.
+	return filepath.Clean(baseDir)
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,11 +6,7 @@ ARG TARGETOS
 ARG TARGETARCH
 ARG SURGE_VERSION
 
-RUN if [ -z "${SURGE_VERSION}" ]; then \
-      echo "SURGE_VERSION build arg is required for reproducible Docker builds" >&2; \
-      exit 1; \
-    fi && \
-    if [ "${TARGETOS:-linux}" != "linux" ]; then \
+RUN if [ "${TARGETOS:-linux}" != "linux" ]; then \
       echo "Unsupported target OS: ${TARGETOS}" >&2; \
       exit 1; \
     fi && \
@@ -20,6 +16,12 @@ RUN if [ -z "${SURGE_VERSION}" ]; then \
       arm) SURGE_ARCH="arm" ;; \
       *) echo "Unsupported target architecture: ${TARGETARCH}" >&2; exit 1 ;; \
     esac && \
+    if [ -z "${SURGE_VERSION}" ]; then \
+      echo "Fetching latest surge release..."; \
+      SURGE_VERSION=$(curl -fsSL https://api.github.com/repos/SurgeDM/Surge/releases/latest | jq -r .tag_name | sed 's/^v//'); \
+    else \
+      echo "Using specified surge version: ${SURGE_VERSION}"; \
+    fi && \
     echo "Downloading surge v${SURGE_VERSION} for ${TARGETOS:-linux}/${SURGE_ARCH}" && \
     curl -fsSL -o /tmp/surge.tar.gz \
       "https://github.com/SurgeDM/Surge/releases/download/v${SURGE_VERSION}/surge_${SURGE_VERSION}_linux_${SURGE_ARCH}.tar.gz" && \
@@ -29,9 +31,12 @@ RUN if [ -z "${SURGE_VERSION}" ]; then \
 
 FROM alpine:3.21
 
+ARG SURGE_UID=1000
+ARG SURGE_GID=1000
+
 RUN apk add --no-cache ca-certificates && \
-    addgroup -g 1000 -S surge && \
-    adduser -u 1000 -S -D -h /home/surge -G surge surge && \
+    addgroup -g ${SURGE_GID} -S surge && \
+    adduser -u ${SURGE_UID} -S -D -h /home/surge -G surge surge && \
     mkdir -p /downloads /var/lib/surge /home/surge && \
     chown -R surge:surge /downloads /var/lib/surge /home/surge
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,38 +1,55 @@
+FROM alpine:3.21 AS downloader
+
+RUN apk add --no-cache ca-certificates curl jq tar
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG SURGE_VERSION
+
+RUN if [ -z "${SURGE_VERSION}" ]; then \
+      echo "SURGE_VERSION build arg is required for reproducible Docker builds" >&2; \
+      exit 1; \
+    fi && \
+    if [ "${TARGETOS:-linux}" != "linux" ]; then \
+      echo "Unsupported target OS: ${TARGETOS}" >&2; \
+      exit 1; \
+    fi && \
+    case "${TARGETARCH}" in \
+      amd64) SURGE_ARCH="amd64" ;; \
+      arm64) SURGE_ARCH="arm64" ;; \
+      arm) SURGE_ARCH="arm" ;; \
+      *) echo "Unsupported target architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac && \
+    echo "Downloading surge v${SURGE_VERSION} for ${TARGETOS:-linux}/${SURGE_ARCH}" && \
+    curl -fsSL -o /tmp/surge.tar.gz \
+      "https://github.com/SurgeDM/Surge/releases/download/v${SURGE_VERSION}/surge_${SURGE_VERSION}_linux_${SURGE_ARCH}.tar.gz" && \
+    mkdir -p /tmp/surge-extract /out && \
+    tar -xzf /tmp/surge.tar.gz -C /tmp/surge-extract && \
+    install -m 0755 /tmp/surge-extract/surge /out/surge
+
 FROM alpine:3.21
 
-RUN apk add --no-cache ca-certificates curl jq
+RUN apk add --no-cache ca-certificates && \
+    addgroup -g 1000 -S surge && \
+    adduser -u 1000 -S -D -h /home/surge -G surge surge && \
+    mkdir -p /downloads /var/lib/surge /home/surge && \
+    chown -R surge:surge /downloads /var/lib/surge /home/surge
 
-ARG SURGE_VERSION=""
+COPY --from=downloader /out/surge /usr/local/bin/surge
 
-RUN ARCH=$(uname -m) && \
-    case ${ARCH} in \
-    x86_64) SURGE_ARCH="amd64" ;; \
-    aarch64) SURGE_ARCH="arm64" ;; \
-    armv7l) SURGE_ARCH="arm" ;; \
-    *) echo "Unsupported architecture: ${ARCH}" && exit 1 ;; \
-    esac && \
-    if [ -z "$SURGE_VERSION" ]; then \
-    echo "Fetching latest surge release..."; \
-    SURGE_VERSION=$(curl -s https://api.github.com/repos/SurgeDM/Surge/releases/latest | jq -r .tag_name | sed 's/^v//'); \
-    else \
-    echo "Using specified surge version: $SURGE_VERSION"; \
-    fi && \
-    echo "Downloading surge v${SURGE_VERSION} for architecture: ${SURGE_ARCH}" && \
-    curl -L -o /tmp/surge.tar.gz \
-    "https://github.com/SurgeDM/Surge/releases/download/v${SURGE_VERSION}/surge_${SURGE_VERSION}_linux_${SURGE_ARCH}.tar.gz" && \
-    tar -xzf /tmp/surge.tar.gz -C /usr/local/bin && \
-    rm /tmp/surge.tar.gz && \
-    chmod +x /usr/local/bin/surge && \
-    echo "Installed surge v${SURGE_VERSION}" && \
-    apk del curl jq
-
-RUN mkdir -p /root/.local/state/surge/logs /downloads
+ENV HOME=/home/surge \
+    XDG_CONFIG_HOME=/var/lib \
+    XDG_STATE_HOME=/var/lib
 
 WORKDIR /downloads
+
+VOLUME ["/downloads", "/var/lib/surge"]
 
 LABEL org.opencontainers.image.source="https://github.com/SurgeDM/Surge"
 LABEL org.opencontainers.image.description="Surge download manager"
 LABEL org.opencontainers.image.licenses="MIT"
+
+USER surge
 
 EXPOSE 1700
 

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -1,17 +1,19 @@
 services:
   surge:
-    image: ghcr.io/SurgeDM/Surge # OR surge:latest if building
+    image: ghcr.io/surgedm/surge # Or build locally with the commented block below.
     #    build:
     #      context: .
     #      dockerfile: Dockerfile
+    #      args:
+    #        SURGE_VERSION: "0.8.0"
     container_name: surge
     ports:
       - "1700:1700"
     volumes:
       #- ~/docker/volumes/surge/downloads:/downloads # isolation if using in a professional envir
-      #- ~/docker/volumes/surge/config:/root/.surge  # isolation if using in a professional envir
+      #- ~/docker/volumes/surge/config:/var/lib/surge # state, token, logs
       - ./downloads:/downloads
-      - ./surge-config:/root/.local/state/surge
+      - ./surge-config:/var/lib/surge
     restart: unless-stopped
     environment:
       - TZ=UTC

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -5,31 +5,27 @@ services:
     #      context: .
     #      dockerfile: Dockerfile
     #      args:
-    #        SURGE_VERSION: "0.8.0"
+    #        SURGE_VERSION: "0.8.0" # Optional. Omit to build from the latest release.
+    #        SURGE_UID: ${UID:-1000}
+    #        SURGE_GID: ${GID:-1000}
     container_name: surge
+    user: "${UID:-1000}:${GID:-1000}"
     ports:
       - "1700:1700"
     volumes:
-      #- ~/docker/volumes/surge/downloads:/downloads # isolation if using in a professional envir
-      #- ~/docker/volumes/surge/config:/var/lib/surge # state, token, logs
       - ./downloads:/downloads
       - ./surge-config:/var/lib/surge
     restart: unless-stopped
     environment:
       - TZ=UTC
-    #healthcheck:
-    #  test: ["CMD", "surge", "server", "status"]  # at times during release the conatiner health check can break having manual health check for testing and trouble shooting is nice. 
-    #  interval: 30s
-    #  timeout: 10s
-    #  retries: 3
-    # start_period: 5s
-    deploy:
-      resources:
-        limits:
-          cpus: '0.5'
-          memory: 256M # change to your liking or specs
+    # Resource limits are optional. Uncomment and tune based on your hardware.
+    # deploy:
+    #   resources:
+    #     limits:
+    #       cpus: '2.0'
+    #       memory: 1G
     logging:
-      driver: "json-file" # etting this up proper you want to see logs all Terminal based apps should have logs
+      driver: "json-file"
       options:
         max-size: "10m"
         max-file: "3"

--- a/internal/utils/path.go
+++ b/internal/utils/path.go
@@ -74,6 +74,9 @@ func MapWindowsPathToDefaultDir(requestPath, defaultDir string) (string, bool) {
 		if part == "" || part == "." {
 			continue
 		}
+		if part == ".." {
+			return "", false
+		}
 		relParts = append(relParts, part)
 	}
 

--- a/internal/utils/path.go
+++ b/internal/utils/path.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"path/filepath"
+	"strings"
 )
 
 // EnsureAbsPath takes a clean path and forces it to be absolute.
@@ -15,4 +16,70 @@ func EnsureAbsPath(path string) string {
 		return abs
 	}
 	return path
+}
+
+// IsWindowsAbsPath reports whether p looks like a Windows absolute path even
+// when running on a non-Windows host (for example inside Docker on Linux).
+func IsWindowsAbsPath(p string) bool {
+	p = strings.TrimSpace(p)
+	if len(p) >= 3 &&
+		((p[0] >= 'A' && p[0] <= 'Z') || (p[0] >= 'a' && p[0] <= 'z')) &&
+		p[1] == ':' &&
+		(p[2] == '/' || p[2] == '\\') {
+		return true
+	}
+
+	// UNC paths also need to be treated as absolute across platforms.
+	if len(p) >= 2 && ((p[0] == '\\' && p[1] == '\\') || (p[0] == '/' && p[1] == '/')) {
+		return true
+	}
+
+	return false
+}
+
+// MapWindowsPathToDefaultDir projects a Windows absolute client path onto a
+// server-side default download directory by preserving only the suffix beneath
+// the matching root folder name. Example:
+//
+//	C:/Users/me/Downloads/subdir -> /downloads/subdir
+func MapWindowsPathToDefaultDir(requestPath, defaultDir string) (string, bool) {
+	requestPath = strings.TrimSpace(requestPath)
+	defaultDir = strings.TrimSpace(defaultDir)
+	if requestPath == "" || defaultDir == "" || !IsWindowsAbsPath(requestPath) {
+		return "", false
+	}
+
+	defaultBase := strings.TrimSpace(filepath.Base(filepath.Clean(defaultDir)))
+	if defaultBase == "" || defaultBase == "." || defaultBase == string(filepath.Separator) {
+		return "", false
+	}
+
+	normalized := strings.ReplaceAll(requestPath, "\\", "/")
+	parts := strings.Split(normalized, "/")
+
+	match := -1
+	for i, part := range parts {
+		if strings.EqualFold(strings.TrimSpace(part), defaultBase) {
+			match = i
+		}
+	}
+	if match == -1 {
+		return "", false
+	}
+
+	relParts := make([]string, 0, len(parts)-match-1)
+	for _, part := range parts[match+1:] {
+		part = strings.TrimSpace(part)
+		if part == "" || part == "." {
+			continue
+		}
+		relParts = append(relParts, part)
+	}
+
+	if len(relParts) == 0 {
+		return filepath.Clean(defaultDir), true
+	}
+
+	joined := append([]string{filepath.Clean(defaultDir)}, relParts...)
+	return filepath.Join(joined...), true
 }

--- a/internal/utils/path.go
+++ b/internal/utils/path.go
@@ -29,8 +29,8 @@ func IsWindowsAbsPath(p string) bool {
 		return true
 	}
 
-	// UNC paths also need to be treated as absolute across platforms.
-	if len(p) >= 2 && ((p[0] == '\\' && p[1] == '\\') || (p[0] == '/' && p[1] == '/')) {
+	// UNC paths (Windows-only; // is POSIX-legal and must not be excluded).
+	if len(p) >= 2 && p[0] == '\\' && p[1] == '\\' {
 		return true
 	}
 

--- a/internal/utils/path.go
+++ b/internal/utils/path.go
@@ -61,6 +61,7 @@ func MapWindowsPathToDefaultDir(requestPath, defaultDir string) (string, bool) {
 	for i, part := range parts {
 		if strings.EqualFold(strings.TrimSpace(part), defaultBase) {
 			match = i
+			break
 		}
 	}
 	if match == -1 {

--- a/internal/utils/path_test.go
+++ b/internal/utils/path_test.go
@@ -111,6 +111,12 @@ func TestMapWindowsPathToDefaultDir(t *testing.T) {
 			wantOK:     false,
 		},
 		{
+			name:       "parent traversal segment is rejected",
+			request:    `C:/Downloads/../../etc/passwd`,
+			defaultDir: `/downloads`,
+			wantOK:     false,
+		},
+		{
 			name:       "empty request path",
 			request:    "",
 			defaultDir: `/downloads`,

--- a/internal/utils/path_test.go
+++ b/internal/utils/path_test.go
@@ -98,6 +98,13 @@ func TestMapWindowsPathToDefaultDir(t *testing.T) {
 			wantOK:     true,
 		},
 		{
+			name:       "first matching segment wins when name repeats",
+			request:    `C:/Downloads/archive/Downloads/final`,
+			defaultDir: `/downloads`,
+			want:       filepath.Join(filepath.Clean(`/downloads`), `archive`, `Downloads`, `final`),
+			wantOK:     true,
+		},
+		{
 			name:       "non matching root is not mapped",
 			request:    `C:/Users/me/Desktop`,
 			defaultDir: `/downloads`,

--- a/internal/utils/path_test.go
+++ b/internal/utils/path_test.go
@@ -63,7 +63,7 @@ func TestIsWindowsAbsPath(t *testing.T) {
 
 	for _, tt := range tests {
 		if got := IsWindowsAbsPath(tt.path); got != tt.want {
-			t.Fatalf("IsWindowsAbsPath(%q) = %v, want %v", tt.path, got, tt.want)
+			t.Errorf("IsWindowsAbsPath(%q) = %v, want %v", tt.path, got, tt.want)
 		}
 	}
 }

--- a/internal/utils/path_test.go
+++ b/internal/utils/path_test.go
@@ -103,6 +103,18 @@ func TestMapWindowsPathToDefaultDir(t *testing.T) {
 			defaultDir: `/downloads`,
 			wantOK:     false,
 		},
+		{
+			name:       "empty request path",
+			request:    "",
+			defaultDir: `/downloads`,
+			wantOK:     false,
+		},
+		{
+			name:       "linux path is not mapped",
+			request:    `/tmp/downloads`,
+			defaultDir: `/downloads`,
+			wantOK:     false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/utils/path_test.go
+++ b/internal/utils/path_test.go
@@ -48,3 +48,72 @@ func TestEnsureAbsPath(t *testing.T) {
 		})
 	}
 }
+
+func TestIsWindowsAbsPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{path: `C:\Users\me\Downloads`, want: true},
+		{path: `C:/Users/me/Downloads`, want: true},
+		{path: `\\server\share\file.zip`, want: true},
+		{path: `/tmp/downloads`, want: false},
+		{path: `downloads/subdir`, want: false},
+	}
+
+	for _, tt := range tests {
+		if got := IsWindowsAbsPath(tt.path); got != tt.want {
+			t.Fatalf("IsWindowsAbsPath(%q) = %v, want %v", tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestMapWindowsPathToDefaultDir(t *testing.T) {
+	tests := []struct {
+		name       string
+		request    string
+		defaultDir string
+		want       string
+		wantOK     bool
+	}{
+		{
+			name:       "download root maps to default dir",
+			request:    `C:/Users/me/Downloads`,
+			defaultDir: `/downloads`,
+			want:       filepath.Clean(`/downloads`),
+			wantOK:     true,
+		},
+		{
+			name:       "nested subdir preserved",
+			request:    `C:/Users/me/Downloads/surge-repro`,
+			defaultDir: `/downloads`,
+			want:       filepath.Join(filepath.Clean(`/downloads`), `surge-repro`),
+			wantOK:     true,
+		},
+		{
+			name:       "custom root basename matches case-insensitively",
+			request:    `D:/Archive/Downloads/Nested/Deep`,
+			defaultDir: `/DownLoads`,
+			want:       filepath.Join(filepath.Clean(`/DownLoads`), `Nested`, `Deep`),
+			wantOK:     true,
+		},
+		{
+			name:       "non matching root is not mapped",
+			request:    `C:/Users/me/Desktop`,
+			defaultDir: `/downloads`,
+			wantOK:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := MapWindowsPathToDefaultDir(tt.request, tt.defaultDir)
+			if ok != tt.wantOK {
+				t.Fatalf("MapWindowsPathToDefaultDir(%q, %q) ok = %v, want %v", tt.request, tt.defaultDir, ok, tt.wantOK)
+			}
+			if got != tt.want {
+				t.Fatalf("MapWindowsPathToDefaultDir(%q, %q) = %q, want %q", tt.request, tt.defaultDir, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Windows absolute paths (drive letters and UNC) sent by WSL clients not being mapped to the server-side Linux download directory. It introduces `IsWindowsAbsPath`, `MapWindowsPathToDefaultDir`, and `mapClientWindowsPath` with segment-name matching and `..` traversal rejection, and adds corresponding tests. The change is correct and addresses the previously raised silent-fallthrough concern.

The PR bundles several unrelated improvements — a Docker multi-stage build refactor with a non-root user, updated `compose.yml`, and a new CI tag-based workflow trigger — alongside the core path fix; these should ideally be separate PRs per the project's contribution guidelines.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all remaining findings are P2 style/test suggestions with no blocking correctness or security issues.

The core path-mapping logic is correct, traversal attacks are rejected in MapWindowsPathToDefaultDir, and the previously raised silent-fallthrough concern is addressed by the new fallback mechanism. All open comments are non-blocking P2 improvements.

docker/compose.yml — the user field may silently default to 1000:1000 in most environments.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/utils/path.go | Adds IsWindowsAbsPath and MapWindowsPathToDefaultDir with sound logic; POSIX // negative test case missing from companion test file. |
| cmd/root_downloads.go | Adds mapClientWindowsPath and shouldFallbackUnmappedWindowsPath; correctly falls back to baseDir for unmapped Windows paths; missing end-to-end test for explicit non-RelativeToDefaultDir unmapped path on Linux. |
| cmd/http_handler_test.go | Refactors path resolution tests to use pre-computed expectedOutputPath; adds Windows path cases and TestShouldFallbackUnmappedWindowsPath; lacks explicit unmapped Windows path test without RelativeToDefaultDir. |
| internal/utils/path_test.go | Adds TestIsWindowsAbsPath and TestMapWindowsPathToDefaultDir with traversal, case-insensitive, and no-match cases; missing //server/share negative case. |
| docker/Dockerfile | Clean multi-stage build with non-root surge user, proper volume declarations, and TARGETOS/TARGETARCH build args; jq correctly scoped to downloader stage. |
| docker/compose.yml | Adds user field for non-root execution but $UID is not exported by bash by default so the value silently defaults to 1000 in most environments. |
| .github/workflows/build-push-images.yml | Adds tag-based trigger, automatic version extraction from tag name, and a latest-tag step gated on clean semver tags; logic is correct. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Client sends DownloadRequest] --> B{IsWindowsAbsPath?}
    B -- No --> C{RelativeToDefaultDir?}
    B -- Yes --> D[mapClientWindowsPath]
    C -- Yes --> E[Join baseDir + reqPath]
    C -- No --> F[EnsureAbsPath reqPath]
    D --> G{MapWindowsPathToDefaultDir matches?}
    G -- Yes --> H[Return baseDir/suffix]
    G -- No --> I{shouldFallbackUnmappedWindowsPath?}
    I -- true --> J[Return filepath.Clean baseDir]
    I -- false --> K[Return empty, fall through]
    H --> L[resolveOutputDir returns path]
    J --> L
    E --> L
    F --> L
    K --> C
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: docker/compose.yml
Line: 12

Comment:
**`${UID}` is not exported by bash by default**

`$UID` is a bash read-only special variable that is NOT exported to child processes. When Docker Compose is launched normally, it won't see the host user's UID from the environment — `${UID:-1000}` will always resolve to `1000`, defeating the purpose of the mapping. Users need to explicitly export it or set it before running compose:

```bash
UID=$(id -u) GID=$(id -g) docker compose up
```

Or add to a `.env` file alongside `compose.yml`:
```
UID=1000
GID=1000
```

Consider adding a comment or README note explaining this requirement, or using a wrapper script that pre-sets the variables.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/utils/path_test.go
Line: 51-63

Comment:
**Missing negative test for POSIX `//` double-slash path**

The implementation explicitly notes that `//path` is POSIX-legal and must NOT be treated as a Windows UNC path (only `\\` backslash-backslash is UNC). There's no test case confirming `//server/share` returns `false`, which is the critical distinction the code comment calls out.

```suggestion
	tests := []struct {
		path string
		want bool
	}{
		{path: `C:\Users\me\Downloads`, want: true},
		{path: `C:/Users/me/Downloads`, want: true},
		{path: `\\server\share\file.zip`, want: true},
		{path: `/tmp/downloads`, want: false},
		{path: `downloads/subdir`, want: false},
		{path: `//server/share`, want: false},
	}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: cmd/http_handler_test.go
Line: 155-165

Comment:
**No test for explicit unmapped Windows path on Linux without `RelativeToDefaultDir`**

The "Unmatched Windows Path Falls Back To Default Dir" case only covers the `RelativeToDefaultDir: true` branch. However, `shouldFallbackUnmappedWindowsPath(false, "linux")` also returns `true`, meaning an explicit Windows path that doesn't match the server's download folder name silently falls back to the default dir on Linux. Consider adding a case with `Path: "E:/Torrents/complete"` and no `RelativeToDefaultDir` flag to cover this branch end-to-end.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (8): Last reviewed commit: ["fix(utils): reject parent traversal segm..."](https://github.com/surgedm/surge/commit/dc342e08d66f50b2bde863675576556334bc6bba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28175562)</sub>

**Context used:**

- Rule used - What: Flag commits that bundle unnecessary changes... ([source](https://app.greptile.com/review/custom-context?memory=74a28159-60fc-4201-a661-331594ebaf90))

<!-- /greptile_comment -->