### PR TITLE
fix: implement sequential fallback for failed probe requests to allow download processing

### DIFF
--- a/cmd/http_handler_test.go
+++ b/cmd/http_handler_test.go
@@ -370,11 +370,8 @@ func TestHandleDownload_EnqueueError_RecordsPreflightError(t *testing.T) {
 		GlobalProgressCh = nil
 	})
 
-	// Create a lifecycle manager whose addFunc should never be reached
-	// because the probe will fail first (invalid URL scheme).
 	GlobalLifecycle = processing.NewLifecycleManager(func(string, string, string, []string, map[string]string, bool, int64, bool) (string, error) {
-		t.Fatal("addFunc should not be called when probe fails")
-		return "", nil
+		return "", errors.New("simulated enqueue error")
 	}, nil)
 
 	svc := core.NewLocalDownloadService(nil)
@@ -383,8 +380,7 @@ func TestHandleDownload_EnqueueError_RecordsPreflightError(t *testing.T) {
 		_ = svc.Shutdown()
 	})
 
-	// Use a URL with an invalid scheme so ProbeServer fails immediately.
-	body := `{"url": "badscheme://example.com/file.bin", "path": "/tmp", "skip_approval": true}`
+	body := `{"url": "http://example.com/file.bin", "path": "/tmp", "skip_approval": true}`
 	req := httptest.NewRequest(http.MethodPost, "/download", bytes.NewBufferString(body))
 	rec := httptest.NewRecorder()
 
@@ -402,7 +398,7 @@ func TestHandleDownload_EnqueueError_RecordsPreflightError(t *testing.T) {
 
 	found := false
 	for _, entry := range list.Downloads {
-		if strings.Contains(entry.URL, "badscheme://example.com/file.bin") && entry.Status == "error" {
+		if strings.Contains(entry.URL, "http://example.com/file.bin") && entry.Status == "error" {
 			found = true
 			break
 		}

--- a/cmd/http_handler_test.go
+++ b/cmd/http_handler_test.go
@@ -404,7 +404,7 @@ func TestHandleDownload_EnqueueError_RecordsPreflightError(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Fatal("expected errored download entry in master list after probe failure via HTTP API")
+		t.Fatal("expected errored download entry in master list after enqueue failure via HTTP API")
 	}
 }
 

--- a/internal/download/fallback_test.go
+++ b/internal/download/fallback_test.go
@@ -33,7 +33,7 @@ func TestTUIDownload_ConcurrentFails_FallsBackToSingle(t *testing.T) {
 		t.Logf("Mock server: received normal request, succeeding")
 		w.Header().Set("Content-Length", "5")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("hello"))
+		_, _ = w.Write([]byte("hello"))
 	}))
 	defer server.Close()
 
@@ -46,7 +46,7 @@ func TestTUIDownload_ConcurrentFails_FallsBackToSingle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create surge file: %v", err)
 	}
-	f.Close()
+	_ = f.Close()
 
 	cfg := &types.DownloadConfig{
 		ID:            "test-concurrent-fail",
@@ -109,7 +109,7 @@ func TestTUIDownload_ProbeFails_FallsBackToSingleGracefully(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Length", "5")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("world"))
+		_, _ = w.Write([]byte("world"))
 	}))
 	defer server.Close()
 
@@ -121,7 +121,7 @@ func TestTUIDownload_ProbeFails_FallsBackToSingleGracefully(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create surge file: %v", err)
 	}
-	f.Close()
+	_ = f.Close()
 
 	cfg := &types.DownloadConfig{
 		ID:            "test-probe-fail",
@@ -173,7 +173,7 @@ func TestTUIDownload_ContextCanceled_AbortsFallback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create surge file: %v", err)
 	}
-	f.Close()
+	_ = f.Close()
 
 	cfg := &types.DownloadConfig{
 		ID:            "test-cancel",

--- a/internal/download/fallback_test.go
+++ b/internal/download/fallback_test.go
@@ -178,6 +178,8 @@ func TestTUIDownload_ContextCanceled_AbortsFallback(t *testing.T) {
 	cfg := &types.DownloadConfig{
 		ID:            "test-cancel",
 		URL:           server.URL,
+		OutputPath:    tmpDir,
+		Filename:      "file.txt",
 		DestPath:      outPath,
 		TotalSize:     5,
 		SupportsRange: true,
@@ -191,7 +193,7 @@ func TestTUIDownload_ContextCanceled_AbortsFallback(t *testing.T) {
 	cancel()
 
 	err = TUIDownload(ctx, cfg)
-	if err == nil || !strings.Contains(err.Error(), "context canceled") {
-		t.Fatalf("expected context canceled error, got: %v", err)
+	if err != nil {
+		t.Fatalf("expected nil (clean cancellation), got: %v", err)
 	}
 }

--- a/internal/download/fallback_test.go
+++ b/internal/download/fallback_test.go
@@ -1,0 +1,197 @@
+package download
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/SurgeDM/Surge/internal/engine/state"
+	"github.com/SurgeDM/Surge/internal/engine/types"
+)
+
+func setupState(t *testing.T) {
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, fmt.Sprintf("%s-surge.db", t.Name()))
+	state.Configure(dbPath)
+}
+
+func TestTUIDownload_ConcurrentFails_FallsBackToSingle(t *testing.T) {
+	setupState(t)
+
+	// Create a mock server that fails when range requests are made, but succeeds on normal GET
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Range") != "" {
+			t.Logf("Mock server: received range request %q, failing", r.Header.Get("Range"))
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		t.Logf("Mock server: received normal request, succeeding")
+		w.Header().Set("Content-Length", "5")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("hello"))
+	}))
+	defer server.Close()
+
+	tmpDir := t.TempDir()
+	outPath := filepath.Join(tmpDir, "file.txt")
+	surgePath := outPath + types.IncompleteSuffix
+
+	// Create empty .surge file expected by processors
+	f, err := os.Create(surgePath)
+	if err != nil {
+		t.Fatalf("failed to create surge file: %v", err)
+	}
+	f.Close()
+
+	cfg := &types.DownloadConfig{
+		ID:            "test-concurrent-fail",
+		URL:           server.URL,
+		OutputPath:    tmpDir,
+		Filename:      "file.txt",
+		DestPath:      outPath,
+		TotalSize:     5,
+		SupportsRange: true, // Force concurrent to start
+		Runtime: &types.RuntimeConfig{
+			WorkerBufferSize:      1024,
+			MinChunkSize:          1,
+			MaxConnectionsPerHost: 2,
+			MaxTaskRetries:        1,
+		},
+		State: types.NewProgressState("test-concurrent-fail", 5),
+	}
+
+	// Pre-fill some state to verify it gets cleared
+	cfg.State.Downloaded.Store(1)
+	cfg.State.InitBitmap(5, 1)
+	cfg.State.UpdateChunkStatus(0, 1, types.ChunkDownloading)
+
+	err = TUIDownload(context.Background(), cfg)
+	if err != nil && !strings.Contains(err.Error(), "context canceled") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify state reset happened
+	if cfg.State.Downloaded.Load() != 5 {
+		t.Errorf("expected final downloaded 5, got %d", cfg.State.Downloaded.Load())
+	}
+	if cfg.State.ChunkBitmap != nil {
+		t.Error("expected ChunkBitmap to be nil after successful single-threaded download")
+	}
+
+	// Make sure the single downloader successfully ran and populated the incomplete file
+	info, err := os.Stat(surgePath)
+	if err != nil {
+		t.Fatalf("failed to stat output file: %v", err)
+	}
+	t.Logf("Final file size: %d", info.Size())
+
+	content, err := os.ReadFile(surgePath)
+	if err != nil {
+		t.Fatalf("failed to read output file: %v", err)
+	}
+	t.Logf("Final file content: %q", string(content))
+	if string(content) != "hello" {
+		t.Fatalf("expected 'hello', got %q (len=%d)", string(content), len(content))
+	}
+}
+
+func TestTUIDownload_ProbeFails_FallsBackToSingleGracefully(t *testing.T) {
+	setupState(t)
+
+	// If probe failed, SupportsRange will be false and TotalSize will be 0.
+	// We want to ensure TUIDownload gracefully goes straight to single-threaded downloader
+	// and still downloads successfully.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "5")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("world"))
+	}))
+	defer server.Close()
+
+	tmpDir := t.TempDir()
+	outPath := filepath.Join(tmpDir, "file.txt")
+	surgePath := outPath + types.IncompleteSuffix
+
+	f, err := os.Create(surgePath)
+	if err != nil {
+		t.Fatalf("failed to create surge file: %v", err)
+	}
+	f.Close()
+
+	cfg := &types.DownloadConfig{
+		ID:            "test-probe-fail",
+		URL:           server.URL,
+		OutputPath:    tmpDir,
+		Filename:      "file.txt",
+		DestPath:      outPath,
+		TotalSize:     0,     // Simulates failed probe
+		SupportsRange: false, // Simulates failed probe
+		Runtime:       &types.RuntimeConfig{},
+		State:         types.NewProgressState("test-probe-fail", 0),
+	}
+
+	err = TUIDownload(context.Background(), cfg)
+	if err != nil && !strings.Contains(err.Error(), "context canceled") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	content, err := os.ReadFile(surgePath)
+	if err != nil {
+		t.Fatalf("failed to read output file: %v", err)
+	}
+	if string(content) != "world" {
+		t.Fatalf("expected 'world', got %q", string(content))
+	}
+}
+
+func TestTUIDownload_ContextCanceled_AbortsFallback(t *testing.T) {
+	setupState(t)
+
+	// Mock server that hangs on the first request to allow time for cancellation
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Range") != "" {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		// Single downloader request: block until context canceled
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	tmpDir := t.TempDir()
+	outPath := filepath.Join(tmpDir, "file.txt")
+	surgePath := outPath + types.IncompleteSuffix
+
+	f, err := os.Create(surgePath)
+	if err != nil {
+		t.Fatalf("failed to create surge file: %v", err)
+	}
+	f.Close()
+
+	cfg := &types.DownloadConfig{
+		ID:            "test-cancel",
+		URL:           server.URL,
+		DestPath:      outPath,
+		TotalSize:     5,
+		SupportsRange: true,
+		Runtime: &types.RuntimeConfig{
+			MaxTaskRetries: 1,
+		},
+		State: types.NewProgressState("test-cancel", 5),
+	}
+
+	// Cancel before single downloader starts
+	cancel()
+
+	err = TUIDownload(ctx, cfg)
+	if err == nil || !strings.Contains(err.Error(), "context canceled") {
+		t.Fatalf("expected context canceled error, got: %v", err)
+	}
+}

--- a/internal/download/manager.go
+++ b/internal/download/manager.go
@@ -177,6 +177,29 @@ func TUIDownload(ctx context.Context, cfg *types.DownloadConfig) error {
 		d.Headers = cfg.Headers // Forward custom headers from browser extension
 		utils.Debug("Calling Download with mirrors: %v", mirrors)
 		downloadErr = d.Download(ctx, cfg.URL, mirrors, activeMirrors, finalDestPath, cfg.TotalSize)
+
+		if downloadErr != nil && !errors.Is(downloadErr, context.Canceled) && !errors.Is(downloadErr, types.ErrPaused) {
+			utils.Debug("Concurrent download failed: %v. Falling back to single-threaded downloader", downloadErr)
+			
+			// Reset state before fallback
+			if cfg.State != nil {
+				cfg.State.ChunkBitmap = nil
+				cfg.State.ChunkProgress = nil
+				cfg.State.Downloaded.Store(0)
+				cfg.State.VerifiedProgress.Store(0)
+				cfg.State.ActiveWorkers.Store(0)
+			}
+			
+			// Clear any partially written data
+			workingPath := finalDestPath + types.IncompleteSuffix
+			if f, err := os.OpenFile(workingPath, os.O_WRONLY|os.O_TRUNC, 0); err == nil {
+				f.Close()
+			}
+			
+			dSingle := single.NewSingleDownloader(cfg.ID, cfg.ProgressCh, cfg.State, cfg.Runtime)
+			dSingle.Headers = cfg.Headers
+			downloadErr = dSingle.Download(ctx, cfg.URL, finalDestPath, cfg.TotalSize, finalFilename)
+		}
 	} else {
 		// Fallback to single-threaded downloader
 		utils.Debug("Using single-threaded downloader")

--- a/internal/download/manager.go
+++ b/internal/download/manager.go
@@ -180,7 +180,7 @@ func TUIDownload(ctx context.Context, cfg *types.DownloadConfig) error {
 
 		if downloadErr != nil && !errors.Is(downloadErr, context.Canceled) && !errors.Is(downloadErr, types.ErrPaused) {
 			utils.Debug("Concurrent download failed: %v. Falling back to single-threaded downloader", downloadErr)
-			
+
 			// Reset state before fallback
 			if cfg.State != nil {
 				cfg.State.ChunkBitmap = nil
@@ -189,13 +189,13 @@ func TUIDownload(ctx context.Context, cfg *types.DownloadConfig) error {
 				cfg.State.VerifiedProgress.Store(0)
 				cfg.State.ActiveWorkers.Store(0)
 			}
-			
+
 			// Clear any partially written data
 			workingPath := finalDestPath + types.IncompleteSuffix
 			if f, err := os.OpenFile(workingPath, os.O_WRONLY|os.O_TRUNC, 0); err == nil {
 				f.Close()
 			}
-			
+
 			dSingle := single.NewSingleDownloader(cfg.ID, cfg.ProgressCh, cfg.State, cfg.Runtime)
 			dSingle.Headers = cfg.Headers
 			downloadErr = dSingle.Download(ctx, cfg.URL, finalDestPath, cfg.TotalSize, finalFilename)

--- a/internal/download/manager.go
+++ b/internal/download/manager.go
@@ -193,7 +193,9 @@ func TUIDownload(ctx context.Context, cfg *types.DownloadConfig) error {
 			// Clear any partially written data
 			workingPath := finalDestPath + types.IncompleteSuffix
 			if f, err := os.OpenFile(workingPath, os.O_WRONLY|os.O_TRUNC, 0); err == nil {
-				f.Close()
+				if closeErr := f.Close(); closeErr != nil {
+					utils.Debug("Failed to close truncated working file %s: %v", workingPath, closeErr)
+				}
 			}
 
 			dSingle := single.NewSingleDownloader(cfg.ID, cfg.ProgressCh, cfg.State, cfg.Runtime)

--- a/internal/engine/concurrent/downloader.go
+++ b/internal/engine/concurrent/downloader.go
@@ -505,6 +505,8 @@ func (d *ConcurrentDownloader) Download(ctx context.Context, rawurl string, cand
 			defer wg.Done()
 			err := d.worker(downloadCtx, workerID, workerMirrors, outFile, queue, fileSize, client)
 			if err != nil && err != context.Canceled {
+				// Cancel ALL workers and helpers on first terminal error
+				cancel()
 				workerErrors <- err
 			}
 		}(i)

--- a/internal/processing/manager.go
+++ b/internal/processing/manager.go
@@ -254,10 +254,19 @@ func (mgr *LifecycleManager) enqueueResolved(ctx context.Context, req *DownloadR
 		defer func() { mgr.probeSem <- struct{}{} }()
 	}
 
-	probe, err := ProbeServerWithProxy(ctx, req.URL, req.Filename, req.Headers, settings.ToRuntimeConfig())
-	if err != nil {
-		utils.Debug("Lifecycle: Probe failed: %v\n", err)
-		return "", "", fmt.Errorf("probe failed: %w", err)
+	probe, probeErr := ProbeServerWithProxy(ctx, req.URL, req.Filename, req.Headers, settings.ToRuntimeConfig())
+	if probeErr != nil {
+		utils.Debug("Lifecycle: Probe failed: %v — enqueueing with zero metadata (sequential fallback)\n", probeErr)
+		// Probe failures are non-fatal: the server may block probe requests but
+		// still serve the actual download (e.g. Overleaf returning 403 on a
+		// Range probe while the authenticated download flow succeeds). Fall back
+		// to a zero-value ProbeResult so the engine uses the single-threaded
+		// downloader instead of rejecting the request entirely.
+		probe = &ProbeResult{}
+		if req.Filename != "" {
+			probe.Filename = req.Filename
+			probe.DetectedFilename = req.Filename
+		}
 	}
 
 	isNameActive := mgr.buildIsNameActive()

--- a/internal/processing/probe_test.go
+++ b/internal/processing/probe_test.go
@@ -138,7 +138,7 @@ func TestProbeServer_RangedProbeRetryLogic(t *testing.T) {
 		// Second attempt (without Range) should succeed
 		w.Header().Set("Content-Length", "100")
 		w.WriteHeader(http.StatusOK)
-		w.Write(make([]byte, 100))
+		_, _ = w.Write(make([]byte, 100))
 	}))
 	defer server.Close()
 

--- a/internal/processing/probe_test.go
+++ b/internal/processing/probe_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -122,5 +123,52 @@ func TestProbeServer_ReadsBodyBeforeContextCancel(t *testing.T) {
 	}
 	if result.Filename != "delayed.txt" {
 		t.Errorf("Expected filename 'delayed.txt', got %q. The context might have been prematurely canceled.", result.Filename)
+	}
+}
+
+func TestProbeServer_RangedProbeRetryLogic(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		if r.Header.Get("Range") != "" {
+			// Simulate origin rejecting ranged probe
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		// Second attempt (without Range) should succeed
+		w.Header().Set("Content-Length", "100")
+		w.WriteHeader(http.StatusOK)
+		w.Write(make([]byte, 100))
+	}))
+	defer server.Close()
+
+	result, err := processing.ProbeServerWithProxy(context.Background(), server.URL, "", nil, nil)
+	if err != nil {
+		t.Fatalf("ProbeServerWithProxy() failed: %v", err)
+	}
+
+	if attempts.Load() != 2 {
+		t.Errorf("Expected 2 attempts, got %d", attempts.Load())
+	}
+	if result.SupportsRange {
+		t.Error("Expected SupportsRange to be false after retry without Range")
+	}
+	if result.FileSize != 100 {
+		t.Errorf("Expected FileSize 100, got %d", result.FileSize)
+	}
+}
+
+func TestProbeServer_HandlesServerErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	_, err := processing.ProbeServerWithProxy(context.Background(), server.URL, "", nil, nil)
+	if err == nil {
+		t.Fatal("Expected error for 500 status code, got nil")
+	}
+	if !strings.Contains(err.Error(), "unexpected status code: 500") {
+		t.Errorf("Expected error to contain 'unexpected status code: 500', got: %v", err)
 	}
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a sequential fallback in `enqueueResolved` so that a failed `ProbeServerWithProxy` call (e.g. a server that rejects range-probe requests with 403) no longer blocks the download from being queued — the engine falls back to the single-threaded downloader using a zero-value `ProbeResult`. Accompanying tests cover the concurrent→single fallback in `TUIDownload`, the zero-metadata probe-fail path, and context cancellation cleanup.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the weak error assertions in the new tests and confirming the ctx.Err() pre-check is intentionally deferred to the loop guard.

The core fallback logic is sound and the previously flagged broken test (TestTUIDownload_ContextCanceled_AbortsFallback) has been corrected. The remaining concern is the weak !strings.Contains(err.Error(), "context canceled") gate in two tests, which could silently mask regressions in the fallback path — a P2 issue that keeps the score at 4.

internal/download/fallback_test.go — the error assertion pattern at lines 74 and 139

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/processing/manager.go | Adds sequential fallback on probe failure (lines 258–270); ctx.Err() is not checked before entering the fallback branch so a cancelled context still creates a zero-metadata ProbeResult, relying on the loop guard at line 275 to abort later |
| internal/download/fallback_test.go | New test file with three TUIDownload scenarios; TestTUIDownload_ContextCanceled_AbortsFallback is now correctly structured with OutputPath/Filename and a nil assertion, but two other tests use a weak error check that silently accepts context.Canceled |
| internal/processing/probe_test.go | Adds TestProbeServer_HandlesServerErrors verifying 500 responses return an error; straightforward and correct |
| cmd/http_handler_test.go | Adds integration tests for skip_approval lifecycle path and error recording on enqueue/publish failures; tests look structurally sound |
| internal/engine/concurrent/downloader.go | No functional regressions visible; supports the zero-metadata (TotalSize=0) case by routing through single-threaded path in the caller before this file is reached |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/download/fallback_test.go
Line: 74-76

Comment:
**Weak error assertion masks unexpected cancellations**

The pattern `if err != nil && !strings.Contains(err.Error(), "context canceled")` silently accepts a `context.Canceled` return as success. If the single-threaded fallback path spuriously returns a cancellation error (e.g., due to a race in the fallback state-reset), this test would pass without ever verifying that the download actually completed. The content check on line 98 acts as a secondary safety net, but the error gate itself should be a simple `if err != nil`.

```suggestion
	if err != nil {
		t.Fatalf("unexpected error: %v", err)
	}
```

The same pattern applies to `TestTUIDownload_ProbeFails_FallsBackToSingleGracefully` at line 139.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["test: update fallback cancellation test ..."](https://github.com/surgedm/surge/commit/88f9c3a287cc30910523f20addff74677939dca0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28996436)</sub>

<!-- /greptile_comment -->