### PR TITLE
feat: add GitHub Sponsors link to release footer

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,6 +22,7 @@ release:
   footer: |
     ---
     **Enjoying Surge?** Consider supporting the project to keep it blazing fast!
+    - [GitHub Sponsors](https://github.com/sponsors/SurgeDM)
     - [Buy Me a Coffee](https://buymeacoffee.com/surge.downloader)
     - Release automation powered by [GoReleaser Pro](https://goreleaser.com/pro/)
   extra_files:


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a GitHub Sponsors link (`https://github.com/sponsors/SurgeDM`) to the GoReleaser release footer, alongside the existing Buy Me a Coffee link. The change is minimal and the sponsor URL is consistent with the `SurgeDM` org name already used throughout the config.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely a cosmetic/copy change to the release footer.

Single-line addition to a markdown footer template; no logic, no code paths, no security implications.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .goreleaser.yaml | Adds a GitHub Sponsors link to the release footer, consistent with existing sponsor links and `SurgeDM` org references in the file. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add GitHub Sponsors link to releas..."](https://github.com/surgedm/surge/commit/c0addf299ca4d1a374eb103bfd87f94d2d8caae7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28989249)</sub>

<!-- /greptile_comment -->