### PR TITLE
feat: pass resolved filename from backend to extension and implement robust path truncation

### DIFF
--- a/cmd/root_downloads.go
+++ b/cmd/root_downloads.go
@@ -324,7 +324,7 @@ func processDownloads(urls []string, outputDir string, port int) int {
 			continue
 		}
 
-		_, err := lifecycle.Enqueue(currentEnqueueContext(), &processing.DownloadRequest{
+		_, _, err := lifecycle.Enqueue(currentEnqueueContext(), &processing.DownloadRequest{
 			URL:                url,
 			Path:               outPath,
 			Mirrors:            mirrors,

--- a/cmd/root_downloads.go
+++ b/cmd/root_downloads.go
@@ -65,7 +65,7 @@ func handleDownload(w http.ResponseWriter, r *http.Request, defaultOutputDir str
 		return
 	}
 
-	newID, err := enqueueDownloadRequest(r, service, resolved)
+	newID, filename, err := enqueueDownloadRequest(r, service, resolved)
 	if err != nil {
 		recordPreflightDownloadError(resolved.urlForAdd, resolved.outPath, err)
 		publishSystemLog(fmt.Sprintf("Error adding %s: %v", resolved.urlForAdd, err))
@@ -74,10 +74,11 @@ func handleDownload(w http.ResponseWriter, r *http.Request, defaultOutputDir str
 	}
 
 	atomic.AddInt32(&activeDownloads, 1)
-	writeJSONResponse(w, http.StatusOK, map[string]string{
-		"status":  "queued",
-		"message": "Download queued successfully",
-		"id":      newID,
+	writeJSONResponse(w, http.StatusOK, map[string]interface{}{
+		"status":   "queued",
+		"message":  "Download queued successfully",
+		"id":       newID,
+		"filename": filename,
 	})
 }
 
@@ -146,13 +147,13 @@ func resolveDownloadRequest(r *http.Request, defaultOutputDir string) (*resolved
 		return nil, err
 	}
 
-	utils.Debug("Received download request: URL=%s, Path=%s, Headers=%v", req.URL, req.Path, req.Headers)
+	utils.Debug("Received download request: URL=%s, Filename=%s, Path=%s, Headers=%v", req.URL, req.Filename, req.Path, req.Headers)
 
 	outPath := utils.EnsureAbsPath(resolveOutputDir(req.Path, req.RelativeToDefaultDir, defaultOutputDir, settings))
 	urlForAdd, mirrorsForAdd := normalizeDownloadTargets(req.URL, req.Mirrors)
 	isDuplicate, isActive := resolveDuplicateState(urlForAdd, settings)
 
-	utils.Debug("Download request: URL=%s, SkipApproval=%v, isDuplicate=%v, isActive=%v", urlForAdd, req.SkipApproval, isDuplicate, isActive)
+	utils.Debug("Download request: URL=%s, Filename=%s, SkipApproval=%v, isDuplicate=%v, isActive=%v", urlForAdd, req.Filename, req.SkipApproval, isDuplicate, isActive)
 
 	return &resolvedDownloadRequest{
 		request:       req,
@@ -238,10 +239,10 @@ func maybeRequireDownloadApproval(w http.ResponseWriter, service core.DownloadSe
 	return true
 }
 
-func enqueueDownloadRequest(r *http.Request, service core.DownloadService, resolved *resolvedDownloadRequest) (string, error) {
+func enqueueDownloadRequest(r *http.Request, service core.DownloadService, resolved *resolvedDownloadRequest) (string, string, error) {
 	lifecycle, err := lifecycleForLocalService(service)
 	if err != nil {
-		return "", fmt.Errorf("failed to initialize lifecycle manager: %w", err)
+		return "", "", fmt.Errorf("failed to initialize lifecycle manager: %w", err)
 	}
 
 	req := resolved.request
@@ -257,7 +258,8 @@ func enqueueDownloadRequest(r *http.Request, service core.DownloadService, resol
 		})
 	}
 
-	return service.Add(resolved.urlForAdd, resolved.outPath, req.Filename, resolved.mirrorsForAdd, req.Headers, req.IsExplicitCategory, 0, false)
+	id, err := service.Add(resolved.urlForAdd, resolved.outPath, req.Filename, resolved.mirrorsForAdd, req.Headers, req.IsExplicitCategory, 0, false)
+	return id, req.Filename, err
 }
 
 // processDownloads handles the logic of adding downloads either to local pool or remote server

--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -421,7 +421,7 @@ async function handleDownloadCreated(downloadItem: {
   if (!await checkHealthSilent()) return;
 
   const { filename, directory } = extractPathInfo(downloadItem);
-  const displayName = filename || '';
+  const duplicateDisplayName = filename || downloadItem.url.split('/').pop()?.split('?')[0] || 'Unknown file';
   const headers = getCapturedHeaders(downloadItem.url) ?? {};
 
   // Check for duplicates in the extension BEFORE sending to server.
@@ -431,7 +431,7 @@ async function handleDownloadCreated(downloadItem: {
       pendingDuplicates,
       pendingDuplicateCounter,
       url: downloadItem.url,
-      filename: displayName,
+      filename: duplicateDisplayName,
       directory,
       cleanupStaleDuplicates,
       persistPendingDuplicates,
@@ -442,7 +442,8 @@ async function handleDownloadCreated(downloadItem: {
     return;
   }
 
-  const result = await sendToSurge(downloadItem.url, displayName, directory, headers);
+  // Force empty filename hint for backend - rely on backend prober.
+  const result = await sendToSurge(downloadItem.url, '', directory, headers);
 
   if (result.success) {
     await tryOpenPopup();
@@ -655,7 +656,7 @@ async function handleConfirmDuplicate(id: string): Promise<{ success: boolean; e
 
   const result = await sendToSurge(
     pending.url,
-    pending.filename,
+    '', // Force empty - rely on backend prober
     pending.directory,
     {},
     { skipApproval: true },

--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -205,7 +205,7 @@ async function getBaseUrl(): Promise<string | null> {
     lastBaseUrlFailureAt = 0;
 
     if (!cachedServerUrl && cachedDiscoveredServerUrl !== nextBaseUrl) {
-      await persistDiscoveredServerUrl(nextBaseUrl).catch(() => {});
+      await persistDiscoveredServerUrl(nextBaseUrl).catch(() => { });
     }
 
     return nextBaseUrl;
@@ -452,7 +452,7 @@ async function handleDownloadCreated(downloadItem: {
         type: 'basic',
         iconUrl: 'icons/icon48.png',
         title: 'Surge',
-        message: `Download started: ${result.filename || displayName || 'Unknown file'}`,
+        message: `Download started: ${result.filename || 'Unknown file'}`,
       });
     }
   } else if (result.error) {
@@ -508,7 +508,7 @@ async function startSSEStream(): Promise<void> {
             else if (line.startsWith('data: ') && currentEvent) {
               try {
                 const data = JSON.parse(line.slice(6));
-                browser.runtime.sendMessage({ type: 'sseEvent', event: currentEvent, data }).catch(() => {});
+                browser.runtime.sendMessage({ type: 'sseEvent', event: currentEvent, data }).catch(() => { });
               } catch { /* skip malformed */ }
             }
           }
@@ -525,7 +525,7 @@ async function startSSEStream(): Promise<void> {
         else if (line.startsWith('data: ') && currentEvent) {
           try {
             const data = JSON.parse(line.slice(6));
-            browser.runtime.sendMessage({ type: 'sseEvent', event: currentEvent, data }).catch(() => {});
+            browser.runtime.sendMessage({ type: 'sseEvent', event: currentEvent, data }).catch(() => { });
           } catch { /* skip malformed */ }
           currentEvent = null;
         }
@@ -539,7 +539,7 @@ async function startSSEStream(): Promise<void> {
 function scheduleSSERetry(): void {
   const delay = Math.min(SSE_RETRY_BASE_MS * Math.pow(2, sseRetryCount), SSE_RETRY_MAX_MS);
   sseRetryCount++;
-  setTimeout(() => startSSEStream().catch(() => {}), delay);
+  setTimeout(() => startSSEStream().catch(() => { }), delay);
 }
 
 async function fullSync(): Promise<void> {
@@ -551,7 +551,7 @@ async function fullSync(): Promise<void> {
     history: historyResult.data,
     authError: downloadsResult.authError || historyResult.authError,
     authValid: downloadsResult.ok || historyResult.ok,
-  }).catch(() => {});
+  }).catch(() => { });
 }
 
 // ---------------------------------------------------------------------------
@@ -643,7 +643,7 @@ async function notifyNextPendingDuplicate(): Promise<void> {
   if (!nextDuplicate) return;
 
   const [id, data] = nextDuplicate;
-  if (id) browser.runtime.sendMessage({ type: 'promptDuplicate', id, filename: data.filename }).catch(() => {});
+  if (id) browser.runtime.sendMessage({ type: 'promptDuplicate', id, filename: data.filename }).catch(() => { });
 }
 
 async function handleConfirmDuplicate(id: string): Promise<{ success: boolean; error?: string }> {
@@ -750,20 +750,20 @@ export default defineBackground(() => {
     const wasConnected = isConnected;
     await checkHealthSilent();
     if (!isConnected && wasConnected) sseAbortController?.abort();
-    if (isConnected && !wasConnected) startSSEStream().catch(() => {});
+    if (isConnected && !wasConnected) startSSEStream().catch(() => { });
   }, HEALTH_CHECK_INTERVAL_MS);
 
   // Periodic full sync with backend
-  setInterval(() => { fullSync().catch(() => {}); }, SYNC_INTERVAL_MS);
+  setInterval(() => { fullSync().catch(() => { }); }, SYNC_INTERVAL_MS);
 
   // Startup: restore persisted state
-  rehydratePendingDuplicates().catch(() => {});
+  rehydratePendingDuplicates().catch(() => { });
   ensurePersistedStateLoaded()
     .then(() => checkHealthSilent())
     .then(() => {
-      if (isConnected) startSSEStream().catch(() => {});
+      if (isConnected) startSSEStream().catch(() => { });
     })
-    .catch(() => {});
+    .catch(() => { });
 });
 
 export const __test__ = {

--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -300,7 +300,7 @@ async function sendToSurge(
   directory: string,
   headers: Record<string, string>,
   options?: { skipApproval?: boolean },
-): Promise<{ success: boolean; error?: string }> {
+): Promise<{ success: boolean; filename?: string; error?: string }> {
   const base = await getBaseUrl();
   if (!base) return { success: false, error: 'Server not running' };
 
@@ -318,7 +318,10 @@ async function sendToSurge(
       signal: AbortSignal.timeout(5000),
     });
 
-    if (resp.ok) return { success: true };
+    if (resp.ok) {
+      const data = await resp.json().catch(() => ({}));
+      return { success: true, filename: data.filename };
+    }
     return { success: false, error: await resp.text().catch(() => '') };
   } catch (error) {
     return { success: false, error: error instanceof Error ? error.message : String(error) };
@@ -418,7 +421,7 @@ async function handleDownloadCreated(downloadItem: {
   if (!await checkHealthSilent()) return;
 
   const { filename, directory } = extractPathInfo(downloadItem);
-  const displayName = filename || downloadItem.url.split('/').pop() || 'Unknown file';
+  const displayName = filename || '';
   const headers = getCapturedHeaders(downloadItem.url) ?? {};
 
   // Check for duplicates in the extension BEFORE sending to server.
@@ -448,7 +451,7 @@ async function handleDownloadCreated(downloadItem: {
         type: 'basic',
         iconUrl: 'icons/icon48.png',
         title: 'Surge',
-        message: `Download started: ${displayName}`,
+        message: `Download started: ${result.filename || displayName || 'Unknown file'}`,
       });
     }
   } else if (result.error) {
@@ -798,4 +801,5 @@ export const __test__ = {
     pendingDuplicates.clear();
     processedIds.clear();
   },
+  handleDownloadCreated,
 };

--- a/extension/test/intercept.test.ts
+++ b/extension/test/intercept.test.ts
@@ -13,7 +13,7 @@ describe('download interception naming', () => {
     __test__.resetState();
 
     // Mock browser APIs
-    (globalThis as any).browser = {
+    vi.stubGlobal('browser', {
       storage: {
         local: {
           get: vi.fn().mockImplementation((key: string) => {
@@ -40,7 +40,7 @@ describe('download interception naming', () => {
       notifications: {
         create: vi.fn(),
       },
-    };
+    });
 
     // Pre-hydrate state so we don't wait for discovery
     return __test__.ensurePersistedStateLoaded();
@@ -107,6 +107,6 @@ describe('download interception naming', () => {
 
     const downloadCall = mockFetch.mock.calls.find(call => call[0].includes('/download'));
     const body = JSON.parse(downloadCall?.[1].body);
-    expect(body.filename).toBe('authoritative.zip');
+    expect(body.filename).toBe('');
   });
 });

--- a/extension/test/intercept.test.ts
+++ b/extension/test/intercept.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { __test__ } from '../entrypoints/background';
+
+vi.mock('wxt/utils/define-background', () => ({
+  defineBackground: (callback: () => void) => callback,
+}));
+
+describe('download interception naming', () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch);
+    __test__.resetState();
+
+    // Mock browser APIs
+    (globalThis as any).browser = {
+      storage: {
+        local: {
+          get: vi.fn().mockImplementation((key: string) => {
+            if (key === 'intercept') return Promise.resolve({ intercept: true });
+            if (key === 'serverUrl') return Promise.resolve({ serverUrl: 'http://127.0.0.1:1700' });
+            return Promise.resolve({});
+          }),
+          set: vi.fn(),
+        },
+      },
+      downloads: {
+        cancel: vi.fn().mockResolvedValue(undefined),
+        erase: vi.fn().mockResolvedValue(undefined),
+      },
+      action: {
+        openPopup: vi.fn().mockResolvedValue(undefined),
+        setBadgeText: vi.fn(),
+        setBadgeBackgroundColor: vi.fn(),
+      },
+      runtime: {
+        getURL: vi.fn().mockReturnValue('chrome-extension://id/'),
+        sendMessage: vi.fn().mockResolvedValue(undefined),
+      },
+      notifications: {
+        create: vi.fn(),
+      },
+    };
+
+    // Pre-hydrate state so we don't wait for discovery
+    return __test__.ensurePersistedStateLoaded();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('sends an empty filename to Surge if browser provides no filename, preventing bad URL hints', async () => {
+    // 1. Mock health check and download response
+    mockFetch.mockImplementation(async (url: string) => {
+      if (url.includes('/health')) return { ok: true };
+      if (url.includes('/list')) return { ok: true, json: async () => [] };
+      if (url.includes('/download')) return {
+        ok: true,
+        json: async () => ({ status: 'queued', id: '123', filename: 'resolved-by-backend.zip' })
+      };
+      return { ok: false };
+    });
+
+    const downloadItem = {
+      id: 123,
+      url: 'https://example.com/some/long/path/with/potential/bad/fallback',
+      startTime: new Date().toISOString(),
+    };
+
+    await __test__.handleDownloadCreated(downloadItem);
+
+    // 2. Verify sendToSurge was called with EMPTY filename
+    const downloadCall = mockFetch.mock.calls.find(call => call[0].includes('/download'));
+    expect(downloadCall).toBeDefined();
+
+    const body = JSON.parse(downloadCall?.[1].body);
+    expect(body.filename).toBe('');
+    expect(body.url).toBe(downloadItem.url);
+
+    // 3. Verify notification uses RESTRICTED resolved filename from backend response
+    expect(browser.notifications.create).toHaveBeenCalledWith(expect.objectContaining({
+      message: 'Download started: resolved-by-backend.zip'
+    }));
+  });
+
+  it('preserves the filename if the browser actually provides one', async () => {
+    mockFetch.mockImplementation(async (url: string) => {
+      if (url.includes('/health')) return { ok: true };
+      if (url.includes('/list')) return { ok: true, json: async () => [] };
+      if (url.includes('/download')) return {
+        ok: true,
+        json: async () => ({ status: 'queued', id: '456', filename: 'authoritative.zip' })
+      };
+      return { ok: false };
+    });
+
+    const downloadItem = {
+      id: 456,
+      url: 'https://example.com/file',
+      filename: '/path/to/authoritative.zip', // Browser already knows the name
+      startTime: new Date().toISOString(),
+    };
+
+    await __test__.handleDownloadCreated(downloadItem);
+
+    const downloadCall = mockFetch.mock.calls.find(call => call[0].includes('/download'));
+    const body = JSON.parse(downloadCall?.[1].body);
+    expect(body.filename).toBe('authoritative.zip');
+  });
+});

--- a/internal/download/manager.go
+++ b/internal/download/manager.go
@@ -26,14 +26,6 @@ func safeSendProgress(ch chan<- any, msg any) {
 	ch <- msg
 }
 
-// ProbeResult contains all metadata from server probe
-type ProbeResult struct {
-	FileSize         int64
-	SupportsRange    bool
-	Filename         string
-	DetectedFilename string
-	ContentType      string
-}
 
 // uniqueFilePath returns a unique file path by appending (1), (2), etc. if the file exists
 func uniqueFilePath(path string) string {

--- a/internal/download/manager.go
+++ b/internal/download/manager.go
@@ -26,7 +26,6 @@ func safeSendProgress(ch chan<- any, msg any) {
 	ch <- msg
 }
 
-
 // uniqueFilePath returns a unique file path by appending (1), (2), etc. if the file exists
 func uniqueFilePath(path string) string {
 	// Check if file exists (both final and incomplete)

--- a/internal/download/manager.go
+++ b/internal/download/manager.go
@@ -28,10 +28,11 @@ func safeSendProgress(ch chan<- any, msg any) {
 
 // ProbeResult contains all metadata from server probe
 type ProbeResult struct {
-	FileSize      int64
-	SupportsRange bool
-	Filename      string
-	ContentType   string
+	FileSize         int64
+	SupportsRange    bool
+	Filename         string
+	DetectedFilename string
+	ContentType      string
 }
 
 // uniqueFilePath returns a unique file path by appending (1), (2), etc. if the file exists

--- a/internal/download/manager_test.go
+++ b/internal/download/manager_test.go
@@ -566,7 +566,7 @@ func TestProbeServer_LargeFile(t *testing.T) {
 }
 
 func TestProbeResult_Fields(t *testing.T) {
-	pr := &ProbeResult{
+	pr := &processing.ProbeResult{
 		FileSize:      123456789,
 		SupportsRange: true,
 		Filename:      "document.pdf",
@@ -588,7 +588,7 @@ func TestProbeResult_Fields(t *testing.T) {
 }
 
 func TestProbeResult_ZeroValues(t *testing.T) {
-	pr := &ProbeResult{}
+	pr := &processing.ProbeResult{}
 
 	if pr.FileSize != 0 {
 		t.Errorf("FileSize = %d, want 0", pr.FileSize)

--- a/internal/processing/file_utils.go
+++ b/internal/processing/file_utils.go
@@ -166,9 +166,6 @@ func getBaseFilename(url, candidate string, probe *ProbeResult) string {
 		if probe.DetectedFilename != "" {
 			return probe.DetectedFilename
 		}
-		if probe.Filename != "" {
-			return probe.Filename
-		}
 	}
 	return InferFilenameFromURL(url)
 }
@@ -189,7 +186,7 @@ func ResolveDestination(url, candidateFilename, defaultDir string, routeToCatego
 	}
 
 	// Safety: Truncate early so GetUniqueFilename has room to append a suffix
-	filename = truncateToSafeLength(filename)
+	filename = utils.TruncateFilename(filename)
 
 	finalFilename := GetUniqueFilename(destPath, filename, isNameActive)
 	if finalFilename == "" {
@@ -199,27 +196,6 @@ func ResolveDestination(url, candidateFilename, defaultDir string, routeToCatego
 	return destPath, finalFilename, nil
 }
 
-func truncateToSafeLength(name string) string {
-	if len(name) <= utils.MaxFilenameLength {
-		return name
-	}
-
-	ext := filepath.Ext(name)
-	baseRunes := []rune(strings.TrimSuffix(name, ext))
-	extRunes := []rune(ext)
-	maxBase := utils.MaxFilenameLength - len(extRunes)
-
-	if maxBase < 1 {
-		// If even the extension is too long, just hard truncate the runes
-		truncated := string([]rune(name)[:utils.MaxFilenameLength])
-		utils.Debug("Truncated extremely long extension-only filename %q to %q", name, truncated)
-		return truncated
-	}
-
-	truncated := string(baseRunes[:maxBase]) + ext
-	utils.Debug("Truncated final filename %q to %q for OS safety", name, truncated)
-	return truncated
-}
 
 // RemoveIncompleteFile drops only the reserved working file, leaving any
 // promoted final file untouched.

--- a/internal/processing/file_utils.go
+++ b/internal/processing/file_utils.go
@@ -158,7 +158,6 @@ func GetCategoryPath(filename, defaultDir string, settings *config.Settings) (st
 
 // getBaseFilename keeps naming deterministic across retries by preferring the
 // most authoritative source available before uniqueness is applied.
-// getBaseFilename selects the starting point for the download name.
 func getBaseFilename(url, candidate string, probe *ProbeResult) string {
 	if candidate != "" {
 		return candidate
@@ -189,13 +188,13 @@ func ResolveDestination(url, candidateFilename, defaultDir string, routeToCatego
 		}
 	}
 
+	// Safety: Truncate early so GetUniqueFilename has room to append a suffix
+	filename = truncateToSafeLength(filename)
+
 	finalFilename := GetUniqueFilename(destPath, filename, isNameActive)
 	if finalFilename == "" {
 		return "", "", fmt.Errorf("could not determine a unique filename for %s", url)
 	}
-
-	// Safety: Ensure the final filename is truncated to OS limits
-	finalFilename = truncateToSafeLength(finalFilename)
 
 	return destPath, finalFilename, nil
 }
@@ -206,14 +205,18 @@ func truncateToSafeLength(name string) string {
 	}
 
 	ext := filepath.Ext(name)
-	base := strings.TrimSuffix(name, ext)
-	maxBase := utils.MaxFilenameLength - len(ext)
+	baseRunes := []rune(strings.TrimSuffix(name, ext))
+	extRunes := []rune(ext)
+	maxBase := utils.MaxFilenameLength - len(extRunes)
 
 	if maxBase < 1 {
-		return name[:utils.MaxFilenameLength]
+		// If even the extension is too long, just hard truncate the runes
+		truncated := string([]rune(name)[:utils.MaxFilenameLength])
+		utils.Debug("Truncated extremely long extension-only filename %q to %q", name, truncated)
+		return truncated
 	}
 
-	truncated := base[:maxBase] + ext
+	truncated := string(baseRunes[:maxBase]) + ext
 	utils.Debug("Truncated final filename %q to %q for OS safety", name, truncated)
 	return truncated
 }

--- a/internal/processing/file_utils.go
+++ b/internal/processing/file_utils.go
@@ -44,11 +44,13 @@ func InferFilenameFromURL(rawURL string) string {
 	query := parsed.Query()
 	if name := strings.TrimSpace(query.Get("filename")); name != "" {
 		if base := strings.TrimSpace(path.Base(name)); isSafeComponent(base) {
+			utils.Debug("Inferred filename from query param 'filename': %s", base)
 			return base
 		}
 	}
 	if name := strings.TrimSpace(query.Get("file")); name != "" {
 		if base := strings.TrimSpace(path.Base(name)); isSafeComponent(base) {
+			utils.Debug("Inferred filename from query param 'file': %s", base)
 			return base
 		}
 	}
@@ -57,6 +59,7 @@ func InferFilenameFromURL(rawURL string) string {
 	if !isSafeComponent(base) {
 		return ""
 	}
+	utils.Debug("Inferred filename from URL path: %s", base)
 	return base
 }
 
@@ -155,15 +158,22 @@ func GetCategoryPath(filename, defaultDir string, settings *config.Settings) (st
 
 // getBaseFilename keeps naming deterministic across retries by preferring the
 // most authoritative source available before uniqueness is applied.
+// getBaseFilename selects the starting point for the download name.
 func getBaseFilename(url, candidate string, probe *ProbeResult) string {
 	if candidate != "" {
 		return candidate
 	}
-	if probe != nil && probe.Filename != "" {
-		return probe.Filename
+	if probe != nil {
+		if probe.DetectedFilename != "" {
+			return probe.DetectedFilename
+		}
+		if probe.Filename != "" {
+			return probe.Filename
+		}
 	}
 	return InferFilenameFromURL(url)
 }
+
 
 // ResolveDestination centralizes routing and naming so CLI, TUI, and API
 // requests all land on the same final path before the engine starts downloading.
@@ -184,7 +194,28 @@ func ResolveDestination(url, candidateFilename, defaultDir string, routeToCatego
 		return "", "", fmt.Errorf("could not determine a unique filename for %s", url)
 	}
 
+	// Safety: Ensure the final filename is truncated to OS limits
+	finalFilename = truncateToSafeLength(finalFilename)
+
 	return destPath, finalFilename, nil
+}
+
+func truncateToSafeLength(name string) string {
+	if len(name) <= utils.MaxFilenameLength {
+		return name
+	}
+
+	ext := filepath.Ext(name)
+	base := strings.TrimSuffix(name, ext)
+	maxBase := utils.MaxFilenameLength - len(ext)
+
+	if maxBase < 1 {
+		return name[:utils.MaxFilenameLength]
+	}
+
+	truncated := base[:maxBase] + ext
+	utils.Debug("Truncated final filename %q to %q for OS safety", name, truncated)
+	return truncated
 }
 
 // RemoveIncompleteFile drops only the reserved working file, leaving any

--- a/internal/processing/file_utils.go
+++ b/internal/processing/file_utils.go
@@ -170,7 +170,6 @@ func getBaseFilename(url, candidate string, probe *ProbeResult) string {
 	return InferFilenameFromURL(url)
 }
 
-
 // ResolveDestination centralizes routing and naming so CLI, TUI, and API
 // requests all land on the same final path before the engine starts downloading.
 func ResolveDestination(url, candidateFilename, defaultDir string, routeToCategory bool, settings *config.Settings, probe *ProbeResult, isNameActive func(string, string) bool) (string, string, error) {
@@ -195,7 +194,6 @@ func ResolveDestination(url, candidateFilename, defaultDir string, routeToCatego
 
 	return destPath, finalFilename, nil
 }
-
 
 // RemoveIncompleteFile drops only the reserved working file, leaving any
 // promoted final file untouched.

--- a/internal/processing/file_utils_test.go
+++ b/internal/processing/file_utils_test.go
@@ -186,6 +186,7 @@ func TestResolveDestination_Priority(t *testing.T) {
 
 	// 4. URL Fallback when probe has empty filename
 	_, name, _ = processing.ResolveDestination("http://example.com/some.rar", "", defaultDir, false, settings, &processing.ProbeResult{Filename: ""}, nil)
+	_, name, _ = processing.ResolveDestination("http://example.com/some.rar", "", defaultDir, false, settings, &processing.ProbeResult{DetectedFilename: ""}, nil)
 	if name != "some.rar" {
 		t.Errorf("Expected some.rar, got %s", name)
 	}

--- a/internal/processing/file_utils_test.go
+++ b/internal/processing/file_utils_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/SurgeDM/Surge/internal/config"
@@ -187,6 +188,26 @@ func TestResolveDestination_Priority(t *testing.T) {
 	_, name, _ = processing.ResolveDestination("http://example.com/some.rar", "", defaultDir, false, settings, &processing.ProbeResult{Filename: ""}, nil)
 	if name != "some.rar" {
 		t.Errorf("Expected some.rar, got %s", name)
+	}
+
+	// 5. Long candidate hint is preserved (but truncated)
+	longHint := "WrTLulKik3KpjnMuO-0gDohCI1WaybS779E_l6yr1UHGRMFfTkE7B5t5Ys5_N2qu8u6HmpGsrEZKftnkvhgxcvRqn6Pp9kceoiJRSTvPjlX8oDQW70mjRG9HlCYBmFoOYLJ7t133YpIR5xQXdPT8QWAMMUNyp6K3jeNJ3YmAez-_9MdrMBv6HlBRmDwSBwrubB895P34XJ40NUUmb6t0ITGTyZVc3kUBZ_emFeD-h8m-S--dzrdsyXdUQGI0amVV7cMetT2bifXVgzJaFn4mGZAvs7bIwe63xm1ARB2jF4hQ0V0hq8Db_6F4yH4_37XoubaVenavjGN5gW3uR2_FLFGc5JCMtlRwsBvF9wxcLTpWvn9IW61s-1aiAHnUbL9eesMzzY5DLXXgTkxTDre21UP4L6kNymwWFhjdbFzxIzBg_Z1RzzIzXVSYXu1O71Hvpu_FSW4N881BlaIZNCZPPtqqDrSwq3wdYECu_Sm1WxQ3kZOU9wjNu_03YHlpsYTm8lLK3EsxVGSgmpiLxLS4XI7lqVWI1_20Lkako4spInGKQYkq-E2S6k6opM58WLuz3-DyW0s-BTpUWPvYoazIc3eY_f4bCmy3uXsZ165iukgHvOnS6_ruKFw3kQMDuZVe"
+	_, name, _ = processing.ResolveDestination("http://example.com/"+longHint, longHint, defaultDir, false, settings, &processing.ProbeResult{DetectedFilename: "correct.rar"}, nil)
+	if name == "correct.rar" {
+		t.Errorf("Expected longHint to be used because heuristic was removed, but got correct.rar")
+	}
+	if len(name) > 240 {
+		t.Errorf("Expected truncated longHint, but length is %d", len(name))
+	}
+
+	// 6. Universal truncation in ResolveDestination
+	veryLongName := "this_is_a_very_long_filename_that_exceeds_the_limit_of_two_hundred_and_forty_characters_to_ensure_the_truncation_logic_is_working_correctly_at_the_destination_resolution_level_and_not_just_at_the_probing_utility_level_which_was_the_previous_bug.zip"
+	_, name, _ = processing.ResolveDestination("http://example.com/long", veryLongName, defaultDir, false, settings, nil, nil)
+	if len(name) > 240 {
+		t.Errorf("Expected filename to be truncated to <= 240 chars, got length %d", len(name))
+	}
+	if !strings.HasSuffix(name, ".zip") {
+		t.Errorf("Expected truncated filename to preserve .zip extension, got %s", name)
 	}
 }
 

--- a/internal/processing/file_utils_test.go
+++ b/internal/processing/file_utils_test.go
@@ -167,13 +167,13 @@ func TestResolveDestination_Priority(t *testing.T) {
 	defaultDir := "/downloads"
 
 	// 1. User defined beats all
-	_, name, _ := processing.ResolveDestination("http://example.com/file.zip", "user.txt", defaultDir, false, settings, &processing.ProbeResult{Filename: "probe.zip"}, nil)
+	_, name, _ := processing.ResolveDestination("http://example.com/file.zip", "user.txt", defaultDir, false, settings, &processing.ProbeResult{DetectedFilename: "probe.zip"}, nil)
 	if name != "user.txt" {
 		t.Errorf("Expected user.txt as candidate priority, got %s", name)
 	}
 
 	// 2. Probe beats URL fallback
-	_, name, _ = processing.ResolveDestination("http://example.com/file.zip", "", defaultDir, false, settings, &processing.ProbeResult{Filename: "probe.zip"}, nil)
+	_, name, _ = processing.ResolveDestination("http://example.com/file.zip", "", defaultDir, false, settings, &processing.ProbeResult{DetectedFilename: "probe.zip"}, nil)
 	if name != "probe.zip" {
 		t.Errorf("Expected probe.zip, got %s", name)
 	}
@@ -185,7 +185,6 @@ func TestResolveDestination_Priority(t *testing.T) {
 	}
 
 	// 4. URL Fallback when probe has empty filename
-	_, name, _ = processing.ResolveDestination("http://example.com/some.rar", "", defaultDir, false, settings, &processing.ProbeResult{Filename: ""}, nil)
 	_, name, _ = processing.ResolveDestination("http://example.com/some.rar", "", defaultDir, false, settings, &processing.ProbeResult{DetectedFilename: ""}, nil)
 	if name != "some.rar" {
 		t.Errorf("Expected some.rar, got %s", name)

--- a/internal/processing/manager.go
+++ b/internal/processing/manager.go
@@ -189,12 +189,12 @@ type DownloadRequest struct {
 }
 
 // Enqueue probes and reserves a stable destination before dispatching to the queue layer.
-func (mgr *LifecycleManager) Enqueue(ctx context.Context, req *DownloadRequest) (string, error) {
+func (mgr *LifecycleManager) Enqueue(ctx context.Context, req *DownloadRequest) (string, string, error) {
 	if mgr.addFunc == nil {
-		return "", fmt.Errorf("add function unavailable")
+		return "", "", fmt.Errorf("add function unavailable")
 	}
 
-	utils.Debug("Lifecycle: Enqueue %s", req.URL)
+	utils.Debug("Lifecycle: Enqueue %s (Filename: %s)", req.URL, req.Filename)
 	return mgr.enqueueResolved(ctx, req, func(finalPath, finalFilename string, probe *ProbeResult) (string, error) {
 		return mgr.addFunc(
 			req.URL,
@@ -210,9 +210,9 @@ func (mgr *LifecycleManager) Enqueue(ctx context.Context, req *DownloadRequest) 
 }
 
 // EnqueueWithID does the same lifecycle work as Enqueue while preserving a caller-owned id.
-func (mgr *LifecycleManager) EnqueueWithID(ctx context.Context, req *DownloadRequest, requestID string) (string, error) {
+func (mgr *LifecycleManager) EnqueueWithID(ctx context.Context, req *DownloadRequest, requestID string) (string, string, error) {
 	if mgr.addWithIDFunc == nil {
-		return "", fmt.Errorf("addWithID function unavailable")
+		return "", "", fmt.Errorf("addWithID function unavailable")
 	}
 
 	utils.Debug("Lifecycle: EnqueueWithID %s (%s)", req.URL, requestID)
@@ -232,12 +232,12 @@ func (mgr *LifecycleManager) EnqueueWithID(ctx context.Context, req *DownloadReq
 
 // enqueueResolved prepares the final path and working file before handing the
 // download to the engine, so workers and lifecycle events agree on one stable destination.
-func (mgr *LifecycleManager) enqueueResolved(ctx context.Context, req *DownloadRequest, dispatch func(string, string, *ProbeResult) (string, error)) (string, error) {
+func (mgr *LifecycleManager) enqueueResolved(ctx context.Context, req *DownloadRequest, dispatch func(string, string, *ProbeResult) (string, error)) (string, string, error) {
 	if req.URL == "" {
-		return "", fmt.Errorf("URL is required")
+		return "", "", fmt.Errorf("URL is required")
 	}
 	if req.Path == "" {
-		return "", fmt.Errorf("destination path is required")
+		return "", "", fmt.Errorf("destination path is required")
 	}
 
 	settings := mgr.GetSettings()
@@ -249,7 +249,7 @@ func (mgr *LifecycleManager) enqueueResolved(ctx context.Context, req *DownloadR
 		case <-mgr.probeSem:
 			// acquired
 		case <-ctx.Done():
-			return "", fmt.Errorf("enqueue aborted before probe: %w", ctx.Err())
+			return "", "", fmt.Errorf("enqueue aborted before probe: %w", ctx.Err())
 		}
 		defer func() { mgr.probeSem <- struct{}{} }()
 	}
@@ -257,14 +257,14 @@ func (mgr *LifecycleManager) enqueueResolved(ctx context.Context, req *DownloadR
 	probe, err := ProbeServerWithProxy(ctx, req.URL, req.Filename, req.Headers, settings.ToRuntimeConfig())
 	if err != nil {
 		utils.Debug("Lifecycle: Probe failed: %v\n", err)
-		return "", fmt.Errorf("probe failed: %w", err)
+		return "", "", fmt.Errorf("probe failed: %w", err)
 	}
 
 	isNameActive := mgr.buildIsNameActive()
 
 	for attempt := 0; attempt < maxWorkingFileReservationAttempts; attempt++ {
 		if ctx.Err() != nil {
-			return "", fmt.Errorf("enqueue aborted: %w", ctx.Err())
+			return "", "", fmt.Errorf("enqueue aborted: %w", ctx.Err())
 		}
 
 		finalPath, finalFilename, err := ResolveDestination(
@@ -277,7 +277,7 @@ func (mgr *LifecycleManager) enqueueResolved(ctx context.Context, req *DownloadR
 			isNameActive,
 		)
 		if err != nil {
-			return "", fmt.Errorf("failed to resolve destination: %w", err)
+			return "", "", fmt.Errorf("failed to resolve destination: %w", err)
 		}
 
 		// Reserve the working path before dispatch so a concurrent enqueue has to
@@ -286,14 +286,14 @@ func (mgr *LifecycleManager) enqueueResolved(ctx context.Context, req *DownloadR
 			if errors.Is(err, os.ErrExist) {
 				continue
 			}
-			return "", err
+			return "", "", err
 		}
 
 		surgePath := filepath.Join(finalPath, finalFilename) + types.IncompleteSuffix
 		newID, err := dispatch(finalPath, finalFilename, probe)
 		if err != nil {
 			_ = os.Remove(surgePath)
-			return "", err
+			return "", "", err
 		}
 
 		// Emit queued event now that the pool has accepted the download.
@@ -310,10 +310,10 @@ func (mgr *LifecycleManager) enqueueResolved(ctx context.Context, req *DownloadR
 			})
 		}
 
-		return newID, nil
+		return newID, finalFilename, nil
 	}
 
-	return "", fmt.Errorf("failed to reserve unique working file for %q after %d attempts", req.URL, maxWorkingFileReservationAttempts)
+	return "", "", fmt.Errorf("failed to reserve unique working file for %q after %d attempts", req.URL, maxWorkingFileReservationAttempts)
 }
 
 // IsNameActive reports whether the configured active-download callback would

--- a/internal/processing/manager_test.go
+++ b/internal/processing/manager_test.go
@@ -93,7 +93,7 @@ func TestLifecycleManager_Enqueue_PrecreatesWorkingFileBeforeDispatch(t *testing
 		IsExplicitCategory: true,
 	}
 
-	id, err := mgr.Enqueue(context.Background(), req)
+	id, _, err := mgr.Enqueue(context.Background(), req)
 	if err != nil {
 		t.Fatalf("Enqueue failed: %v", err)
 	}
@@ -151,7 +151,7 @@ func TestLifecycleManager_EnqueueWithID_PrecreatesWorkingFileBeforeDispatch(t *t
 		IsExplicitCategory: true,
 	}
 
-	id, err := mgr.EnqueueWithID(context.Background(), req, expectedID)
+	id, _, err := mgr.EnqueueWithID(context.Background(), req, expectedID)
 	if err != nil {
 		t.Fatalf("EnqueueWithID failed: %v", err)
 	}
@@ -178,7 +178,7 @@ func TestLifecycleManager_Enqueue_RemovesWorkingFileOnDispatchError(t *testing.T
 		return "", expectedErr
 	}
 
-	_, err := mgr.Enqueue(context.Background(), &DownloadRequest{
+	_, _, err := mgr.Enqueue(context.Background(), &DownloadRequest{
 		URL:                server.URL,
 		Filename:           expectedFile,
 		Path:               tempDir,
@@ -237,7 +237,7 @@ func TestLifecycleManager_Enqueue_RetriesWhenWorkingFileReservationCollides(t *t
 		return "retry-id", nil
 	}
 
-	id, err := mgr.Enqueue(context.Background(), &DownloadRequest{
+	id, _, err := mgr.Enqueue(context.Background(), &DownloadRequest{
 		URL:                server.URL,
 		Filename:           "archive.zip",
 		Path:               tempDir,
@@ -310,7 +310,7 @@ func TestLifecycleManager_EnqueueWithID_RetriesWhenWorkingFileReservationCollide
 		return gotRequestID, nil
 	}
 
-	id, err := mgr.EnqueueWithID(context.Background(), &DownloadRequest{
+	id, _, err := mgr.EnqueueWithID(context.Background(), &DownloadRequest{
 		URL:                server.URL,
 		Filename:           "archive.zip",
 		Path:               tempDir,
@@ -352,7 +352,7 @@ func TestLifecycleManager_EnqueueWithID_RemovesWorkingFileOnDispatchError(t *tes
 		return "", expectedErr
 	}
 
-	_, err := mgr.EnqueueWithID(context.Background(), &DownloadRequest{
+	_, _, err := mgr.EnqueueWithID(context.Background(), &DownloadRequest{
 		URL:                server.URL,
 		Filename:           expectedFile,
 		Path:               tempDir,
@@ -394,7 +394,7 @@ func TestLifecycleManager_Enqueue_FailsAfterReservationAttemptLimit(t *testing.T
 		return "", nil
 	}
 
-	_, err := mgr.Enqueue(context.Background(), &DownloadRequest{
+	_, _, err := mgr.Enqueue(context.Background(), &DownloadRequest{
 		URL:                server.URL,
 		Filename:           "archive.zip",
 		Path:               tempDir,
@@ -482,7 +482,7 @@ func TestLifecycleManager_Enqueue_ContextCancellationDuringProbe(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := mgr.Enqueue(ctx, &DownloadRequest{
+	_, _, err := mgr.Enqueue(ctx, &DownloadRequest{
 		URL:      server.URL,
 		Filename: "test.zip",
 		Path:     t.TempDir(),
@@ -522,7 +522,7 @@ func TestLifecycleManager_EnqueueWithID_FailsAfterReservationAttemptLimit(t *tes
 		return "", nil
 	}
 
-	_, err := mgr.EnqueueWithID(context.Background(), &DownloadRequest{
+	_, _, err := mgr.EnqueueWithID(context.Background(), &DownloadRequest{
 		URL:                server.URL,
 		Filename:           "archive.zip",
 		Path:               tempDir,
@@ -539,7 +539,7 @@ func TestLifecycleManager_EnqueueWithID_FailsAfterReservationAttemptLimit(t *tes
 
 func TestLifecycleManager_Enqueue_EmptyURL(t *testing.T) {
 	mgr := newLifecycleManagerForTest()
-	_, err := mgr.Enqueue(context.Background(), &DownloadRequest{
+	_, _, err := mgr.Enqueue(context.Background(), &DownloadRequest{
 		URL:  "",
 		Path: t.TempDir(),
 	})
@@ -552,7 +552,7 @@ func TestLifecycleManager_Enqueue_EmptyPath(t *testing.T) {
 	server := newProbeTestServer(t, 2048)
 	defer server.Close()
 	mgr := newLifecycleManagerForTest()
-	_, err := mgr.Enqueue(context.Background(), &DownloadRequest{
+	_, _, err := mgr.Enqueue(context.Background(), &DownloadRequest{
 		URL:  server.URL,
 		Path: "",
 	})
@@ -581,7 +581,7 @@ func TestLifecycleManager_Enqueue_ContextCancellationBeforeReservation(t *testin
 		return "", nil
 	}
 
-	_, err := mgr.Enqueue(ctx, &DownloadRequest{
+	_, _, err := mgr.Enqueue(ctx, &DownloadRequest{
 		URL:      server.URL,
 		Filename: "test.zip",
 		Path:     t.TempDir(),
@@ -1039,7 +1039,7 @@ func TestLifecycleManager_ProbeSemaphore_LimitsInflight(t *testing.T) {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
-			_, errs[idx] = mgr.Enqueue(context.Background(), &DownloadRequest{
+			_, _, errs[idx] = mgr.Enqueue(context.Background(), &DownloadRequest{
 				URL:      server.URL,
 				Filename: fmt.Sprintf("file%d.zip", idx),
 				Path:     tempDir,
@@ -1090,7 +1090,7 @@ func TestLifecycleManager_ProbeSemaphore_CancelledContextAbortsWait(t *testing.T
 	cancel() // already cancelled
 
 	start := time.Now()
-	_, err := mgr.Enqueue(ctx, &DownloadRequest{
+	_, _, err := mgr.Enqueue(ctx, &DownloadRequest{
 		URL:  "http://127.0.0.1:0/dummy",
 		Path: t.TempDir(),
 	})

--- a/internal/processing/probe.go
+++ b/internal/processing/probe.go
@@ -31,10 +31,11 @@ const maxProbeClients = 8
 
 // ProbeResult contains all metadata from server probe
 type ProbeResult struct {
-	FileSize      int64
-	SupportsRange bool
-	Filename      string
-	ContentType   string
+	FileSize         int64
+	SupportsRange    bool
+	Filename         string
+	DetectedFilename string
+	ContentType      string
 }
 
 // probeHeadersContextKey is used to pass custom headers to the HTTP client's CheckRedirect function
@@ -205,6 +206,8 @@ func ProbeServerWithProxy(ctx context.Context, rawurl string, filenameHint strin
 		utils.Debug("Error determining filename: %v", err)
 		name = "download.bin"
 	}
+
+	result.DetectedFilename = name
 
 	if filenameHint != "" {
 		result.Filename = filenameHint

--- a/internal/tui/process.go
+++ b/internal/tui/process.go
@@ -184,22 +184,29 @@ func (m RootModel) startDownload(url string, mirrors []string, headers map[strin
 
 	cmd := func() tea.Msg {
 		ctx := m.downloadEnqueueContext()
-		var newID string
+		var newID, finalFilename string
 		var err error
 		if requestID != "" {
-			newID, err = m.Orchestrator.EnqueueWithID(ctx, req, requestID)
+			newID, finalFilename, err = m.Orchestrator.EnqueueWithID(ctx, req, requestID)
 		} else {
-			newID, err = m.Orchestrator.Enqueue(ctx, req)
+			newID, finalFilename, err = m.Orchestrator.Enqueue(ctx, req)
 		}
 		if err != nil {
 			return enqueueErrorMsg{tempID: optimisticID, err: err}
 		}
+
+		// Use the server-resolved filename if available
+		displayFilename := finalFilename
+		if displayFilename == "" {
+			displayFilename = optimisticFilename
+		}
+
 		return enqueueSuccessMsg{
 			tempID:   optimisticID,
 			id:       newID,
 			url:      url,
 			path:     resolvedPath,
-			filename: optimisticFilename,
+			filename: displayFilename,
 		}
 	}
 

--- a/internal/utils/filename.go
+++ b/internal/utils/filename.go
@@ -163,14 +163,15 @@ func sanitizeFilename(name string) string {
 
 	if len(name) > MaxFilenameLength {
 		ext := filepath.Ext(name)
-		base := strings.TrimSuffix(name, ext)
+		baseRunes := []rune(strings.TrimSuffix(name, ext))
+		extRunes := []rune(ext)
+		maxBase := MaxFilenameLength - len(extRunes)
 
-		maxBase := MaxFilenameLength - len(ext)
 		if maxBase < 1 {
-			// If even the extension is too long, just hard truncate
-			name = name[:MaxFilenameLength]
+			// If even the extension is too long, just hard truncate the runes
+			name = string([]rune(name)[:MaxFilenameLength])
 		} else {
-			name = base[:maxBase] + ext
+			name = string(baseRunes[:maxBase]) + ext
 		}
 		Debug("Truncated extremely long filename to %d characters", MaxFilenameLength)
 	}

--- a/internal/utils/filename.go
+++ b/internal/utils/filename.go
@@ -14,6 +14,8 @@ import (
 	"github.com/vfaronov/httpheader"
 )
 
+const MaxFilenameLength = 240
+
 // DetermineFilename extracts the filename from a URL and HTTP response,
 // applying various heuristics. It returns the determined filename,
 // a new io.Reader that includes any sniffed header bytes, and an error.
@@ -48,6 +50,7 @@ func DetermineFilename(rawurl string, resp *http.Response) (string, io.Reader, e
 	// 3. URL Path
 	if candidate == "" {
 		candidate = filepath.Base(parsed.Path)
+		Debug("Filename from URL path: %s", candidate)
 	}
 
 	filename := sanitizeFilename(candidate)
@@ -109,6 +112,8 @@ func DetermineFilename(rawurl string, resp *http.Response) (string, io.Reader, e
 		Debug("Falling back to default filename: download.bin")
 	}
 
+	Debug("Final resolved filename: %s", filename)
+
 	return filename, body, nil
 }
 
@@ -154,6 +159,20 @@ func sanitizeFilename(name string) string {
 
 	if name == "" {
 		return "_"
+	}
+
+	if len(name) > MaxFilenameLength {
+		ext := filepath.Ext(name)
+		base := strings.TrimSuffix(name, ext)
+
+		maxBase := MaxFilenameLength - len(ext)
+		if maxBase < 1 {
+			// If even the extension is too long, just hard truncate
+			name = name[:MaxFilenameLength]
+		} else {
+			name = base[:maxBase] + ext
+		}
+		Debug("Truncated extremely long filename to %d characters", MaxFilenameLength)
 	}
 
 	return name

--- a/internal/utils/filename.go
+++ b/internal/utils/filename.go
@@ -133,19 +133,20 @@ func sanitizedBecameExtensionOnly(original, sanitized string) bool {
 // TruncateFilename ensures a filename does not exceed MaxFilenameLength
 // while preserving the extension and being UTF-8 safe.
 func TruncateFilename(name string) string {
-	if len(name) <= MaxFilenameLength {
+	runes := []rune(name)
+	if len(runes) <= MaxFilenameLength {
 		return name
 	}
 	ext := filepath.Ext(name)
-	baseRunes := []rune(strings.TrimSuffix(name, ext))
 	extRunes := []rune(ext)
 	maxBase := MaxFilenameLength - len(extRunes)
 
 	if maxBase < 1 {
 		// If even the extension is too long, just hard truncate the runes
-		return string([]rune(name)[:MaxFilenameLength])
+		return string(runes[:MaxFilenameLength])
 	}
 
+	baseRunes := []rune(strings.TrimSuffix(name, ext))
 	return string(baseRunes[:maxBase]) + ext
 }
 

--- a/internal/utils/filename.go
+++ b/internal/utils/filename.go
@@ -130,6 +130,25 @@ func sanitizedBecameExtensionOnly(original, sanitized string) bool {
 	return !strings.HasPrefix(originalBase, ".")
 }
 
+// TruncateFilename ensures a filename does not exceed MaxFilenameLength
+// while preserving the extension and being UTF-8 safe.
+func TruncateFilename(name string) string {
+	if len(name) <= MaxFilenameLength {
+		return name
+	}
+	ext := filepath.Ext(name)
+	baseRunes := []rune(strings.TrimSuffix(name, ext))
+	extRunes := []rune(ext)
+	maxBase := MaxFilenameLength - len(extRunes)
+
+	if maxBase < 1 {
+		// If even the extension is too long, just hard truncate the runes
+		return string([]rune(name)[:MaxFilenameLength])
+	}
+
+	return string(baseRunes[:maxBase]) + ext
+}
+
 func sanitizeFilename(name string) string {
 	name = strings.ReplaceAll(name, "\\", "/")
 	name = filepath.Base(name)
@@ -162,17 +181,7 @@ func sanitizeFilename(name string) string {
 	}
 
 	if len(name) > MaxFilenameLength {
-		ext := filepath.Ext(name)
-		baseRunes := []rune(strings.TrimSuffix(name, ext))
-		extRunes := []rune(ext)
-		maxBase := MaxFilenameLength - len(extRunes)
-
-		if maxBase < 1 {
-			// If even the extension is too long, just hard truncate the runes
-			name = string([]rune(name)[:MaxFilenameLength])
-		} else {
-			name = string(baseRunes[:maxBase]) + ext
-		}
+		name = TruncateFilename(name)
 		Debug("Truncated extremely long filename to %d characters", MaxFilenameLength)
 	}
 

--- a/internal/utils/filename.go
+++ b/internal/utils/filename.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/h2non/filetype"
 	"github.com/vfaronov/httpheader"
@@ -133,21 +134,30 @@ func sanitizedBecameExtensionOnly(original, sanitized string) bool {
 // TruncateFilename ensures a filename does not exceed MaxFilenameLength
 // while preserving the extension and being UTF-8 safe.
 func TruncateFilename(name string) string {
-	runes := []rune(name)
-	if len(runes) <= MaxFilenameLength {
+	if len(name) <= MaxFilenameLength {
 		return name
 	}
 	ext := filepath.Ext(name)
-	extRunes := []rune(ext)
-	maxBase := MaxFilenameLength - len(extRunes)
+	extBytes := len(ext)
+	maxBase := MaxFilenameLength - extBytes
 
 	if maxBase < 1 {
-		// If even the extension is too long, just hard truncate the runes
-		return string(runes[:MaxFilenameLength])
+		// Extension alone is too long — hard-truncate by rune so we don't split mid-char
+		b := []byte(name)
+		for len(b) > MaxFilenameLength {
+			_, size := utf8.DecodeLastRune(b)
+			b = b[:len(b)-size]
+		}
+		return string(b)
 	}
 
-	baseRunes := []rune(strings.TrimSuffix(name, ext))
-	return string(baseRunes[:maxBase]) + ext
+	base := strings.TrimSuffix(name, ext)
+	b := []byte(base)
+	for len(b) > maxBase {
+		_, size := utf8.DecodeLastRune(b)
+		b = b[:len(b)-size]
+	}
+	return string(b) + ext
 }
 
 func sanitizeFilename(name string) string {
@@ -183,7 +193,7 @@ func sanitizeFilename(name string) string {
 
 	if len(name) > MaxFilenameLength {
 		name = TruncateFilename(name)
-		Debug("Truncated extremely long filename to %d characters", MaxFilenameLength)
+		Debug("Truncated extremely long filename to %d bytes", MaxFilenameLength)
 	}
 
 	return name

--- a/internal/utils/filename_test.go
+++ b/internal/utils/filename_test.go
@@ -47,10 +47,10 @@ func TestSanitizeFilename(t *testing.T) {
 		{"ansi escape codes", "\x1b[31mred.zip", "[31mred.zip"},
 		{"control chars", "file\x07name.zip", "filename.zip"},
 		{"extremely long filename", strings.Repeat("a", 300) + ".zip", strings.Repeat("a", 236) + ".zip"},
-		{"long unicode filename", strings.Repeat("文件", 150) + ".zip", string([]rune(strings.Repeat("文件", 150))[:236]) + ".zip"},
-		{"mid-length unicode filename", strings.Repeat("中", 100) + ".zip", strings.Repeat("中", 100) + ".zip"},
-		{"unicode filename over limit", strings.Repeat("中", 250) + ".zip", strings.Repeat("中", 236) + ".zip"},
-		{"unicode filename with long extension", strings.Repeat("中", 10) + "." + strings.Repeat("a", 250), string([]rune(strings.Repeat("中", 10) + "." + strings.Repeat("a", 250))[:240])},
+		{"long unicode filename", strings.Repeat("文件", 150) + ".zip", strings.Repeat("文件", 39) + ".zip"},
+		{"mid-length unicode filename", strings.Repeat("中", 100) + ".zip", strings.Repeat("中", 78) + ".zip"},
+		{"unicode filename over limit", strings.Repeat("中", 250) + ".zip", strings.Repeat("中", 78) + ".zip"},
+		{"unicode filename with long extension", strings.Repeat("中", 10) + "." + strings.Repeat("a", 250), strings.Repeat("中", 10) + "." + strings.Repeat("a", 209)},
 	}
 
 	for _, tt := range tests {

--- a/internal/utils/filename_test.go
+++ b/internal/utils/filename_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -45,6 +46,7 @@ func TestSanitizeFilename(t *testing.T) {
 		// Security test cases
 		{"ansi escape codes", "\x1b[31mred.zip", "[31mred.zip"},
 		{"control chars", "file\x07name.zip", "filename.zip"},
+		{"extremely long filename", strings.Repeat("a", 300) + ".zip", strings.Repeat("a", 236) + ".zip"},
 	}
 
 	for _, tt := range tests {

--- a/internal/utils/filename_test.go
+++ b/internal/utils/filename_test.go
@@ -47,6 +47,7 @@ func TestSanitizeFilename(t *testing.T) {
 		{"ansi escape codes", "\x1b[31mred.zip", "[31mred.zip"},
 		{"control chars", "file\x07name.zip", "filename.zip"},
 		{"extremely long filename", strings.Repeat("a", 300) + ".zip", strings.Repeat("a", 236) + ".zip"},
+		{"long unicode filename", strings.Repeat("文件", 150) + ".zip", string([]rune(strings.Repeat("文件", 150))[:236]) + ".zip"},
 	}
 
 	for _, tt := range tests {

--- a/internal/utils/filename_test.go
+++ b/internal/utils/filename_test.go
@@ -48,6 +48,9 @@ func TestSanitizeFilename(t *testing.T) {
 		{"control chars", "file\x07name.zip", "filename.zip"},
 		{"extremely long filename", strings.Repeat("a", 300) + ".zip", strings.Repeat("a", 236) + ".zip"},
 		{"long unicode filename", strings.Repeat("文件", 150) + ".zip", string([]rune(strings.Repeat("文件", 150))[:236]) + ".zip"},
+		{"mid-length unicode filename", strings.Repeat("中", 100) + ".zip", strings.Repeat("中", 100) + ".zip"},
+		{"unicode filename over limit", strings.Repeat("中", 250) + ".zip", strings.Repeat("中", 236) + ".zip"},
+		{"unicode filename with long extension", strings.Repeat("中", 10) + "." + strings.Repeat("a", 250), string([]rune(strings.Repeat("中", 10) + "." + strings.Repeat("a", 250))[:240])},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires the backend-resolved filename (from the HTTP probe) back through the API response to the browser extension, replacing the previous approach where the extension forwarded a browser-derived filename hint that could be a raw URL fragment. It also introduces a byte-safe, UTF-8-aware `TruncateFilename` utility that fixes long-filename handling across the probe, resolution, and sanitization layers.

<h3>Confidence Score: 5/5</h3>

- Safe to merge; the core feature is correctly wired through the lifecycle path and the truncation logic is byte-safe.
- All remaining findings are P2: one misleading test name and one commented-but-undocumented silent degradation in the remote-service fallback path. Neither affects the primary use case (extension → local Surge server) or correctness of the byte-safe truncation.
- cmd/root_downloads.go (fallback path comment), extension/test/intercept.test.ts (test name)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/root_downloads.go | HTTP handler updated to propagate the backend-resolved filename back to callers. The primary lifecycle path correctly returns the probe-detected filename; fallback path (remote service) still returns req.Filename which is always empty under the new extension behavior. |
| extension/test/intercept.test.ts | New integration tests for the interception naming flow. First test is accurate; second test name ("preserves the filename if the browser actually provides one") contradicts its own assertion that an empty filename is always sent. |
| internal/utils/filename.go | New TruncateFilename function exported with MaxFilenameLength=240. Uses byte-length fast path (correct for filesystem limits) and UTF-8-safe trimming via utf8.DecodeLastRune, addressing prior concerns about byte-slicing multi-byte characters. |
| internal/processing/probe.go | ProbeResult gains a DetectedFilename field (always the probe-detected name) separate from Filename (hint or detected). Both fields are set correctly in ProbeServerWithProxy. |
| internal/processing/manager.go | Enqueue/EnqueueWithID/enqueueResolved all updated to return (id, finalFilename, error). The resolved filename is propagated all the way from ResolveDestination back to the HTTP handler. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Ext as Browser Extension
    participant API as HTTP Handler (root_downloads.go)
    participant LM as LifecycleManager.Enqueue
    participant Probe as ProbeServerWithProxy
    participant Res as ResolveDestination

    Ext->>API: "POST /download {url, filename: ""}"
    API->>LM: "Enqueue(ctx, req{Filename: ""})"
    LM->>Probe: "ProbeServerWithProxy(url, hint="")"
    Probe-->>LM: "ProbeResult{DetectedFilename: "real.zip", Filename: "real.zip"}"
    LM->>Res: "ResolveDestination(url, candidate="", probe)"
    Note over Res: getBaseFilename uses probe.DetectedFilename
    Res-->>LM: "finalPath, finalFilename="real.zip""
    LM-->>API: "id, finalFilename="real.zip", nil"
    API-->>Ext: "{status:"queued", id, filename:"real.zip"}"
    Ext->>Ext: notification: "Download started: real.zip"
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/processing/file_utils.go`, line 192-198 ([link](https://github.com/surgedm/surge/blob/ec7865d0b107d3a5d5e8b4b47b40635e06981975/internal/processing/file_utils.go#L192-L198)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Uniqueness suffix truncated for max-length filenames**

   `truncateToSafeLength` runs *after* `GetUniqueFilename`, so any disambiguation suffix (`(1)`, `(2)`, …) added by the uniqueness step is silently cut off when the base name is already at or near 240 bytes. For a 240-char filename where a collision exists, `GetUniqueFilename` returns `name(1).ext` (244 chars) → `truncateToSafeLength` strips `(1)` → result is identical to the original reserved name → the `os.O_EXCL` reservation in `enqueueResolved` keeps failing → download aborts after `maxWorkingFileReservationAttempts`.

   The fix is to truncate the *base* name before uniqueness is applied, leaving room for the suffix:

   ```go
   func ResolveDestination(...) (string, string, error) {
       filename := getBaseFilename(url, candidateFilename, probe)
       // Truncate early so GetUniqueFilename has room to append a suffix
       filename = truncateToSafeLength(filename)
       ...
       finalFilename := GetUniqueFilename(destPath, filename, isNameActive)
       if finalFilename == "" {
           return "", "", fmt.Errorf("could not determine a unique filename for %s", url)
       }
       return destPath, finalFilename, nil
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/processing/file_utils.go
   Line: 192-198

   Comment:
   **Uniqueness suffix truncated for max-length filenames**

   `truncateToSafeLength` runs *after* `GetUniqueFilename`, so any disambiguation suffix (`(1)`, `(2)`, …) added by the uniqueness step is silently cut off when the base name is already at or near 240 bytes. For a 240-char filename where a collision exists, `GetUniqueFilename` returns `name(1).ext` (244 chars) → `truncateToSafeLength` strips `(1)` → result is identical to the original reserved name → the `os.O_EXCL` reservation in `enqueueResolved` keeps failing → download aborts after `maxWorkingFileReservationAttempts`.

   The fix is to truncate the *base* name before uniqueness is applied, leaving room for the suffix:

   ```go
   func ResolveDestination(...) (string, string, error) {
       filename := getBaseFilename(url, candidateFilename, probe)
       // Truncate early so GetUniqueFilename has room to append a suffix
       filename = truncateToSafeLength(filename)
       ...
       finalFilename := GetUniqueFilename(destPath, filename, isNameActive)
       if finalFilename == "" {
           return "", "", fmt.Errorf("could not determine a unique filename for %s", url)
       }
       return destPath, finalFilename, nil
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: extension/test/intercept.test.ts
Line: 328

Comment:
**Misleading test name**

The test name says "preserves the filename if the browser actually provides one", but the assertion on line 350 is `expect(body.filename).toBe('')` — i.e., the extension sends an *empty* filename even when the browser provides one. The name implies the browser filename is forwarded, which is the exact old behavior this PR removes.

```suggestion
  it('sends empty filename to Surge even when browser provides one, deferring to backend prober', async () => {
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: cmd/root_downloads.go
Line: 261-262

Comment:
**Fallback path returns empty filename**

When `lifecycle` is nil (remote-service path), `req.Filename` is returned as the resolved filename. Since the extension now always sends `""`, this means any caller reaching the fallback will always get `"filename": ""` in the response — the notification would fall back to `"Unknown file"` instead of the resolved name.

This is an edge-case (the extension connects to a local server where `lifecycle != nil`), but the silent degradation is worth a comment so future maintainers understand why `req.Filename` isn't the final answer here:

```suggestion
	// Fallback: no lifecycle manager (e.g. forwarding to a remote server).
	// req.Filename is typically empty because the extension always sends an empty hint;
	// the resolved filename is not available from service.Add, so the response will
	// contain an empty filename field in this path.
	id, err := service.Add(resolved.urlForAdd, resolved.outPath, req.Filename, resolved.mirrorsForAdd, req.Headers, req.IsExplicitCategory, 0, false)
	return id, req.Filename, err
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (5): Last reviewed commit: ["refactor: standardize catch blocks and s..."](https://github.com/surgedm/surge/commit/19b6b5e68d64304c8e9cea0f43973bb87e6b6b13) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28333138)</sub>

<!-- /greptile_comment -->