### PR TITLE
feat: auto-approve non-duplicate extension requests in headless mode

### DIFF
--- a/cmd/headless_approval_test.go
+++ b/cmd/headless_approval_test.go
@@ -102,3 +102,36 @@ func TestHandleDownload_HeadlessMode_RejectsDuplicateWithWarn(t *testing.T) {
 		t.Fatalf("expected 409 Conflict for duplicate in headless mode, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
+
+func TestHandleDownload_HeadlessMode_RejectsExtensionPromptDuplicate(t *testing.T) {
+	setupIsolatedCmdState(t)
+	serverProgram = nil
+	t.Cleanup(func() { serverProgram = nil })
+
+	settings := config.DefaultSettings()
+	settings.Extension.ExtensionPrompt = true
+	settings.General.WarnOnDuplicate = false
+	if err := config.SaveSettings(settings); err != nil {
+		t.Fatalf("SaveSettings failed: %v", err)
+	}
+
+	url := "http://example.com/already-downloaded.bin"
+	_ = state.AddToMasterList(types.DownloadEntry{
+		ID: "ext-dup-id", URL: url, Filename: "already-downloaded.bin", Status: "completed",
+	})
+
+	progressCh := make(chan any, 10)
+	GlobalProgressCh = progressCh
+	GlobalPool = download.NewWorkerPool(progressCh, 1)
+	svc := core.NewLocalDownloadService(GlobalPool)
+	GlobalService = svc
+
+	body := fmt.Sprintf(`{"url": %q, "skip_approval": false}`, url)
+	req := httptest.NewRequest(http.MethodPost, "/download", bytes.NewBufferString(body))
+	rec := httptest.NewRecorder()
+	handleDownload(rec, req, t.TempDir(), svc)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409 for duplicate with ExtensionPrompt=true, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/cmd/headless_approval_test.go
+++ b/cmd/headless_approval_test.go
@@ -19,8 +19,20 @@ func TestHandleDownload_HeadlessMode_AutoApprovesNonDuplicate(t *testing.T) {
 	setupIsolatedCmdState(t)
 
 	// Simulation: headless mode (no TUI)
+	origServerProgram := serverProgram
 	serverProgram = nil
-	t.Cleanup(func() { serverProgram = nil })
+	t.Cleanup(func() { serverProgram = origServerProgram })
+
+	origLifecycle := GlobalLifecycle
+	origPool := GlobalPool
+	origProgress := GlobalProgressCh
+	origService := GlobalService
+	t.Cleanup(func() {
+		GlobalLifecycle = origLifecycle
+		GlobalPool = origPool
+		GlobalProgressCh = origProgress
+		GlobalService = origService
+	})
 
 	// Enable ExtensionPrompt (default is true, but let's be explicit)
 	settings := config.DefaultSettings()
@@ -65,8 +77,18 @@ func TestHandleDownload_HeadlessMode_RejectsDuplicateWithWarn(t *testing.T) {
 	setupIsolatedCmdState(t)
 
 	// Simulation: headless mode
+	origServerProgram := serverProgram
 	serverProgram = nil
-	t.Cleanup(func() { serverProgram = nil })
+	t.Cleanup(func() { serverProgram = origServerProgram })
+
+	origPool := GlobalPool
+	origProgress := GlobalProgressCh
+	origService := GlobalService
+	t.Cleanup(func() {
+		GlobalPool = origPool
+		GlobalProgressCh = origProgress
+		GlobalService = origService
+	})
 
 	// Enable WarnOnDuplicate
 	settings := config.DefaultSettings()
@@ -105,8 +127,18 @@ func TestHandleDownload_HeadlessMode_RejectsDuplicateWithWarn(t *testing.T) {
 
 func TestHandleDownload_HeadlessMode_RejectsExtensionPromptDuplicate(t *testing.T) {
 	setupIsolatedCmdState(t)
+	origServerProgram := serverProgram
 	serverProgram = nil
-	t.Cleanup(func() { serverProgram = nil })
+	t.Cleanup(func() { serverProgram = origServerProgram })
+
+	origPool := GlobalPool
+	origProgress := GlobalProgressCh
+	origService := GlobalService
+	t.Cleanup(func() {
+		GlobalPool = origPool
+		GlobalProgressCh = origProgress
+		GlobalService = origService
+	})
 
 	settings := config.DefaultSettings()
 	settings.Extension.ExtensionPrompt = true

--- a/cmd/headless_approval_test.go
+++ b/cmd/headless_approval_test.go
@@ -84,10 +84,12 @@ func TestHandleDownload_HeadlessMode_RejectsDuplicateWithWarn(t *testing.T) {
 	origPool := GlobalPool
 	origProgress := GlobalProgressCh
 	origService := GlobalService
+	origLifecycle := GlobalLifecycle
 	t.Cleanup(func() {
 		GlobalPool = origPool
 		GlobalProgressCh = origProgress
 		GlobalService = origService
+		GlobalLifecycle = origLifecycle
 	})
 
 	// Enable WarnOnDuplicate
@@ -134,10 +136,12 @@ func TestHandleDownload_HeadlessMode_RejectsExtensionPromptDuplicate(t *testing.
 	origPool := GlobalPool
 	origProgress := GlobalProgressCh
 	origService := GlobalService
+	origLifecycle := GlobalLifecycle
 	t.Cleanup(func() {
 		GlobalPool = origPool
 		GlobalProgressCh = origProgress
 		GlobalService = origService
+		GlobalLifecycle = origLifecycle
 	})
 
 	settings := config.DefaultSettings()

--- a/cmd/headless_approval_test.go
+++ b/cmd/headless_approval_test.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/SurgeDM/Surge/internal/config"
+	"github.com/SurgeDM/Surge/internal/core"
+	"github.com/SurgeDM/Surge/internal/download"
+	"github.com/SurgeDM/Surge/internal/engine/state"
+	"github.com/SurgeDM/Surge/internal/engine/types"
+	"github.com/SurgeDM/Surge/internal/processing"
+)
+
+func TestHandleDownload_HeadlessMode_AutoApprovesNonDuplicate(t *testing.T) {
+	setupIsolatedCmdState(t)
+
+	// Simulation: headless mode (no TUI)
+	serverProgram = nil
+	t.Cleanup(func() { serverProgram = nil })
+
+	// Enable ExtensionPrompt (default is true, but let's be explicit)
+	settings := config.DefaultSettings()
+	settings.Extension.ExtensionPrompt = true
+	if err := config.SaveSettings(settings); err != nil {
+		t.Fatalf("SaveSettings failed: %v", err)
+	}
+
+	// Mock server for probe
+	probeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "1024")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(make([]byte, 10))
+	}))
+	defer probeServer.Close()
+
+	progressCh := make(chan any, 10)
+	GlobalProgressCh = progressCh
+	GlobalPool = download.NewWorkerPool(progressCh, 1)
+
+	// Mock lifecycle to bypass real downloads
+	GlobalLifecycle = processing.NewLifecycleManager(func(url, path, filename string, _ []string, headers map[string]string, explicit bool, totalSize int64, supportsRange bool) (string, error) {
+		return "queued-id", nil
+	}, nil)
+
+	svc := core.NewLocalDownloadService(GlobalPool)
+	GlobalService = svc
+
+	// Verify it auto-approves even with ExtensionPrompt=true
+	body := fmt.Sprintf(`{"url": %q, "skip_approval": false}`, probeServer.URL)
+	req := httptest.NewRequest(http.MethodPost, "/download", bytes.NewBufferString(body))
+	rec := httptest.NewRecorder()
+
+	handleDownload(rec, req, t.TempDir(), svc)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK in headless mode for non-duplicate, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleDownload_HeadlessMode_RejectsDuplicateWithWarn(t *testing.T) {
+	setupIsolatedCmdState(t)
+
+	// Simulation: headless mode
+	serverProgram = nil
+	t.Cleanup(func() { serverProgram = nil })
+
+	// Enable WarnOnDuplicate
+	settings := config.DefaultSettings()
+	settings.General.WarnOnDuplicate = true
+	if err := config.SaveSettings(settings); err != nil {
+		t.Fatalf("SaveSettings failed: %v", err)
+	}
+
+	progressCh := make(chan any, 10)
+	GlobalProgressCh = progressCh
+	GlobalPool = download.NewWorkerPool(progressCh, 1)
+
+	// Seed the DB with a "duplicate" entry
+	url := "http://example.com/duplicate.bin"
+	_ = state.AddToMasterList(types.DownloadEntry{
+		ID:       "dup-id",
+		URL:      url,
+		Filename: "duplicate.bin",
+		Status:   "completed",
+	})
+
+	svc := core.NewLocalDownloadService(GlobalPool)
+	GlobalService = svc
+
+	// Verify it still rejects duplicates when WarnOnDuplicate is on
+	body := fmt.Sprintf(`{"url": %q, "skip_approval": false}`, url)
+	req := httptest.NewRequest(http.MethodPost, "/download", bytes.NewBufferString(body))
+	rec := httptest.NewRecorder()
+
+	handleDownload(rec, req, t.TempDir(), svc)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409 Conflict for duplicate in headless mode, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/cmd/http_handler_test.go
+++ b/cmd/http_handler_test.go
@@ -424,10 +424,18 @@ func (f *failingPublishService) Publish(msg interface{}) error {
 func TestHandleDownload_PublishError_RecordsPreflightError(t *testing.T) {
 	setupIsolatedCmdState(t)
 
-	GlobalPool = download.NewWorkerPool(nil, 1)
+	origPool := GlobalPool
+	origProgress := GlobalProgressCh
+	origService := GlobalService
+	origLifecycle := GlobalLifecycle
 	t.Cleanup(func() {
-		GlobalPool = nil
+		GlobalPool = origPool
+		GlobalProgressCh = origProgress
+		GlobalService = origService
+		GlobalLifecycle = origLifecycle
 	})
+
+	GlobalPool = download.NewWorkerPool(nil, 1)
 
 	origServerProgram := serverProgram
 	serverProgram = &tea.Program{}
@@ -441,11 +449,7 @@ func TestHandleDownload_PublishError_RecordsPreflightError(t *testing.T) {
 	}
 
 	svc := &failingPublishService{publishErr: errors.New("publish failed")}
-	origService := GlobalService
 	GlobalService = svc
-	t.Cleanup(func() {
-		GlobalService = origService
-	})
 
 	outDir := t.TempDir()
 	body := fmt.Sprintf(`{"url": %q, "path": %q}`, "http://example.com/file.bin", outDir)

--- a/cmd/root_downloads.go
+++ b/cmd/root_downloads.go
@@ -232,6 +232,15 @@ func maybeRequireDownloadApproval(w http.ResponseWriter, service core.DownloadSe
 		return true
 	}
 
+	// HEADLESS/SERVER MODE:
+	// If we're here, shouldPrompt must be true but we have no TUI.
+	// We auto-approve extension requests that are NOT duplicates, as there is
+	// no way to display a confirmation prompt in headless mode.
+	if !resolved.isDuplicate {
+		utils.Debug("Headless mode: auto-approving extension request (bypass ExtensionPrompt)")
+		return false
+	}
+
 	writeJSONResponse(w, http.StatusConflict, map[string]string{
 		"status":  "error",
 		"message": "Download rejected: Duplicate download or approval required (Headless mode)",

--- a/cmd/root_downloads.go
+++ b/cmd/root_downloads.go
@@ -183,7 +183,7 @@ func resolveDuplicateState(urlForAdd string, settings *config.Settings) (bool, b
 		return active
 	}
 
-	dupResult := processing.CheckForDuplicate(urlForAdd, settings, activeDownloadsFunc)
+	dupResult := processing.CheckForDuplicate(urlForAdd, activeDownloadsFunc)
 	if dupResult == nil {
 		return false, false
 	}

--- a/cmd/root_downloads.go
+++ b/cmd/root_downloads.go
@@ -243,7 +243,7 @@ func maybeRequireDownloadApproval(w http.ResponseWriter, service core.DownloadSe
 
 	writeJSONResponse(w, http.StatusConflict, map[string]string{
 		"status":  "error",
-		"message": "Download rejected: Duplicate download or approval required (Headless mode)",
+		"message": "Download rejected: Duplicate download detected (Headless mode)",
 	})
 	return true
 }

--- a/internal/processing/duplicate.go
+++ b/internal/processing/duplicate.go
@@ -18,10 +18,6 @@ type DuplicateResult struct {
 
 // CheckForDuplicate inspects active and persisted downloads for duplicate URLs.
 func CheckForDuplicate(url string, settings *config.Settings, activeDownloads func() map[string]*types.DownloadConfig) *DuplicateResult {
-	if !settings.General.WarnOnDuplicate {
-		return nil
-	}
-
 	normalizedInputURL := strings.TrimRight(url, "/")
 
 	// Check active downloads

--- a/internal/processing/duplicate.go
+++ b/internal/processing/duplicate.go
@@ -17,6 +17,10 @@ type DuplicateResult struct {
 }
 
 // CheckForDuplicate inspects active and persisted downloads for duplicate URLs.
+// It always performs the scan regardless of settings.General.WarnOnDuplicate.
+// Policy decisions (whether to warn, block, or auto-approve) are the caller's
+// responsibility. This separation is required so that headless mode can always
+// distinguish duplicates from new downloads, even when WarnOnDuplicate is off.
 func CheckForDuplicate(url string, settings *config.Settings, activeDownloads func() map[string]*types.DownloadConfig) *DuplicateResult {
 	normalizedInputURL := strings.TrimRight(url, "/")
 

--- a/internal/processing/duplicate.go
+++ b/internal/processing/duplicate.go
@@ -3,7 +3,6 @@ package processing
 import (
 	"strings"
 
-	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/engine/state"
 	"github.com/SurgeDM/Surge/internal/engine/types"
 )
@@ -21,7 +20,7 @@ type DuplicateResult struct {
 // Policy decisions (whether to warn, block, or auto-approve) are the caller's
 // responsibility. This separation is required so that headless mode can always
 // distinguish duplicates from new downloads, even when WarnOnDuplicate is off.
-func CheckForDuplicate(url string, settings *config.Settings, activeDownloads func() map[string]*types.DownloadConfig) *DuplicateResult {
+func CheckForDuplicate(url string, activeDownloads func() map[string]*types.DownloadConfig) *DuplicateResult {
 	normalizedInputURL := strings.TrimRight(url, "/")
 
 	// Check active downloads

--- a/internal/tui/helpers.go
+++ b/internal/tui/helpers.go
@@ -168,7 +168,7 @@ func (m RootModel) checkForDuplicate(url string) *processing.DuplicateResult {
 		}
 		return active
 	}
-	return processing.CheckForDuplicate(url, m.Settings, activeDownloads)
+	return processing.CheckForDuplicate(url, activeDownloads)
 }
 
 // renderEmptyMessage provides a consistent visual for "no data" states in dashboard panes.


### PR DESCRIPTION
Close #384

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds headless-mode (no TUI) auto-approval logic for extension download requests: non-duplicate URLs are approved automatically, while duplicates are rejected with 409 Conflict. To support this, `CheckForDuplicate` was refactored to always perform its DB scan and delegate policy decisions (warn, block, auto-approve) entirely to the caller.

- The unresolved concern from the previous review thread remains: `update_input.go` (line 99) and `update_modals.go` (line 86) call `checkForDuplicate` without a `WarnOnDuplicate` guard, so with `CheckForDuplicate` now always scanning, these TUI paths will surface the duplicate warning dialog even when the user has `WarnOnDuplicate=false`.

<h3>Confidence Score: 4/5</h3>

Safe to merge once the TUI regression from the CheckForDuplicate refactor is resolved

The headless-mode logic in root_downloads.go and all three new tests are correct. However, the prior-review P1 finding — that removing the WarnOnDuplicate early return from CheckForDuplicate breaks the unguarded TUI call sites in update_input.go and update_modals.go — remains unaddressed in this revision, keeping the score at 4.

internal/processing/duplicate.go and internal/tui/helpers.go (and its callers update_input.go:99, update_modals.go:86)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/processing/duplicate.go | Removes WarnOnDuplicate early-return, making CheckForDuplicate always scan regardless of settings — correct for headless mode but breaks TUI callers that relied on nil return to skip duplicate UI (flagged in prior review threads) |
| cmd/root_downloads.go | Adds headless-mode branch in maybeRequireDownloadApproval: auto-approves non-duplicate extension requests and returns 409 for duplicates when no TUI is running; logic and conditions are correct |
| cmd/headless_approval_test.go | Adds three headless-mode tests covering auto-approve for non-duplicate, reject for duplicate+WarnOnDuplicate, and reject for duplicate+ExtensionPrompt+WarnOnDuplicate=false; coverage is thorough for the new code path |
| cmd/http_handler_test.go | Unchanged tests; no new issues introduced |
| internal/tui/helpers.go | checkForDuplicate delegates to processing.CheckForDuplicate without any WarnOnDuplicate guard; now that CheckForDuplicate always scans, call sites in update_input.go and update_modals.go will trigger duplicate UI even when WarnOnDuplicate=false (unresolved concern from prior review) |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `cmd/root_downloads.go`, line 244-248 ([link](https://github.com/surgedm/surge/blob/29c97755b95547f44f7845f8792d1dbee9f0e34c/cmd/root_downloads.go#L244-L248)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Stale "or approval required" in error message**

   After this change, the 409 path is only reachable when `isDuplicate=true` — non-duplicates are now auto-approved above. The "or approval required" clause in the message no longer corresponds to any real code path and will confuse callers trying to diagnose a rejection.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: cmd/root_downloads.go
   Line: 244-248

   Comment:
   **Stale "or approval required" in error message**

   After this change, the 409 path is only reachable when `isDuplicate=true` — non-duplicates are now auto-approved above. The "or approval required" clause in the message no longer corresponds to any real code path and will confuse callers trying to diagnose a rejection.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (6): Last reviewed commit: ["refactor: standardize global state clean..."](https://github.com/surgedm/surge/commit/6e609510476bee6f67e42e40c929aa9caf0fb833) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28848616)</sub>

<!-- /greptile_comment -->