### PR TITLE
Fix WSL download path handling

### DIFF
--- a/cmd/root_downloads.go
+++ b/cmd/root_downloads.go
@@ -356,6 +356,11 @@ func resolveOutputDir(reqPath string, relativeToDefaultDir bool, defaultOutputDi
 		if baseDir == "" {
 			baseDir = "."
 		}
+		// Windows absolute path from browser extension on Linux/Docker host:
+		// treat it as the default dir to avoid joining it as a subdirectory.
+		if utils.IsWindowsAbsPath(reqPath) {
+			return baseDir
+		}
 		outPath = filepath.Join(baseDir, reqPath)
 	} else if outPath == "" {
 		if defaultOutputDir != "" {

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/SurgeDM/Surge/internal/config"
 )
 
 func TestResolveClientOutputPath(t *testing.T) {
@@ -100,6 +102,58 @@ func TestResolveClientOutputPath(t *testing.T) {
 				if err != nil || strings.HasPrefix(rel, "..") {
 					t.Errorf("resolveClientOutputPath(%q) = %q, want prefix %q", tt.outputDir, got, tt.wantPrefix)
 				}
+			}
+		})
+	}
+}
+
+func TestResolveOutputDir(t *testing.T) {
+	settings := config.DefaultSettings()
+	settings.General.DefaultDownloadDir = "/downloads"
+
+	tests := []struct {
+		name                string
+		reqPath             string
+		relativeToDefault   bool
+		defaultOutputDir    string
+		want                string
+	}{
+		{
+			name:              "WSL Windows path with relativeToDefaultDir",
+			reqPath:           "C:/Users/me/Downloads",
+			relativeToDefault: true,
+			defaultOutputDir:  "/downloads",
+			want:              "/downloads",
+		},
+		{
+			name:              "WSL Windows path backslash with relativeToDefaultDir",
+			reqPath:           `C:\Users\me\Downloads`,
+			relativeToDefault: true,
+			defaultOutputDir:  "/downloads",
+			want:              "/downloads",
+		},
+		{
+			name:              "normal relative subdir",
+			reqPath:           "subdir",
+			relativeToDefault: true,
+			defaultOutputDir:  "/downloads",
+			want:              "/downloads/subdir",
+		},
+		{
+			name:              "empty path uses default",
+			reqPath:           "",
+			relativeToDefault: false,
+			defaultOutputDir:  "/downloads",
+			want:              "/downloads",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveOutputDir(tt.reqPath, tt.relativeToDefault, tt.defaultOutputDir, settings)
+			if got != tt.want {
+				t.Errorf("resolveOutputDir(%q, %v, %q) = %q, want %q",
+					tt.reqPath, tt.relativeToDefault, tt.defaultOutputDir, got, tt.want)
 			}
 		})
 	}

--- a/internal/utils/path.go
+++ b/internal/utils/path.go
@@ -18,23 +18,13 @@ func EnsureAbsPath(path string) string {
 	return path
 }
 
-// IsWindowsAbsPath reports whether p looks like a Windows absolute path even
-// when running on a non-Windows host (for example inside Docker on Linux).
+// IsWindowsAbsPath reports whether p is a Windows-style absolute path (e.g. C:/ or C:\).
 func IsWindowsAbsPath(p string) bool {
-	p = strings.TrimSpace(p)
-	if len(p) >= 3 &&
-		((p[0] >= 'A' && p[0] <= 'Z') || (p[0] >= 'a' && p[0] <= 'z')) &&
-		p[1] == ':' &&
-		(p[2] == '/' || p[2] == '\\') {
-		return true
+	if len(p) < 3 {
+		return false
 	}
-
-	// UNC paths (Windows-only; // is POSIX-legal and must not be excluded).
-	if len(p) >= 2 && p[0] == '\\' && p[1] == '\\' {
-		return true
-	}
-
-	return false
+	c := p[0]
+	return (c >= 'A' && c <= 'Z' || c >= 'a' && c <= 'z') && p[1] == ':' && (p[2] == '/' || p[2] == '\\')
 }
 
 // MapWindowsPathToDefaultDir projects a Windows absolute client path onto a

--- a/internal/utils/path_test.go
+++ b/internal/utils/path_test.go
@@ -6,6 +6,30 @@ import (
 	"testing"
 )
 
+func TestIsWindowsAbsPath(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"C:/Users/me/Downloads", true},
+		{"C:\\Users\\me\\Downloads", true},
+		{"c:/users/me", true},
+		{"D:/foo", true},
+		{"/downloads", false},
+		{"relative/path", false},
+		{"C:", false},
+		{"C", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		got := IsWindowsAbsPath(tt.in)
+		if got != tt.want {
+			t.Errorf("IsWindowsAbsPath(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}
+
 func TestEnsureAbsPath(t *testing.T) {
 	wd, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
Fixes #365

Windows absolute paths from the browser extension were being joined with the default path as if they were relative subdirectories. Added a check to detect and skip Windows paths. Includes tests for both forward and backslash formats.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes WSL/Linux handling of Windows-style absolute paths sent by the browser extension, preventing them from being incorrectly joined as a relative subdirectory of the default download directory. However, there are three issues that need to be addressed before merge:

- `internal/utils/path_test.go` adds a second `TestIsWindowsAbsPath` on top of an existing one — this is a compile error that blocks the test suite from building.
- The refactored `IsWindowsAbsPath` silently drops UNC-path detection (`\\\\server\\share`), but the pre-existing test at line 82 still asserts UNC paths return `true`, so the existing test will fail once the duplicate is resolved.
- The new `IsWindowsAbsPath` guard added to `resolveOutputDir` is unreachable dead code: `mapClientWindowsPath` (called first) always returns a non-empty value for Windows paths when `relativeToDefaultDir=true`, so execution never reaches the new check.

<h3>Confidence Score: 3/5</h3>

Not safe to merge — the test package will not compile due to a duplicate function name, and the new implementation has a dead-code guard and drops UNC path support without cleaning up the existing test.

A P0 compile error (duplicate TestIsWindowsAbsPath) prevents the test suite from building entirely. There are also two P1 issues: an existing UNC-path test that would fail once the duplicate is fixed, and a dead-code guard that gives false assurance while the real fix is in mapClientWindowsPath.

internal/utils/path_test.go (duplicate function / compile error) and internal/utils/path.go (UNC support removal) need immediate attention; cmd/root_downloads.go dead-code guard should also be cleaned up.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/utils/path_test.go | Added a new TestIsWindowsAbsPath function that duplicates the existing one — causes a compile error; also the existing function tests UNC paths that the new implementation no longer supports. |
| internal/utils/path.go | Simplified IsWindowsAbsPath removes UNC path support and strings.TrimSpace; also missing trailing newline. UNC removal breaks an existing test case. |
| cmd/root_downloads.go | New IsWindowsAbsPath guard added inside the relativeToDefaultDir branch is unreachable dead code — mapClientWindowsPath already handles all Windows paths before this block can execute. |
| cmd/utils_test.go | Adds TestResolveOutputDir covering WSL forward-slash, backslash, normal subdir, and empty-path cases; tests are correct but exercise mapClientWindowsPath rather than the new dead-code guard. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["resolveOutputDir(reqPath, relativeToDefault, defaultOutputDir, settings)"] --> B["mapClientWindowsPath(reqPath, ...)"]
    B --> C{IsWindowsAbsPath?}
    C -- No --> D["return ''"]
    C -- Yes --> E["MapWindowsPathToDefaultDir(reqPath, baseDir)"]
    E -- ok=true --> F["return mapped path"]
    E -- ok=false --> G{"shouldFallbackUnmappedWindowsPath\n(relativeToDefault || OS≠windows)"}
    G -- false --> H["return ''"]
    G -- true --> I["return filepath.Clean(baseDir)"]
    D --> J{relativeToDefault && reqPath≠''}
    H --> J
    J -- Yes --> K["IsWindowsAbsPath(reqPath)\n⚠️ Dead code — never reached for Windows paths on Linux"]
    K -- true --> L["return baseDir"]
    K -- false --> M["filepath.Join(baseDir, reqPath)"]
    J -- No --> N{outPath == ''}
    N -- Yes --> O["use defaultOutputDir / settings / '.'"]
    N -- No --> P["return outPath"]
    F --> Q["return mapped ✓"]
    I --> Q
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/utils/path_test.go
Line: 9-31

Comment:
**Duplicate function name causes compile error**

This PR adds a new `TestIsWindowsAbsPath` starting at line 9, but the file already contains a `TestIsWindowsAbsPath` at line 76. Go does not allow two functions with the same name in the same package — this is a compile-time error that will prevent the entire test suite from building.

The existing function at line 76 also includes a UNC-path case (`\\server\share\file.zip → true`) that the new simplified `IsWindowsAbsPath` implementation no longer supports, so the two functions are inconsistent. One of them must be removed and the other must reflect the current contract of the function (with or without UNC support).

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/utils/path.go
Line: 22-28

Comment:
**UNC path detection silently dropped**

The original `IsWindowsAbsPath` also recognised UNC paths (e.g. `\\server\share\file.zip`). The refactored version only handles drive-letter paths. The existing test at line 82 of this file asserts `\\server\share\file.zip → true`; with this change that assertion will fail once the duplicate-function compile error is resolved.

If UNC paths are intentionally out of scope for this fix, the corresponding test case must be removed (or updated) and a comment should explain why UNC paths are no longer considered Windows-absolute. If they should still be handled, the old two-character prefix check needs to be restored.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: cmd/root_downloads.go
Line: 361-363

Comment:
**New guard is unreachable dead code**

This block is inside `if relativeToDefaultDir && reqPath != ""`. For that branch to be reached, `mapClientWindowsPath` (line 347) must have returned `""`. However, when `relativeToDefaultDir == true`, `shouldFallbackUnmappedWindowsPath` always returns `true` regardless of OS, so `mapClientWindowsPath` always returns a non-empty string for any Windows-absolute path (either the mapped result or `filepath.Clean(baseDir)` as the fallback). The new `IsWindowsAbsPath` check can therefore never execute.

The actual protection against joining a Windows path as a subdirectory is already provided by `mapClientWindowsPath`; this extra guard gives a false sense of safety while adding confusion. It should either be removed, or the comment should be on the `mapClientWindowsPath` call where the real work happens.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/utils/path.go
Line: 79

Comment:
**Missing newline at end of file**

The diff shows `\ No newline at end of file`. Go source files (and most linters/formatters) expect a trailing newline.

```suggestion
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Fix WSL download path handling"](https://github.com/surgedm/surge/commit/cbb7d8735e7cb87ba08b60f50dfb602ab8901c4d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28589064)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->