### PR TITLE
ci: automate extension versioning and upload to AMO

### DIFF
--- a/.github/workflows/extension.yml
+++ b/.github/workflows/extension.yml
@@ -53,13 +53,21 @@ jobs:
       - name: Build and Package
         run: |
           npm run zip -- -b ${{ matrix.browser }}
-          mv output/*-${{ matrix.browser }}.zip output/extension-${{ matrix.browser }}.zip
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
           name: extension-${{ matrix.browser }}
-          path: extension/output/extension-${{ matrix.browser }}.zip
+          path: extension/output/*.zip
           if-no-files-found: error
+      - name: Submit to AMO
+        if: matrix.browser == 'firefox' && startsWith(github.ref, 'refs/tags/ext-v')
+        run: |
+          npx wxt submit \
+            --firefox-zip output/*-firefox.zip \
+            --firefox-sources-zip output/*-sources.zip
+        env:
+          FIREFOX_JWT_ISSUER: ${{ secrets.AMO_JWT_ISSUER }}
+          FIREFOX_JWT_SECRET: ${{ secrets.AMO_JWT_SECRET }}
 
   release:
     name: Create Release

--- a/.github/workflows/extension.yml
+++ b/.github/workflows/extension.yml
@@ -44,6 +44,12 @@ jobs:
           cache: "npm"
           cache-dependency-path: extension/package-lock.json
       - run: npm ci
+      - name: Update Version
+        if: startsWith(github.ref, 'refs/tags/ext-v')
+        run: |
+          VERSION=${GITHUB_REF_NAME#ext-v}
+          echo "Setting version to $VERSION"
+          npm version $VERSION --no-git-tag-version
       - name: Build and Package
         run: |
           npm run zip -- -b ${{ matrix.browser }}

--- a/extension/wxt.config.ts
+++ b/extension/wxt.config.ts
@@ -12,7 +12,6 @@ export default defineConfig({
   manifest: ({ browser }) => {
     const base: Record<string, unknown> = {
       name: 'Surge Download Manager',
-      version: '2.0.0',
       description:
         'High-performance download acceleration with live progress tracking. Intercepts downloads and accelerates them using Surge\'s multi-connection engine.',
       permissions: ['downloads', 'storage', 'notifications', 'webRequest'],


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR automates extension versioning by extracting the version from an `ext-v*` git tag and running `npm version` before the build, and removes the hardcoded `version: '2.0.0'` from `wxt.config.ts` so the manifest version is driven by `package.json`.

- **`npm version` will fail on the first release**: `package.json` is currently at `2.0.0`, so pushing `ext-v2.0.0` will hit npm's same-version guard. Adding `--allow-same-version` to the command fixes this.
- **AMO upload is absent**: The PR title explicitly promises "upload to AMO" but the `release` job only creates a GitHub release — no `web-ext sign` or equivalent AMO submission step was added.

<h3>Confidence Score: 3/5</h3>

- Not safe to merge — the versioning step will fail on the natural first release tag, and the AMO upload described in the PR title is unimplemented.
- Two P1 issues: the `npm version` same-version failure would immediately break the `ext-v2.0.0` release build, and the AMO upload (the other half of the stated PR goal) is entirely missing.
- .github/workflows/extension.yml requires both fixes before this workflow is production-ready.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/extension.yml | Adds automatic versioning from tag, but `npm version` will fail on same-version tags and the advertised AMO upload step is missing entirely. |
| extension/wxt.config.ts | Removes hardcoded `version: '2.0.0'` from the WXT manifest config so the version is sourced from `package.json`; correct and safe change. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub
    participant CI as CI Runner (x3: chrome/firefox/edge)
    participant GHR as GitHub Release
    participant AMO as Firefox AMO

    Dev->>GH: "Push tag ext-v*"
    GH->>CI: Trigger Extension CI/CD
    CI->>CI: npm ci
    CI->>CI: Strip ext-v prefix → VERSION
    CI->>CI: npm version $VERSION --no-git-tag-version
    CI->>CI: npm run zip (per browser)
    CI->>GH: "Upload artifact (extension-{browser}.zip)"
    GH->>GHR: softprops/action-gh-release → Create Release
    Note over AMO: ❌ Missing: AMO upload step
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/extension.yml`, line 64-84 ([link](https://github.com/surgedm/surge/blob/e1a6a4802bdbd136d2dcaf3643a333caec83e487/.github/workflows/extension.yml#L64-L84)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **AMO upload missing despite PR title**

   The PR title is "ci: automate extension versioning and upload to AMO", but the `release` job only creates a GitHub release — there is no step to sign or submit the Firefox `.zip` to addons.mozilla.org. The AMO upload (typically via `web-ext sign` or an action like `tox0n/amo-upload`) using the `WEB_EXT_API_KEY` / `WEB_EXT_API_SECRET` secrets is entirely absent.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/extension.yml
   Line: 64-84

   Comment:
   **AMO upload missing despite PR title**

   The PR title is "ci: automate extension versioning and upload to AMO", but the `release` job only creates a GitHub release — there is no step to sign or submit the Firefox `.zip` to addons.mozilla.org. The AMO upload (typically via `web-ext sign` or an action like `tox0n/amo-upload`) using the `WEB_EXT_API_KEY` / `WEB_EXT_API_SECRET` secrets is entirely absent.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/extension.yml
Line: 52

Comment:
**`npm version` fails on unchanged version**

`npm version <same-version> --no-git-tag-version` exits with a non-zero code when the requested version matches the current one in `package.json`. Since `package.json` is currently at `2.0.0`, pushing the tag `ext-v2.0.0` (the natural first release) will immediately fail this step. Add `--allow-same-version` to make the step idempotent.

```suggestion
          npm version $VERSION --no-git-tag-version --allow-same-version
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/extension.yml
Line: 64-84

Comment:
**AMO upload missing despite PR title**

The PR title is "ci: automate extension versioning and upload to AMO", but the `release` job only creates a GitHub release — there is no step to sign or submit the Firefox `.zip` to addons.mozilla.org. The AMO upload (typically via `web-ext sign` or an action like `tox0n/amo-upload`) using the `WEB_EXT_API_KEY` / `WEB_EXT_API_SECRET` secrets is entirely absent.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: automate Firefox extension submiss..."](https://github.com/surgedm/surge/commit/e1a6a4802bdbd136d2dcaf3643a333caec83e487) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28380012)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->