### PR TITLE
feat: implement validation error reporting for settings updates in TUI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,3 +34,5 @@ linters:
     - gocritic
     - revive
     - goconst
+    - unparam
+    

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -130,6 +130,7 @@ type RootModel struct {
 	SettingsFileBrowsing  bool             // Whether browsing for a directory
 	ExtensionFileBrowsing bool             // Whether browsing for extension prompt path
 	ExtensionTokenCopied  bool             // Flash message for "Token Copied!"
+	SettingsError         string           // Current validation error message for settings
 
 	// Selection persistence
 	SelectedDownloadID string // ID of the currently selected download

--- a/internal/tui/update_settings.go
+++ b/internal/tui/update_settings.go
@@ -25,6 +25,7 @@ func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if m.SettingsIsEditing {
 		if key.Matches(msg, m.keys.SettingsEditor.Cancel) {
 			// Cancel editing
+			m.SettingsError = ""
 			m.SettingsIsEditing = false
 			m.SettingsInput.Blur()
 			return m, nil
@@ -32,7 +33,11 @@ func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		if key.Matches(msg, m.keys.SettingsEditor.Confirm) {
 			currentCategory := categories[m.SettingsActiveTab]
 			settingKey := m.getCurrentSettingKey()
-			_ = m.setSettingValue(currentCategory, settingKey, m.SettingsInput.Value())
+			if err := m.setSettingValue(currentCategory, settingKey, m.SettingsInput.Value()); err != nil {
+				m.SettingsError = err.Error()
+				return m, nil
+			}
+			m.SettingsError = ""
 			m.SettingsIsEditing = false
 			m.SettingsInput.Blur()
 			return m, nil
@@ -62,6 +67,7 @@ func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		if key.Matches(msg, binding) {
 			if categoryCount > i {
 				m.SettingsActiveTab = i
+				m.SettingsError = ""
 			}
 			m.SettingsSelectedRow = 0
 			return m, nil
@@ -72,11 +78,13 @@ func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if key.Matches(msg, m.keys.Settings.NextTab) {
 		m.SettingsActiveTab = (m.SettingsActiveTab + 1) % categoryCount
 		m.SettingsSelectedRow = 0
+		m.SettingsError = ""
 		return m, nil
 	}
 	if key.Matches(msg, m.keys.Settings.PrevTab) {
 		m.SettingsActiveTab = (m.SettingsActiveTab - 1 + categoryCount) % categoryCount
 		m.SettingsSelectedRow = 0
+		m.SettingsError = ""
 		return m, nil
 	}
 
@@ -99,6 +107,7 @@ func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if key.Matches(msg, m.keys.Settings.Up) {
 		if m.SettingsSelectedRow > 0 {
 			m.SettingsSelectedRow--
+			m.SettingsError = ""
 		}
 		return m, nil
 	}
@@ -106,6 +115,7 @@ func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		maxRow := m.getSettingsCount() - 1
 		if m.SettingsSelectedRow < maxRow {
 			m.SettingsSelectedRow++
+			m.SettingsError = ""
 		}
 		return m, nil
 	}
@@ -161,6 +171,7 @@ func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		currentCategory := categories[m.SettingsActiveTab]
 		if typ == "bool" {
 			_ = m.setSettingValue(currentCategory, settingKey, "")
+			m.SettingsError = ""
 		} else {
 			// Enter edit mode
 			m.SettingsIsEditing = true
@@ -185,6 +196,7 @@ func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		if settingKey == "theme" {
 			m.ApplyTheme(m.Settings.General.Theme)
 		}
+		m.SettingsError = ""
 		return m, nil
 	}
 

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -340,6 +340,16 @@ func (m RootModel) renderSettingsDetailBlock(settingsMeta []config.SettingMeta, 
 	valueDisplay := valueLabelStyle.Render(valueLabel) + valueContentStyle.Render(valueStr)
 	valueDisplay = lipgloss.NewStyle().Width(innerWidth).MaxWidth(innerWidth).Render(valueDisplay)
 
+	var errorDisplay string
+	if m.SettingsError != "" {
+		errorDisplay = "\n" + lipgloss.NewStyle().
+			Foreground(colors.StateError).
+			Bold(true).
+			Width(innerWidth).
+			MaxWidth(innerWidth).
+			Render("Error: "+m.SettingsError)
+	}
+
 	divider := lipgloss.NewStyle().
 		Foreground(colors.Gray).
 		Render(strings.Repeat("─", innerWidth))
@@ -352,6 +362,7 @@ func (m RootModel) renderSettingsDetailBlock(settingsMeta []config.SettingMeta, 
 
 	detail := lipgloss.JoinVertical(lipgloss.Left,
 		valueDisplay,
+		errorDisplay,
 		"",
 		divider,
 		"",
@@ -602,7 +613,7 @@ func (m *RootModel) setSettingValue(category, key, value string) error {
 					if v, err := strconv.Atoi(value); err == nil && v >= 0 && v <= 2 {
 						theme = v
 					} else {
-						return nil // Invalid
+						return fmt.Errorf("invalid theme: %q (use system, light, or dark)", value)
 					}
 				}
 				targetField.Set(reflect.ValueOf(theme))
@@ -617,7 +628,10 @@ func (m *RootModel) setSettingValue(category, key, value string) error {
 				if value == "" {
 					targetField.SetBool(!targetField.Bool())
 				} else {
-					b, _ := strconv.ParseBool(value)
+					b, err := strconv.ParseBool(value)
+					if err != nil {
+						return fmt.Errorf("invalid boolean: %q (use true or false)", value)
+					}
 					targetField.SetBool(b)
 				}
 			case reflect.String:
@@ -625,30 +639,41 @@ func (m *RootModel) setSettingValue(category, key, value string) error {
 			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32:
 				if v, err := strconv.Atoi(value); err == nil {
 					targetField.SetInt(int64(v))
+				} else {
+					return fmt.Errorf("invalid integer: %q", value)
 				}
 			case reflect.Int64:
 				if targetField.Type().String() == "time.Duration" {
+					parseVal := value
 					if _, err := strconv.ParseFloat(value, 64); err == nil {
-						value += "s"
+						parseVal += "s"
 					}
-					if v, err := time.ParseDuration(value); err == nil {
-						targetField.Set(reflect.ValueOf(v))
+					v, err := time.ParseDuration(parseVal)
+					if err != nil {
+						return fmt.Errorf("invalid duration: %q (e.g. 5, 5s, 1m)", value)
 					}
+					targetField.Set(reflect.ValueOf(v))
 				} else {
 					// Handle KB/MB scaling gracefully if specified
 					if key == "min_chunk_size" {
 						if v, err := strconv.ParseFloat(value, 64); err == nil {
 							targetField.SetInt(int64(v * float64(config.MB)))
+						} else {
+							return fmt.Errorf("invalid number: %q", value)
 						}
 					} else {
 						if v, err := strconv.ParseInt(value, 10, 64); err == nil {
 							targetField.SetInt(v)
+						} else {
+							return fmt.Errorf("invalid integer: %q", value)
 						}
 					}
 				}
 			case reflect.Float32, reflect.Float64:
 				if v, err := strconv.ParseFloat(value, 64); err == nil {
 					targetField.SetFloat(v)
+				} else {
+					return fmt.Errorf("invalid decimal: %q", value)
 				}
 			}
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires up proper validation error reporting for settings edits in the TUI: the previously discarded `_ = m.setSettingValue(...)` result is now captured and surfaced as an inline `SettingsError` string, rendered inside the detail panel. Error state is cleared consistently across tab switches, navigation, cancel, and successful confirm.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are P2 style/layout suggestions that do not block functionality.

The core change — capturing and displaying `setSettingValue` errors instead of silently discarding them — is correct and well-integrated. The two findings are minor: a layout spacing inconsistency (extra blank line with `"
"` prefix) and a boundary-case UX quirk in Up/Down error clearing. Neither causes incorrect behavior or data loss.

internal/tui/view_settings.go — the `errorDisplay` `"
"` prefix in `renderSettingsDetailBlock` is worth fixing before this becomes a user-visible annoyance on small terminals.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/tui/model.go | Adds `SettingsError string` field to `RootModel` to hold the current validation error message; straightforward struct addition with no issues. |
| internal/tui/update_settings.go | Replaces discarded `_ = m.setSettingValue(...)` with proper error propagation into `m.SettingsError`; error clearing added at all navigation points, but Up/Down only clear on successful cursor movement (minor inconsistency). |
| internal/tui/view_settings.go | Adds inline error rendering in `renderSettingsDetailBlock`; the `"\n"` prefix on `errorDisplay` inflates the block height by 2 lines instead of 1 when an error is present, potentially clipping the description in constrained terminals. |
| .golangci.yml | Adds `unparam` linter to the enabled set; no issues. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User presses Edit / Enter] --> B{Setting type?}
    B -- bool --> C[toggleSettingValue]
    C --> D[SettingsError = '']
    D --> E[Return]
    B -- other --> F[SettingsIsEditing = true\nPre-fill input]
    F --> G[User types value]
    G --> H{Key pressed?}
    H -- Cancel / Esc --> I[SettingsError = ''\nSettingsIsEditing = false]
    H -- Confirm / Enter --> J[setSettingValue]
    J --> K{Error?}
    K -- Yes --> L[SettingsError = err.Error\nStay in edit mode]
    L --> G
    K -- No --> M[SettingsError = ''\nSettingsIsEditing = false]
    N[Navigation Up/Down/Tab] --> O[SettingsError = '' on movement]
    O --> P[Re-render detail block]
    M --> P
    I --> P
    P --> Q{SettingsError non-empty?}
    Q -- Yes --> R[Render Error in detail panel]
    Q -- No --> S[Render value + description only]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/tui/view_settings.go`, line 343-372 ([link](https://github.com/surgedm/surge/blob/f2870438d37615f10ccffd186a26916afb229a9b/internal/tui/view_settings.go#L343-L372)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Extra blank line inflates error block height**

   `errorDisplay` is prefixed with `"\n"` before being joined via `lipgloss.JoinVertical`. The join already inserts a `\n` between each element, so the error state produces 8 rendered lines while the no-error state produces only 6. The 2-line difference pushes the description out of the view in constrained terminal heights (where `formatSettingsBlock` simply truncates to `rows`).

   Removing the `"\n"` prefix — and relying solely on the existing `""` separator already in `JoinVertical` — keeps both states at the same height (error simply replaces one blank line with the error line):

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/tui/view_settings.go
   Line: 343-372

   Comment:
   **Extra blank line inflates error block height**

   `errorDisplay` is prefixed with `"\n"` before being joined via `lipgloss.JoinVertical`. The join already inserts a `\n` between each element, so the error state produces 8 rendered lines while the no-error state produces only 6. The 2-line difference pushes the description out of the view in constrained terminal heights (where `formatSettingsBlock` simply truncates to `rows`).

   Removing the `"\n"` prefix — and relying solely on the existing `""` separator already in `JoinVertical` — keeps both states at the same height (error simply replaces one blank line with the error line):

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/tui/view_settings.go
Line: 343-372

Comment:
**Extra blank line inflates error block height**

`errorDisplay` is prefixed with `"\n"` before being joined via `lipgloss.JoinVertical`. The join already inserts a `\n` between each element, so the error state produces 8 rendered lines while the no-error state produces only 6. The 2-line difference pushes the description out of the view in constrained terminal heights (where `formatSettingsBlock` simply truncates to `rows`).

Removing the `"\n"` prefix — and relying solely on the existing `""` separator already in `JoinVertical` — keeps both states at the same height (error simply replaces one blank line with the error line):

```suggestion
	var errorDisplay string
	if m.SettingsError != "" {
		errorDisplay = lipgloss.NewStyle().
			Foreground(colors.StateError).
			Bold(true).
			Width(innerWidth).
			MaxWidth(innerWidth).
			Render("Error: " + m.SettingsError)
	}

	divider := lipgloss.NewStyle().
		Foreground(colors.Gray).
		Render(strings.Repeat("─", innerWidth))

	descDisplay := lipgloss.NewStyle().
		Foreground(colors.LightGray).
		Width(innerWidth).
		MaxWidth(innerWidth).
		Render(meta.Description)

	detail := lipgloss.JoinVertical(lipgloss.Left,
		valueDisplay,
		errorDisplay,
		"",
		divider,
		"",
		descDisplay,
	)
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/tui/update_settings.go
Line: 107-120

Comment:
**Error only dismissed on successful cursor movement**

`m.SettingsError = ""` sits inside the boundary-guard `if` blocks, so pressing Up at row 0 or Down at the last row leaves any existing error message on screen. While the practical impact is limited (errors are only set while `SettingsIsEditing` is true, and exiting editing always clears the error), the intent of the surrounding navigation handlers is clearly to dismiss stale errors on any navigation attempt, not just successful ones. Moving the clears outside the guards is consistent with `NextTab`/`PrevTab`, which always clear regardless of outcome.

```suggestion
	if key.Matches(msg, m.keys.Settings.Up) {
		if m.SettingsSelectedRow > 0 {
			m.SettingsSelectedRow--
		}
		m.SettingsError = ""
		return m, nil
	}
	if key.Matches(msg, m.keys.Settings.Down) {
		maxRow := m.getSettingsCount() - 1
		if m.SettingsSelectedRow < maxRow {
			m.SettingsSelectedRow++
		}
		m.SettingsError = ""
		return m, nil
	}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: implement validation error reporti..."](https://github.com/surgedm/surge/commit/f2870438d37615f10ccffd186a26916afb229a9b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28400945)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->