### PR TITLE
feat: implement fallback to single-threaded downloader on probe failure and concurrent download errors

### DIFF
--- a/internal/download/manager.go
+++ b/internal/download/manager.go
@@ -144,7 +144,9 @@ func TUIDownload(ctx context.Context, cfg *types.DownloadConfig) error {
 
 	// Choose downloader based on probe results
 	var downloadErr error
-	if cfg.SupportsRange && cfg.TotalSize > 0 {
+	useConcurrent := cfg.SupportsRange && cfg.TotalSize > 0
+
+	if useConcurrent {
 		utils.Debug("Using concurrent downloader")
 
 		// We probe all candidate mirrors (mirrors) to filter out invalid ones
@@ -177,7 +179,16 @@ func TUIDownload(ctx context.Context, cfg *types.DownloadConfig) error {
 		d.Headers = cfg.Headers // Forward custom headers from browser extension
 		utils.Debug("Calling Download with mirrors: %v", mirrors)
 		downloadErr = d.Download(ctx, cfg.URL, mirrors, activeMirrors, finalDestPath, cfg.TotalSize)
-	} else {
+
+		// Determine if we should attempt a fallback to single-threaded mode.
+		// We fallback if concurrent failed, but it wasn't a clean pause or external cancellation.
+		if downloadErr != nil && !errors.Is(downloadErr, types.ErrPaused) && !errors.Is(downloadErr, context.Canceled) {
+			utils.Debug("Concurrent download failed: %v — falling back to single-threaded", downloadErr)
+			useConcurrent = false // Trigger sequential block below
+		}
+	}
+
+	if !useConcurrent {
 		// Fallback to single-threaded downloader
 		utils.Debug("Using single-threaded downloader")
 		d := single.NewSingleDownloader(cfg.ID, cfg.ProgressCh, cfg.State, cfg.Runtime)

--- a/internal/processing/manager.go
+++ b/internal/processing/manager.go
@@ -254,10 +254,19 @@ func (mgr *LifecycleManager) enqueueResolved(ctx context.Context, req *DownloadR
 		defer func() { mgr.probeSem <- struct{}{} }()
 	}
 
-	probe, err := ProbeServerWithProxy(ctx, req.URL, req.Filename, req.Headers, settings.ToRuntimeConfig())
-	if err != nil {
-		utils.Debug("Lifecycle: Probe failed: %v\n", err)
-		return "", "", fmt.Errorf("probe failed: %w", err)
+	probe, probeErr := ProbeServerWithProxy(ctx, req.URL, req.Filename, req.Headers, settings.ToRuntimeConfig())
+	if probeErr != nil {
+		utils.Debug("Lifecycle: Probe failed: %v — enqueueing with zero metadata (sequential fallback)\n", probeErr)
+		// Probe failures are non-fatal: the server may block probe requests but
+		// still serve the actual download (e.g. Overleaf returning 403 on a
+		// Range probe while the authenticated download flow succeeds). Fall back
+		// to a zero-value ProbeResult so the engine uses the single-threaded
+		// downloader instead of rejecting the request entirely.
+		probe = &ProbeResult{}
+		if req.Filename != "" {
+			probe.Filename = req.Filename
+			probe.DetectedFilename = req.Filename
+		}
 	}
 
 	isNameActive := mgr.buildIsNameActive()

--- a/scratch/investigate_probe.go
+++ b/scratch/investigate_probe.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"github.com/SurgeDM/Surge/internal/processing"
+	"github.com/SurgeDM/Surge/internal/config"
+)
+
+func main() {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Printf("Probe request: %s %s Range: %s\n", r.Method, r.URL, r.Header.Get("Range"))
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	runCfg := config.DefaultSettings().ToRuntimeConfig()
+	
+	fmt.Println("Probing server that returns 403...")
+	result, err := processing.ProbeServerWithProxy(ctx, server.URL, "test.bin", nil, runCfg)
+	
+	if err != nil {
+		fmt.Printf("Probe failed as expected: %v\n", err)
+	} else {
+		fmt.Printf("Probe succeeded surprisingly! Result: %+v\n", result)
+	}
+    
+    if result == nil {
+        fmt.Println("Result is nil on error.")
+    }
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two resilience layers: `enqueueResolved` now treats a failed probe as non-fatal (falling back to single-threaded mode), and `TUIDownload` retries a failed concurrent download with the single-threaded downloader. The probe-fallback change is clean, but the concurrent-to-single fallback in `TUIDownload` has two issues worth addressing before merge:

- Shared `cfg.State` and the `.surge` partial file from the concurrent attempt are carried unchanged into the single-threaded downloader, risking corrupted or double-counted downloads.
- `context.DeadlineExceeded` is not excluded from the fallback guard, so a deadline-expired download triggers an unnecessary (and immediately-failing) single-threaded retry.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is due to potential silent download corruption when the concurrent-to-single fallback path is taken.

Two P1 findings on the concurrent-to-single fallback path: shared mutable state/partial files and missing `context.DeadlineExceeded` guard. The probe-failure path in processing/manager.go is clean. The scratch file should be removed before merge.

`internal/download/manager.go` — the fallback block at lines 191–197 needs state cleanup and the guard at line 185 needs to cover `context.DeadlineExceeded`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/download/manager.go | Refactors concurrent/single-threaded downloader selection into two separate `if` blocks to allow fallback; shares `cfg.State` and `finalDestPath` across the two downloaders without cleanup, risking state pollution and partial-file conflicts on fallback; also missing `context.DeadlineExceeded` guard. |
| internal/processing/manager.go | Makes probe failures non-fatal by substituting a zero-value `ProbeResult` so the engine falls back to single-threaded mode; context-cancellation during probe is still caught by the loop guard; approach is sound but context-canceled probe errors are silently swallowed rather than propagated. |
| scratch/investigate_probe.go | Temporary debug investigation script using `net/http/httptest`; should not be committed alongside production changes. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/download/manager.go`, line 191-197 ([link](https://github.com/surgedm/surge/blob/2ed55728f2d3c02bf4397ccedc94da012cb43b83/internal/download/manager.go#L191-L197)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Shared state and partial file not reset before single-threaded fallback**

   When the concurrent downloader fails mid-download and this block executes, `cfg.State` has already been mutated (progress bytes, error flags, internal counters) and the `.surge` working file at `finalDestPath` likely contains partial multi-part data. The single-threaded downloader receives the same `cfg.State` and the same `finalDestPath`, so it may interpret leftover state as a resume offset, write to an already-populated partial file, or produce a silently corrupted download. Before handing off to the single-threaded downloader, the state should be reset and any partial file written by the concurrent downloader should be removed.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/download/manager.go
   Line: 191-197

   Comment:
   **Shared state and partial file not reset before single-threaded fallback**

   When the concurrent downloader fails mid-download and this block executes, `cfg.State` has already been mutated (progress bytes, error flags, internal counters) and the `.surge` working file at `finalDestPath` likely contains partial multi-part data. The single-threaded downloader receives the same `cfg.State` and the same `finalDestPath`, so it may interpret leftover state as a resume offset, write to an already-populated partial file, or produce a silently corrupted download. Before handing off to the single-threaded downloader, the state should be reset and any partial file written by the concurrent downloader should be removed.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/download/manager.go
Line: 191-197

Comment:
**Shared state and partial file not reset before single-threaded fallback**

When the concurrent downloader fails mid-download and this block executes, `cfg.State` has already been mutated (progress bytes, error flags, internal counters) and the `.surge` working file at `finalDestPath` likely contains partial multi-part data. The single-threaded downloader receives the same `cfg.State` and the same `finalDestPath`, so it may interpret leftover state as a resume offset, write to an already-populated partial file, or produce a silently corrupted download. Before handing off to the single-threaded downloader, the state should be reset and any partial file written by the concurrent downloader should be removed.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/download/manager.go
Line: 185-188

Comment:
**`context.DeadlineExceeded` not excluded from fallback trigger**

`errors.Is(downloadErr, context.Canceled)` returns `false` when the error wraps `context.DeadlineExceeded` — these are distinct sentinel values in Go's context package. A download cancelled because its deadline expired will bypass the guard, trigger the fallback, and launch a single-threaded attempt against a context that has already expired. The single-threaded download then fails immediately, wasting a retry cycle and producing a confusing error path.

```suggestion
		if downloadErr != nil && !errors.Is(downloadErr, types.ErrPaused) &&
			!errors.Is(downloadErr, context.Canceled) && !errors.Is(downloadErr, context.DeadlineExceeded) {
			utils.Debug("Concurrent download failed: %v — falling back to single-threaded", downloadErr)
			useConcurrent = false // reuse the single-threaded block rather than duplicating it inline
		}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: scratch/investigate_probe.go
Line: 1-34

Comment:
**Debug investigation script committed to repository**

This file uses `net/http/httptest` — a test-only standard-library package — inside a `scratch/` directory in what will become a shipped binary. It appears to be temporary investigation code written while developing the probe-fallback feature and should not be merged into `main`. The `scratch/` directory adds maintenance surface and would be built as part of `./...` targets.

**Rule Used:** What: Flag commits that bundle unnecessary changes... ([source](https://app.greptile.com/review/custom-context?memory=74a28159-60fc-4201-a661-331594ebaf90))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/download/manager.go
Line: 187

Comment:
**Comment restates code rather than explaining intent**

`// Trigger sequential block below` describes exactly what the assignment does, not why `useConcurrent = false` is the chosen mechanism or what constraints informed that design decision.

```suggestion
			useConcurrent = false // reuse the single-threaded block rather than duplicating it inline
```

**Rule Used:** What: Comments must explain *why* code exists, not... ([source](https://app.greptile.com/review/custom-context?memory=4e45ef13-32c2-4753-8060-a44ef767144d))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: implement fallback to single-threa..."](https://github.com/surgedm/surge/commit/2ed55728f2d3c02bf4397ccedc94da012cb43b83) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29008253)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Rule used - What: Flag commits that bundle unnecessary changes... ([source](https://app.greptile.com/review/custom-context?memory=74a28159-60fc-4201-a661-331594ebaf90))
- Rule used - What: Comments must explain *why* code exists, not... ([source](https://app.greptile.com/review/custom-context?memory=4e45ef13-32c2-4753-8060-a44ef767144d))

<!-- /greptile_comment -->