### PR TITLE
chore: add FIREFOX_EXTENSION_ID to extension workflow environment variables

### DIFF
--- a/.github/workflows/extension.yml
+++ b/.github/workflows/extension.yml
@@ -68,6 +68,7 @@ jobs:
         env:
           FIREFOX_JWT_ISSUER: ${{ secrets.AMO_JWT_ISSUER }}
           FIREFOX_JWT_SECRET: ${{ secrets.AMO_JWT_SECRET }}
+          FIREFOX_EXTENSION_ID: surge@surge-downloader.com
 
   release:
     name: Create Release


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `FIREFOX_EXTENSION_ID: surge@surge-downloader.com` to the `Submit to AMO` step's environment variables in the extension workflow. Firefox extension IDs are public identifiers (visible in the manifest and on AMO), so hardcoding the value directly is appropriate here rather than using a secret.

<h3>Confidence Score: 5/5</h3>

Safe to merge — small, focused change with no correctness or security concerns.

The change is minimal and correct: it adds the required extension ID env var for wxt's AMO submission. The value is a public identifier, not a secret, so inline hardcoding is fine.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/extension.yml | Adds FIREFOX_EXTENSION_ID as a plaintext env var to the AMO submission step; value is a public extension identifier, not sensitive |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add FIREFOX\_EXTENSION\_ID to exten..."](https://github.com/surgedm/surge/commit/c8027ff32c365af4082e47622900c26bca5b398a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28991708)</sub>

<!-- /greptile_comment -->