### PR TITLE
fix(tui): Fixed a bug that caused tui to be stuck in filepath picker box

### DIFF
--- a/internal/tui/helpers.go
+++ b/internal/tui/helpers.go
@@ -69,27 +69,33 @@ func (m *RootModel) removeDownloadByID(id string) bool {
 }
 
 func (m *RootModel) handleFilePickerSelection(path string) (tea.Model, tea.Cmd) {
-	if m.SettingsFileBrowsing {
+	switch m.filepickerOrigin {
+	case FilePickerOriginSettings:
 		m.Settings.General.DefaultDownloadDir = path
-		m.SettingsFileBrowsing = false
+		m.filepickerOrigin = FilePickerOriginNone
 		m.state = SettingsState
 		return m, nil
-	}
-	if m.ExtensionFileBrowsing {
+	case FilePickerOriginExtension:
 		m.inputs[2].SetValue(path)
-		m.ExtensionFileBrowsing = false
+		m.focusInput(2)
+		m.filepickerOrigin = FilePickerOriginNone
 		m.state = ExtensionConfirmationState
 		return m, nil
-	}
-	if m.catMgrFileBrowsing {
+	case FilePickerOriginCategory:
 		m.catMgrInputs[3].SetValue(path)
-		m.catMgrFileBrowsing = false
+		m.catMgrEditField = 3
+		m.blurAllCatInputs()
+		m.catMgrInputs[3].Focus()
+		m.filepickerOrigin = FilePickerOriginNone
 		m.state = CategoryManagerState
 		return m, nil
+	default:
+		m.inputs[2].SetValue(path)
+		m.focusInput(2)
+		m.filepickerOrigin = FilePickerOriginNone
+		m.state = InputState
+		return m, nil
 	}
-	m.inputs[2].SetValue(path)
-	m.state = InputState
-	return m, nil
 }
 
 func (m *RootModel) handleFilePickerGotoHome() tea.Cmd {
@@ -106,6 +112,14 @@ func (m *RootModel) resetFilepickerToDirMode() {
 	m.filepicker.FileAllowed = false
 	m.filepicker.DirAllowed = true
 	m.filepicker.AllowedTypes = nil
+}
+
+func (m *RootModel) openDirectoryPicker(origin FilePickerOrigin, originalPath, browseDir string) tea.Cmd {
+	m.filepickerOrigin = origin
+	m.filepickerOriginalPath = originalPath
+	m.state = FilePickerState
+	m.filepicker = newFilepicker(browseDir)
+	return m.filepicker.Init()
 }
 
 // checkForDuplicate checks if a compatible download already exists

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -54,6 +54,16 @@ const (
 	HelpModalState                            // HelpModalState is 15
 )
 
+type FilePickerOrigin int
+
+const (
+	FilePickerOriginNone FilePickerOrigin = iota
+	FilePickerOriginAdd
+	FilePickerOriginSettings
+	FilePickerOriginExtension
+	FilePickerOriginCategory
+)
+
 const (
 	TabQueued = 0
 	TabActive = 1
@@ -104,6 +114,7 @@ type RootModel struct {
 	// File picker for directory selection
 	filepicker             filepicker.Model
 	filepickerOriginalPath string
+	filepickerOrigin       FilePickerOrigin
 
 	// Bubbles help component
 	help help.Model
@@ -132,14 +143,12 @@ type RootModel struct {
 	logFocused  bool           // Whether the log viewport is focused
 
 	// Settings
-	Settings              *config.Settings // Application settings
-	SettingsActiveTab     int              // Active category tab (0-3)
-	SettingsSelectedRow   int              // Selected setting within current tab
-	SettingsIsEditing     bool             // Whether currently editing a value
-	SettingsInput         textinput.Model  // Input for editing string/int values
-	SettingsFileBrowsing  bool             // Whether browsing for a directory
-	ExtensionFileBrowsing bool             // Whether browsing for extension prompt path
-	ExtensionTokenCopied  bool             // Flash message for "Token Copied!"
+	Settings             *config.Settings // Application settings
+	SettingsActiveTab    int              // Active category tab (0-3)
+	SettingsSelectedRow  int              // Selected setting within current tab
+	SettingsIsEditing    bool             // Whether currently editing a value
+	SettingsInput        textinput.Model  // Input for editing string/int values
+	ExtensionTokenCopied bool             // Flash message for "Token Copied!"
 
 	// Selection persistence
 	SelectedDownloadID string // ID of the currently selected download
@@ -158,14 +167,12 @@ type RootModel struct {
 	urlUpdateInput textinput.Model // Text input for updating URL
 
 	// Category manager
-	categoryFilter     string             // Dashboard filter ("" = all)
-	catMgrCursor       int                // Selected category index
-	catMgrEditing      bool               // Whether editing a category
-	catMgrEditField    int                // 0=Name, 1=Description, 2=Pattern, 3=Path
-	catMgrInputs       [4]textinput.Model // Inputs for Name, Description, Pattern, Path
-	catMgrIsNew        bool               // Whether adding a new category
-	catMgrFileBrowsing bool               // Whether browsing for a category path
-
+	categoryFilter  string             // Dashboard filter ("" = all)
+	catMgrCursor    int                // Selected category index
+	catMgrEditing   bool               // Whether editing a category
+	catMgrEditField int                // 0=Name, 1=Description, 2=Pattern, 3=Path
+	catMgrInputs    [4]textinput.Model // Inputs for Name, Description, Pattern, Path
+	catMgrIsNew     bool               // Whether adding a new category
 	// Quit confirm button focus (0 = Yep!, 1 = Nope)
 	quitConfirmFocused int
 
@@ -571,6 +578,8 @@ func newFilepicker(currentDir string) filepicker.Model {
 	// We also keep 'right' for Open to allow directory navigation.
 	fp.KeyMap.Select = key.NewBinding(key.WithKeys("."))
 	fp.KeyMap.Open = key.NewBinding(key.WithKeys(".", "right"))
+	// Keep ESC reserved for dismissing the modal; use left/backspace/h to go up.
+	fp.KeyMap.Back = key.NewBinding(key.WithKeys("h", "backspace", "left"))
 
 	return fp
 }

--- a/internal/tui/update_category.go
+++ b/internal/tui/update_category.go
@@ -117,18 +117,15 @@ func (m RootModel) updateCategoryManager(msg tea.KeyPressMsg) (tea.Model, tea.Cm
 		if key.Matches(msg, m.keys.CategoryMgr.Tab) {
 			// On Path field, open file picker for directory browsing
 			if m.catMgrEditField == 3 {
-				m.filepickerOriginalPath = m.catMgrInputs[3].Value()
-				browseDir := strings.TrimSpace(m.filepickerOriginalPath)
+				originalPath := m.catMgrInputs[3].Value()
+				browseDir := strings.TrimSpace(originalPath)
 				if browseDir == "" {
 					browseDir = m.Settings.General.DefaultDownloadDir
 				}
 				if browseDir == "" {
 					browseDir = m.PWD
 				}
-				m.catMgrFileBrowsing = true
-				m.state = FilePickerState
-				m.filepicker = newFilepicker(browseDir)
-				return m, m.filepicker.Init()
+				return m, m.openDirectoryPicker(FilePickerOriginCategory, originalPath, browseDir)
 			}
 			// Cycle fields
 			m.catMgrInputs[m.catMgrEditField].Blur()

--- a/internal/tui/update_filepicker.go
+++ b/internal/tui/update_filepicker.go
@@ -23,28 +23,33 @@ func (m *RootModel) handleBatchFileSelection(path string) (tea.Model, tea.Cmd) {
 
 func (m RootModel) updateFilePicker(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if key.Matches(msg, m.keys.FilePicker.Cancel) {
-		// Cancel and return to appropriate state
-		if m.SettingsFileBrowsing {
+		switch m.filepickerOrigin {
+		case FilePickerOriginSettings:
 			m.Settings.General.DefaultDownloadDir = m.filepickerOriginalPath
-			m.SettingsFileBrowsing = false
+			m.filepickerOrigin = FilePickerOriginNone
 			m.state = SettingsState
 			return m, nil
-		}
-		if m.ExtensionFileBrowsing {
+		case FilePickerOriginExtension:
 			m.inputs[2].SetValue(m.filepickerOriginalPath)
-			m.ExtensionFileBrowsing = false
+			m.focusInput(2)
+			m.filepickerOrigin = FilePickerOriginNone
 			m.state = ExtensionConfirmationState
 			return m, nil
-		}
-		if m.catMgrFileBrowsing {
+		case FilePickerOriginCategory:
 			m.catMgrInputs[3].SetValue(m.filepickerOriginalPath)
-			m.catMgrFileBrowsing = false
+			m.catMgrEditField = 3
+			m.blurAllCatInputs()
+			m.catMgrInputs[3].Focus()
+			m.filepickerOrigin = FilePickerOriginNone
 			m.state = CategoryManagerState
 			return m, nil
+		default:
+			m.inputs[2].SetValue(m.filepickerOriginalPath)
+			m.focusInput(2)
+			m.filepickerOrigin = FilePickerOriginNone
+			m.state = InputState
+			return m, nil
 		}
-		m.inputs[2].SetValue(m.filepickerOriginalPath)
-		m.state = InputState
-		return m, nil
 	}
 
 	// H key to jump to default download directory

--- a/internal/tui/update_input.go
+++ b/internal/tui/update_input.go
@@ -27,10 +27,15 @@ func (m RootModel) updateInput(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 
 	if key.Matches(msg, m.keys.Input.Tab) && m.focusedInput == 2 {
-		m.state = FilePickerState
-		m.filepickerOriginalPath = m.inputs[2].Value()
-		m.filepicker = newFilepicker(m.PWD)
-		return m, m.filepicker.Init()
+		originalPath := m.inputs[2].Value()
+		browseDir := strings.TrimSpace(originalPath)
+		if browseDir == "" {
+			browseDir = m.Settings.General.DefaultDownloadDir
+		}
+		if browseDir == "" {
+			browseDir = m.PWD
+		}
+		return m, m.openDirectoryPicker(FilePickerOriginAdd, originalPath, browseDir)
 	}
 
 	if key.Matches(msg, m.keys.Input.Up) && m.focusedInput > 0 {
@@ -130,15 +135,12 @@ func parseURLInput(input string) (url string, mirrors []string) {
 
 func (m RootModel) updateExtensionConfirmation(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if key.Matches(msg, m.keys.Extension.Browse) && m.focusedInput == 2 {
-		m.ExtensionFileBrowsing = true
-		m.filepickerOriginalPath = m.inputs[2].Value()
-		browseDir := strings.TrimSpace(m.filepickerOriginalPath)
+		originalPath := m.inputs[2].Value()
+		browseDir := strings.TrimSpace(originalPath)
 		if browseDir == "" {
 			browseDir = m.PWD
 		}
-		m.state = FilePickerState
-		m.filepicker = newFilepicker(browseDir)
-		return m, m.filepicker.Init()
+		return m, m.openDirectoryPicker(FilePickerOriginExtension, originalPath, browseDir)
 	}
 
 	if key.Matches(msg, m.keys.Extension.Next) || key.Matches(msg, m.keys.Extension.Prev) {
@@ -173,7 +175,7 @@ func (m RootModel) updateExtensionConfirmation(msg tea.KeyPressMsg) (tea.Model, 
 	}
 
 	if key.Matches(msg, m.keys.Extension.Cancel) {
-		m.ExtensionFileBrowsing = false
+		m.filepickerOrigin = FilePickerOriginNone
 		m.blurAllInputs()
 		m.state = DashboardState
 		return m, nil

--- a/internal/tui/update_settings.go
+++ b/internal/tui/update_settings.go
@@ -84,11 +84,12 @@ func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if key.Matches(msg, m.keys.Settings.Browse) {
 		settingKey := m.getCurrentSettingKey()
 		if settingKey == "default_download_dir" {
-			m.SettingsFileBrowsing = true
-			m.filepickerOriginalPath = m.Settings.General.DefaultDownloadDir
-			m.state = FilePickerState
-			m.filepicker = newFilepicker(m.filepickerOriginalPath)
-			return m, m.filepicker.Init()
+			originalPath := m.Settings.General.DefaultDownloadDir
+			browseDir := originalPath
+			if browseDir == "" {
+				browseDir = m.PWD
+			}
+			return m, m.openDirectoryPicker(FilePickerOriginSettings, originalPath, browseDir)
 		}
 		return m, nil
 	}

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -3,10 +3,12 @@ package tui
 import (
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/textinput"
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
@@ -19,6 +21,27 @@ import (
 )
 
 var errTest = errors.New("test error")
+
+func newInputModels() []textinput.Model {
+	inputs := []textinput.Model{textinput.New(), textinput.New(), textinput.New(), textinput.New()}
+	for i := range inputs {
+		inputs[i].Prompt = ""
+	}
+	return inputs
+}
+
+func unwrapRootModel(t *testing.T, model tea.Model) RootModel {
+	t.Helper()
+	switch v := model.(type) {
+	case RootModel:
+		return v
+	case *RootModel:
+		return *v
+	default:
+		t.Fatalf("unexpected tea.Model type %T", model)
+		return RootModel{}
+	}
+}
 
 func TestUpdate_ResumeResultSetsResuming(t *testing.T) {
 	m := RootModel{
@@ -660,7 +683,7 @@ func TestQuitConfirm_TabWrapsFromNoToYes(t *testing.T) {
 	m := newQuitConfirmModel()
 	m.quitConfirmFocused = 1
 	updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
-	m2 := updated.(RootModel)
+	m2 := unwrapRootModel(t, updated)
 	if m2.quitConfirmFocused != 0 {
 		t.Fatal("expected tab on Nope to wrap back to Yep!")
 	}
@@ -868,18 +891,10 @@ func TestUpdate_RefreshShortcut(t *testing.T) {
 }
 
 func TestUpdate_InputStatePasteRoutesToFocusedField(t *testing.T) {
-	makeInputs := func() []textinput.Model {
-		in := []textinput.Model{textinput.New(), textinput.New(), textinput.New(), textinput.New()}
-		for i := range in {
-			in[i].Prompt = ""
-		}
-		return in
-	}
-
 	m := RootModel{
 		state:        InputState,
 		focusedInput: 0,
-		inputs:       makeInputs(),
+		inputs:       newInputModels(),
 	}
 	m.inputs[0].Focus()
 
@@ -908,6 +923,114 @@ func TestUpdate_InputStatePasteRoutesToFocusedField(t *testing.T) {
 	m4 := updated.(RootModel)
 	if got := m4.inputs[2].Value(); got != "/tmp/downloads" {
 		t.Fatalf("extension path input paste = %q, want %q", got, "/tmp/downloads")
+	}
+}
+
+func TestUpdate_AddPathBrowseUsesCurrentPathAndEscReturnsToInput(t *testing.T) {
+	browseDir := t.TempDir()
+
+	m := RootModel{
+		state:        InputState,
+		focusedInput: 2,
+		inputs:       newInputModels(),
+		keys:         Keys,
+		PWD:          filepath.Dir(browseDir),
+		Settings:     config.DefaultSettings(),
+	}
+	m.inputs[2].SetValue(browseDir)
+	m.inputs[2].Focus()
+
+	updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	m2 := updated.(RootModel)
+
+	if got, want := m2.state, FilePickerState; got != want {
+		t.Fatalf("state = %v, want %v", got, want)
+	}
+	if got, want := m2.filepickerOrigin, FilePickerOriginAdd; got != want {
+		t.Fatalf("filepickerOrigin = %v, want %v", got, want)
+	}
+	if got, want := m2.filepicker.CurrentDirectory, browseDir; got != want {
+		t.Fatalf("current directory = %q, want %q", got, want)
+	}
+
+	updated, _ = m2.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	m3 := unwrapRootModel(t, updated)
+
+	if got, want := m3.state, InputState; got != want {
+		t.Fatalf("state after esc = %v, want %v", got, want)
+	}
+	if got := m3.filepickerOrigin; got != FilePickerOriginNone {
+		t.Fatalf("filepickerOrigin after esc = %v, want none", got)
+	}
+	if got, want := m3.focusedInput, 2; got != want {
+		t.Fatalf("focusedInput after esc = %d, want %d", got, want)
+	}
+	if got, want := m3.inputs[2].Value(), browseDir; got != want {
+		t.Fatalf("path input after esc = %q, want %q", got, want)
+	}
+}
+
+func TestUpdate_FilePickerUseDirReturnsToAddInput(t *testing.T) {
+	browseDir := t.TempDir()
+
+	m := RootModel{
+		state:            FilePickerState,
+		focusedInput:     2,
+		inputs:           newInputModels(),
+		keys:             Keys,
+		Settings:         config.DefaultSettings(),
+		filepicker:       newFilepicker(browseDir),
+		filepickerOrigin: FilePickerOriginAdd,
+	}
+	m.filepicker.CurrentDirectory = browseDir
+
+	updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m2 := unwrapRootModel(t, updated)
+
+	if got, want := m2.state, InputState; got != want {
+		t.Fatalf("state after use dir = %v, want %v", got, want)
+	}
+	if got, want := m2.inputs[2].Value(), browseDir; got != want {
+		t.Fatalf("path input after use dir = %q, want %q", got, want)
+	}
+	if got, want := m2.focusedInput, 2; got != want {
+		t.Fatalf("focusedInput after use dir = %d, want %d", got, want)
+	}
+}
+
+func TestNewFilepickerEscIsCancelOnly(t *testing.T) {
+	fp := newFilepicker(t.TempDir())
+	esc := tea.KeyPressMsg{Code: tea.KeyEscape}
+
+	if key.Matches(esc, fp.KeyMap.Back) {
+		t.Fatal("expected esc not to match filepicker back key")
+	}
+}
+
+func TestUpdate_FilePickerLeftAtRootStaysOpen(t *testing.T) {
+	rootDir := string(os.PathSeparator)
+	if volume := filepath.VolumeName(t.TempDir()); volume != "" {
+		rootDir = volume + string(os.PathSeparator)
+	}
+
+	m := RootModel{
+		state:            FilePickerState,
+		inputs:           newInputModels(),
+		keys:             Keys,
+		Settings:         config.DefaultSettings(),
+		filepicker:       newFilepicker(rootDir),
+		filepickerOrigin: FilePickerOriginAdd,
+	}
+	m.filepicker.CurrentDirectory = rootDir
+
+	updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyLeft})
+	m2 := unwrapRootModel(t, updated)
+
+	if got, want := m2.state, FilePickerState; got != want {
+		t.Fatalf("state after left at root = %v, want %v", got, want)
+	}
+	if got, want := filepath.Clean(m2.filepicker.CurrentDirectory), filepath.Clean(rootDir); got != want {
+		t.Fatalf("current directory after left at root = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces three independent boolean browsing flags (`SettingsFileBrowsing`, `ExtensionFileBrowsing`, `catMgrFileBrowsing`) with a single `FilePickerOrigin` enum, adds a centralised `openDirectoryPicker` helper, and ensures `focusInput(2)` is called on picker return — fixing the root cause of the \"stuck in file picker\" bug. New tests cover open, cancel, confirm, and root-directory edge cases.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all remaining findings are minor style suggestions with no correctness impact.

The bug fix is well-targeted: the enum refactor eliminates the flag-management scatter, and adding focusInput(2) on picker dismissal directly addresses the stuck-input regression. Both open code paths and cancel paths are handled symmetrically. The only findings are a P2 implicit default case and a P2 test naming inconsistency — neither affects runtime behaviour.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/tui/helpers.go | Replaces three boolean browsing flags with a FilePickerOrigin switch; adds openDirectoryPicker helper to centralise setup. Logic is correct; FilePickerOriginAdd handled implicitly by default. |
| internal/tui/model.go | Introduces FilePickerOrigin enum and filepickerOrigin field; removes SettingsFileBrowsing, ExtensionFileBrowsing, and catMgrFileBrowsing booleans. Clean structural improvement. |
| internal/tui/update_filepicker.go | Cancel handler migrated to origin-based switch with proper state restoration for all origins including the new default (InputState) path. Correct. |
| internal/tui/update_input.go | Tab on input[2] now calls openDirectoryPicker with FilePickerOriginAdd and preserves the original path for cancel restoration. Fixes the stuck-in-picker regression. |
| internal/tui/update_settings.go | Browse shortcut delegates to openDirectoryPicker(FilePickerOriginSettings). Removes SettingsFileBrowsing flag usage. No issues. |
| internal/tui/update_category.go | Tab on path field delegates to openDirectoryPicker(FilePickerOriginCategory). Removes catMgrFileBrowsing flag usage. No issues. |
| internal/tui/update_test.go | New tests cover the browse-open, esc-cancel, enter-confirm, root-dir-stay-open flows; uses unwrapRootModel helper. Test name TestUpdate_FilePickerUseDirReturnsToAddInput misleadingly uses Enter key instead of the UseDir (.) key. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[InputState / SettingsState / ExtensionState / CategoryState] -->|Tab / Browse key| B[openDirectoryPicker\nsets filepickerOrigin + state=FilePickerState]
    B --> C{FilePickerState}
    C -->|UseDir / Enter selects path| D[handleFilePickerSelection]
    C -->|Escape / Cancel| E[updateFilePicker cancel switch]
    D --> F{filepickerOrigin}
    E --> F
    F -->|OriginSettings| G[SettingsState\nset DefaultDownloadDir]
    F -->|OriginExtension| H[ExtensionConfirmationState\nset inputs2 + focusInput 2]
    F -->|OriginCategory| I[CategoryManagerState\nset catMgrInputs3 + focus]
    F -->|OriginAdd / default| J[InputState\nset inputs2 + focusInput 2]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/tui/helpers.go
Line: 92-98

Comment:
**`FilePickerOriginAdd` silently handled by `default`**

`FilePickerOriginAdd` is defined in the enum but never explicitly cased in this switch (or in the cancel switch in `update_filepicker.go`). It currently falls through to `default`, which is correct, but it means adding a new origin in the future could accidentally inherit the "go to InputState" behaviour without any compile-time signal. An explicit case makes the intent clear and makes the switch exhaustive for all declared origins.

```suggestion
	case FilePickerOriginAdd:
		m.inputs[2].SetValue(path)
		m.focusInput(2)
		m.filepickerOrigin = FilePickerOriginNone
		m.state = InputState
		return m, nil
	default:
		m.inputs[2].SetValue(path)
		m.focusInput(2)
		m.filepickerOrigin = FilePickerOriginNone
		m.state = InputState
		return m, nil
	}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/tui/update_test.go
Line: 956-990

Comment:
**Test name says "UseDir" but tests `Enter`, not the `UseDir` (`.`) key**

The `UseDir` key binding maps to `.` (period) and explicitly selects the current directory via `handleFilePickerSelection`. `Enter` is passed to the underlying filepicker component and relies on `DidSelectFile` returning true — a different code path. Naming the test `UseDirReturnsToAddInput` while sending `KeyEnter` is misleading; consider renaming it to `TestUpdate_FilePickerEnterConfirmsDirReturnsToAddInput` or testing the actual `.` key press to match the name.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tui): Fixed a bug that caused tui to..."](https://github.com/surgedm/surge/commit/bcb1f5c8a81e67267bdfeb807ce0e1a5a2c6f4eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28952224)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->