### PR TITLE
lint

### DIFF
--- a/.github/workflows/core-lint.yml
+++ b/.github/workflows/core-lint.yml
@@ -23,8 +23,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25.0'
+          go-version-file: go.mod
+          cache: false
+
       - name: golangci-lint
-        run: go run github.com/golangci/golangci-lint/cmd/golangci-lint@latest run
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.11
+          args: --timeout=5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,259 @@
+# golangci-lint v2 — Surge Download Manager
+# https://golangci-lint.run/docs/configuration/file/
+version: "2"
+
+run:
+  timeout: 5m
+  tests: true
+
+# ─────────────────────────────────────────────
+# FORMATTERS (v2: separate from linters)
+# ─────────────────────────────────────────────
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/SurgeDM/Surge
+
+# ─────────────────────────────────────────────
+# LINTERS
+# ─────────────────────────────────────────────
+linters:
+  default: none
+  enable:
+    # ── Correctness & Safety ─────────────────
+    - errcheck          # unchecked errors in write/read paths → silent corruption
+    - govet             # copies of sync.Mutex, shadowed vars, fieldalignment
+    - staticcheck       # SA* dead code, S* simplifications, QF* quick-fixes
+    - ineffassign       # assigned values never used
+    - unused            # unexported symbols never referenced (post surge-core extraction)
+    - unparam           # params always called with same value → dead flexibility
+    - makezero          # slice created with non-zero length then appended
+    - wastedassign      # assigned then immediately overwritten
+
+    # ── Concurrency (critical for worker pools) ──
+    - copyloopvar       # loop-var capture in goroutines (classic download-worker bug)
+    - noctx             # HTTP calls without context → goroutine leak on failed downloads
+    - bodyclose         # response body not closed → memory leak in concurrent fetcher
+    - contextcheck      # context not propagated through call chain
+    - fatcontext        # context.WithValue inside loops → alloc pressure
+
+    # ── Performance ──────────────────────────
+    - prealloc          # slices that can be pre-allocated (chunk assembly, buffer paths)
+    - perfsprint        # fmt.Sprintf → cheaper alternatives in hot paths
+    - mirror            # prefer strings.* over bytes.* conversions where free
+
+    # ── Dead Code ────────────────────────────
+    - exhaustive        # missing enum cases in switch → silently dead branches
+    - nilerr            # return nil where err != nil is ignored
+    - nilnil            # functions returning (nil, nil) — ambiguous contract
+
+    # ── Duplication & Complexity ─────────────
+    - dupl              # structurally similar blocks (chunk/worker logic)
+    - gocognit          # cognitive complexity — update/reconcile loop reasoning
+    - cyclop            # cyclomatic complexity
+    - nestif            # deeply nested ifs in state machines
+    - funlen            # oversized functions in view_dashboard_* files
+    - maintidx          # maintainability index — catches entropy in processing pipeline
+    - gocritic          # multi-check: hugeParam, sloppyLen, appendAssign, dupImport
+
+    # ── Binary / Dep hygiene ─────────────────
+    - depguard          # block heavy/banned imports
+    - gomodguard        # module-level allow/deny (keep surge-core lean)
+    - unparam           # see above — also signals unused injection points
+
+    # ── Security ─────────────────────────────
+    - gosec             # G115 int overflow in byte-offset arithmetic, G304 file paths
+
+    # ── Error handling ────────────────────────
+    - errorlint         # errors.Is/As usage — wrapping bugs
+    - nolintlint        # malformed or unnecessary nolint directives
+
+    # ── Style (kept minimal) ─────────────────
+    - misspell          # typos in comments/strings
+    - godot             # comment punctuation
+    - whitespace        # trailing newlines
+    - goconst           # repeated string → const candidate
+
+  settings:
+
+    # ── govet ────────────────────────────────
+    govet:
+      enable:
+        - fieldalignment  # struct padding; matters with thousands of chunk structs
+        - shadow          # shadowed variables across goroutine closures
+        - loopclosure     # goroutine captures loop variable
+
+    # ── prealloc ─────────────────────────────
+    prealloc:
+      simple: true
+      range-loops: true
+      for-loops: true
+
+    # ── dupl ─────────────────────────────────
+    dupl:
+      threshold: 120   # lines; tune down if Downloader impls diverge further
+
+    # ── gocognit ─────────────────────────────
+    gocognit:
+      min-complexity: 20   # TUI update() gets complex; don't fire on every branch
+
+    # ── cyclop ───────────────────────────────
+    cyclop:
+      max-complexity: 15
+      skip-tests: true
+
+    # ── funlen ───────────────────────────────
+    funlen:
+      lines: 80
+      statements: 50
+
+    # ── nestif ───────────────────────────────
+    nestif:
+      min-complexity: 6
+
+    # ── maintidx ─────────────────────────────
+    maintidx:
+      under: 20
+
+    # ── gocritic ─────────────────────────────
+    gocritic:
+      enabled-checks:
+        - hugeParam        # large structs passed by value in worker fns
+        - sloppyLen        # len(s) > 0 → len(s) != 0
+        - appendAssign     # append result not assigned back
+        - dupImport        # same package imported twice
+        - rangeValCopy     # range copies large value
+        - paramTypeCombine # func(a int, b int) → func(a, b int)
+      disabled-checks:
+        - whyNoLint        # covered by nolintlint
+
+    # ── gosec ────────────────────────────────
+    gosec:
+      includes:
+        - G115   # integer overflow on type conversion (byte offsets!)
+        - G304   # file path injection
+        - G306   # file permissions
+        - G401   # weak crypto (not expected but catch early)
+      excludes:
+        - G104   # errors unhandled — errcheck covers this better
+        - G307   # defer close — bodyclose is more precise
+
+    # ── exhaustive ───────────────────────────
+    exhaustive:
+      default-signifies-exhaustive: true   # allow default: to satisfy exhaustion
+
+    # ── goconst ──────────────────────────────
+    goconst:
+      min-len: 3
+      min-occurrences: 3
+      ignore-tests: true
+
+    # ── errorlint ────────────────────────────
+    errorlint:
+      errorf: true
+      errorf-multi: true
+      asserts: true
+      comparison: true
+
+    # ── depguard ─────────────────────────────
+    depguard:
+      rules:
+        no-unsafe:
+          deny:
+            - pkg: unsafe
+              desc: "use unsafe only with explicit justification and nolint"
+        prefer-stdlib-json:
+          deny:
+            - pkg: "github.com/json-iterator/go"
+              desc: "benchmark before replacing stdlib encoding/json"
+
+    # ── gomodguard ───────────────────────────
+    gomodguard:
+      blocked:
+        modules:
+          - github.com/pkg/errors:
+              recommendations:
+                - errors
+                - fmt
+              reason: "use stdlib errors with %w wrapping"
+
+    # ── nolintlint ───────────────────────────
+    nolintlint:
+      require-explanation: true   # force a comment on every nolint
+      require-specific: true      # nolint:all is forbidden
+      allow-unused: false
+
+    # ── misspell ─────────────────────────────
+    misspell:
+      locale: US
+
+    # ── perfsprint ───────────────────────────
+    perfsprint:
+      err-error: true
+      errorf: true
+      sprintf1: true
+      strconcat: false   # keep readable in TUI label building
+
+  # ── Exclusions ──────────────────────────────
+  exclusions:
+    generated: lax
+    rules:
+      # Test files: relax complexity and param rules
+      - path: "_test\\.go"
+        linters:
+          - funlen
+          - gocognit
+          - cyclop
+          - dupl
+          - goconst
+          - maintidx
+
+      # TUI view files: large render functions are expected
+      - path: "view_dashboard.*\\.go"
+        linters:
+          - funlen
+          - gocognit
+
+      # Bubble Tea Update() — intentionally large switch
+      - path: "update\\.go"
+        linters:
+          - cyclop
+          - gocognit
+          - funlen
+
+      # concurrent downloader worker/task — similar by design
+      - path: "(worker|task)\\.go"
+        linters:
+          - dupl
+
+      # main entrypoint
+      - path: "main\\.go"
+        linters:
+          - funlen
+
+    # Exclude the browser extension (JS/TS — not Go)
+    paths:
+      - extension/
+
+# ─────────────────────────────────────────────
+# ISSUES OUTPUT
+# ─────────────────────────────────────────────
+issues:
+  max-issues-per-linter: 50
+  max-same-issues: 5
+  uniq-by-line: false   # show all linters firing on the same line
+
+output:
+  formats:
+    colored-line-number:
+      path: stdout
+  print-issued-lines: true
+  print-linter-name: true
+  sort-results: true
+  sort-order:
+    - linter
+    - file

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -1,10 +1,12 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
-	"github.com/SurgeDM/Surge/internal/utils"
 	"github.com/spf13/cobra"
+
+	"github.com/SurgeDM/Surge/internal/utils"
 )
 
 var addCmd = &cobra.Command{
@@ -13,7 +15,7 @@ var addCmd = &cobra.Command{
 	Short:   "Add a new download to the running Surge instance",
 	Long:    `Add one or more URLs to the download queue of a running Surge instance.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		//initializeGlobally is required to ensure that the config and logger are set up before we attempt to resolve the API connection or read the batch file.
+		// initializeGlobally is required to ensure that the config and logger are set up before we attempt to resolve the API connection or read the batch file.
 		if err := initializeGlobalState(); err != nil {
 			return err
 		}
@@ -66,10 +68,10 @@ var addCmd = &cobra.Command{
 		}
 
 		if attempted > 0 {
-			return fmt.Errorf("failed to add any downloads")
+			return errors.New("failed to add any downloads")
 		}
 
-		return fmt.Errorf("no valid URLs to add")
+		return errors.New("no valid URLs to add")
 	},
 }
 

--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/SurgeDM/Surge/internal/utils"
 )
 
-// TestResolveDownloadID_Remote verifies that resolveDownloadID queries the server
+// TestResolveDownloadID_Remote verifies that resolveDownloadID queries the server.
 func TestResolveDownloadID_Remote(t *testing.T) {
 	// 1. Mock Server
 	downloads := []types.DownloadStatus{
@@ -178,7 +178,7 @@ func TestResolveDownloadID_LocalModeFallsBackToDBWhenRemoteListFails(t *testing.
 	}
 }
 
-// TestLsCmd_Alias verify 'l' alias exists
+// TestLsCmd_Alias verify 'l' alias exists.
 func TestLsCmd_Alias(t *testing.T) {
 	found := false
 	for _, alias := range lsCmd.Aliases {
@@ -192,7 +192,7 @@ func TestLsCmd_Alias(t *testing.T) {
 	}
 }
 
-// TestGetRemoteDownloads verify it parses response
+// TestGetRemoteDownloads verify it parses response.
 func TestGetRemoteDownloads(t *testing.T) {
 	server := testutil.NewHTTPServerT(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -379,8 +379,8 @@ func TestServerPIDLifecycle(t *testing.T) {
 func TestFormatSize_Table(t *testing.T) {
 	tests := []struct {
 		name  string
-		bytes int64
 		want  string
+		bytes int64
 	}{
 		{name: "zero", bytes: 0, want: "0 B"},
 		{name: "bytes", bytes: 512, want: "512 B"},
@@ -516,8 +516,8 @@ func TestAddCmdRunE_ReturnsExpectedErrors(t *testing.T) {
 
 func TestActionCommandsRunE_ReturnNoServerErrors(t *testing.T) {
 	tests := []struct {
-		name string
 		run  func() error
+		name string
 	}{
 		{
 			name: "pause",
@@ -583,9 +583,9 @@ func TestActionCommandsRunE_ReturnNoServerErrors(t *testing.T) {
 
 func TestConnectCmd_HostSourcesBypassLocalAutodetect(t *testing.T) {
 	tests := []struct {
+		setup func(t *testing.T)
 		name  string
 		args  []string
-		setup func(t *testing.T)
 	}{
 		{
 			name:  "host flag",
@@ -643,8 +643,8 @@ func TestConnectCmd_HostSourcesBypassLocalAutodetect(t *testing.T) {
 
 func TestActionCommandsRunE_ReturnAmbiguousIDErrors(t *testing.T) {
 	tests := []struct {
-		name string
 		run  func() error
+		name string
 	}{
 		{
 			name: "pause",
@@ -855,8 +855,8 @@ func TestShowDownloadDetails_UsesDatabaseFallback(t *testing.T) {
 func TestSendToServer_SuccessAndServerError(t *testing.T) {
 	tests := []struct {
 		name       string
-		statusCode int
 		body       string
+		statusCode int
 		wantErr    bool
 	}{
 		{name: "success accepted", statusCode: http.StatusAccepted, body: `{"id":"abc"}`},

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -252,8 +252,8 @@ func TestParseConnectTarget_BaseURL(t *testing.T) {
 	tests := []struct {
 		name         string
 		target       string
-		insecureHTTP bool
 		want         string
+		insecureHTTP bool
 		wantErr      bool
 	}{
 		{name: "loopback host:port defaults http", target: "127.0.0.1:1700", want: "http://127.0.0.1:1700"},

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -10,9 +11,10 @@ import (
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/spf13/cobra"
+
 	"github.com/SurgeDM/Surge/internal/core"
 	"github.com/SurgeDM/Surge/internal/tui"
-	"github.com/spf13/cobra"
 )
 
 type connectTarget struct {
@@ -34,7 +36,7 @@ var connectCmd = &cobra.Command{
 		} else {
 			port := readActivePort()
 			if port == 0 {
-				return fmt.Errorf("no local Surge server detected. Start one with 'surge' or 'surge server', or specify a target: surge connect <host:port>")
+				return errors.New("no local Surge server detected. Start one with 'surge' or 'surge server', or specify a target: surge connect <host:port>")
 			}
 			target = fmt.Sprintf("127.0.0.1:%d", port)
 			fmt.Fprintf(os.Stderr, "Auto-detected local server on port %d\n", port)
@@ -127,7 +129,7 @@ func resolveTokenForConnectTarget(target connectTarget) (string, error) {
 func parseConnectTarget(target string, allowInsecureHTTP bool) (connectTarget, error) {
 	target = strings.TrimSpace(target)
 	if target == "" {
-		return connectTarget{}, fmt.Errorf("invalid target: empty target")
+		return connectTarget{}, errors.New("invalid target: empty target")
 	}
 
 	var (
@@ -181,7 +183,7 @@ func parseConnectTarget(target string, allowInsecureHTTP bool) (connectTarget, e
 	}
 
 	if scheme == "http" && !allowInsecureHTTP && !isLoopbackHost(host) && !isPrivateIPHost(host) {
-		return connectTarget{}, fmt.Errorf("refusing insecure HTTP for non-loopback target. Use https:// or --insecure-http")
+		return connectTarget{}, errors.New("refusing insecure HTTP for non-loopback target. Use https:// or --insecure-http")
 	}
 
 	return connectTarget{

--- a/cmd/connect_test.go
+++ b/cmd/connect_test.go
@@ -11,10 +11,10 @@ import (
 )
 
 type fakeRemoteDownloadService struct {
-	addCalls     int
 	lastURL      string
 	lastPath     string
 	lastFile     string
+	addCalls     int
 	lastExplicit bool
 }
 

--- a/cmd/http_api.go
+++ b/cmd/http_api.go
@@ -295,7 +295,7 @@ func ensureOpenActionRequestAllowed(r *http.Request) error {
 		return nil
 	}
 
-	return fmt.Errorf("open actions are only allowed from local host")
+	return errors.New("open actions are only allowed from local host")
 }
 
 func decodeJSONBody(r *http.Request, dst interface{}) error {

--- a/cmd/http_api_test.go
+++ b/cmd/http_api_test.go
@@ -211,13 +211,13 @@ func TestEventsEndpoint_RequiresAuthAndStreamsSSE(t *testing.T) {
 
 func TestResolveDownloadDestPath(t *testing.T) {
 	tests := []struct {
-		name           string
-		useNilService  bool
+		wantErrIs      error
 		service        *httpAPITestService
+		name           string
 		id             string
 		wantPath       string
-		wantErrIs      error
 		wantErrContain string
+		useNilService  bool
 	}{
 		{
 			name:          "service unavailable",
@@ -312,11 +312,11 @@ func TestOpenEndpoints_ReturnMappedResolveStatuses(t *testing.T) {
 	globalSettings = config.DefaultSettings()
 
 	tests := []struct {
+		service    *httpAPITestService
 		name       string
 		path       string
-		useNil     bool
-		service    *httpAPITestService
 		statusCode int
+		useNil     bool
 	}{
 		{
 			name:       "service unavailable returns 503",

--- a/cmd/http_handler_test.go
+++ b/cmd/http_handler_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+
 	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/core"
 	"github.com/SurgeDM/Surge/internal/download"
@@ -207,8 +208,8 @@ func TestHandleDownload_PathResolution(t *testing.T) {
 func TestShouldFallbackUnmappedWindowsPath(t *testing.T) {
 	tests := []struct {
 		name                 string
-		relativeToDefaultDir bool
 		hostOS               string
+		relativeToDefaultDir bool
 		want                 bool
 	}{
 		{
@@ -413,8 +414,8 @@ func TestHandleDownload_EnqueueError_RecordsPreflightError(t *testing.T) {
 }
 
 type failingPublishService struct {
-	fakeRemoteDownloadService
 	publishErr error
+	fakeRemoteDownloadService
 }
 
 func (f *failingPublishService) Publish(msg interface{}) error {

--- a/cmd/lock.go
+++ b/cmd/lock.go
@@ -4,17 +4,18 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/gofrs/flock"
+
+	"github.com/SurgeDM/Surge/internal/config"
 )
 
-// InstanceLock wraps the file locking mechanism
+// InstanceLock wraps the file locking mechanism.
 type InstanceLock struct {
 	flock *flock.Flock
 	path  string
 }
 
-// Global lock instance
+// Global lock instance.
 var instanceLock *InstanceLock
 
 // AcquireLock attempts to acquire the single instance lock.

--- a/cmd/lock_test.go
+++ b/cmd/lock_test.go
@@ -5,10 +5,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/adrg/xdg"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/SurgeDM/Surge/internal/config"
 )
 
 func TestAcquireLock(t *testing.T) {

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -9,10 +9,11 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	"github.com/SurgeDM/Surge/internal/engine/state"
 	"github.com/SurgeDM/Surge/internal/engine/types"
 	"github.com/SurgeDM/Surge/internal/utils"
-	"github.com/spf13/cobra"
 )
 
 var lsCmd = &cobra.Command{
@@ -55,7 +56,7 @@ var lsCmd = &cobra.Command{
 	},
 }
 
-// downloadInfo is a unified structure for display
+// downloadInfo is a unified structure for display.
 type downloadInfo struct {
 	ID         string  `json:"id"`
 	URL        string  `json:"url,omitempty"`

--- a/cmd/mirrors_integration_test.go
+++ b/cmd/mirrors_integration_test.go
@@ -83,7 +83,7 @@ func TestMirrors_CLI_Integration(t *testing.T) {
 	}
 }
 
-// TestParseURLArg_Unit tests the parsing logic directly
+// TestParseURLArg_Unit tests the parsing logic directly.
 func TestParseURLArg_Unit(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/cmd/pause.go
+++ b/cmd/pause.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -20,7 +21,7 @@ var pauseCmd = &cobra.Command{
 		all, _ := cmd.Flags().GetBool("all")
 
 		if !all && len(args) == 0 {
-			return fmt.Errorf("provide a download ID or use --all")
+			return errors.New("provide a download ID or use --all")
 		}
 
 		if all {

--- a/cmd/refresh.go
+++ b/cmd/refresh.go
@@ -7,8 +7,9 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/SurgeDM/Surge/internal/utils"
 	"github.com/spf13/cobra"
+
+	"github.com/SurgeDM/Surge/internal/utils"
 )
 
 var refreshCmd = &cobra.Command{

--- a/cmd/remote_client.go
+++ b/cmd/remote_client.go
@@ -20,9 +20,9 @@ var (
 )
 
 type remoteClientConfig struct {
-	AllowInsecureHTTP bool
-	ConnectTimeout    time.Duration
 	HTTPOptions       core.HTTPClientOptions
+	ConnectTimeout    time.Duration
+	AllowInsecureHTTP bool
 }
 
 func currentRemoteClientConfig() remoteClientConfig {

--- a/cmd/resume.go
+++ b/cmd/resume.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -20,7 +21,7 @@ var resumeCmd = &cobra.Command{
 		all, _ := cmd.Flags().GetBool("all")
 
 		if !all && len(args) == 0 {
-			return fmt.Errorf("provide a download ID or use --all")
+			return errors.New("provide a download ID or use --all")
 		}
 
 		if all {

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -1,11 +1,13 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
-	"github.com/SurgeDM/Surge/internal/engine/state"
 	"github.com/spf13/cobra"
+
+	"github.com/SurgeDM/Surge/internal/engine/state"
 )
 
 var rmCmd = &cobra.Command{
@@ -22,7 +24,7 @@ var rmCmd = &cobra.Command{
 		clean, _ := cmd.Flags().GetBool("clean")
 
 		if !clean && len(args) == 0 {
-			return fmt.Errorf("provide a download ID or use --clean")
+			return errors.New("provide a download ID or use --clean")
 		}
 
 		if clean {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -28,7 +29,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Version information - set via ldflags during build
+// Version information - set via ldflags during build.
 var (
 	Version   = "dev"
 	BuildTime = "unknown"
@@ -46,7 +47,7 @@ func init() {
 // activeDownloads tracks in-flight downloads for headless/server exit logic.
 var activeDownloads int32
 
-// pendingEnqueue tracks the number of pending batch enqueues to avoid premature exit
+// pendingEnqueue tracks the number of pending batch enqueues to avoid premature exit.
 var pendingEnqueue int32
 
 var (
@@ -54,7 +55,7 @@ var (
 	globalToken string
 )
 
-// Globals for Unified Backend
+// Globals for Unified Backend.
 var (
 	GlobalPool              *download.WorkerPool
 	GlobalProgressCh        chan any
@@ -300,9 +301,9 @@ func isExplicitOutputPath(outPath, defaultDir string) bool {
 }
 
 type rootRunOptions struct {
-	portFlag     int
 	batchFile    string
 	outputDir    string
+	portFlag     int
 	noResume     bool
 	exitWhenDone bool
 }
@@ -330,7 +331,7 @@ func maybeRunRemoteTUI(cmd *cobra.Command, args []string) (bool, error) {
 	}
 
 	if len(args) > 0 {
-		return false, fmt.Errorf("URLs cannot be passed when using --host. Use 'surge add <url>' after connecting")
+		return false, errors.New("URLs cannot be passed when using --host. Use 'surge add <url>' after connecting")
 	}
 
 	if err := connectAndRunTUI(cmd, hostTarget); err != nil {
@@ -346,7 +347,7 @@ func acquireRootInstanceLock() (func(), error) {
 	}
 
 	if !isMaster {
-		return nil, fmt.Errorf("surge is already running. Use 'surge add <url>' to add a download to the active instance")
+		return nil, errors.New("surge is already running. Use 'surge add <url>' to add a download to the active instance")
 	}
 
 	return func() {
@@ -407,14 +408,14 @@ func queueInitialRootDownloads(args []string, opts rootRunOptions) {
 	}()
 }
 
-// rootCmd represents the base command when called without any subcommands
+// rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
 	Use:           "surge [url]...",
 	Short:         "Blazing fast TUI download manager built in Go for power users",
 	Long:          `Surge is a blazing fast TUI download manager built in Go for power users. Find more info here: https://github.com/SurgeDM/Surge`,
 	Version:       Version,
 	Args:          cobra.ArbitraryArgs,
-	SilenceErrors: true, //errors are printed in main.go this prevents double printing
+	SilenceErrors: true, // errors are printed in main.go this prevents double printing
 	SilenceUsage:  true, // prevent usage text from being printed on every error
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		GlobalProgressCh = make(chan any, 100)
@@ -453,7 +454,7 @@ var rootCmd = &cobra.Command{
 	},
 }
 
-// startTUI initializes and runs the TUI program
+// startTUI initializes and runs the TUI program.
 func startTUI(port int, exitWhenDone bool, noResume bool) error {
 	tui.InitializeTUI()
 	// Initialize TUI

--- a/cmd/root_downloads.go
+++ b/cmd/root_downloads.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -9,24 +10,25 @@ import (
 	"strings"
 	"sync/atomic"
 
+	"github.com/google/uuid"
+
 	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/core"
 	"github.com/SurgeDM/Surge/internal/engine/events"
 	"github.com/SurgeDM/Surge/internal/engine/types"
 	"github.com/SurgeDM/Surge/internal/processing"
 	"github.com/SurgeDM/Surge/internal/utils"
-	"github.com/google/uuid"
 )
 
-// DownloadRequest represents a download request from the browser extension
+// DownloadRequest represents a download request from the browser extension.
 type DownloadRequest struct {
+	Headers              map[string]string `json:"headers,omitempty"`
 	URL                  string            `json:"url"`
 	Filename             string            `json:"filename,omitempty"`
 	Path                 string            `json:"path,omitempty"`
-	RelativeToDefaultDir bool              `json:"relative_to_default_dir,omitempty"`
 	Mirrors              []string          `json:"mirrors,omitempty"`
-	SkipApproval         bool              `json:"skip_approval,omitempty"` // Extension validated request, skip TUI prompt
-	Headers              map[string]string `json:"headers,omitempty"`       // Custom HTTP headers from browser (cookies, auth, etc.)
+	RelativeToDefaultDir bool              `json:"relative_to_default_dir,omitempty"`
+	SkipApproval         bool              `json:"skip_approval,omitempty"`
 	IsExplicitCategory   bool              `json:"is_explicit_category,omitempty"`
 }
 
@@ -114,26 +116,26 @@ func decodeAndValidateDownloadRequest(r *http.Request) (DownloadRequest, error) 
 		return req, fmt.Errorf("invalid json: %w", err)
 	}
 	if req.URL == "" {
-		return req, fmt.Errorf("url is required")
+		return req, errors.New("url is required")
 	}
 	if strings.Contains(req.Filename, "..") {
-		return req, fmt.Errorf("invalid filename")
+		return req, errors.New("invalid filename")
 	}
 	if strings.Contains(req.Filename, "/") || strings.Contains(req.Filename, "\\") {
-		return req, fmt.Errorf("invalid filename")
+		return req, errors.New("invalid filename")
 	}
 	if strings.Contains(req.Path, "..") {
-		return req, fmt.Errorf("invalid path")
+		return req, errors.New("invalid path")
 	}
 	if req.RelativeToDefaultDir && req.Path != "" {
 		// Linux filepath.IsAbs does not recognize Windows drive paths, so those
 		// are normalized later against the daemon's default download directory.
 		if filepath.IsAbs(req.Path) && !utils.IsWindowsAbsPath(req.Path) {
-			return req, fmt.Errorf("invalid path")
+			return req, errors.New("invalid path")
 		}
 		cleanPath := filepath.Clean(req.Path)
 		if cleanPath == ".." || strings.HasPrefix(cleanPath, ".."+string(filepath.Separator)) {
-			return req, fmt.Errorf("invalid path")
+			return req, errors.New("invalid path")
 		}
 		req.Path = cleanPath
 	}
@@ -272,7 +274,7 @@ func enqueueDownloadRequest(r *http.Request, service core.DownloadService, resol
 }
 
 // processDownloads handles the logic of adding downloads either to local pool or remote server
-// Returns the number of successfully added downloads
+// Returns the number of successfully added downloads.
 func processDownloads(urls []string, outputDir string, port int) int {
 	successCount := 0
 
@@ -327,7 +329,7 @@ func processDownloads(urls []string, outputDir string, port int) int {
 		// CLI explicit arg means we do not auto-route when user provided an explicit output path.
 		isExplicit := isExplicitOutputPath(outPath, settings.General.DefaultDownloadDir)
 		if lifecycle == nil {
-			err := fmt.Errorf("lifecycle manager unavailable")
+			err := errors.New("lifecycle manager unavailable")
 			recordPreflightDownloadError(url, outPath, err)
 			publishSystemLog(fmt.Sprintf("Error adding %s: %v", url, err))
 			continue

--- a/cmd/root_headless.go
+++ b/cmd/root_headless.go
@@ -9,7 +9,7 @@ import (
 	"github.com/SurgeDM/Surge/internal/utils"
 )
 
-// StartHeadlessConsumer starts a goroutine to consume progress messages and log to stdout
+// StartHeadlessConsumer starts a goroutine to consume progress messages and log to stdout.
 func StartHeadlessConsumer() {
 	go func() {
 		if GlobalService == nil {
@@ -45,7 +45,7 @@ func StartHeadlessConsumer() {
 	}()
 }
 
-// truncateID shortens a UUID to its first 8 characters for display
+// truncateID shortens a UUID to its first 8 characters for display.
 func truncateID(id string) string {
 	if len(id) > 8 {
 		return id[:8]

--- a/cmd/root_http_server.go
+++ b/cmd/root_http_server.go
@@ -2,22 +2,25 @@ package cmd
 
 import (
 	"crypto/subtle"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+
+	"github.com/google/uuid"
 
 	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/core"
 	"github.com/SurgeDM/Surge/internal/utils"
-	"github.com/google/uuid"
 )
 
 const serverBindHost = "0.0.0.0"
 
-// findAvailablePort tries ports starting from 'start' until one is available
+// findAvailablePort tries ports starting from 'start' until one is available.
 func findAvailablePort(start int) (int, net.Listener) {
 	bindHost := serverBindHost
 	for port := start; port < start+100; port++ {
@@ -40,7 +43,7 @@ func bindServerListener(portFlag int) (int, net.Listener, error) {
 	}
 	port, ln := findAvailablePort(1700)
 	if ln == nil {
-		return 0, nil, fmt.Errorf("could not find available port")
+		return 0, nil, errors.New("could not find available port")
 	}
 	return port, ln, nil
 }
@@ -53,13 +56,13 @@ func saveActivePort(port int) {
 	}
 
 	portFile := filepath.Join(config.GetRuntimeDir(), "port")
-	if err := os.WriteFile(portFile, []byte(fmt.Sprintf("%d", port)), 0o644); err != nil {
+	if err := os.WriteFile(portFile, []byte(strconv.Itoa(port)), 0o644); err != nil {
 		utils.Debug("Error writing port file: %v", err)
 	}
 	utils.Debug("HTTP server listening on port %d", port)
 }
 
-// removeActivePort cleans up the port file on exit
+// removeActivePort cleans up the port file on exit.
 func removeActivePort() {
 	portFile := filepath.Join(config.GetRuntimeDir(), "port")
 	if err := os.Remove(portFile); err != nil && !os.IsNotExist(err) {
@@ -67,7 +70,7 @@ func removeActivePort() {
 	}
 }
 
-// startHTTPServer starts the HTTP server using an existing listener
+// startHTTPServer starts the HTTP server using an existing listener.
 func startHTTPServer(ln net.Listener, port int, defaultOutputDir string, service core.DownloadService, tokenOverride string) {
 	authToken := strings.TrimSpace(tokenOverride)
 	if authToken == "" {

--- a/cmd/root_lifecycle_test.go
+++ b/cmd/root_lifecycle_test.go
@@ -23,11 +23,11 @@ import (
 )
 
 type countingLifecycleService struct {
-	streamCalls atomic.Int32
 	streamCh    chan interface{}
-	cleanupMu   sync.Mutex
-	cleaned     bool
 	logs        []string
+	cleanupMu   sync.Mutex
+	streamCalls atomic.Int32
+	cleaned     bool
 }
 
 var _ core.DownloadService = (*countingLifecycleService)(nil)

--- a/cmd/root_startup.go
+++ b/cmd/root_startup.go
@@ -35,7 +35,7 @@ func runStartupIntegrityCheck() string {
 	return ""
 }
 
-// initializeGlobalState sets up the environment and configures the engine state and logging
+// initializeGlobalState sets up the environment and configures the engine state and logging.
 func initializeGlobalState() error {
 	stateDir := config.GetStateDir()
 	logsDir := config.GetLogsDir()

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	"os"
@@ -12,9 +13,10 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/utils"
-	"github.com/spf13/cobra"
 )
 
 var serverCmd = &cobra.Command{
@@ -37,7 +39,7 @@ var serverStartCmd = &cobra.Command{
 		}
 
 		if !isMaster {
-			return fmt.Errorf("surge server is already running")
+			return errors.New("surge server is already running")
 		}
 		defer func() {
 			if err := ReleaseLock(); err != nil {
@@ -149,7 +151,7 @@ func savePID() {
 		return
 	}
 	pidFile := filepath.Join(config.GetRuntimeDir(), "pid")
-	if err := os.WriteFile(pidFile, []byte(fmt.Sprintf("%d", pid)), 0o644); err != nil {
+	if err := os.WriteFile(pidFile, []byte(strconv.Itoa(pid)), 0o644); err != nil {
 		utils.Debug("Error writing PID file: %v", err)
 	}
 }

--- a/cmd/shutdown_test.go
+++ b/cmd/shutdown_test.go
@@ -35,8 +35,8 @@ func TestExecuteGlobalShutdown_Once(t *testing.T) {
 }
 
 type fakeShutdownService struct {
-	fakeRemoteDownloadService
 	onShutdown func()
+	fakeRemoteDownloadService
 }
 
 func (f *fakeShutdownService) StreamEvents(context.Context) (<-chan interface{}, func(), error) {

--- a/cmd/startup_test.go
+++ b/cmd/startup_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/SurgeDM/Surge/internal/utils"
 )
 
-// TestServer_Startup_HandlesResume verifies that resumePausedDownloads() works for server mode
+// TestServer_Startup_HandlesResume verifies that resumePausedDownloads() works for server mode.
 func TestServer_Startup_HandlesResume(t *testing.T) {
 	// 1. Setup Environment
 	tmpDir, err := os.MkdirTemp("", "surge-server-startup-test")
@@ -108,7 +108,7 @@ func TestStartupIntegrityCheck_RemovesMissingPausedEntry(t *testing.T) {
 	}
 }
 
-// Helper: Setup XDG_CONFIG_HOME and Settings
+// Helper: Setup XDG_CONFIG_HOME and Settings.
 func setupTestEnv(t *testing.T, tmpDir string) {
 	originalXDG := os.Getenv("XDG_CONFIG_HOME")
 	_ = os.Setenv("XDG_CONFIG_HOME", tmpDir)

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -17,7 +17,7 @@ import (
 	"github.com/SurgeDM/Surge/internal/utils"
 )
 
-// readActivePort reads the port from the port file
+// readActivePort reads the port from the port file.
 func readActivePort() int {
 	portFile := filepath.Join(config.GetRuntimeDir(), "port")
 	data, err := os.ReadFile(portFile)
@@ -30,7 +30,7 @@ func readActivePort() int {
 }
 
 // ParseURLArg parses a command line argument that might contain comma-separated mirrors
-// Returns the primary URL and a list of all mirrors (including the primary)
+// Returns the primary URL and a list of all mirrors (including the primary).
 func ParseURLArg(arg string) (string, []string) {
 	parts := strings.Split(arg, ",")
 	var urls []string
@@ -155,7 +155,7 @@ func sendToServer(url string, mirrors []string, outPath string, baseURL string, 
 	return nil
 }
 
-// GetRemoteDownloads fetches all downloads from the running server
+// GetRemoteDownloads fetches all downloads from the running server.
 func GetRemoteDownloads(baseURL string, token string) ([]types.DownloadStatus, error) {
 	resp, err := doAPIRequest(http.MethodGet, baseURL, token, "/list", nil)
 	if err != nil {

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -21,7 +21,7 @@ func getXDGBaseDir(envKey, fallback string) string {
 // GetSurgeDir returns the directory for configuration files (settings.json).
 // Linux: $XDG_CONFIG_HOME/surge or ~/.config/surge
 // macOS: ~/Library/Application Support/surge
-// Windows: %APPDATA%/surge
+// Windows: %APPDATA%/surge.
 func GetSurgeDir() string {
 	if runtime.GOOS == "windows" {
 		// Preserve legacy location for existing Windows installs.
@@ -106,17 +106,17 @@ func GetPicturesDir() string {
 	return xdg.UserDirs.Pictures
 }
 
-// GetLogsDir returns the directory for logs
+// GetLogsDir returns the directory for logs.
 func GetLogsDir() string {
 	return filepath.Join(GetStateDir(), "logs")
 }
 
-// GetThemesDir returns the directory for themes
+// GetThemesDir returns the directory for themes.
 func GetThemesDir() string {
 	return filepath.Join(GetSurgeDir(), "themes")
 }
 
-// EnsureDirs creates all required directories
+// EnsureDirs creates all required directories.
 func EnsureDirs() error {
 	dirs := []string{GetSurgeDir(), GetStateDir(), GetRuntimeDir(), GetLogsDir(), GetThemesDir()}
 	for _, dir := range dirs {

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -27,12 +27,11 @@ type GeneralSettings struct {
 	AllowRemoteOpenActions       bool   `json:"allow_remote_open_actions" ui_label:"Allow Remote Open Actions" ui_desc:"Allow /open-file and /open-folder API calls from non-loopback clients. Disabled by default for security."`
 	AutoResume                   bool   `json:"auto_resume" ui_label:"Auto Resume" ui_desc:"Automatically resume paused downloads on startup."`
 	SkipUpdateCheck              bool   `json:"skip_update_check" ui_label:"Skip Update Check" ui_desc:"Disable automatic check for new versions on startup."`
-
-	ClipboardMonitor  bool   `json:"clipboard_monitor" ui_label:"Clipboard Monitor" ui_desc:"Watch clipboard for URLs and prompt to download them."`
-	Theme             int    `json:"theme" ui_label:"App Theme" ui_desc:"UI Theme (System, Light, Dark)."`
-	ThemePath         string `json:"theme_path" ui_label:"Theme File" ui_desc:"Path to a custom .toml color scheme."`
-	LogRetentionCount int    `json:"log_retention_count" ui_label:"Log Retention Count" ui_desc:"Number of recent log files to keep."`
-	LiveSpeedGraph    bool   `json:"live_speed_graph" ui_label:"Live Speed Graph" ui_desc:"Use live speed for graph instead of EMA smoothed speed."`
+	ClipboardMonitor             bool   `json:"clipboard_monitor" ui_label:"Clipboard Monitor" ui_desc:"Watch clipboard for URLs and prompt to download them."`
+	Theme                        int    `json:"theme" ui_label:"App Theme" ui_desc:"UI Theme (System, Light, Dark)."`
+	ThemePath                    string `json:"theme_path" ui_label:"Theme File" ui_desc:"Path to a custom .toml color scheme."`
+	LogRetentionCount            int    `json:"log_retention_count" ui_label:"Log Retention Count" ui_desc:"Number of recent log files to keep."`
+	LiveSpeedGraph               bool   `json:"live_speed_graph" ui_label:"Live Speed Graph" ui_desc:"Use live speed for graph instead of EMA smoothed speed."`
 }
 
 const (
@@ -194,7 +193,6 @@ const (
 
 // DefaultSettings returns a new Settings instance with sensible defaults.
 func DefaultSettings() *Settings {
-
 	defaultDir := GetDownloadsDir()
 
 	return &Settings{
@@ -295,15 +293,14 @@ func SaveSettings(s *Settings) error {
 }
 
 // ToRuntimeConfig converts Settings to a downloader RuntimeConfig
-// This is used to pass user settings to the download engine
+// This is used to pass user settings to the download engine.
 type RuntimeConfig struct {
-	MaxConnectionsPerHost int
-	MaxConcurrentProbes   int
-	UserAgent             string
 	ProxyURL              string
 	CustomDNS             string
-	SequentialDownload    bool
+	UserAgent             string
 	MinChunkSize          int64
+	MaxConcurrentProbes   int
+	MaxConnectionsPerHost int
 	WorkerBufferSize      int
 	DialHedgeCount        int
 	MaxTaskRetries        int
@@ -311,9 +308,10 @@ type RuntimeConfig struct {
 	SlowWorkerGracePeriod time.Duration
 	StallTimeout          time.Duration
 	SpeedEmaAlpha         float64
+	SequentialDownload    bool
 }
 
-// ToRuntimeConfig creates a RuntimeConfig from user Settings
+// ToRuntimeConfig creates a RuntimeConfig from user Settings.
 func (s *Settings) ToRuntimeConfig() *RuntimeConfig {
 	return &RuntimeConfig{
 		MaxConnectionsPerHost: s.Network.MaxConnectionsPerHost,

--- a/internal/core/http_client.go
+++ b/internal/core/http_client.go
@@ -12,9 +12,9 @@ import (
 )
 
 type HTTPClientOptions struct {
+	CAFile             string
 	Timeout            time.Duration
 	InsecureSkipVerify bool
-	CAFile             string
 }
 
 func NewHTTPClient(opts HTTPClientOptions) (*http.Client, error) {

--- a/internal/core/local_service.go
+++ b/internal/core/local_service.go
@@ -2,11 +2,14 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
 
 	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/download"
@@ -14,7 +17,6 @@ import (
 	"github.com/SurgeDM/Surge/internal/engine/state"
 	"github.com/SurgeDM/Surge/internal/engine/types"
 	"github.com/SurgeDM/Surge/internal/utils"
-	"github.com/google/uuid"
 )
 
 func completedSpeedMBps(entry types.DownloadEntry) float64 {
@@ -30,7 +32,7 @@ func completedSpeedMBps(entry types.DownloadEntry) float64 {
 	return 0
 }
 
-// ReloadSettings reloads settings from disk
+// ReloadSettings reloads settings from disk.
 func (s *LocalDownloadService) ReloadSettings() error {
 	settings, err := config.LoadSettings()
 	if err != nil {
@@ -44,29 +46,20 @@ func (s *LocalDownloadService) ReloadSettings() error {
 
 // LocalDownloadService implements DownloadService for the local embedded engine.
 type LocalDownloadService struct {
-	Pool    *download.WorkerPool
-	InputCh chan interface{}
-
-	// Broadcast fields
-	listeners  []chan interface{}
-	listenerMu sync.Mutex
-
-	broadcastWG  sync.WaitGroup
-	reportTicker *time.Ticker
-	reportWG     sync.WaitGroup
-
-	// Lifecycle
-	ctx    context.Context
-	cancel context.CancelFunc
-	// shutdownOnce guarantees Shutdown is safe to call multiple times.
-	shutdownOnce sync.Once
-	shutdownErr  error
-
-	// Settings Cache
-	settings   *config.Settings
-	settingsMu sync.RWMutex
-
 	lifecycleHooks LifecycleHooks
+	ctx            context.Context
+	shutdownErr    error
+	InputCh        chan interface{}
+	reportTicker   *time.Ticker
+	cancel         context.CancelFunc
+	Pool           *download.WorkerPool
+	settings       *config.Settings
+	listeners      []chan interface{}
+	broadcastWG    sync.WaitGroup
+	reportWG       sync.WaitGroup
+	settingsMu     sync.RWMutex
+	shutdownOnce   sync.Once
+	listenerMu     sync.Mutex
 }
 
 // LifecycleHooks routes service-level management calls through the LifecycleManager.
@@ -318,13 +311,13 @@ func (s *LocalDownloadService) StreamEvents(ctx context.Context) (<-chan interfa
 // Publish emits an event into the service's event stream.
 func (s *LocalDownloadService) Publish(msg interface{}) error {
 	if s.InputCh == nil {
-		return fmt.Errorf("input channel not initialized")
+		return errors.New("input channel not initialized")
 	}
 	select {
 	case s.InputCh <- msg:
 		return nil
 	case <-time.After(1 * time.Second):
-		return fmt.Errorf("event publish timeout")
+		return errors.New("event publish timeout")
 	}
 }
 
@@ -467,7 +460,7 @@ func (s *LocalDownloadService) AddWithID(url string, path string, filename strin
 
 func (s *LocalDownloadService) add(url string, path string, filename string, mirrors []string, headers map[string]string, requestedID string, isExplicitCategory bool, totalSize int64, supportsRange bool) (string, error) {
 	if s.Pool == nil {
-		return "", fmt.Errorf("worker pool not initialized")
+		return "", errors.New("worker pool not initialized")
 	}
 
 	s.settingsMu.RLock()
@@ -489,12 +482,12 @@ func (s *LocalDownloadService) add(url string, path string, filename string, mir
 		id = uuid.New().String()
 	}
 	if st := s.Pool.GetStatus(id); st != nil {
-		return "", fmt.Errorf("download id already exists")
+		return "", errors.New("download id already exists")
 	}
 	if entry, err := state.GetDownload(id); err != nil {
 		return "", fmt.Errorf("failed to query download state: %w", err)
 	} else if entry != nil {
-		return "", fmt.Errorf("download id already exists")
+		return "", errors.New("download id already exists")
 	}
 
 	state := types.NewProgressState(id, 0)
@@ -525,7 +518,7 @@ func (s *LocalDownloadService) Pause(id string) error {
 	if s.lifecycleHooks.Pause != nil {
 		return s.lifecycleHooks.Pause(id)
 	}
-	return fmt.Errorf("PauseFunc not initialized")
+	return errors.New("PauseFunc not initialized")
 }
 
 // Resume resumes a paused download.
@@ -533,7 +526,7 @@ func (s *LocalDownloadService) Resume(id string) error {
 	if s.lifecycleHooks.Resume != nil {
 		return s.lifecycleHooks.Resume(id)
 	}
-	return fmt.Errorf("ResumeFunc not initialized")
+	return errors.New("ResumeFunc not initialized")
 }
 
 // ResumeBatch resumes multiple paused downloads efficiently.
@@ -543,7 +536,7 @@ func (s *LocalDownloadService) ResumeBatch(ids []string) []error {
 	}
 	errs := make([]error, len(ids))
 	for i := range errs {
-		errs[i] = fmt.Errorf("ResumeBatchFunc not initialized")
+		errs[i] = errors.New("ResumeBatchFunc not initialized")
 	}
 	return errs
 }
@@ -554,14 +547,14 @@ func (s *LocalDownloadService) SetLifecycleHooks(hooks LifecycleHooks) {
 	s.lifecycleHooks = hooks
 }
 
-// UpdateURL updates the URL of a paused or errored download
+// UpdateURL updates the URL of a paused or errored download.
 func (s *LocalDownloadService) UpdateURL(id string, newURL string) error {
 	if s.lifecycleHooks.UpdateURL != nil {
 		return s.lifecycleHooks.UpdateURL(id, newURL)
 	}
 	// Fallback: update pool in-memory only (no DB persistence)
 	if s.Pool == nil {
-		return fmt.Errorf("worker pool not initialized")
+		return errors.New("worker pool not initialized")
 	}
 	return s.Pool.UpdateURL(id, newURL)
 }
@@ -573,7 +566,7 @@ func (s *LocalDownloadService) Delete(id string) error {
 	}
 	// Fallback when lifecycle hooks not wired (e.g. tests)
 	if s.Pool == nil {
-		return fmt.Errorf("worker pool not initialized")
+		return errors.New("worker pool not initialized")
 	}
 	s.Pool.Cancel(id)
 	if entry, err := state.GetDownload(id); err == nil && entry != nil {
@@ -592,7 +585,7 @@ func (s *LocalDownloadService) Delete(id string) error {
 // GetStatus returns a status for a single download by id.
 func (s *LocalDownloadService) GetStatus(id string) (*types.DownloadStatus, error) {
 	if id == "" {
-		return nil, fmt.Errorf("missing id")
+		return nil, errors.New("missing id")
 	}
 
 	// 1. Check active pool
@@ -628,10 +621,10 @@ func (s *LocalDownloadService) GetStatus(id string) (*types.DownloadStatus, erro
 		return &status, nil
 	}
 
-	return nil, fmt.Errorf("download not found")
+	return nil, errors.New("download not found")
 }
 
-// History returns completed downloads
+// History returns completed downloads.
 func (s *LocalDownloadService) History() ([]types.DownloadEntry, error) {
 	// For local service, we can directly access the state DB
 	return state.LoadCompletedDownloads()

--- a/internal/core/remote_service.go
+++ b/internal/core/remote_service.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -19,12 +20,12 @@ import (
 
 // RemoteDownloadService implements DownloadService for a remote daemon.
 type RemoteDownloadService struct {
-	BaseURL   string
-	Token     string
+	ctx       context.Context
 	Client    *http.Client
 	SSEClient *http.Client
-	ctx       context.Context
 	cancel    context.CancelFunc
+	BaseURL   string
+	Token     string
 }
 
 // NewRemoteDownloadService creates a new remote service instance.
@@ -100,7 +101,7 @@ func (s *RemoteDownloadService) List() ([]types.DownloadStatus, error) {
 	return statuses, nil
 }
 
-// History returns completed downloads
+// History returns completed downloads.
 func (s *RemoteDownloadService) History() ([]types.DownloadEntry, error) {
 	resp, err := s.doRequest("GET", "/history", nil)
 	if err != nil {
@@ -261,7 +262,7 @@ func (s *RemoteDownloadService) StreamEvents(ctx context.Context) (<-chan interf
 // Publish emits an event into the service's event stream.
 // Remote services do not accept client-side event injection.
 func (s *RemoteDownloadService) Publish(msg interface{}) error {
-	return fmt.Errorf("publish not supported for remote service")
+	return errors.New("publish not supported for remote service")
 }
 
 func (s *RemoteDownloadService) streamWithReconnect(ctx context.Context, ch chan interface{}) {

--- a/internal/download/filename_test.go
+++ b/internal/download/filename_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-// Tests requested by user: ensure "file (1)" is preserved if it doesn't exist
+// Tests requested by user: ensure "file (1)" is preserved if it doesn't exist.
 func TestUniqueFilePath_Preservation(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "surge-filename-*")
 	if err != nil {
@@ -47,7 +47,7 @@ func TestUniqueFilePath_Preservation(t *testing.T) {
 	}
 }
 
-// Additional robustness tests
+// Additional robustness tests.
 func TestUniqueFilePath_WhitespaceParsing(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "surge-filename-*")
 	if err != nil {

--- a/internal/download/manager.go
+++ b/internal/download/manager.go
@@ -26,7 +26,7 @@ func safeSendProgress(ch chan<- any, msg any) {
 	ch <- msg
 }
 
-// uniqueFilePath returns a unique file path by appending (1), (2), etc. if the file exists
+// uniqueFilePath returns a unique file path by appending (1), (2), etc. if the file exists.
 func uniqueFilePath(path string) string {
 	// Check if file exists (both final and incomplete)
 	if _, err := os.Stat(path); os.IsNotExist(err) {
@@ -72,7 +72,7 @@ func uniqueFilePath(path string) string {
 	return path
 }
 
-// TUIDownload is the main entry point for downloads executed by the Engine pool
+// TUIDownload is the main entry point for downloads executed by the Engine pool.
 func TUIDownload(ctx context.Context, cfg *types.DownloadConfig) error {
 	start := time.Now()
 	// Engine expects cfg.OutputPath and cfg.Filename to be fully resolved by the processing layer
@@ -238,7 +238,7 @@ func TUIDownload(ctx context.Context, cfg *types.DownloadConfig) error {
 	return downloadErr
 }
 
-// Download is the CLI entry point (non-TUI) - convenience wrapper
+// Download is the CLI entry point (non-TUI) - convenience wrapper.
 func Download(ctx context.Context, url string, outPath string, progressCh chan<- any, id string) error {
 	cfg := types.DownloadConfig{
 		URL:        url,

--- a/internal/download/manager_test.go
+++ b/internal/download/manager_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -34,9 +35,9 @@ func TestUniqueFilePath(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		existing []string
 		input    string
 		want     string
+		existing []string
 	}{
 		{
 			name:     "No conflict",
@@ -434,7 +435,7 @@ func TestProbeServer_ContextCancellation(t *testing.T) {
 
 	_, err := processing.ProbeServer(ctx, server.URL(), "", nil)
 	if err == nil {
-		t.Error("Expected error when context is cancelled")
+		t.Error("Expected error when context is canceled")
 	}
 }
 
@@ -613,9 +614,9 @@ func TestDownload_BuildsConfig(t *testing.T) {
 
 	err := Download(ctx, "http://example.com/file", "/tmp/output", nil, "test-id")
 
-	// Should fail because context is cancelled
+	// Should fail because context is canceled
 	if err == nil {
-		t.Log("Download returned nil error with cancelled context - this may be acceptable")
+		t.Log("Download returned nil error with canceled context - this may be acceptable")
 	}
 }
 
@@ -648,9 +649,11 @@ func TestUniqueFilePath_LongFilename(t *testing.T) {
 
 	// Create a file with a long name (within OS limits)
 	longName := ""
+	var longNameSb651 strings.Builder
 	for i := 0; i < 50; i++ {
-		longName += "a"
+		longNameSb651.WriteString("a")
 	}
+	longName += longNameSb651.String()
 	longName += ".txt"
 
 	existingFile := filepath.Join(tmpDir, longName)

--- a/internal/download/mirror_resume_test.go
+++ b/internal/download/mirror_resume_test.go
@@ -9,13 +9,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/SurgeDM/Surge/internal/download"
 	"github.com/SurgeDM/Surge/internal/engine/state"
 	"github.com/SurgeDM/Surge/internal/engine/types"
 	"github.com/SurgeDM/Surge/internal/processing"
 	"github.com/SurgeDM/Surge/internal/testutil"
 	"github.com/SurgeDM/Surge/internal/utils"
-	"github.com/google/uuid"
 )
 
 func TestIntegration_MirrorResume(t *testing.T) {

--- a/internal/download/pool.go
+++ b/internal/download/pool.go
@@ -2,7 +2,7 @@ package download
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"path/filepath"
 	"sync"
 	"sync/atomic"
@@ -12,11 +12,10 @@ import (
 	"github.com/SurgeDM/Surge/internal/utils"
 )
 
-// activeDownload tracks a download that's currently running
+// activeDownload tracks a download that's currently running.
 type activeDownload struct {
-	config types.DownloadConfig
-	cancel context.CancelFunc
-	// running is true while the worker goroutine is executing TUIDownload for this config.
+	cancel  context.CancelFunc
+	config  types.DownloadConfig
 	running atomic.Bool
 }
 
@@ -132,7 +131,7 @@ func (p *WorkerPool) HasDownload(url string) bool {
 	return false
 }
 
-// ActiveCount returns the number of currently active (downloading/pausing) downloads
+// ActiveCount returns the number of currently active (downloading/pausing) downloads.
 func (p *WorkerPool) ActiveCount() int {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
@@ -149,7 +148,7 @@ func (p *WorkerPool) ActiveCount() int {
 	return count
 }
 
-// GetAll returns all active download configs (for listing)
+// GetAll returns all active download configs (for listing).
 func (p *WorkerPool) GetAll() []types.DownloadConfig {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
@@ -203,7 +202,7 @@ func (p *WorkerPool) Pause(downloadID string) bool {
 	return true
 }
 
-// PauseAll pauses all active downloads (for graceful shutdown)
+// PauseAll pauses all active downloads (for graceful shutdown).
 func (p *WorkerPool) PauseAll() {
 	p.mu.RLock()
 	ids := make([]string, 0, len(p.downloads)) // This stores the uuids of the downloads to be paused
@@ -308,14 +307,14 @@ func (p *WorkerPool) UpdateURL(downloadID string, newURL string) error {
 
 	if qExists {
 		p.mu.Unlock()
-		return fmt.Errorf("cannot update URL for a queued download, please cancel or wait for it to start")
+		return errors.New("cannot update URL for a queued download, please cancel or wait for it to start")
 	}
 
 	if exists && ad != nil {
 		if ad.config.State != nil && !ad.config.State.IsPaused() {
 			if ad.running.Load() {
 				p.mu.Unlock()
-				return fmt.Errorf("download is currently active, please pause it before updating the URL")
+				return errors.New("download is currently active, please pause it before updating the URL")
 			}
 		}
 		ad.config.URL = newURL
@@ -382,7 +381,6 @@ func (p *WorkerPool) worker() {
 			p.mu.Lock()
 			delete(p.downloads, cfg.ID)
 			p.mu.Unlock()
-
 		} else {
 			// Only mark as done if not paused
 			if cfg.State != nil {
@@ -400,7 +398,7 @@ func (p *WorkerPool) worker() {
 	}
 }
 
-// GetStatus returns the status of an active download
+// GetStatus returns the status of an active download.
 func (p *WorkerPool) GetStatus(id string) *types.DownloadStatus {
 	p.mu.RLock()
 	ad, exists := p.downloads[id]
@@ -481,7 +479,7 @@ func (p *WorkerPool) GetStatus(id string) *types.DownloadStatus {
 	return status
 }
 
-// GracefulShutdown pauses all downloads and waits for them to save state
+// GracefulShutdown pauses all downloads and waits for them to save state.
 func (p *WorkerPool) GracefulShutdown() {
 	p.PauseAll()
 

--- a/internal/download/resume_test.go
+++ b/internal/download/resume_test.go
@@ -9,12 +9,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/SurgeDM/Surge/internal/download"
 	"github.com/SurgeDM/Surge/internal/engine/state"
 	"github.com/SurgeDM/Surge/internal/engine/types"
 	"github.com/SurgeDM/Surge/internal/processing"
 	"github.com/SurgeDM/Surge/internal/testutil"
-	"github.com/google/uuid"
 )
 
 func TestIntegration_PauseResume(t *testing.T) {
@@ -122,7 +123,7 @@ func TestIntegration_PauseResume(t *testing.T) {
 	// Wait for download to return
 	select {
 	case err := <-errCh:
-		if err != nil && err != context.Canceled && !errors.Is(err, types.ErrPaused) {
+		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, types.ErrPaused) {
 			t.Logf("Download returned error: %v", err)
 		}
 	case <-time.After(15 * time.Second):

--- a/internal/engine/concurrent/chunk_test.go
+++ b/internal/engine/concurrent/chunk_test.go
@@ -3,8 +3,9 @@ package concurrent
 import (
 	"testing"
 
-	"github.com/SurgeDM/Surge/internal/engine/types"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/SurgeDM/Surge/internal/engine/types"
 )
 
 func TestTaskRangeAssignment(t *testing.T) {

--- a/internal/engine/concurrent/concurrent_test.go
+++ b/internal/engine/concurrent/concurrent_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Helper to init state just for tests (avoiding global init if possible,
-// using temporary directories for each test)
+// using temporary directories for each test).
 func initTestState(t *testing.T) (string, func()) {
 	state.CloseDB() // Ensure any previous DB is closed
 
@@ -317,7 +317,6 @@ func TestConcurrentDownloader_SmallFile(t *testing.T) {
 	if err := testutil.VerifyFileSize(destPath+types.IncompleteSuffix, fileSize); err != nil {
 		t.Error(err)
 	}
-
 }
 
 func TestConcurrentDownloader_MediumFile(t *testing.T) {
@@ -446,7 +445,6 @@ func TestConcurrentDownloader_PauseAtCompletionFinalizesAsCompleted(t *testing.T
 	if err := testutil.VerifyFileSize(destPath+types.IncompleteSuffix, fileSize); err != nil {
 		t.Fatal(err)
 	}
-
 }
 
 func TestConcurrentDownloader_ProgressTracking(t *testing.T) {
@@ -639,7 +637,6 @@ func TestConcurrentDownloader_ResumePartialDownload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Resume download failed: %v", err)
 	}
-
 }
 
 // =============================================================================

--- a/internal/engine/concurrent/downloader.go
+++ b/internal/engine/concurrent/downloader.go
@@ -3,6 +3,7 @@ package concurrent
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"math"
 	"net"
@@ -19,21 +20,21 @@ import (
 	"github.com/SurgeDM/Surge/internal/utils"
 )
 
-// ConcurrentDownloader handles multi-connection downloads
+// ConcurrentDownloader handles multi-connection downloads.
 type ConcurrentDownloader struct {
-	ProgressChan chan<- any           // Channel for events (start/complete/error)
-	ID           string               // Download ID
-	State        *types.ProgressState // Shared state for TUI polling
-	activeTasks  map[int]*ActiveTask
-	activeMu     sync.Mutex
-	URL          string // For pause/resume
-	DestPath     string // For pause/resume
-	Runtime      *types.RuntimeConfig
 	bufPool      sync.Pool
-	Headers      map[string]string // Custom HTTP headers from browser (cookies, auth, etc.)
+	ProgressChan chan<- any
+	State        *types.ProgressState
+	activeTasks  map[int]*ActiveTask
+	Runtime      *types.RuntimeConfig
+	Headers      map[string]string
+	ID           string
+	URL          string
+	DestPath     string
+	activeMu     sync.Mutex
 }
 
-// NewConcurrentDownloader creates a new concurrent downloader with all required parameters
+// NewConcurrentDownloader creates a new concurrent downloader with all required parameters.
 func NewConcurrentDownloader(id string, progressCh chan<- any, progState *types.ProgressState, runtime *types.RuntimeConfig) *ConcurrentDownloader {
 	if runtime == nil {
 		runtime = &types.RuntimeConfig{
@@ -61,7 +62,7 @@ func NewConcurrentDownloader(id string, progressCh chan<- any, progState *types.
 	}
 }
 
-// getInitialConnections returns the starting number of connections based on file size
+// getInitialConnections returns the starting number of connections based on file size.
 func (d *ConcurrentDownloader) getInitialConnections(fileSize int64) int {
 	maxConns := d.Runtime.GetMaxConnectionsPerHost()
 	minChunkSize := d.Runtime.GetMinChunkSize() // e.g., 1MB or 5MB
@@ -98,7 +99,7 @@ func (d *ConcurrentDownloader) getInitialConnections(fileSize int64) int {
 	return calculatedWorkers
 }
 
-// ReportMirrorError marks a mirror as having an error in the state
+// ReportMirrorError marks a mirror as having an error in the state.
 func (d *ConcurrentDownloader) ReportMirrorError(url string) {
 	if d.State == nil {
 		return
@@ -119,7 +120,7 @@ func (d *ConcurrentDownloader) ReportMirrorError(url string) {
 	}
 }
 
-// calculateChunkSize determines optimal chunk size
+// calculateChunkSize determines optimal chunk size.
 func (d *ConcurrentDownloader) calculateChunkSize(fileSize int64, numConns int) int64 {
 	// Safety check
 	if numConns <= 0 {
@@ -144,7 +145,7 @@ func (d *ConcurrentDownloader) calculateChunkSize(fileSize int64, numConns int) 
 	return chunkSize
 }
 
-// determineChunkSize decides the strategy (Sequential vs Parallel)
+// determineChunkSize decides the strategy (Sequential vs Parallel).
 func (d *ConcurrentDownloader) determineChunkSize(fileSize int64, numConns int) int64 {
 	if d.Runtime.SequentialDownload {
 		// Sequential mode: Use small fixed chunks (MinChunkSize) to ensure strict ordering
@@ -164,7 +165,7 @@ func (d *ConcurrentDownloader) determineChunkSize(fileSize int64, numConns int) 
 	return d.calculateChunkSize(fileSize, numConns)
 }
 
-// createTasks generates initial task queue from file size and chunk size
+// createTasks generates initial task queue from file size and chunk size.
 func createTasks(fileSize, chunkSize int64) []types.Task {
 	if chunkSize <= 0 {
 		return nil
@@ -184,7 +185,7 @@ func createTasks(fileSize, chunkSize int64) []types.Task {
 	return tasks
 }
 
-// newConcurrentClient creates an http.Client tuned for concurrent downloads
+// newConcurrentClient creates an http.Client tuned for concurrent downloads.
 func (d *ConcurrentDownloader) newConcurrentClient(numConns int) *http.Client {
 	// Ensure we have enough connections per host
 	maxConns := d.Runtime.GetMaxConnectionsPerHost()
@@ -239,7 +240,7 @@ func (d *ConcurrentDownloader) newConcurrentClient(numConns int) *http.Client {
 		// Since these headers were explicitly provided by the browser for this download, we forward them.
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= 10 {
-				return fmt.Errorf("stopped after 10 redirects")
+				return errors.New("stopped after 10 redirects")
 			}
 			// Copy headers from original request to redirect request
 			if len(via) > 0 {
@@ -257,7 +258,7 @@ func (d *ConcurrentDownloader) newConcurrentClient(numConns int) *http.Client {
 }
 
 // Download downloads a file using multiple concurrent connections
-// Uses pre-probed metadata (file size already known)
+// Uses pre-probed metadata (file size already known).
 func (d *ConcurrentDownloader) Download(ctx context.Context, rawurl string, candidateMirrors []string, activeMirrors []string, destPath string, fileSize int64) error {
 	utils.Debug("ConcurrentDownloader.Download: %s -> %s (size: %d, mirrors: %d)", rawurl, destPath, fileSize, len(activeMirrors))
 
@@ -504,7 +505,7 @@ func (d *ConcurrentDownloader) Download(ctx context.Context, rawurl string, cand
 		go func(workerID int) {
 			defer wg.Done()
 			err := d.worker(downloadCtx, workerID, workerMirrors, outFile, queue, fileSize, client)
-			if err != nil && err != context.Canceled {
+			if err != nil && !errors.Is(err, context.Canceled) {
 				workerErrors <- err
 			}
 		}(i)
@@ -592,7 +593,7 @@ func (d *ConcurrentDownloader) Download(ctx context.Context, rawurl string, cand
 		return types.ErrPaused // Signal valid pause to caller
 	}
 
-	// Handle cancel: context was cancelled but not via Pause()
+	// Handle cancel: context was canceled but not via Pause()
 	// Propagate cancellation so callers don't treat this as a successful completion.
 	if downloadCtx.Err() == context.Canceled {
 		return context.Canceled
@@ -606,7 +607,7 @@ func (d *ConcurrentDownloader) Download(ctx context.Context, rawurl string, cand
 	return finalizeCompletedDownload()
 }
 
-// prewarmConnections fires off concurrent pings to the mirrors to populate the connection pool
+// prewarmConnections fires off concurrent pings to the mirrors to populate the connection pool.
 func (d *ConcurrentDownloader) prewarmConnections(ctx context.Context, client *http.Client, numRequired, hedgeCount int, mirrors []string) {
 	totalToStart := numRequired + hedgeCount
 	if totalToStart > 128 { // Safety cap
@@ -622,7 +623,6 @@ func (d *ConcurrentDownloader) prewarmConnections(ctx context.Context, client *h
 
 	for i := 0; i < totalToStart; i++ {
 		go func(idx int) {
-
 			// Round-robin mirrors
 			mirror := mirrors[idx%len(mirrors)]
 
@@ -675,5 +675,5 @@ func (d *ConcurrentDownloader) prewarmConnections(ctx context.Context, client *h
 	}
 
 	utils.Debug("Pre-warming complete: %d connections hot", completed)
-	// Remaining pings will be cancelled by defer cancelPings()
+	// Remaining pings will be canceled by defer cancelPings()
 }

--- a/internal/engine/concurrent/health.go
+++ b/internal/engine/concurrent/health.go
@@ -7,7 +7,7 @@ import (
 	"github.com/SurgeDM/Surge/internal/utils"
 )
 
-// checkWorkerHealth detects slow workers and cancels them
+// checkWorkerHealth detects slow workers and cancels them.
 func (d *ConcurrentDownloader) checkWorkerHealth() {
 	d.activeMu.Lock()
 	defer d.activeMu.Unlock()
@@ -55,7 +55,6 @@ func (d *ConcurrentDownloader) checkWorkerHealth() {
 	// Second pass: check for slow and stalled workers
 	stallTimeout := d.Runtime.GetStallTimeout()
 	for workerID, active := range d.activeTasks {
-
 		// timeSinceActivity := now.Sub(lastTime)
 		taskDuration := now.Sub(active.StartTime)
 
@@ -71,12 +70,12 @@ func (d *ConcurrentDownloader) checkWorkerHealth() {
 		if lastActivity > 0 {
 			timeSinceData := now.Sub(time.Unix(0, lastActivity))
 			if timeSinceData >= stallTimeout {
-				utils.Debug("Health: Worker %d stalled (no data for %v), cancelling",
+				utils.Debug("Health: Worker %d stalled (no data for %v), canceling",
 					workerID, timeSinceData.Truncate(time.Millisecond))
 				if active.Cancel != nil {
 					active.Cancel()
 				}
-				continue // Already cancelled, skip speed check
+				continue // Already canceled, skip speed check
 			}
 		}
 
@@ -88,7 +87,7 @@ func (d *ConcurrentDownloader) checkWorkerHealth() {
 			isBelowThreshold := workerSpeed > 0 && workerSpeed < threshold*meanSpeed
 
 			if isBelowThreshold {
-				utils.Debug("Health: Worker %d slow (%.2f KB/s vs mean %.2f KB/s), cancelling",
+				utils.Debug("Health: Worker %d slow (%.2f KB/s vs mean %.2f KB/s), canceling",
 					workerID, workerSpeed/float64(types.KB), meanSpeed/float64(types.KB))
 				if active.Cancel != nil {
 					active.Cancel()

--- a/internal/engine/concurrent/health_test.go
+++ b/internal/engine/concurrent/health_test.go
@@ -48,9 +48,9 @@ func TestHealth_LastManStanding(t *testing.T) {
 	// 4. Verify Cancellation
 	select {
 	case <-ctx.Done():
-		// Success: context cancelled
+		// Success: context canceled
 	default:
-		t.Errorf("Worker should have been cancelled (Global Speed ~10MB/s, Worker 1MB/s)")
+		t.Errorf("Worker should have been canceled (Global Speed ~10MB/s, Worker 1MB/s)")
 	}
 }
 
@@ -83,23 +83,23 @@ func TestHealth_MultipleWorkers(t *testing.T) {
 
 	d.checkWorkerHealth()
 
-	// Verify Worker 2 cancelled
+	// Verify Worker 2 canceled
 	select {
 	case <-w2Ctx.Done():
 		// Success
 	default:
-		t.Error("Worker 2 should have been cancelled")
+		t.Error("Worker 2 should have been canceled")
 	}
 
-	// Verify others NOT cancelled
+	// Verify others NOT canceled
 	select {
 	case <-w0Ctx.Done():
-		t.Error("Worker 0 should NOT have been cancelled")
+		t.Error("Worker 0 should NOT have been canceled")
 	default:
 	}
 	select {
 	case <-w1Ctx.Done():
-		t.Error("Worker 1 should NOT have been cancelled")
+		t.Error("Worker 1 should NOT have been canceled")
 	default:
 	}
 }
@@ -129,24 +129,24 @@ func TestHealth_GracePeriod(t *testing.T) {
 
 	d.checkWorkerHealth()
 
-	// Verify Worker 1 NOT cancelled due to grace period
+	// Verify Worker 1 NOT canceled due to grace period
 	select {
 	case <-w1Ctx.Done():
-		t.Error("Worker 1 should NOT have been cancelled (Grace Period)")
+		t.Error("Worker 1 should NOT have been canceled (Grace Period)")
 	default:
 		// Success
 	}
 
-	// Verify Worker 0 NOT cancelled (Fast enough)
+	// Verify Worker 0 NOT canceled (Fast enough)
 	select {
 	case <-w0Ctx.Done():
-		t.Error("Worker 0 should NOT have been cancelled")
+		t.Error("Worker 0 should NOT have been canceled")
 	default:
 	}
 }
 
 func TestHealth_StallDetection(t *testing.T) {
-	// A worker that has received no data for StallTimeout should be cancelled
+	// A worker that has received no data for StallTimeout should be canceled
 	// regardless of speed comparison
 	runtime := &types.RuntimeConfig{
 		SlowWorkerThreshold:   0.5,
@@ -173,11 +173,11 @@ func TestHealth_StallDetection(t *testing.T) {
 
 	d.checkWorkerHealth()
 
-	// Verify stalled worker was cancelled
+	// Verify stalled worker was canceled
 	select {
 	case <-stalledCtx.Done():
-		// Success: stall detected and cancelled
+		// Success: stall detected and canceled
 	default:
-		t.Error("Stalled worker should have been cancelled")
+		t.Error("Stalled worker should have been canceled")
 	}
 }

--- a/internal/engine/concurrent/task.go
+++ b/internal/engine/concurrent/task.go
@@ -9,29 +9,23 @@ import (
 	"github.com/SurgeDM/Surge/internal/engine/types"
 )
 
-// ActiveTask tracks a task currently being processed by a worker
+// ActiveTask tracks a task currently being processed by a worker.
 type ActiveTask struct {
-	Task          types.Task
-	CurrentOffset atomic.Int64
-	StopAt        atomic.Int64
-
-	// Health monitoring fields
-	LastActivity atomic.Int64       // Unix nano timestamp of last data received
-	Speed        float64            // EMA-smoothed speed in bytes/sec (protected by mutex)
-	StartTime    time.Time          // When this task started
-	Cancel       context.CancelFunc // Cancel function to abort this task
-	SpeedMu      sync.Mutex         // Protects Speed field
-
-	// Sliding window for recent speed tracking
-	WindowStart time.Time    // When current measurement window started
-	WindowBytes atomic.Int64 // Bytes downloaded in current window
-
-	// Hedged request tracking
-	Hedged          atomic.Int32  // 1 if an idle worker is already racing this task
-	SharedMaxOffset *atomic.Int64 // Highest offset reached by any racing worker
+	Task            types.Task
+	StartTime       time.Time
+	WindowStart     time.Time
+	Cancel          context.CancelFunc
+	SharedMaxOffset *atomic.Int64
+	CurrentOffset   atomic.Int64
+	StopAt          atomic.Int64
+	LastActivity    atomic.Int64
+	Speed           float64
+	WindowBytes     atomic.Int64
+	SpeedMu         sync.Mutex
+	Hedged          atomic.Int32
 }
 
-// RemainingBytes returns the number of bytes left for this task
+// RemainingBytes returns the number of bytes left for this task.
 func (at *ActiveTask) RemainingBytes() int64 {
 	current := at.CurrentOffset.Load()
 	stopAt := at.StopAt.Load()
@@ -41,7 +35,7 @@ func (at *ActiveTask) RemainingBytes() int64 {
 	return stopAt - current
 }
 
-// RemainingTask returns a Task representing the remaining work, or nil if complete
+// RemainingTask returns a Task representing the remaining work, or nil if complete.
 func (at *ActiveTask) RemainingTask() *types.Task {
 	current := at.CurrentOffset.Load()
 	stopAt := at.StopAt.Load()
@@ -51,7 +45,7 @@ func (at *ActiveTask) RemainingTask() *types.Task {
 	return &types.Task{Offset: current, Length: stopAt - current}
 }
 
-// GetSpeed returns the current EMA-smoothed speed, decaying if stalled
+// GetSpeed returns the current EMA-smoothed speed, decaying if stalled.
 func (at *ActiveTask) GetSpeed() float64 {
 	at.SpeedMu.Lock()
 	speed := at.Speed
@@ -77,7 +71,7 @@ func (at *ActiveTask) GetSpeed() float64 {
 }
 
 // alignedSplitSize calculates a split size that is half of remaining, aligned to AlignSize
-// Returns 0 if the split would be smaller than MinChunk
+// Returns 0 if the split would be smaller than MinChunk.
 func alignedSplitSize(remaining int64) int64 {
 	half := (remaining / 2 / types.AlignSize) * types.AlignSize
 	if half < types.MinChunk {

--- a/internal/engine/concurrent/task_queue.go
+++ b/internal/engine/concurrent/task_queue.go
@@ -7,16 +7,16 @@ import (
 	"github.com/SurgeDM/Surge/internal/engine/types"
 )
 
-// TaskQueue is a thread-safe work-stealing queue
+// TaskQueue is a thread-safe work-stealing queue.
 type TaskQueue struct {
+	cond        *sync.Cond
 	tasks       []types.Task
 	head        int
+	idleWorkers atomic.Int64
+	waiting     atomic.Int64
+	size        atomic.Int64
 	mu          sync.Mutex
-	cond        *sync.Cond
 	done        bool
-	idleWorkers atomic.Int64 // Atomic counter for idle workers
-	waiting     atomic.Int64 // Number of workers currently waiting on cond
-	size        atomic.Int64 // Queue size to avoid lock contention in Len callers
 }
 
 func NewTaskQueue() *TaskQueue {
@@ -65,7 +65,6 @@ func (q *TaskQueue) Pop() (types.Task, bool) {
 	q.head++
 	q.size.Add(-1)
 	if q.head > len(q.tasks)/2 {
-
 		// slice instead of copy to avoid allocation
 		q.tasks = q.tasks[q.head:]
 		q.head = 0
@@ -88,7 +87,7 @@ func (q *TaskQueue) IdleWorkers() int64 {
 	return q.idleWorkers.Load()
 }
 
-// DrainRemaining returns all remaining tasks in the queue (used for pause/resume)
+// DrainRemaining returns all remaining tasks in the queue (used for pause/resume).
 func (q *TaskQueue) DrainRemaining() []types.Task {
 	q.mu.Lock()
 	defer q.mu.Unlock()

--- a/internal/engine/concurrent/task_test.go
+++ b/internal/engine/concurrent/task_test.go
@@ -99,10 +99,10 @@ func TestActiveTask_Cancel(t *testing.T) {
 		Cancel: cancel,
 	}
 
-	// Verify context is not cancelled
+	// Verify context is not canceled
 	select {
 	case <-ctx.Done():
-		t.Fatal("Context should not be cancelled")
+		t.Fatal("Context should not be canceled")
 	default:
 	}
 
@@ -113,7 +113,7 @@ func TestActiveTask_Cancel(t *testing.T) {
 	case <-ctx.Done():
 		// Expected
 	default:
-		t.Error("Context should be cancelled after Cancel()")
+		t.Error("Context should be canceled after Cancel()")
 	}
 }
 

--- a/internal/engine/concurrent/worker.go
+++ b/internal/engine/concurrent/worker.go
@@ -2,6 +2,7 @@ package concurrent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -13,7 +14,7 @@ import (
 	"github.com/SurgeDM/Surge/internal/utils"
 )
 
-// worker downloads tasks from the queue
+// worker downloads tasks from the queue.
 func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []string, file *os.File, queue *TaskQueue, totalSize int64, client *http.Client) error {
 	// Get pooled buffer
 	bufPtr := d.bufPool.Get().(*[]byte)
@@ -43,7 +44,6 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 		maxRetries := d.Runtime.GetMaxTaskRetries()
 		for attempt := 0; attempt < maxRetries; attempt++ {
 			if attempt > 0 {
-
 				if len(mirrors) == 1 {
 					time.Sleep(time.Duration(1<<attempt) * types.RetryBaseDelay) // Exponential backoff incase of failure
 				}
@@ -109,14 +109,14 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 				return ctx.Err()
 			}
 
-			// Check if TASK context was cancelled by Health Monitor (not by us calling taskCancel)
+			// Check if TASK context was canceled by Health Monitor (not by us calling taskCancel)
 			// but parent context is still fine
 			if wasExternallyCancelled && lastErr != nil {
-				// Health monitor cancelled this task - re-queue REMAINING work only
+				// Health monitor canceled this task - re-queue REMAINING work only
 
 				// Force rotation to next mirror to avoid getting stuck on the slow one
 				currentMirrorIdx = (currentMirrorIdx + 1) % len(mirrors)
-				utils.Debug("Worker %d: Health check cancelled task, rotating from mirror %s to %s", id, mirrors[(currentMirrorIdx+len(mirrors)-1)%len(mirrors)], mirrors[currentMirrorIdx])
+				utils.Debug("Worker %d: Health check canceled task, rotating from mirror %s to %s", id, mirrors[(currentMirrorIdx+len(mirrors)-1)%len(mirrors)], mirrors[currentMirrorIdx])
 
 				if remaining := activeTask.RemainingTask(); remaining != nil {
 					// Clamp to original task end (don't go past original boundary)
@@ -126,7 +126,7 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 					}
 					if remaining.Length > 0 {
 						queue.Push(*remaining)
-						utils.Debug("Worker %d: health-cancelled task requeued (remaining: %d bytes from offset %d)",
+						utils.Debug("Worker %d: health-canceled task requeued (remaining: %d bytes from offset %d)",
 							id, remaining.Length, remaining.Offset)
 					}
 				}
@@ -139,7 +139,7 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 				break // Exit retry loop, get next task
 			}
 
-			// Only delete from activeTasks on normal completion (not cancelled)
+			// Only delete from activeTasks on normal completion (not canceled)
 			d.activeMu.Lock()
 			delete(d.activeTasks, id)
 			d.activeMu.Unlock()
@@ -179,7 +179,7 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 	}
 }
 
-// downloadTask downloads a single byte range and writes to file at offset
+// downloadTask downloads a single byte range and writes to file at offset.
 func (d *ConcurrentDownloader) downloadTask(ctx context.Context, rawurl string, file *os.File, activeTask *ActiveTask, buf []byte, client *http.Client, totalSize int64) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawurl, nil)
 	if err != nil {
@@ -215,7 +215,7 @@ func (d *ConcurrentDownloader) downloadTask(ctx context.Context, rawurl string, 
 
 	// Handle rate limiting explicitly
 	if resp.StatusCode == http.StatusTooManyRequests {
-		return fmt.Errorf("rate limited (429)")
+		return errors.New("rate limited (429)")
 	}
 
 	// Validate status code
@@ -223,7 +223,7 @@ func (d *ConcurrentDownloader) downloadTask(ctx context.Context, rawurl string, 
 		// Valid only if we requested the full file
 		// If we wanted a partial range but got the whole file (200), that's an error because we can't handle the full stream at a non-zero offset
 		if task.Offset != 0 || task.Length != totalSize {
-			return fmt.Errorf("server indicated success (200) but ignored range request (expected 206)")
+			return errors.New("server indicated success (200) but ignored range request (expected 206)")
 		}
 	} else if resp.StatusCode != http.StatusPartialContent {
 		return fmt.Errorf("unexpected status: %d", resp.StatusCode)
@@ -301,7 +301,6 @@ func (d *ConcurrentDownloader) downloadTask(ctx context.Context, rawurl string, 
 		}
 
 		if readSoFar > 0 {
-
 			// check stopAt again before writing
 			// truncate readSoFar
 			currentStopAt := activeTask.StopAt.Load()

--- a/internal/engine/events/events.go
+++ b/internal/engine/events/events.go
@@ -8,21 +8,21 @@ import (
 	"github.com/SurgeDM/Surge/internal/engine/types"
 )
 
-// ProgressMsg represents a progress update from the downloader
+// ProgressMsg represents a progress update from the downloader.
 type ProgressMsg struct {
 	DownloadID        string
+	ChunkBitmap       []byte
+	ChunkProgress     []int64
 	Downloaded        int64
 	Total             int64
-	Speed             float64 // bytes per second
+	Speed             float64
 	Elapsed           time.Duration
 	ActiveConnections int
-	ChunkBitmap       []byte
 	BitmapWidth       int
 	ActualChunkSize   int64
-	ChunkProgress     []int64
 }
 
-// DownloadCompleteMsg signals that the download finished successfully
+// DownloadCompleteMsg signals that the download finished successfully.
 type DownloadCompleteMsg struct {
 	DownloadID string
 	Filename   string
@@ -31,12 +31,12 @@ type DownloadCompleteMsg struct {
 	AvgSpeed   float64 // Average download speed in bytes/sec
 }
 
-// DownloadErrorMsg signals that an error occurred
+// DownloadErrorMsg signals that an error occurred.
 type DownloadErrorMsg struct {
+	Err        error
 	DownloadID string
 	Filename   string
 	DestPath   string
-	Err        error
 }
 
 func (m DownloadErrorMsg) MarshalJSON() ([]byte, error) {
@@ -96,21 +96,21 @@ func (m *DownloadErrorMsg) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// DownloadStartedMsg is sent when a download actually starts (after metadata fetch)
+// DownloadStartedMsg is sent when a download actually starts (after metadata fetch).
 type DownloadStartedMsg struct {
+	State      *types.ProgressState `json:"-"`
 	DownloadID string
 	URL        string
 	Filename   string
+	DestPath   string
 	Total      int64
-	DestPath   string               // Full path to the destination file
-	State      *types.ProgressState `json:"-"`
 }
 
 type DownloadPausedMsg struct {
+	State      *types.DownloadState `json:"-"`
 	DownloadID string
 	Filename   string
 	Downloaded int64
-	State      *types.DownloadState `json:"-"`
 }
 
 type DownloadResumedMsg struct {
@@ -138,18 +138,18 @@ type SystemLogMsg struct {
 	Message string
 }
 
-// BatchProgressMsg represents a batch of progress updates to reduce TUI render calls
+// BatchProgressMsg represents a batch of progress updates to reduce TUI render calls.
 type BatchProgressMsg []ProgressMsg
 
 // DownloadRequestMsg signals a request to start a download (e.g. from extension)
-// that may need user confirmation or duplicate checking
+// that may need user confirmation or duplicate checking.
 type DownloadRequestMsg struct {
+	Headers  map[string]string
 	ID       string
 	URL      string
 	Filename string
 	Path     string
 	Mirrors  []string
-	Headers  map[string]string
 }
 
 const (

--- a/internal/engine/single/downloader.go
+++ b/internal/engine/single/downloader.go
@@ -2,6 +2,7 @@ package single
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -20,17 +21,17 @@ import (
 // the server doesn't support Range headers. If interrupted, the download must restart.
 type SingleDownloader struct {
 	Client       *http.Client
-	ProgressChan chan<- any           // Channel for events (start/complete/error)
-	ID           string               // Download ID
-	State        *types.ProgressState // Shared state for TUI polling
+	ProgressChan chan<- any
+	State        *types.ProgressState
 	Runtime      *types.RuntimeConfig
-	Headers      map[string]string // Custom HTTP headers (cookies, auth, etc.)
+	Headers      map[string]string
+	ID           string
 }
 
 type singleTransportKey struct {
 	proxyURL  string
-	maxConns  int
 	customDNS string
+	maxConns  int
 }
 
 var singleTransportCache sync.Map // map[singleTransportKey]*http.Transport
@@ -42,7 +43,7 @@ var bufPool = sync.Pool{
 	},
 }
 
-// NewSingleDownloader creates a new single-threaded downloader with all required parameters
+// NewSingleDownloader creates a new single-threaded downloader with all required parameters.
 func NewSingleDownloader(id string, progressCh chan<- any, state *types.ProgressState, runtime *types.RuntimeConfig) *SingleDownloader {
 	if runtime == nil {
 		runtime = &types.RuntimeConfig{}
@@ -65,7 +66,7 @@ func newSingleClient(runtime *types.RuntimeConfig, sd *SingleDownloader) *http.C
 		Transport: transport,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= 10 {
-				return fmt.Errorf("stopped after 10 redirects")
+				return errors.New("stopped after 10 redirects")
 			}
 			if len(via) > 0 {
 				utils.CopyRedirectHeaders(req, via[0])
@@ -237,13 +238,13 @@ func (d *SingleDownloader) Download(ctx context.Context, rawurl, destPath string
 }
 
 type progressReader struct {
+	lastFlush     time.Time
 	reader        io.Reader
 	state         *types.ProgressState
 	batchSize     int64
 	batchInterval time.Duration
 	written       int64
 	pending       int64
-	lastFlush     time.Time
 	readChecks    uint8
 }
 

--- a/internal/engine/single/downloader_test.go
+++ b/internal/engine/single/downloader_test.go
@@ -2,6 +2,7 @@ package single
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -424,7 +425,7 @@ func TestSingleDownloader_Download_Cancellation(t *testing.T) {
 	select {
 	case err := <-done:
 		// Accept context.Canceled or wrapped errors
-		if err != nil && err != context.Canceled && err.Error() != "context canceled" {
+		if err != nil && !errors.Is(err, context.Canceled) && err.Error() != "context canceled" {
 			t.Logf("Expected context.Canceled, got: %v", err)
 		}
 	case <-time.After(5 * time.Second):

--- a/internal/engine/state/db.go
+++ b/internal/engine/state/db.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"log"
 	"sync"
@@ -16,7 +17,7 @@ var (
 	configured bool
 )
 
-// Configure sets the path for the SQLite database
+// Configure sets the path for the SQLite database.
 func Configure(path string) {
 	dbMu.Lock()
 	defer dbMu.Unlock()
@@ -24,7 +25,7 @@ func Configure(path string) {
 	configured = true
 }
 
-// initDBLocked initialises the database connection.
+// initDBLocked initializes the database connection.
 // Caller must hold dbMu.
 func initDBLocked() error {
 	if db != nil {
@@ -32,7 +33,7 @@ func initDBLocked() error {
 	}
 
 	if !configured || dbPath == "" {
-		return fmt.Errorf("state database not configured: call state.Configure() first")
+		return errors.New("state database not configured: call state.Configure() first")
 	}
 
 	var err error
@@ -168,7 +169,7 @@ func GetDB() (*sql.DB, error) {
 	return db, nil
 }
 
-// Helper to ensure DB is initialized and return it
+// Helper to ensure DB is initialized and return it.
 func getDBHelper() *sql.DB {
 	d, err := GetDB()
 	if err != nil {
@@ -178,11 +179,11 @@ func getDBHelper() *sql.DB {
 	return d
 }
 
-// Transaction helper
+// Transaction helper.
 func withTx(fn func(*sql.Tx) error) error {
 	d := getDBHelper()
 	if d == nil {
-		return fmt.Errorf("database not initialized")
+		return errors.New("database not initialized")
 	}
 
 	tx, err := d.Begin()

--- a/internal/engine/state/db_test.go
+++ b/internal/engine/state/db_test.go
@@ -2,7 +2,7 @@ package state
 
 import (
 	"database/sql"
-	"fmt"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -104,7 +104,7 @@ func TestWithTx_Rollback(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedErr := fmt.Errorf("intentional error")
+	expectedErr := errors.New("intentional error")
 	err := withTx(func(tx *sql.Tx) error {
 		_, err := tx.Exec("INSERT INTO downloads (id, url, dest_path) VALUES (?, ?, ?)", "tx-test-2", "http://tx.com/2", "/tmp/2")
 		if err != nil {
@@ -114,7 +114,7 @@ func TestWithTx_Rollback(t *testing.T) {
 		return expectedErr
 	})
 
-	if err != expectedErr {
+	if !errors.Is(err, expectedErr) {
 		t.Fatalf("Expected error %v, got %v", expectedErr, err)
 	}
 

--- a/internal/engine/state/state.go
+++ b/internal/engine/state/state.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -12,9 +13,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/SurgeDM/Surge/internal/engine/types"
 	"github.com/SurgeDM/Surge/internal/utils"
-	"github.com/google/uuid"
 )
 
 const (
@@ -36,13 +38,13 @@ type SaveStateOptions struct {
 }
 
 // URLHash returns a short hash of the URL for master list keying
-// This is used for tracking completed downloads by URL
+// This is used for tracking completed downloads by URL.
 func URLHash(url string) string {
 	h := sha256.Sum256([]byte(url))
 	return hex.EncodeToString(h[:8]) // 16 chars
 }
 
-// SaveState saves download state to SQLite
+// SaveState saves download state to SQLite.
 func SaveState(url string, destPath string, state *types.DownloadState) error {
 	return SaveStateWithOptions(url, destPath, state, SaveStateOptions{})
 }
@@ -244,12 +246,11 @@ func parseStoredHash(storedHash string) (algo, value string) {
 	}
 }
 
-// LoadState loads download state from SQLite
+// LoadState loads download state from SQLite.
 func LoadState(url string, destPath string) (*types.DownloadState, error) {
-
 	db := getDBHelper()
 	if db == nil {
-		return nil, fmt.Errorf("database not initialized")
+		return nil, errors.New("database not initialized")
 	}
 
 	var state types.DownloadState
@@ -270,7 +271,7 @@ func LoadState(url string, destPath string) (*types.DownloadState, error) {
 		&createdAt, &pausedAt, &timeTaken, &mirrors, &chunkBitmap, &actualChunkSize, &fileHash,
 	)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			// Try finding without status constraint (just in case)
 			return nil, fmt.Errorf("state not found: %w", os.ErrNotExist) // mimic os.ErrNotExist for compatibility
 		}
@@ -319,15 +320,15 @@ func LoadState(url string, destPath string) (*types.DownloadState, error) {
 	return &state, nil
 }
 
-// DeleteState removes the state from SQLite
+// DeleteState removes the state from SQLite.
 func DeleteState(id string) error {
 	db := getDBHelper()
 	if db == nil {
-		return fmt.Errorf("database not initialized")
+		return errors.New("database not initialized")
 	}
 
 	if id == "" {
-		return fmt.Errorf("id cannot be empty")
+		return errors.New("id cannot be empty")
 	}
 
 	if err := removeDownloadAndTasks(id); err != nil {
@@ -341,11 +342,11 @@ func DeleteState(id string) error {
 func DeleteTasks(id string) error {
 	db := getDBHelper()
 	if db == nil {
-		return fmt.Errorf("database not initialized")
+		return errors.New("database not initialized")
 	}
 
 	if id == "" {
-		return fmt.Errorf("id cannot be empty")
+		return errors.New("id cannot be empty")
 	}
 
 	_, err := db.Exec("DELETE FROM tasks WHERE download_id = ?", id)
@@ -358,7 +359,7 @@ func DeleteTasks(id string) error {
 
 // ================== Master List Functions ==================
 
-// LoadMasterList loads ALL downloads (paused and completed)
+// LoadMasterList loads ALL downloads (paused and completed).
 func LoadMasterList() (*types.MasterList, error) {
 	db := getDBHelper()
 	if db == nil {
@@ -418,7 +419,7 @@ func LoadMasterList() (*types.MasterList, error) {
 	return &list, nil
 }
 
-// AddToMasterList adds or updates a download entry
+// AddToMasterList adds or updates a download entry.
 func AddToMasterList(entry types.DownloadEntry) error {
 	// Ensure ID
 	if entry.ID == "" {
@@ -455,18 +456,18 @@ func AddToMasterList(entry types.DownloadEntry) error {
 	})
 }
 
-// RemoveFromMasterList removes a download entry
+// RemoveFromMasterList removes a download entry.
 func RemoveFromMasterList(id string) error {
 	db := getDBHelper()
 	if db == nil {
-		return fmt.Errorf("database not initialized")
+		return errors.New("database not initialized")
 	}
 
 	_, err := db.Exec("DELETE FROM downloads WHERE id = ?", id)
 	return err
 }
 
-// GetDownload returns a single download by ID
+// GetDownload returns a single download by ID.
 func GetDownload(id string) (*types.DownloadEntry, error) {
 	db := getDBHelper()
 	if db == nil {
@@ -516,7 +517,7 @@ func GetDownload(id string) (*types.DownloadEntry, error) {
 	return &e, nil
 }
 
-// LoadPausedDownloads returns all paused downloads
+// LoadPausedDownloads returns all paused downloads.
 func LoadPausedDownloads() ([]types.DownloadEntry, error) {
 	// Reuse LoadMasterList logic or optimize with WHERE
 	list, err := LoadMasterList()
@@ -533,7 +534,7 @@ func LoadPausedDownloads() ([]types.DownloadEntry, error) {
 	return paused, nil
 }
 
-// LoadCompletedDownloads returns all completed downloads
+// LoadCompletedDownloads returns all completed downloads.
 func LoadCompletedDownloads() ([]types.DownloadEntry, error) {
 	list, err := LoadMasterList()
 	if err != nil {
@@ -549,11 +550,11 @@ func LoadCompletedDownloads() ([]types.DownloadEntry, error) {
 	return completed, nil
 }
 
-// CheckDownloadExists checks if a download with the given URL exists in the database
+// CheckDownloadExists checks if a download with the given URL exists in the database.
 func CheckDownloadExists(url string) (bool, error) {
 	db := getDBHelper()
 	if db == nil {
-		return false, fmt.Errorf("database not initialized")
+		return false, errors.New("database not initialized")
 	}
 
 	var count int
@@ -566,11 +567,11 @@ func CheckDownloadExists(url string) (bool, error) {
 	return count > 0, nil
 }
 
-// UpdateStatus updates the status of a download by ID
+// UpdateStatus updates the status of a download by ID.
 func UpdateStatus(id string, status string) error {
 	db := getDBHelper()
 	if db == nil {
-		return fmt.Errorf("database not initialized")
+		return errors.New("database not initialized")
 	}
 
 	result, err := db.Exec("UPDATE downloads SET status = ? WHERE id = ?", status, id)
@@ -586,11 +587,11 @@ func UpdateStatus(id string, status string) error {
 	return nil
 }
 
-// UpdateURL updates the URL of a download by ID
+// UpdateURL updates the URL of a download by ID.
 func UpdateURL(id string, newURL string) error {
 	db := getDBHelper()
 	if db == nil {
-		return fmt.Errorf("database not initialized")
+		return errors.New("database not initialized")
 	}
 
 	newHash := URLHash(newURL)
@@ -608,29 +609,29 @@ func UpdateURL(id string, newURL string) error {
 	return nil
 }
 
-// PauseAllDownloads pauses all non-completed downloads
+// PauseAllDownloads pauses all non-completed downloads.
 func PauseAllDownloads() error {
 	db := getDBHelper()
 	if db == nil {
-		return fmt.Errorf("database not initialized")
+		return errors.New("database not initialized")
 	}
 
 	_, err := db.Exec("UPDATE downloads SET status = 'paused' WHERE status != 'completed'")
 	return err
 }
 
-// ResumeAllDownloads resumes all paused downloads (sets to queued)
+// ResumeAllDownloads resumes all paused downloads (sets to queued).
 func ResumeAllDownloads() error {
 	db := getDBHelper()
 	if db == nil {
-		return fmt.Errorf("database not initialized")
+		return errors.New("database not initialized")
 	}
 
 	_, err := db.Exec("UPDATE downloads SET status = 'queued' WHERE status = 'paused'")
 	return err
 }
 
-// ListAllDownloads returns all downloads
+// ListAllDownloads returns all downloads.
 func ListAllDownloads() ([]types.DownloadEntry, error) {
 	list, err := LoadMasterList()
 	if err != nil {
@@ -639,11 +640,11 @@ func ListAllDownloads() ([]types.DownloadEntry, error) {
 	return list.Downloads, nil
 }
 
-// RemoveCompletedDownloads removes all completed downloads and returns count
+// RemoveCompletedDownloads removes all completed downloads and returns count.
 func RemoveCompletedDownloads() (int64, error) {
 	db := getDBHelper()
 	if db == nil {
-		return 0, fmt.Errorf("database not initialized")
+		return 0, errors.New("database not initialized")
 	}
 
 	result, err := db.Exec("DELETE FROM downloads WHERE status = 'completed'")
@@ -655,7 +656,7 @@ func RemoveCompletedDownloads() (int64, error) {
 	return count, nil
 }
 
-// LoadStates loads multiple download states from SQLite in batch
+// LoadStates loads multiple download states from SQLite in batch.
 func LoadStates(ids []string) (map[string]*types.DownloadState, error) {
 	if len(ids) == 0 {
 		return make(map[string]*types.DownloadState), nil
@@ -663,7 +664,7 @@ func LoadStates(ids []string) (map[string]*types.DownloadState, error) {
 
 	db := getDBHelper()
 	if db == nil {
-		return nil, fmt.Errorf("database not initialized")
+		return nil, errors.New("database not initialized")
 	}
 
 	// Prepare IN clause placeholders
@@ -792,7 +793,7 @@ func removeDownloadAndTasks(id string) error {
 func NormalizeStaleDownloads() (int, error) {
 	db := getDBHelper()
 	if db == nil {
-		return 0, fmt.Errorf("database not initialized")
+		return 0, errors.New("database not initialized")
 	}
 
 	result, err := db.Exec(`UPDATE downloads SET status = 'paused' WHERE status = 'downloading'`)
@@ -810,7 +811,7 @@ func NormalizeStaleDownloads() (int, error) {
 func ValidateIntegrity() (int, error) {
 	db := getDBHelper()
 	if db == nil {
-		return 0, fmt.Errorf("database not initialized")
+		return 0, errors.New("database not initialized")
 	}
 
 	// Load all paused/queued downloads

--- a/internal/engine/state/state_test.go
+++ b/internal/engine/state/state_test.go
@@ -2,13 +2,15 @@ package state
 
 import (
 	"database/sql"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/SurgeDM/Surge/internal/engine/types"
 	"github.com/google/uuid"
+
+	"github.com/SurgeDM/Surge/internal/engine/types"
 )
 
 func setupTestDB(t *testing.T) string {
@@ -269,11 +271,10 @@ func TestDeleteState(t *testing.T) {
 
 	// Verify it was deleted
 	_, err := LoadState(testURL, testDestPath)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		t.Error("LoadState should fail after DeleteState")
-	case sql.ErrNoRows:
-		// Acceptable error
+	case errors.Is(err, sql.ErrNoRows):
 	}
 }
 

--- a/internal/engine/types/config.go
+++ b/internal/engine/types/config.go
@@ -4,34 +4,34 @@ import (
 	"time"
 )
 
-// Size constants
+// Size constants.
 const (
 	KB = 1 << 10
 	MB = 1 << 20
 	GB = 1 << 30
 
-	// IncompleteSuffix is appended to files while downloading
+	// IncompleteSuffix is appended to files while downloading.
 	IncompleteSuffix = ".surge"
 )
 
-// Chunk size constants for concurrent downloads
+// Chunk size constants for concurrent downloads.
 const (
 	MinChunk     = 2 * MB // Minimum chunk size
 	AlignSize    = 4 * KB // Align chunks to 4KB for filesystem
 	WorkerBuffer = 512 * KB
 
-	// Batching constants for worker updates
+	// Batching constants for worker updates.
 	WorkerBatchSize     = 1 * MB                 // Batch updates until 1MB is downloaded
 	WorkerBatchInterval = 200 * time.Millisecond // Or until 200ms passes
 )
 
-// Connection limits
+// Connection limits.
 const (
 	PerHostMax     = 64 // Max concurrent connections per host
 	DialHedgeCount = 4  // Extra connections to dial pre-emptively
 )
 
-// HTTP Client Tuning
+// HTTP Client Tuning.
 const (
 	DefaultMaxIdleConns          = 100
 	DefaultIdleConnTimeout       = 90 * time.Second
@@ -43,49 +43,48 @@ const (
 	ProbeTimeout                 = 30 * time.Second
 )
 
-// Channel buffer sizes
+// Channel buffer sizes.
 const (
 	ProgressChannelBuffer = 100
 )
 
-// DownloadConfig contains all parameters needed to start a download
+// DownloadConfig contains all parameters needed to start a download.
 type DownloadConfig struct {
-	URL                string
-	OutputPath         string
-	DestPath           string // Full destination path (for resume state lookup)
-	ID                 string
-	Filename           string
-	IsResume           bool // True if this is explicitly a resume, not a fresh download
+	Runtime            *RuntimeConfig
 	ProgressCh         chan<- any
+	Headers            map[string]string
 	State              *ProgressState
-	SavedState         *DownloadState    // Pre-loaded state for resume optimization
-	Runtime            *RuntimeConfig    // Dynamic settings from user config
-	Mirrors            []string          // List of mirror URLs (including primary)
-	Headers            map[string]string // Custom HTTP headers to include in download requests
-	IsExplicitCategory bool              // Used to override category routing from TUI
-	TotalSize          int64             // Total size in bytes of the required download
-	SupportsRange      bool              // Indicates whether the server supports range requests for concurrency
+	SavedState         *DownloadState
+	Filename           string
+	OutputPath         string
+	URL                string
+	ID                 string
+	DestPath           string
+	Mirrors            []string
+	TotalSize          int64
+	IsResume           bool
+	IsExplicitCategory bool
+	SupportsRange      bool
 }
 
-// RuntimeConfig holds dynamic settings that can override defaults
+// RuntimeConfig holds dynamic settings that can override defaults.
 type RuntimeConfig struct {
-	MaxConnectionsPerHost int
+	CustomDNS             string
 	UserAgent             string
 	ProxyURL              string
-	CustomDNS             string
-	SequentialDownload    bool
-	MinChunkSize          int64
-
 	WorkerBufferSize      int
+	MinChunkSize          int64
+	MaxConnectionsPerHost int
 	MaxTaskRetries        int
 	DialHedgeCount        int
 	SlowWorkerThreshold   float64
 	SlowWorkerGracePeriod time.Duration
 	StallTimeout          time.Duration
 	SpeedEmaAlpha         float64
+	SequentialDownload    bool
 }
 
-// GetUserAgent returns the configured user agent or the default
+// GetUserAgent returns the configured user agent or the default.
 func (r *RuntimeConfig) GetUserAgent() string {
 	if r == nil || r.UserAgent == "" {
 		return "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
@@ -93,7 +92,7 @@ func (r *RuntimeConfig) GetUserAgent() string {
 	return r.UserAgent
 }
 
-// GetMaxConnectionsPerHost returns configured value or default
+// GetMaxConnectionsPerHost returns configured value or default.
 func (r *RuntimeConfig) GetMaxConnectionsPerHost() int {
 	if r == nil || r.MaxConnectionsPerHost <= 0 {
 		return PerHostMax
@@ -101,7 +100,7 @@ func (r *RuntimeConfig) GetMaxConnectionsPerHost() int {
 	return r.MaxConnectionsPerHost
 }
 
-// GetMinChunkSize returns configured value or default
+// GetMinChunkSize returns configured value or default.
 func (r *RuntimeConfig) GetMinChunkSize() int64 {
 	if r == nil || r.MinChunkSize <= 0 {
 		return MinChunk
@@ -109,7 +108,7 @@ func (r *RuntimeConfig) GetMinChunkSize() int64 {
 	return r.MinChunkSize
 }
 
-// GetWorkerBufferSize returns configured value or default
+// GetWorkerBufferSize returns configured value or default.
 func (r *RuntimeConfig) GetWorkerBufferSize() int {
 	if r == nil || r.WorkerBufferSize <= 0 {
 		return WorkerBuffer
@@ -121,7 +120,7 @@ const (
 	MaxTaskRetries = 3
 	RetryBaseDelay = 200 * time.Millisecond
 
-	// Health check constants
+	// Health check constants.
 	HealthCheckInterval = 1 * time.Second // How often to check worker health
 	SlowWorkerThreshold = 0.50            // Restart if speed < x times of mean
 	SlowWorkerGrace     = 5 * time.Second // Grace period before checking speed
@@ -129,7 +128,7 @@ const (
 	SpeedEMAAlpha       = 0.3             // EMA smoothing factor
 )
 
-// GetMaxTaskRetries returns configured value or default
+// GetMaxTaskRetries returns configured value or default.
 func (r *RuntimeConfig) GetMaxTaskRetries() int {
 	if r == nil || r.MaxTaskRetries <= 0 {
 		return MaxTaskRetries
@@ -137,7 +136,7 @@ func (r *RuntimeConfig) GetMaxTaskRetries() int {
 	return r.MaxTaskRetries
 }
 
-// GetDialHedgeCount returns configured value or default
+// GetDialHedgeCount returns configured value or default.
 func (r *RuntimeConfig) GetDialHedgeCount() int {
 	if r == nil {
 		return DialHedgeCount
@@ -149,7 +148,7 @@ func (r *RuntimeConfig) GetDialHedgeCount() int {
 	return r.DialHedgeCount
 }
 
-// GetSlowWorkerThreshold returns configured value or default
+// GetSlowWorkerThreshold returns configured value or default.
 func (r *RuntimeConfig) GetSlowWorkerThreshold() float64 {
 	if r == nil || r.SlowWorkerThreshold <= 0 {
 		return SlowWorkerThreshold
@@ -157,7 +156,7 @@ func (r *RuntimeConfig) GetSlowWorkerThreshold() float64 {
 	return r.SlowWorkerThreshold
 }
 
-// GetSlowWorkerGracePeriod returns configured value or default
+// GetSlowWorkerGracePeriod returns configured value or default.
 func (r *RuntimeConfig) GetSlowWorkerGracePeriod() time.Duration {
 	if r == nil || r.SlowWorkerGracePeriod <= 0 {
 		return SlowWorkerGrace
@@ -165,7 +164,7 @@ func (r *RuntimeConfig) GetSlowWorkerGracePeriod() time.Duration {
 	return r.SlowWorkerGracePeriod
 }
 
-// GetStallTimeout returns configured value or default
+// GetStallTimeout returns configured value or default.
 func (r *RuntimeConfig) GetStallTimeout() time.Duration {
 	if r == nil || r.StallTimeout <= 0 {
 		return StallTimeout
@@ -173,7 +172,7 @@ func (r *RuntimeConfig) GetStallTimeout() time.Duration {
 	return r.StallTimeout
 }
 
-// GetSpeedEmaAlpha returns configured value or default
+// GetSpeedEmaAlpha returns configured value or default.
 func (r *RuntimeConfig) GetSpeedEmaAlpha() float64 {
 	if r == nil || r.SpeedEmaAlpha <= 0 {
 		return SpeedEMAAlpha

--- a/internal/engine/types/errors.go
+++ b/internal/engine/types/errors.go
@@ -2,7 +2,7 @@ package types
 
 import "errors"
 
-// Common errors
+// Common errors.
 var (
 	ErrPaused = errors.New("download paused")
 )

--- a/internal/engine/types/models.go
+++ b/internal/engine/types/models.go
@@ -2,83 +2,79 @@ package types
 
 import "sync/atomic"
 
-// Task represents a byte range to download
+// Task represents a byte range to download.
 type Task struct {
+	SharedMaxOffset *atomic.Int64 `json:"-"`
 	Offset          int64         `json:"offset"`
 	Length          int64         `json:"length"`
-	SharedMaxOffset *atomic.Int64 `json:"-"` // Used to deduplicate byte counting in hedged requests
 }
 
-// DownloadState represents persisted download state for resume
+// DownloadState represents persisted download state for resume.
 type DownloadState struct {
-	ID         string   `json:"id"`       // Unique ID of the download
-	URLHash    string   `json:"url_hash"` // Hash of URL only (for master list compatibility)
-	URL        string   `json:"url"`
-	DestPath   string   `json:"dest_path"`
-	TotalSize  int64    `json:"total_size"`
-	Downloaded int64    `json:"downloaded"`
-	Tasks      []Task   `json:"tasks"` // Remaining tasks
-	Filename   string   `json:"filename"`
-	CreatedAt  int64    `json:"created_at"` // Unix timestamp
-	PausedAt   int64    `json:"paused_at"`  // Unix timestamp
-	Elapsed    int64    `json:"elapsed"`    // Elapsed time in nanoseconds
-	Mirrors    []string `json:"mirrors,omitempty"`
-
-	// Bitmap state
-	ChunkBitmap     []byte `json:"chunk_bitmap,omitempty"`
-	ActualChunkSize int64  `json:"actual_chunk_size,omitempty"`
-
-	// Integrity verification
-	FileHash string `json:"file_hash,omitempty"` // SHA-256 hash of the .surge file at pause time
+	ID              string   `json:"id"`
+	URLHash         string   `json:"url_hash"`
+	URL             string   `json:"url"`
+	DestPath        string   `json:"dest_path"`
+	FileHash        string   `json:"file_hash,omitempty"`
+	Filename        string   `json:"filename"`
+	Tasks           []Task   `json:"tasks"`
+	Mirrors         []string `json:"mirrors,omitempty"`
+	ChunkBitmap     []byte   `json:"chunk_bitmap,omitempty"`
+	Downloaded      int64    `json:"downloaded"`
+	CreatedAt       int64    `json:"created_at"`
+	PausedAt        int64    `json:"paused_at"`
+	Elapsed         int64    `json:"elapsed"`
+	ActualChunkSize int64    `json:"actual_chunk_size,omitempty"`
+	TotalSize       int64    `json:"total_size"`
 }
 
-// DownloadEntry represents a download in the master list
+// DownloadEntry represents a download in the master list.
 type DownloadEntry struct {
-	ID          string   `json:"id"`       // Unique ID of the download
-	URLHash     string   `json:"url_hash"` // Hash of URL only (backward compatibility)
+	ID          string   `json:"id"`
+	URLHash     string   `json:"url_hash"`
 	URL         string   `json:"url"`
 	DestPath    string   `json:"dest_path"`
 	Filename    string   `json:"filename"`
-	Status      string   `json:"status"`       // "paused", "completed", "error"
-	TotalSize   int64    `json:"total_size"`   // File size in bytes
-	Downloaded  int64    `json:"downloaded"`   // Bytes downloaded
-	CompletedAt int64    `json:"completed_at"` // Unix timestamp when completed
-	TimeTaken   int64    `json:"time_taken"`   // Duration in milliseconds (for completed)
-	AvgSpeed    float64  `json:"avg_speed"`    // Average speed in bytes/sec (for completed)
+	Status      string   `json:"status"`
 	Mirrors     []string `json:"mirrors,omitempty"`
+	TotalSize   int64    `json:"total_size"`
+	Downloaded  int64    `json:"downloaded"`
+	CompletedAt int64    `json:"completed_at"`
+	TimeTaken   int64    `json:"time_taken"`
+	AvgSpeed    float64  `json:"avg_speed"`
 }
 
-// MasterList holds all tracked downloads
+// MasterList holds all tracked downloads.
 type MasterList struct {
 	Downloads []DownloadEntry `json:"downloads"`
 }
 
-// DownloadStatus represents the transient status of an active download
+// DownloadStatus represents the transient status of an active download.
 type DownloadStatus struct {
-	ID          string  `json:"id"`
+	Error       string  `json:"error,omitempty"`
 	URL         string  `json:"url"`
 	Filename    string  `json:"filename"`
-	DestPath    string  `json:"dest_path,omitempty"` // Full absolute path to file
-	TotalSize   int64   `json:"total_size"`
+	DestPath    string  `json:"dest_path,omitempty"`
+	ID          string  `json:"id"`
+	Status      string  `json:"status"`
+	ETA         int64   `json:"eta"`
 	Downloaded  int64   `json:"downloaded"`
-	Progress    float64 `json:"progress"` // Percentage 0-100
-	Speed       float64 `json:"speed"`    // MB/s
-	Status      string  `json:"status"`   // "queued", "paused", "downloading", "completed", "error"
-	Error       string  `json:"error,omitempty"`
-	ETA         int64   `json:"eta"`         // Estimated seconds remaining
-	Connections int     `json:"connections"` // Active connections
-	AddedAt     int64   `json:"added_at"`    // Unix timestamp when added
-	TimeTaken   int64   `json:"time_taken"`  // Duration in milliseconds (completed only)
-	AvgSpeed    float64 `json:"avg_speed"`   // Average speed in bytes/sec (completed only)
+	Progress    float64 `json:"progress"`
+	TotalSize   int64   `json:"total_size"`
+	Speed       float64 `json:"speed"`
+	Connections int     `json:"connections"`
+	AddedAt     int64   `json:"added_at"`
+	TimeTaken   int64   `json:"time_taken"`
+	AvgSpeed    float64 `json:"avg_speed"`
 }
 
-// CancelResult contains metadata about a cancelled download so callers
+// CancelResult contains metadata about a canceled download so callers
 // can handle event emission and cleanup without the pool needing to import
 // the events package (which would create an import cycle).
 type CancelResult struct {
-	Found     bool
 	Filename  string
 	DestPath  string
+	Found     bool
 	Completed bool
 	WasQueued bool
 }

--- a/internal/engine/types/progress.go
+++ b/internal/engine/types/progress.go
@@ -10,33 +10,28 @@ import (
 )
 
 type ProgressState struct {
-	ID            string
-	Downloaded    atomic.Int64
-	TotalSize     int64
-	DestPath      string // Initial destination path
-	Filename      string // Initial filename
-	URL           string // Source URL
-	StartTime     time.Time
-	ActiveWorkers atomic.Int32
-	Done          atomic.Bool
-	Error         atomic.Pointer[error]
-	Paused        atomic.Bool
-	Pausing       atomic.Bool // Intermediate state: Pause requested but workers not yet exited
-	cancelFunc    context.CancelFunc
-
-	VerifiedProgress  atomic.Int64  // Verified bytes written to disk (for UI progress)
-	SessionStartBytes int64         // SessionStartBytes tracks how many bytes were already downloaded when the current session started
-	SavedElapsed      time.Duration // Time spent in previous sessions
-
-	Mirrors []MirrorStatus // Status of each mirror
-
-	// Chunk Visualization (Bitmap)
-	ChunkBitmap     []byte  // 2 bits per chunk
-	ChunkProgress   []int64 // Bytes downloaded per chunk (runtime only, not persisted)
-	ActualChunkSize int64   // Size of each actual chunk in bytes
-	BitmapWidth     int     // Number of chunks tracked
-
-	mu sync.Mutex // Protects TotalSize, StartTime, SessionStartBytes, SavedElapsed, Mirrors
+	StartTime         time.Time
+	cancelFunc        context.CancelFunc
+	Error             atomic.Pointer[error]
+	DestPath          string
+	Filename          string
+	URL               string
+	ID                string
+	ChunkProgress     []int64
+	ChunkBitmap       []byte
+	Mirrors           []MirrorStatus
+	SavedElapsed      time.Duration
+	VerifiedProgress  atomic.Int64
+	SessionStartBytes int64
+	TotalSize         int64
+	Downloaded        atomic.Int64
+	ActualChunkSize   int64
+	BitmapWidth       int
+	mu                sync.Mutex
+	Pausing           atomic.Bool
+	Paused            atomic.Bool
+	Done              atomic.Bool
+	ActiveWorkers     atomic.Int32
 }
 
 type MirrorStatus struct {
@@ -243,7 +238,7 @@ func (ps *ProgressState) GetMirrors() []MirrorStatus {
 	return mirrors
 }
 
-// ChunkStatus represents the status of a visualization chunk
+// ChunkStatus represents the status of a visualization chunk.
 type ChunkStatus int
 
 const (
@@ -252,7 +247,7 @@ const (
 	ChunkCompleted   ChunkStatus = 2 // 10 (Bit 2 set)
 )
 
-// InitBitmap initializes the chunk bitmap
+// InitBitmap initializes the chunk bitmap.
 func (ps *ProgressState) InitBitmap(totalSize int64, chunkSize int64) {
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
@@ -280,7 +275,7 @@ func (ps *ProgressState) InitBitmap(totalSize int64, chunkSize int64) {
 	ps.ChunkProgress = make([]int64, numChunks)
 }
 
-// RestoreBitmap restores the chunk bitmap from saved state
+// RestoreBitmap restores the chunk bitmap from saved state.
 func (ps *ProgressState) RestoreBitmap(bitmap []byte, actualChunkSize int64) {
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
@@ -289,7 +284,7 @@ func (ps *ProgressState) RestoreBitmap(bitmap []byte, actualChunkSize int64) {
 		return
 	}
 
-	//utils.Debug("RestoreBitmap: Len=%d, ChunkSize=%d", len(bitmap), actualChunkSize)
+	// utils.Debug("RestoreBitmap: Len=%d, ChunkSize=%d", len(bitmap), actualChunkSize)
 
 	ps.ChunkBitmap = bitmap
 	ps.ActualChunkSize = actualChunkSize
@@ -318,14 +313,14 @@ func (ps *ProgressState) SetChunkProgress(progress []int64) {
 	copy(ps.ChunkProgress, progress)
 }
 
-// SetChunkState sets the 2-bit state for a specific chunk index (thread-safe)
+// SetChunkState sets the 2-bit state for a specific chunk index (thread-safe).
 func (ps *ProgressState) SetChunkState(index int, status ChunkStatus) {
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
 	ps.setChunkState(index, status)
 }
 
-// setChunkState sets the 2-bit state (internal, expects lock)
+// setChunkState sets the 2-bit state (internal, expects lock).
 func (ps *ProgressState) setChunkState(index int, status ChunkStatus) {
 	if index < 0 || index >= ps.BitmapWidth {
 		return
@@ -343,14 +338,14 @@ func (ps *ProgressState) setChunkState(index int, status ChunkStatus) {
 	ps.ChunkBitmap[byteIndex] |= val
 }
 
-// GetChunkState gets the 2-bit state for a specific chunk index (thread-safe)
+// GetChunkState gets the 2-bit state for a specific chunk index (thread-safe).
 func (ps *ProgressState) GetChunkState(index int) ChunkStatus {
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
 	return ps.getChunkState(index)
 }
 
-// getChunkState gets the 2-bit state (internal, expects lock)
+// getChunkState gets the 2-bit state (internal, expects lock).
 func (ps *ProgressState) getChunkState(index int) ChunkStatus {
 	if index < 0 || index >= ps.BitmapWidth {
 		return ChunkPending
@@ -363,7 +358,7 @@ func (ps *ProgressState) getChunkState(index int) ChunkStatus {
 	return ChunkStatus(val)
 }
 
-// UpdateChunkStatus updates the bitmap based on byte range
+// UpdateChunkStatus updates the bitmap based on byte range.
 func (ps *ProgressState) UpdateChunkStatus(offset, length int64, status ChunkStatus) {
 	ps.mu.Lock()
 
@@ -455,7 +450,7 @@ func (ps *ProgressState) UpdateChunkStatus(offset, length int64, status ChunkSta
 	}
 }
 
-// RecalculateProgress reconstructs ChunkProgress from remaining tasks (for resume)
+// RecalculateProgress reconstructs ChunkProgress from remaining tasks (for resume).
 func (ps *ProgressState) RecalculateProgress(remainingTasks []Task) {
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
@@ -542,7 +537,7 @@ func (ps *ProgressState) RecalculateProgress(remainingTasks []Task) {
 	}
 }
 
-// GetBitmap returns a copy of the bitmap and metadata
+// GetBitmap returns a copy of the bitmap and metadata.
 func (ps *ProgressState) GetBitmap() ([]byte, int, int64, int64, []int64) {
 	return ps.GetBitmapSnapshot(true)
 }

--- a/internal/engine/types/progress_test.go
+++ b/internal/engine/types/progress_test.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 )
@@ -73,7 +74,7 @@ func TestProgressState_Error(t *testing.T) {
 	testErr := context.DeadlineExceeded
 	ps.SetError(testErr)
 
-	if err := ps.GetError(); err != testErr {
+	if err := ps.GetError(); !errors.Is(err, testErr) {
 		t.Errorf("GetError = %v, want %v", err, testErr)
 	}
 }
@@ -105,10 +106,10 @@ func TestProgressState_PauseWithCancelFunc(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	ps.SetCancelFunc(cancel)
 
-	// Verify context is not cancelled
+	// Verify context is not canceled
 	select {
 	case <-ctx.Done():
-		t.Fatal("Context should not be cancelled yet")
+		t.Fatal("Context should not be canceled yet")
 	default:
 	}
 
@@ -119,7 +120,7 @@ func TestProgressState_PauseWithCancelFunc(t *testing.T) {
 	case <-ctx.Done():
 		// Expected
 	default:
-		t.Error("Context should be cancelled after Pause()")
+		t.Error("Context should be canceled after Pause()")
 	}
 }
 

--- a/internal/processing/duplicate.go
+++ b/internal/processing/duplicate.go
@@ -7,12 +7,12 @@ import (
 	"github.com/SurgeDM/Surge/internal/engine/types"
 )
 
-// DuplicateResult represents the outcome of a duplicate check
+// DuplicateResult represents the outcome of a duplicate check.
 type DuplicateResult struct {
-	Exists   bool
-	IsActive bool
 	Filename string
 	URL      string
+	Exists   bool
+	IsActive bool
 }
 
 // CheckForDuplicate inspects active and persisted downloads for duplicate URLs.

--- a/internal/processing/events.go
+++ b/internal/processing/events.go
@@ -47,7 +47,7 @@ func advanceRemainingTasks(tasks []types.Task, consumed int64) []types.Task {
 
 func finalizeCompletedFile(finalPath string) error {
 	if finalPath == "" {
-		return fmt.Errorf("missing destination path for completed download")
+		return errors.New("missing destination path for completed download")
 	}
 
 	surgePath := finalPath + types.IncompleteSuffix
@@ -75,7 +75,6 @@ func finalizeCompletedFile(finalPath string) error {
 func (mgr *LifecycleManager) StartEventWorker(ch <-chan interface{}) {
 	for msg := range ch {
 		switch m := msg.(type) {
-
 		case events.DownloadStartedMsg:
 			// Persist the started record immediately so crash recovery and later lifecycle
 			// events have a stable destination record even before the first pause snapshot.
@@ -272,7 +271,6 @@ func (mgr *LifecycleManager) StartEventWorker(ch <-chan interface{}) {
 				utils.Debug("Lifecycle: Failed to delete completed tasks: %v", err)
 			}
 			if settings := mgr.GetSettings(); settings != nil && settings.General.DownloadCompleteNotification {
-
 				if filename == "" {
 					filename = m.Filename
 				}
@@ -307,7 +305,6 @@ func (mgr *LifecycleManager) StartEventWorker(ch <-chan interface{}) {
 				}
 			}
 			if settings := mgr.GetSettings(); settings != nil && settings.General.DownloadCompleteNotification {
-
 				filename := m.Filename
 				if filename == "" && existing != nil {
 					filename = existing.Filename

--- a/internal/processing/manager.go
+++ b/internal/processing/manager.go
@@ -25,17 +25,15 @@ type AddDownloadWithIDFunc func(string, string, string, []string, map[string]str
 type IsNameActiveFunc func(dir, name string) bool
 
 type LifecycleManager struct {
-	settings            *config.Settings
-	settingsMu          sync.RWMutex
+	engineHooks         EngineHooks
 	settingsRefreshedAt time.Time
+	settings            *config.Settings
 	addFunc             AddDownloadFunc
 	addWithIDFunc       AddDownloadWithIDFunc
 	isNameActive        IsNameActiveFunc
-	engineHooks         EngineHooks
+	probeSem            chan struct{}
+	settingsMu          sync.RWMutex
 	hooksMu             sync.RWMutex
-	// probeSem caps the number of simultaneous server probes so adding a
-	// large batch of downloads does not flood the network with HEAD requests.
-	probeSem chan struct{}
 }
 
 const (
@@ -179,11 +177,11 @@ func (m *LifecycleManager) SaveSettings(s *config.Settings) error {
 
 // DownloadRequest carries the already-approved inputs needed to probe and reserve a file path.
 type DownloadRequest struct {
+	Headers            map[string]string
 	URL                string
 	Filename           string
 	Path               string
 	Mirrors            []string
-	Headers            map[string]string
 	IsExplicitCategory bool
 	SkipApproval       bool
 }
@@ -191,7 +189,7 @@ type DownloadRequest struct {
 // Enqueue probes and reserves a stable destination before dispatching to the queue layer.
 func (mgr *LifecycleManager) Enqueue(ctx context.Context, req *DownloadRequest) (string, string, error) {
 	if mgr.addFunc == nil {
-		return "", "", fmt.Errorf("add function unavailable")
+		return "", "", errors.New("add function unavailable")
 	}
 
 	utils.Debug("Lifecycle: Enqueue %s (Filename: %s)", req.URL, req.Filename)
@@ -212,7 +210,7 @@ func (mgr *LifecycleManager) Enqueue(ctx context.Context, req *DownloadRequest) 
 // EnqueueWithID does the same lifecycle work as Enqueue while preserving a caller-owned id.
 func (mgr *LifecycleManager) EnqueueWithID(ctx context.Context, req *DownloadRequest, requestID string) (string, string, error) {
 	if mgr.addWithIDFunc == nil {
-		return "", "", fmt.Errorf("addWithID function unavailable")
+		return "", "", errors.New("addWithID function unavailable")
 	}
 
 	utils.Debug("Lifecycle: EnqueueWithID %s (%s)", req.URL, requestID)
@@ -234,16 +232,16 @@ func (mgr *LifecycleManager) EnqueueWithID(ctx context.Context, req *DownloadReq
 // download to the engine, so workers and lifecycle events agree on one stable destination.
 func (mgr *LifecycleManager) enqueueResolved(ctx context.Context, req *DownloadRequest, dispatch func(string, string, *ProbeResult) (string, error)) (string, string, error) {
 	if req.URL == "" {
-		return "", "", fmt.Errorf("URL is required")
+		return "", "", errors.New("URL is required")
 	}
 	if req.Path == "" {
-		return "", "", fmt.Errorf("destination path is required")
+		return "", "", errors.New("destination path is required")
 	}
 
 	settings := mgr.GetSettings()
 
 	// Throttle concurrent probes — acquire a semaphore slot before probing.
-	// If the context is cancelled (e.g., shutdown) we abort immediately.
+	// If the context is canceled (e.g., shutdown) we abort immediately.
 	if mgr.probeSem != nil {
 		select {
 		case <-mgr.probeSem:

--- a/internal/processing/manager_test.go
+++ b/internal/processing/manager_test.go
@@ -961,7 +961,7 @@ func TestLifecycleManager_UpdateURL_Success(t *testing.T) {
 func TestLifecycleManager_UpdateURL_HookError(t *testing.T) {
 	testutil.SetupStateDB(t)
 
-	expectedErr := fmt.Errorf("not in pausable state")
+	expectedErr := errors.New("not in pausable state")
 	mgr := newLifecycleManagerForTest()
 	mgr.SetEngineHooks(EngineHooks{
 		UpdateURL: func(id, newURL string) error { return expectedErr },
@@ -976,7 +976,7 @@ func TestLifecycleManager_UpdateURL_HookError(t *testing.T) {
 // --- Probe semaphore tests ---
 
 // newSlowProbeServer creates an httptest server that serves 206 Partial Content
-// but delays each response by `delay` so we can observe concurrency behaviour.
+// but delays each response by `delay` so we can observe concurrency behavior.
 func newSlowProbeServer(t *testing.T, size int64, delay time.Duration, inflight *int32) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1025,7 +1025,7 @@ func TestLifecycleManager_ProbeSemaphore_LimitsInflight(t *testing.T) {
 
 	mgr := newLifecycleManagerForTest()
 	mgr.addFunc = func(string, string, string, []string, map[string]string, bool, int64, bool) (string, error) {
-		return "", fmt.Errorf("dispatch intentionally rejected for test")
+		return "", errors.New("dispatch intentionally rejected for test")
 	}
 	settings := config.DefaultSettings()
 	settings.Categories.CategoryEnabled = false
@@ -1065,12 +1065,12 @@ func TestLifecycleManager_ProbeSemaphore_LimitsInflight(t *testing.T) {
 
 // TestLifecycleManager_ProbeSemaphore_CancelledContextAbortsWait verifies that
 // a queued enqueue waiting on the semaphore returns immediately when its context
-// is cancelled, without needing to wait for a slot to become available.
+// is canceled, without needing to wait for a slot to become available.
 func TestLifecycleManager_ProbeSemaphore_CancelledContextAbortsWait(t *testing.T) {
 	// Build a manager and fill its semaphore completely so the next Enqueue blocks.
 	mgr := newLifecycleManagerForTest()
 	mgr.addFunc = func(string, string, string, []string, map[string]string, bool, int64, bool) (string, error) {
-		t.Fatal("dispatch should not run when context is cancelled")
+		t.Fatal("dispatch should not run when context is canceled")
 		return "", nil
 	}
 
@@ -1087,7 +1087,7 @@ func TestLifecycleManager_ProbeSemaphore_CancelledContextAbortsWait(t *testing.T
 	}()
 
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // already cancelled
+	cancel() // already canceled
 
 	start := time.Now()
 	_, _, err := mgr.Enqueue(ctx, &DownloadRequest{
@@ -1097,7 +1097,7 @@ func TestLifecycleManager_ProbeSemaphore_CancelledContextAbortsWait(t *testing.T
 	elapsed := time.Since(start)
 
 	if err == nil {
-		t.Fatal("expected error due to cancelled context, got nil")
+		t.Fatal("expected error due to canceled context, got nil")
 	}
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context.Canceled, got %v", err)

--- a/internal/processing/pause_resume.go
+++ b/internal/processing/pause_resume.go
@@ -1,6 +1,7 @@
 package processing
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -36,7 +37,7 @@ type EngineHooks struct {
 func (mgr *LifecycleManager) Pause(id string) error {
 	hooks := mgr.getEngineHooks()
 	if hooks.Pause == nil {
-		return fmt.Errorf("engine not initialized")
+		return errors.New("engine not initialized")
 	}
 
 	if hooks.Pause(id) {
@@ -57,7 +58,7 @@ func (mgr *LifecycleManager) Pause(id string) error {
 		return nil // Already stopped
 	}
 
-	return fmt.Errorf("download not found")
+	return errors.New("download not found")
 }
 
 // hydrateConfigFromDisk loads the latest persisted pause snapshot from disk
@@ -90,7 +91,7 @@ func (mgr *LifecycleManager) Resume(id string) error {
 	// Guard: still transitioning to paused
 	if hooks.GetStatus != nil {
 		if st := hooks.GetStatus(id); st != nil && st.Status == "pausing" {
-			return fmt.Errorf("download is still pausing, try again in a moment")
+			return errors.New("download is still pausing, try again in a moment")
 		}
 	}
 
@@ -115,11 +116,11 @@ func (mgr *LifecycleManager) Resume(id string) error {
 	// Cold path: download from a prior session (only in DB).
 	entry, err := state.GetDownload(id)
 	if err != nil || entry == nil {
-		return fmt.Errorf("download not found")
+		return errors.New("download not found")
 	}
 
 	if entry.Status == "completed" {
-		return fmt.Errorf("download already completed")
+		return errors.New("download already completed")
 	}
 
 	settings := mgr.GetSettings()
@@ -167,7 +168,7 @@ func (mgr *LifecycleManager) ResumeBatch(ids []string) []error {
 	for i, id := range ids {
 		if hooks.GetStatus != nil {
 			if st := hooks.GetStatus(id); st != nil && st.Status == "pausing" {
-				errs[i] = fmt.Errorf("download is still pausing, try again in a moment")
+				errs[i] = errors.New("download is still pausing, try again in a moment")
 				continue
 			}
 		}
@@ -213,7 +214,7 @@ func (mgr *LifecycleManager) ResumeBatch(ids []string) []error {
 		idx := coldIdx[id]
 		savedState, ok := states[id]
 		if !ok {
-			errs[idx] = fmt.Errorf("download not found or completed")
+			errs[idx] = errors.New("download not found or completed")
 			continue
 		}
 
@@ -268,7 +269,7 @@ func (mgr *LifecycleManager) Cancel(id string) error {
 	}
 
 	if !found {
-		return fmt.Errorf("download not found")
+		return errors.New("download not found")
 	}
 
 	// Emit removal event — event worker handles DB deletion and file cleanup.

--- a/internal/processing/probe.go
+++ b/internal/processing/probe.go
@@ -2,6 +2,7 @@ package processing
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -29,16 +30,16 @@ var (
 
 const maxProbeClients = 8
 
-// ProbeResult contains all metadata from server probe
+// ProbeResult contains all metadata from server probe.
 type ProbeResult struct {
-	FileSize         int64
-	SupportsRange    bool
 	Filename         string
 	DetectedFilename string
 	ContentType      string
+	FileSize         int64
+	SupportsRange    bool
 }
 
-// probeHeadersContextKey is used to pass custom headers to the HTTP client's CheckRedirect function
+// probeHeadersContextKey is used to pass custom headers to the HTTP client's CheckRedirect function.
 type probeHeadersContextKey struct{}
 
 func resolveRuntimeConfig() *config.RuntimeConfig {
@@ -63,7 +64,7 @@ var (
 	probeHostLocks sync.Map // map[string]*sync.Mutex
 )
 
-// getProbeHostLock returns a mutex for a specific host to sequentialize probes
+// getProbeHostLock returns a mutex for a specific host to sequentialize probes.
 func getProbeHostLock(rawurl string) *sync.Mutex {
 	parsed, err := neturl.Parse(rawurl)
 	host := "unknown"
@@ -270,7 +271,7 @@ func getProbeClient(runCfg *config.RuntimeConfig) *http.Client {
 		Transport: newProbeTransport(runCfg),
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= 10 {
-				return fmt.Errorf("stopped after 10 redirects")
+				return errors.New("stopped after 10 redirects")
 			}
 			if len(via) > 0 {
 				copyProbeRedirectHeaders(req, via[0])
@@ -388,8 +389,8 @@ func ProbeMirrorsWithProxy(ctx context.Context, mirrors []string, runCfg *config
 	errs = make(map[string]error)
 
 	type mirrorProbeResult struct {
-		valid bool
 		err   error
+		valid bool
 	}
 
 	results := make([]mirrorProbeResult, len(candidates))
@@ -413,7 +414,7 @@ func ProbeMirrorsWithProxy(ctx context.Context, mirrors []string, runCfg *config
 			} else {
 				outcome.valid = result.SupportsRange
 				if !result.SupportsRange {
-					outcome.err = fmt.Errorf("does not support ranges")
+					outcome.err = errors.New("does not support ranges")
 				}
 			}
 			results[idx] = outcome

--- a/internal/testutil/mock_server.go
+++ b/internal/testutil/mock_server.go
@@ -3,6 +3,7 @@ package testutil
 
 import (
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -18,33 +19,27 @@ import (
 
 // MockServer is a configurable HTTP test server for download testing.
 type MockServer struct {
-	Server *httptest.Server
-
-	// Configuration
-	FileSize          int64         // Size of the served file
-	SupportsRanges    bool          // Whether to support HTTP Range requests
-	ContentType       string        // Content-Type header value
-	Filename          string        // Filename in Content-Disposition header
-	RandomData        bool          // If true, serve random data; otherwise serve zeros
-	Latency           time.Duration // Artificial latency per request
-	ByteLatency       time.Duration // Latency per byte (simulates slow connection)
-	FailAfterBytes    int64         // Fail connection after this many bytes (0 = no fail)
-	FailOnNthRequest  int           // Fail on Nth request (0 = don't fail)
-	MaxConcurrentReqs int           // Max concurrent requests (0 = unlimited)
-
-	// Tracking
-	RequestCount   atomic.Int64
-	BytesServed    atomic.Int64
-	ActiveRequests atomic.Int64
-	RangeRequests  atomic.Int64
-	FullRequests   atomic.Int64
-	FailedRequests atomic.Int64
-	requestCountMu sync.Mutex
-	internalReqNum int
-
-	// Internal
-	data          []byte
-	CustomHandler http.HandlerFunc
+	Server            *httptest.Server
+	CustomHandler     http.HandlerFunc
+	ContentType       string
+	Filename          string
+	data              []byte
+	FullRequests      atomic.Int64
+	BytesServed       atomic.Int64
+	ByteLatency       time.Duration
+	FailAfterBytes    int64
+	FailOnNthRequest  int
+	MaxConcurrentReqs int
+	RequestCount      atomic.Int64
+	Latency           time.Duration
+	ActiveRequests    atomic.Int64
+	RangeRequests     atomic.Int64
+	FileSize          int64
+	FailedRequests    atomic.Int64
+	internalReqNum    int
+	requestCountMu    sync.Mutex
+	SupportsRanges    bool
+	RandomData        bool
 }
 
 // MockServerOption is a function that configures a MockServer.
@@ -345,16 +340,16 @@ func (m *MockServer) setCommonHeaders(w http.ResponseWriter, start, end int64) {
 }
 
 // parseRange parses an HTTP Range header and returns start, end positions.
-// Handles formats like "bytes=0-499" or "bytes=500-"
+// Handles formats like "bytes=0-499" or "bytes=500-".
 func parseRange(rangeHeader string, fileSize int64) (int64, int64, error) {
 	if !strings.HasPrefix(rangeHeader, "bytes=") {
-		return 0, 0, fmt.Errorf("invalid range prefix")
+		return 0, 0, errors.New("invalid range prefix")
 	}
 
 	rangeSpec := strings.TrimPrefix(rangeHeader, "bytes=")
 	parts := strings.Split(rangeSpec, "-")
 	if len(parts) != 2 {
-		return 0, 0, fmt.Errorf("invalid range format")
+		return 0, 0, errors.New("invalid range format")
 	}
 
 	var start, end int64
@@ -387,7 +382,7 @@ func parseRange(rangeHeader string, fileSize int64) (int64, int64, error) {
 
 	// Validate
 	if start < 0 || end >= fileSize || start > end {
-		return 0, 0, fmt.Errorf("range out of bounds")
+		return 0, 0, errors.New("range out of bounds")
 	}
 
 	return start, end, nil

--- a/internal/tui/category_regressions_test.go
+++ b/internal/tui/category_regressions_test.go
@@ -6,6 +6,7 @@ import (
 
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
+
 	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/core"
 	"github.com/SurgeDM/Surge/internal/download"

--- a/internal/tui/colors/colors.go
+++ b/internal/tui/colors/colors.go
@@ -14,12 +14,8 @@ import (
 )
 
 type Palette struct {
-	Name    string `toml:"name"`
-	Primary struct {
-		Background string `toml:"background"`
-		Foreground string `toml:"foreground"`
-		Accent     string `toml:"accent"`
-	} `toml:"primary"`
+	Dark   *Palette `toml:"dark"`
+	Light  *Palette `toml:"light"`
 	Normal struct {
 		Black   string `toml:"black"`
 		Red     string `toml:"red"`
@@ -31,18 +27,22 @@ type Palette struct {
 		White   string `toml:"white"`
 	} `toml:"normal"`
 	Bright struct {
-		Black   string `toml:"black"`   // unused by accessors (reserved for future use)
-		Red     string `toml:"red"`     // → Pink(), ProgressStart()
-		Green   string `toml:"green"`   // unused by accessors (reserved for future use)
-		Yellow  string `toml:"yellow"`  // unused by accessors (reserved for future use)
-		Blue    string `toml:"blue"`    // unused by accessors (reserved for future use)
-		Magenta string `toml:"magenta"` // → ProgressEnd()
-		Cyan    string `toml:"cyan"`    // unused by accessors (reserved for future use)
-		White   string `toml:"white"`   // unused by accessors (reserved for future use)
+		Black   string `toml:"black"`
+		Red     string `toml:"red"`
+		Green   string `toml:"green"`
+		Yellow  string `toml:"yellow"`
+		Blue    string `toml:"blue"`
+		Magenta string `toml:"magenta"`
+		Cyan    string `toml:"cyan"`
+		White   string `toml:"white"`
 	} `toml:"bright"`
-
-	Dark  *Palette `toml:"dark"`
-	Light *Palette `toml:"light"`
+	Primary struct {
+		Background string `toml:"background"`
+		Foreground string `toml:"foreground"`
+		Accent     string `toml:"accent"`
+	} `toml:"primary"`
+	Name string `toml:"name"` // unused by accessors (reserved for future use)
+	// unused by accessors (reserved for future use)
 }
 
 type ThemeConfig struct {
@@ -238,7 +238,7 @@ func palette() *Palette {
 func Background() color.Color { return lipgloss.Color(palette().Primary.Background) }
 func Foreground() color.Color { return lipgloss.Color(palette().Primary.Foreground) }
 
-// Semantic Mappings
+// Semantic Mappings.
 func White() color.Color { return lipgloss.Color(palette().Normal.White) }
 func Gray() color.Color  { return lipgloss.Color(palette().Normal.Black) }
 func Red() color.Color   { return lipgloss.Color(palette().Normal.Red) }
@@ -286,14 +286,14 @@ func LightGray() color.Color {
 
 func DarkGray() color.Color { return lipgloss.Color(palette().Primary.Background) }
 
-// State Mappings
+// State Mappings.
 func StateError() color.Color       { return Red() }
 func StatePaused() color.Color      { return Orange() }
 func StateDownloading() color.Color { return Green() }
 func StateDone() color.Color        { return Magenta() }
 func StateVersion() color.Color     { return Blue() }
 
-// Progress Mappings
+// Progress Mappings.
 func ProgressStart() color.Color {
 	acc := palette().Primary.Accent
 	if acc != "" {

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -5,10 +5,11 @@ import (
 	"runtime"
 
 	tea "charm.land/bubbletea/v2"
+
 	"github.com/SurgeDM/Surge/internal/version"
 )
 
-// checkForUpdateCmd performs an async update check
+// checkForUpdateCmd performs an async update check.
 func checkForUpdateCmd(currentVersion string) tea.Cmd {
 	return func() tea.Msg {
 		info, _ := version.CheckForUpdate(currentVersion)
@@ -25,7 +26,7 @@ func shutdownCmd(service interface{ Shutdown() error }) tea.Cmd {
 	}
 }
 
-// openWithSystem opens a file or URL with the system's default application
+// openWithSystem opens a file or URL with the system's default application.
 func openWithSystem(path string) error {
 	var cmd *exec.Cmd
 	switch runtime.GOOS {

--- a/internal/tui/components/add_download_modal.go
+++ b/internal/tui/components/add_download_modal.go
@@ -12,18 +12,18 @@ import (
 
 // AddDownloadModal renders input-driven download forms (add download / extension prompt).
 type AddDownloadModal struct {
+	HelpKeys        help.KeyMap
+	BorderColor     color.Color
+	Help            help.Model
 	Title           string
+	URL             string
 	Inputs          []textinput.Model
 	Labels          []string
 	FocusedInput    int
-	ShowURL         bool
-	URL             string
 	BrowseHintIndex int
-	Help            help.Model
-	HelpKeys        help.KeyMap
-	BorderColor     color.Color
 	Width           int
 	Height          int
+	ShowURL         bool
 }
 
 // View renders the inner content (without border box).

--- a/internal/tui/components/box.go
+++ b/internal/tui/components/box.go
@@ -8,23 +8,23 @@ import (
 )
 
 const (
-	// BorderFrameHeight is the combined height of top and bottom borders (2)
+	// BorderFrameHeight is the combined height of top and bottom borders (2).
 	BorderFrameHeight = 2
-	// BorderFrameWidth is the combined width of left and right borders (2)
+	// BorderFrameWidth is the combined width of left and right borders (2).
 	BorderFrameWidth = 2
-	// BtopBoxOverheadHeight is the header + footer overhead (2)
+	// BtopBoxOverheadHeight is the header + footer overhead (2).
 	BtopBoxOverheadHeight = 2
-	// SingleLineHeight is a standard single line height (1)
+	// SingleLineHeight is a standard single line height (1).
 	SingleLineHeight = 1
 )
 
-// BoxRenderer is the function signature for rendering btop-style boxes
+// BoxRenderer is the function signature for rendering btop-style boxes.
 type BoxRenderer func(leftTitle, rightTitle, content string, width, height int, borderColor color.Color) string
 
 // RenderBtopBox creates a btop-style box with title embedded in the top border.
 // Supports left and right titles (e.g., search on left, pane name on right).
 // Accepts pre-styled title strings.
-// Example: ╭─ 🔍 Search... ─────────── Downloads ─╮
+// Example: ╭─ 🔍 Search... ─────────── Downloads ─╮.
 func RenderBtopBox(leftTitle, rightTitle string, content string, width, height int, borderColor color.Color) string {
 	// Border characters
 	const (
@@ -64,7 +64,6 @@ func RenderBtopBox(leftTitle, rightTitle string, content string, width, height i
 			borderStyler.Render(strings.Repeat(horizontal, remainingWidth)) +
 			rightTitle +
 			borderStyler.Render(topRight)
-
 	} else if leftTitle != "" {
 		// Case 2: Only Left Title
 		remainingWidth := innerWidth - leftTitleWidth - lipgloss.Width(horizontal)
@@ -75,7 +74,6 @@ func RenderBtopBox(leftTitle, rightTitle string, content string, width, height i
 		topBorder = borderStyler.Render(topLeft+horizontal) +
 			leftTitle +
 			borderStyler.Render(strings.Repeat(horizontal, remainingWidth)+topRight)
-
 	} else if rightTitle != "" {
 		// Case 3: Only Right Title
 		remainingWidth := innerWidth - rightTitleWidth - lipgloss.Width(horizontal)
@@ -86,7 +84,6 @@ func RenderBtopBox(leftTitle, rightTitle string, content string, width, height i
 		topBorder = borderStyler.Render(topLeft+strings.Repeat(horizontal, remainingWidth)) +
 			rightTitle +
 			borderStyler.Render(horizontal+topRight)
-
 	} else {
 		// Case 4: No Title
 		topBorder = borderStyler.Render(topLeft + strings.Repeat(horizontal, innerWidth) + topRight)

--- a/internal/tui/components/chunkmap.go
+++ b/internal/tui/components/chunkmap.go
@@ -4,23 +4,24 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
+
 	"github.com/SurgeDM/Surge/internal/engine/types"
 	"github.com/SurgeDM/Surge/internal/tui/colors"
 )
 
-// ChunkMapModel visualizes download chunks as a grid using a bitmap
+// ChunkMapModel visualizes download chunks as a grid using a bitmap.
 type ChunkMapModel struct {
 	Bitmap          []byte
-	BitmapWidth     int // Total number of chunks in bitmap
-	Width           int // UI render width (columns * 2)
-	Height          int // Available height in rows (0 = auto)
-	Paused          bool
+	ChunkProgress   []int64
+	BitmapWidth     int
+	Width           int
+	Height          int
 	TotalSize       int64
 	ActualChunkSize int64
-	ChunkProgress   []int64
+	Paused          bool
 }
 
-// NewChunkMapModel creates a new chunk map visualization
+// NewChunkMapModel creates a new chunk map visualization.
 func NewChunkMapModel(bitmap []byte, bitmapWidth int, width, height int, paused bool, totalSize int64, actualChunkSize int64, chunkProgress []int64) ChunkMapModel {
 	return ChunkMapModel{
 		Bitmap:          bitmap,
@@ -47,7 +48,7 @@ func (m ChunkMapModel) getChunkState(index int) types.ChunkStatus {
 	return types.ChunkStatus(val)
 }
 
-// View renders the chunk grid
+// View renders the chunk grid.
 func (m ChunkMapModel) View() string {
 	if m.BitmapWidth == 0 || len(m.Bitmap) == 0 {
 		return ""
@@ -228,7 +229,7 @@ func (m ChunkMapModel) View() string {
 }
 
 // CalculateHeight returns the number of lines needed to render the chunks
-// Takes available height to support dynamic sizing
+// Takes available height to support dynamic sizing.
 func CalculateHeight(count int, width int, availableHeight int) int {
 	if count == 0 {
 		return 0

--- a/internal/tui/components/chunkmap_test.go
+++ b/internal/tui/components/chunkmap_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"charm.land/lipgloss/v2"
+
 	"github.com/SurgeDM/Surge/internal/engine/types"
 	"github.com/SurgeDM/Surge/internal/tui/colors"
 )
@@ -12,7 +13,7 @@ import (
 // Helper to check for colors
 
 // Helper to set chunk state in a bitmap
-// Index is chunk index. Status: 0=Pending, 1=Downloading, 2=Completed
+// Index is chunk index. Status: 0=Pending, 1=Downloading, 2=Completed.
 func setChunk(bitmap []byte, index int, status int) {
 	byteIndex := index / 4
 	bitOffset := (index % 4) * 2

--- a/internal/tui/components/confirmation_modal.go
+++ b/internal/tui/components/confirmation_modal.go
@@ -10,14 +10,14 @@ import (
 	"charm.land/lipgloss/v2"
 )
 
-// ConfirmationModal renders a styled confirmation dialog box
+// ConfirmationModal renders a styled confirmation dialog box.
 type ConfirmationModal struct {
+	Keys        help.KeyMap
+	BorderColor color.Color
+	Help        help.Model
 	Title       string
 	Message     string
-	Detail      string      // Optional additional detail line (e.g., filename, URL)
-	Keys        help.KeyMap // Key bindings to show in help
-	Help        help.Model  // Help model for rendering keys
-	BorderColor color.Color // Border color for the box
+	Detail      string
 	Width       int
 	Height      int
 }
@@ -28,7 +28,7 @@ type NoKeys struct{}
 func (NoKeys) ShortHelp() []key.Binding  { return nil }
 func (NoKeys) FullHelp() [][]key.Binding { return nil }
 
-// View renders the confirmation modal content (without the box wrapper or help text)
+// View renders the confirmation modal content (without the box wrapper or help text).
 func (m ConfirmationModal) view() string {
 	detailStyle := lipgloss.NewStyle().
 		Foreground(colors.Magenta()).
@@ -49,7 +49,7 @@ func (m ConfirmationModal) view() string {
 }
 
 // RenderWithBtopBox renders the modal using the btop-style box with title in border
-// Help text is pushed to the last line of the modal
+// Help text is pushed to the last line of the modal.
 func (m ConfirmationModal) RenderWithBtopBox(
 	renderBox func(leftTitle, rightTitle, content string, width, height int, borderColor color.Color) string,
 	titleStyle lipgloss.Style,
@@ -107,7 +107,7 @@ func (m ConfirmationModal) RenderWithBtopBox(
 }
 
 // Centered returns the modal centered in the given dimensions (for standalone use)
-// Help text is pushed to the last line
+// Help text is pushed to the last line.
 func (m ConfirmationModal) Centered(width, height int) string {
 	boxStyle := lipgloss.NewStyle().
 		Border(lipgloss.DoubleBorder()).

--- a/internal/tui/components/filepicker_modal.go
+++ b/internal/tui/components/filepicker_modal.go
@@ -10,18 +10,18 @@ import (
 	"charm.land/lipgloss/v2"
 )
 
-// FilePickerModal represents a styled file picker modal
+// FilePickerModal represents a styled file picker modal.
 type FilePickerModal struct {
-	Title       string
-	Picker      *filepicker.Model
-	Help        help.Model
 	HelpKeys    help.KeyMap
 	BorderColor color.Color
+	Picker      *filepicker.Model
+	Help        help.Model
+	Title       string
 	Width       int
 	Height      int
 }
 
-// NewFilePickerModal creates a file picker modal with default styling
+// NewFilePickerModal creates a file picker modal with default styling.
 func NewFilePickerModal(title string, picker *filepicker.Model, helpModel help.Model, helpKeys help.KeyMap, borderColor color.Color) FilePickerModal {
 	return FilePickerModal{
 		Title:       title,
@@ -34,7 +34,7 @@ func NewFilePickerModal(title string, picker *filepicker.Model, helpModel help.M
 	}
 }
 
-// View returns the inner content of the file picker (without the box)
+// View returns the inner content of the file picker (without the box).
 func (m FilePickerModal) View() string {
 	pathStyle := lipgloss.NewStyle().Foreground(colors.LightGray())
 
@@ -50,7 +50,7 @@ func (m FilePickerModal) View() string {
 	return lipgloss.NewStyle().Padding(0, 2).Render(content)
 }
 
-// RenderWithBtopBox renders the modal using the btop-style box
+// RenderWithBtopBox renders the modal using the btop-style box.
 func (m FilePickerModal) RenderWithBtopBox(
 	renderBox func(leftTitle, rightTitle, content string, width, height int, borderColor color.Color) string,
 	titleStyle lipgloss.Style,

--- a/internal/tui/components/help_modal.go
+++ b/internal/tui/components/help_modal.go
@@ -8,17 +8,17 @@ import (
 	"charm.land/lipgloss/v2"
 )
 
-// HelpModal renders a styled help overlay showing all keyboard shortcuts
+// HelpModal renders a styled help overlay showing all keyboard shortcuts.
 type HelpModal struct {
-	Title       string
-	HelpKeys    help.KeyMap // Must implement FullHelp() [][]key.Binding
-	Help        help.Model  // Help model for rendering
+	HelpKeys    help.KeyMap
 	BorderColor color.Color
+	Help        help.Model
+	Title       string
 	Width       int
 	Height      int
 }
 
-// RenderWithBtopBox renders the help modal using a btop-style box with title in border
+// RenderWithBtopBox renders the help modal using a btop-style box with title in border.
 func (m HelpModal) RenderWithBtopBox(
 	renderBox func(leftTitle, rightTitle, content string, width, height int, borderColor color.Color) string,
 	titleStyle lipgloss.Style,

--- a/internal/tui/components/status.go
+++ b/internal/tui/components/status.go
@@ -9,7 +9,7 @@ import (
 	"charm.land/lipgloss/v2"
 )
 
-// DownloadStatus represents the state of a download
+// DownloadStatus represents the state of a download.
 type DownloadStatus int
 
 const (
@@ -20,7 +20,7 @@ const (
 	StatusError
 )
 
-// statusInfo holds the display properties for each status
+// statusInfo holds the display properties for each status.
 type statusInfo struct {
 	icon  string
 	label string
@@ -61,7 +61,7 @@ func rebuildStatusCache() {
 	queuedSpinnerStyle = lipgloss.NewStyle().Foreground(StatusQueued.Color())
 }
 
-// Icon returns the status icon
+// Icon returns the status icon.
 func (s DownloadStatus) Icon() string {
 	if info, ok := statusMap[s]; ok {
 		return info.icon
@@ -69,7 +69,7 @@ func (s DownloadStatus) Icon() string {
 	return "?"
 }
 
-// Label returns the status label
+// Label returns the status label.
 func (s DownloadStatus) Label() string {
 	if info, ok := statusMap[s]; ok {
 		return info.label
@@ -77,7 +77,7 @@ func (s DownloadStatus) Label() string {
 	return "Unknown"
 }
 
-// Color returns the status color
+// Color returns the status color.
 func (s DownloadStatus) Color() color.Color {
 	switch s {
 	case StatusQueued, StatusPaused:
@@ -93,7 +93,7 @@ func (s DownloadStatus) Color() color.Color {
 	}
 }
 
-// Render returns the styled icon + label combination
+// Render returns the styled icon + label combination.
 func (s DownloadStatus) Render() string {
 	cacheMu.RLock()
 	defer cacheMu.RUnlock()
@@ -103,7 +103,7 @@ func (s DownloadStatus) Render() string {
 	return "Unknown"
 }
 
-// RenderWithSpinner returns the styled icon + label combination, conditionally substituting a dynamic spinner for the Queued state
+// RenderWithSpinner returns the styled icon + label combination, conditionally substituting a dynamic spinner for the Queued state.
 func (s DownloadStatus) RenderWithSpinner(spinnerView string) string {
 	if s == StatusQueued {
 		cacheMu.RLock()
@@ -114,7 +114,7 @@ func (s DownloadStatus) RenderWithSpinner(spinnerView string) string {
 	return s.Render()
 }
 
-// RenderIcon returns just the styled icon
+// RenderIcon returns just the styled icon.
 func (s DownloadStatus) RenderIcon() string {
 	cacheMu.RLock()
 	defer cacheMu.RUnlock()
@@ -125,7 +125,7 @@ func (s DownloadStatus) RenderIcon() string {
 }
 
 // DetermineStatus determines the DownloadStatus based on download state
-// This centralizes the status determination logic that was duplicated in view.go and list.go
+// This centralizes the status determination logic that was duplicated in view.go and list.go.
 func DetermineStatus(done bool, paused bool, hasError bool, speed float64, downloaded int64) DownloadStatus {
 	switch {
 	case hasError:

--- a/internal/tui/components/tab_bar.go
+++ b/internal/tui/components/tab_bar.go
@@ -6,7 +6,7 @@ import (
 	"charm.land/lipgloss/v2"
 )
 
-// Tab represents a single tab item
+// Tab represents a single tab item.
 type Tab struct {
 	Label string
 	Count int // If >= 0, displays as "Label (Count)"; if < 0, displays just "Label"
@@ -14,7 +14,7 @@ type Tab struct {
 
 // RenderTabBar renders a horizontal tab bar with the given tabs
 // Each tab is wrapped in a rounded border box for consistent styling
-// activeIndex specifies which tab is currently active (0-indexed)
+// activeIndex specifies which tab is currently active (0-indexed).
 func RenderTabBar(tabs []Tab, activeIndex int, activeStyle, inactiveStyle lipgloss.Style) string {
 	var rendered []string
 	for i, t := range tabs {
@@ -47,7 +47,7 @@ func RenderTabBar(tabs []Tab, activeIndex int, activeStyle, inactiveStyle lipglo
 }
 
 // RenderNumberedTabBar renders tabs with number prefixes like "[1] General"
-// Each tab is wrapped in a rounded border box
+// Each tab is wrapped in a rounded border box.
 func RenderNumberedTabBar(tabs []Tab, activeIndex int, activeStyle, inactiveStyle lipgloss.Style) string {
 	var rendered []string
 	for i, t := range tabs {

--- a/internal/tui/config.go
+++ b/internal/tui/config.go
@@ -3,10 +3,10 @@ package tui
 import "time"
 
 const (
-	// GraphUpdateInterval is the interval at which the speed history is updated (polling rate)
+	// GraphUpdateInterval is the interval at which the speed history is updated (polling rate).
 	GraphUpdateInterval = 500 * time.Millisecond
 
 	// GraphHistoryPoints is the number of data points to keep in history
-	// 60 points * 0.5s interval = 30 seconds of history
+	// 60 points * 0.5s interval = 30 seconds of history.
 	GraphHistoryPoints = 60
 )

--- a/internal/tui/constants.go
+++ b/internal/tui/constants.go
@@ -7,16 +7,16 @@ import (
 )
 
 const (
-	// === Timeouts and Intervals ===
+	// === Timeouts and Intervals ===.
 	TickInterval = 200 * time.Millisecond
 
-	// === Layout Ratios ===
+	// === Layout Ratios ===.
 	ListWidthRatio         = 0.6  // Dashboard: List takes 60% width
 	SettingsWidthRatio     = 0.72 // Modals: Settings/Category use 72% width
 	LogoWidthRatio         = 0.45 // Header: Logo takes 45% of left column
 	GraphTargetHeightRatio = 0.4  // Right Column: Graph target 40% height
 
-	// === Thresholds and Minimums ===
+	// === Thresholds and Minimums ===.
 	MinTermWidth             = 45
 	MinTermHeight            = 12
 	ShortTermHeightThreshold = 25 // Switch to compact header below this height
@@ -36,14 +36,14 @@ const (
 	MinChunkMapHeight   = 4
 	MinChunkMapVisibleH = 18 // Min term height to show chunk map
 
-	// === Component Heights ===
+	// === Component Heights ===.
 	ModalHeightPadding = 4 // Bottom fallback padding for modals to avoid clipping
 	HeaderHeightMax    = 11
 	HeaderHeightMin    = 3
 	FilePickerHeight   = 12
 	CardHeight         = 2 // Compact rows for downloads list
 
-	// === Padding and Offsets ===
+	// === Padding and Offsets ===.
 	DefaultPaddingX        = 1
 	DefaultPaddingY        = 0
 	PopupPaddingX          = 2
@@ -52,26 +52,26 @@ const (
 	HeaderWidthOffset      = 2
 	ProgressBarWidthOffset = 4
 
-	// === Layout Offsets (Clean Math) ===
+	// === Layout Offsets (Clean Math) ===.
 	InternalPaddingHeight = 2 // Standard internal vertical padding
 	InternalPaddingWidth  = 2 // Standard internal horizontal padding
 	FooterHeight          = 1 // Application-wide footer height (keybindings)
 	DividerHeight         = 1 // Horizontal/Vertical divider line
 
-	// === Graph Configuration ===
+	// === Graph Configuration ===.
 	GraphAxisWidth  = 10
 	GraphStatsWidth = 18
 	GraphHeadroom   = 1.1 // Scale max speed by 110% for visual headroom
 
-	// === Input Dimensions ===
+	// === Input Dimensions ===.
 	InputWidth        = 40
 	MinSettingsInputW = 8
 	MaxSettingsInputW = 48
 
-	// === Channel Buffers ===
+	// === Channel Buffers ===.
 	ProgressChannelBuffer = types.ProgressChannelBuffer
 
-	// === Units ===
+	// === Units ===.
 	KB = types.KB
 	MB = types.MB
 	GB = types.GB

--- a/internal/tui/filtering_test.go
+++ b/internal/tui/filtering_test.go
@@ -7,8 +7,8 @@ import (
 func TestTabFiltering(t *testing.T) {
 	tests := []struct {
 		name          string
-		activeTab     int
 		downloads     []*DownloadModel
+		activeTab     int
 		expectedCount int
 	}{
 		{

--- a/internal/tui/gradient.go
+++ b/internal/tui/gradient.go
@@ -9,7 +9,7 @@ import (
 	"charm.land/lipgloss/v2"
 )
 
-// ApplyGradient applies a vertical gradient to a multi-line string
+// ApplyGradient applies a vertical gradient to a multi-line string.
 func ApplyGradient(text string, startColor, endColor color.Color) string {
 	lines := strings.Split(text, "\n")
 	height := len(lines)

--- a/internal/tui/graph.go
+++ b/internal/tui/graph.go
@@ -11,7 +11,7 @@ import (
 	"charm.land/lipgloss/v2"
 )
 
-// GraphStats contains the statistics to overlay on the graph
+// GraphStats contains the statistics to overlay on the graph.
 type GraphStats struct {
 	DownloadSpeed float64 // Current download speed in MB/s
 	DownloadTop   float64 // Top download speed in MB/s
@@ -149,7 +149,7 @@ func renderMultiLineGraph(data []float64, width, height int, maxVal float64, sta
 	return graphStr
 }
 
-// overlayStatsBox renders stats on top of the graph in the top-right area
+// overlayStatsBox renders stats on top of the graph in the top-right area.
 func overlayStatsBox(graph string, stats *GraphStats, width, height int) string {
 	// Create the stats box content - btop style
 	valueStyle := lipgloss.NewStyle().Foreground(colors.Cyan()).Bold(true)

--- a/internal/tui/helpers.go
+++ b/internal/tui/helpers.go
@@ -10,12 +10,13 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+
 	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/engine/types"
 	"github.com/SurgeDM/Surge/internal/processing"
 )
 
-// addLogEntry adds a log entry to the log viewport
+// addLogEntry adds a log entry to the log viewport.
 func (m *RootModel) addLogEntry(msg string) {
 	timestamp := time.Now().Format("15:04:05")
 	entry := fmt.Sprintf("[%s] %s", timestamp, msg)
@@ -151,7 +152,7 @@ func (m *RootModel) openDirectoryPicker(origin FilePickerOrigin, originalPath, b
 	return m.filepicker.Init()
 }
 
-// checkForDuplicate checks if a compatible download already exists
+// checkForDuplicate checks if a compatible download already exists.
 func (m RootModel) checkForDuplicate(url string) *processing.DuplicateResult {
 	activeDownloads := func() map[string]*types.DownloadConfig {
 		active := make(map[string]*types.DownloadConfig)

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -2,7 +2,7 @@ package tui
 
 import "charm.land/bubbles/v2/key"
 
-// KeyMap defines the keybindings for the entire application
+// KeyMap defines the keybindings for the entire application.
 type KeyMap struct {
 	Dashboard      DashboardKeyMap
 	Input          InputKeyMap
@@ -17,7 +17,7 @@ type KeyMap struct {
 	QuitConfirm    QuitConfirmKeyMap
 }
 
-// DashboardKeyMap defines keybindings for the main dashboard
+// DashboardKeyMap defines keybindings for the main dashboard.
 type DashboardKeyMap struct {
 	TabQueued      key.Binding
 	TabActive      key.Binding
@@ -47,7 +47,7 @@ type DashboardKeyMap struct {
 	LogClose  key.Binding
 }
 
-// InputKeyMap defines keybindings for the add download input
+// InputKeyMap defines keybindings for the add download input.
 type InputKeyMap struct {
 	Tab    key.Binding
 	Enter  key.Binding
@@ -57,7 +57,7 @@ type InputKeyMap struct {
 	Cancel key.Binding
 }
 
-// FilePickerKeyMap defines keybindings for the file picker
+// FilePickerKeyMap defines keybindings for the file picker.
 type FilePickerKeyMap struct {
 	UseDir   key.Binding
 	GotoHome key.Binding
@@ -67,14 +67,14 @@ type FilePickerKeyMap struct {
 	Cancel   key.Binding
 }
 
-// DuplicateKeyMap defines keybindings for duplicate warning
+// DuplicateKeyMap defines keybindings for duplicate warning.
 type DuplicateKeyMap struct {
 	Continue key.Binding
 	Focus    key.Binding
 	Cancel   key.Binding
 }
 
-// ExtensionKeyMap defines keybindings for extension confirmation
+// ExtensionKeyMap defines keybindings for extension confirmation.
 type ExtensionKeyMap struct {
 	Confirm key.Binding
 	Browse  key.Binding
@@ -83,7 +83,7 @@ type ExtensionKeyMap struct {
 	Cancel  key.Binding
 }
 
-// SettingsKeyMap defines keybindings for the settings view
+// SettingsKeyMap defines keybindings for the settings view.
 type SettingsKeyMap struct {
 	Tab1    key.Binding
 	Tab2    key.Binding
@@ -100,26 +100,26 @@ type SettingsKeyMap struct {
 	Close   key.Binding
 }
 
-// SettingsEditorKeyMap defines keybindings for editing a setting
+// SettingsEditorKeyMap defines keybindings for editing a setting.
 type SettingsEditorKeyMap struct {
 	Confirm key.Binding
 	Cancel  key.Binding
 }
 
-// BatchConfirmKeyMap defines keybindings for batch import confirmation
+// BatchConfirmKeyMap defines keybindings for batch import confirmation.
 type BatchConfirmKeyMap struct {
 	Confirm key.Binding
 	Cancel  key.Binding
 }
 
-// UpdateKeyMap defines keybindings for update notification
+// UpdateKeyMap defines keybindings for update notification.
 type UpdateKeyMap struct {
 	OpenGitHub  key.Binding
 	IgnoreNow   key.Binding
 	NeverRemind key.Binding
 }
 
-// QuitConfirmKeyMap defines keybindings for the quit confirmation modal
+// QuitConfirmKeyMap defines keybindings for the quit confirmation modal.
 type QuitConfirmKeyMap struct {
 	Left   key.Binding
 	Right  key.Binding
@@ -129,7 +129,7 @@ type QuitConfirmKeyMap struct {
 	Cancel key.Binding
 }
 
-// CategoryManagerKeyMap defines keybindings for the category manager
+// CategoryManagerKeyMap defines keybindings for the category manager.
 type CategoryManagerKeyMap struct {
 	Up     key.Binding
 	Down   key.Binding
@@ -141,7 +141,7 @@ type CategoryManagerKeyMap struct {
 	Close  key.Binding
 }
 
-// Keys contains all the keybindings for the application
+// Keys contains all the keybindings for the application.
 var Keys = KeyMap{
 	Dashboard: DashboardKeyMap{
 		TabQueued: key.NewBinding(
@@ -451,12 +451,12 @@ var Keys = KeyMap{
 	},
 }
 
-// ShortHelp returns keybindings to show in the mini help view
+// ShortHelp returns keybindings to show in the mini help view.
 func (k DashboardKeyMap) ShortHelp() []key.Binding {
 	return []key.Binding{k.ToggleHelp}
 }
 
-// FullHelp returns keybindings for the expanded help view
+// FullHelp returns keybindings for the expanded help view.
 func (k DashboardKeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.TabQueued, k.TabActive, k.TabDone, k.NextTab},

--- a/internal/tui/layout_helpers.go
+++ b/internal/tui/layout_helpers.go
@@ -2,7 +2,7 @@ package tui
 
 import "github.com/SurgeDM/Surge/internal/tui/components"
 
-// GetHeaderHeight returns the appropriate header height based on terminal height
+// GetHeaderHeight returns the appropriate header height based on terminal height.
 func GetHeaderHeight(termHeight int) int {
 	if termHeight < ShortTermHeightThreshold {
 		return HeaderHeightMin
@@ -10,7 +10,7 @@ func GetHeaderHeight(termHeight int) int {
 	return HeaderHeightMax
 }
 
-// GetMinGraphHeight returns the minimum graph height based on terminal height
+// GetMinGraphHeight returns the minimum graph height based on terminal height.
 func GetMinGraphHeight(termHeight int) int {
 	if termHeight < ShortTermHeightThreshold {
 		return MinGraphHeightShort
@@ -18,7 +18,7 @@ func GetMinGraphHeight(termHeight int) int {
 	return MinGraphHeight
 }
 
-// GetSettingsDimensions calculates dimensions for settings/category modals
+// GetSettingsDimensions calculates dimensions for settings/category modals.
 func GetSettingsDimensions(termWidth, termHeight int) (int, int) {
 	width := int(float64(termWidth) * SettingsWidthRatio)
 	if width < MinSettingsWidth {
@@ -48,7 +48,7 @@ func GetSettingsDimensions(termWidth, termHeight int) (int, int) {
 	return width, height
 }
 
-// GetListWidth calculates the list width based on available width
+// GetListWidth calculates the list width based on available width.
 func GetListWidth(availableWidth int) int {
 	leftWidth := int(float64(availableWidth) * ListWidthRatio)
 
@@ -60,12 +60,12 @@ func GetListWidth(availableWidth int) int {
 	return leftWidth
 }
 
-// IsShortTerminal returns true if the terminal height is below the threshold
+// IsShortTerminal returns true if the terminal height is below the threshold.
 func IsShortTerminal(height int) bool {
 	return height < ShortTermHeightThreshold
 }
 
-// GetGraphAreaDimensions calculates dimensions for the graph area
+// GetGraphAreaDimensions calculates dimensions for the graph area.
 func GetGraphAreaDimensions(rightWidth int, isStatsHidden bool) (int, int) {
 	axisWidth := GraphAxisWidth
 	innerWidth := rightWidth - BoxStyle.GetHorizontalFrameSize()
@@ -234,7 +234,6 @@ func CalculateDashboardLayout(termW, termH int) DashboardLayout {
 			l.GraphHeight = targetGraphH
 			l.DetailHeight = l.AvailableHeight - l.GraphHeight
 		}
-
 	}
 
 	// 4. Download List Dimensions

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -14,7 +14,7 @@ import (
 	"charm.land/lipgloss/v2"
 )
 
-// DownloadItem implements list.Item interface for downloads
+// DownloadItem implements list.Item interface for downloads.
 type DownloadItem struct {
 	download    *DownloadModel
 	spinnerView string
@@ -68,7 +68,7 @@ func (i DownloadItem) FilterValue() string {
 	return i.download.Filename
 }
 
-// Custom delegate for rendering download items
+// Custom delegate for rendering download items.
 type downloadDelegate struct {
 	keys           *delegateKeyMap
 	baseTitleStyle lipgloss.Style
@@ -159,19 +159,19 @@ func (d downloadDelegate) Render(w io.Writer, m list.Model, index int, listItem 
 	_, _ = fmt.Fprintf(w, "%s\n%s", line1, line2)
 }
 
-// ShortHelp returns keybindings to show in the mini help view
+// ShortHelp returns keybindings to show in the mini help view.
 func (d downloadDelegate) ShortHelp() []key.Binding {
 	return []key.Binding{d.keys.pause, d.keys.delete}
 }
 
-// FullHelp returns keybindings for the expanded help view
+// FullHelp returns keybindings for the expanded help view.
 func (d downloadDelegate) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{d.keys.pause, d.keys.delete},
 	}
 }
 
-// NewDownloadList creates a new list.Model configured for downloads
+// NewDownloadList creates a new list.Model configured for downloads.
 func NewDownloadList(width, height int) list.Model {
 	delegate := newDownloadDelegate()
 
@@ -209,9 +209,8 @@ func applyListTheme(l *list.Model) {
 		Padding(2, 0)
 }
 
-// UpdateListItems updates the list with filtered downloads based on active tab
+// UpdateListItems updates the list with filtered downloads based on active tab.
 func (m *RootModel) UpdateListItems() {
-
 	if m.list.Width() == 0 {
 		return
 	}
@@ -295,7 +294,7 @@ func (m *RootModel) UpdateListItems() {
 	m.SelectedDownloadID = ""
 }
 
-// GetSelectedDownload returns the currently selected download from the list
+// GetSelectedDownload returns the currently selected download from the list.
 func (m *RootModel) GetSelectedDownload() *DownloadModel {
 	if item := m.list.SelectedItem(); item != nil {
 		if di, ok := item.(DownloadItem); ok {

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -4,10 +4,10 @@ import (
 	"github.com/SurgeDM/Surge/internal/version"
 )
 
-// notificationTickMsg is sent to check if a notification should be cleared
+// notificationTickMsg is sent to check if a notification should be cleared.
 type notificationTickMsg struct{}
 
-// UpdateCheckResultMsg is sent when the update check is complete
+// UpdateCheckResultMsg is sent when the update check is complete.
 type UpdateCheckResultMsg struct {
 	Info *version.UpdateInfo
 }
@@ -25,11 +25,11 @@ type enqueueSuccessMsg struct {
 }
 
 type enqueueErrorMsg struct {
-	tempID string
 	err    error
+	tempID string
 }
 
 type resumeResultMsg struct {
-	id  string
 	err error
+	id  string
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -72,135 +72,91 @@ const (
 )
 
 type DownloadModel struct {
+	progress      progress.Model
+	StartTime     time.Time
+	err           error
+	state         *types.ProgressState
+	Destination   string
 	ID            string
 	URL           string
 	Filename      string
 	FilenameLower string
-	Destination   string // Full path to the destination file
+	lastETA       time.Duration
+	Elapsed       time.Duration
 	Total         int64
-	Downloaded    int64
-	Speed         float64
 	Connections   int
-
-	StartTime time.Time
-	Elapsed   time.Duration
-	lastETA   time.Duration // EMA-smoothed ETA for UI stability
-
-	progress progress.Model
-
-	// Unified architecture: View Model updated by events
-	// No direct state access or polling reporter
-	state *types.ProgressState // Keep for now if needed for details view, but mostly passive
-
-	done     bool
-	err      error
-	paused   bool
-	pausing  bool // UI state: transitioning to pause
-	resuming bool // UI state: waiting for async resume
+	Speed         float64
+	Downloaded    int64
+	done          bool
+	paused        bool
+	pausing       bool
+	resuming      bool
 }
 
 type RootModel struct {
-	downloads    []*DownloadModel
-	width        int
-	height       int
-	state        UIState
-	activeTab    int // 0=Queued, 1=Active, 2=Done
-	inputs       []textinput.Model
-	focusedInput int
-	// Service Interface
-	// Core
-	Service      core.DownloadService
-	Orchestrator *processing.LifecycleManager
-
-	// File picker for directory selection
+	list                   list.Model
 	filepicker             filepicker.Model
+	lastSpeedHistoryUpdate time.Time
+	Service                core.DownloadService
+	enqueueCtx             context.Context
+	Settings               *config.Settings
+	pendingHeaders         map[string]string
+	cancelEnqueue          context.CancelFunc
+	Orchestrator           *processing.LifecycleManager
+	UpdateInfo             *version.UpdateInfo
+	help                   help.Model
+	pendingPath            string
+	pendingFilename        string
+	batchFilePath          string
+	PWD                    string
+	pendingURL             string
+	searchQuery            string
+	ServerHost             string
+	logoCache              string
+	SelectedDownloadID     string
+	CurrentVersion         string
+	duplicateInfo          string
 	filepickerOriginalPath string
+	categoryFilter         string
+	keys                   KeyMap
+	SpeedHistory           []float64
+	logEntries             []string
+	downloads              []*DownloadModel
+	pendingMirrors         []string
+	inputs                 []textinput.Model
+	pendingBatchURLs       []string
+	catMgrInputs           [4]textinput.Model
+	SettingsInput          textinput.Model
+	urlUpdateInput         textinput.Model
+	searchInput            textinput.Model
+	logViewport            viewport.Model
+	spinner                spinner.Model
+	SettingsSelectedRow    int
+	ServerPort             int
+	width                  int
+	height                 int
+	state                  UIState
+	catMgrCursor           int
+	activeTab              int
+	catMgrEditField        int
+	SettingsActiveTab      int
+	focusedInput           int
+	quitConfirmFocused     int
 	filepickerOrigin       FilePickerOrigin
-
-	// Bubbles help component
-	help help.Model
-
-	// Bubbles list component for download listing
-	list list.Model
-
-	PWD string
-
-	// Duplicate detection
-	pendingURL           string // URL pending confirmation
-	pendingPath          string // Path pending confirmation
-	pendingIsDefaultPath bool
-	pendingFilename      string   // Filename pending confirmation
-	pendingMirrors       []string // Mirrors pending confirmation
-	pendingHeaders       map[string]string
-	duplicateInfo        string // Info about the duplicate
-
-	// Graph Data
-	SpeedHistory           []float64 // Stores the last ~60 ticks of speed data
-	lastSpeedHistoryUpdate time.Time // Last time SpeedHistory was updated (for 0.5s sampling)
-
-	// Notification log system
-	logViewport viewport.Model // Scrollable log viewport
-	logEntries  []string       // Log entries for download events
-	logFocused  bool           // Whether the log viewport is focused
-
-	// Settings
-	Settings             *config.Settings // Application settings
-	SettingsActiveTab    int              // Active category tab (0-3)
-	SettingsSelectedRow  int              // Selected setting within current tab
-	SettingsIsEditing    bool             // Whether currently editing a value
-	SettingsInput        textinput.Model  // Input for editing string/int values
-	ExtensionTokenCopied bool             // Flash message for "Token Copied!"
-
-	// Selection persistence
-	SelectedDownloadID string // ID of the currently selected download
-	ManualTabSwitch    bool   // Whether the last tab switch was manual
-
-	// Search functionality
-	searchInput  textinput.Model // Text input for search
-	searchActive bool            // Whether search mode is active
-	searchQuery  string          // Current search query
-
-	// Batch import
-	pendingBatchURLs []string // URLs pending batch import
-	batchFilePath    string   // Path to the batch file
-
-	// URL Refresh
-	urlUpdateInput textinput.Model // Text input for updating URL
-
-	// Category manager
-	categoryFilter  string             // Dashboard filter ("" = all)
-	catMgrCursor    int                // Selected category index
-	catMgrEditing   bool               // Whether editing a category
-	catMgrEditField int                // 0=Name, 1=Description, 2=Pattern, 3=Path
-	catMgrInputs    [4]textinput.Model // Inputs for Name, Description, Pattern, Path
-	catMgrIsNew     bool               // Whether adding a new category
-	// Quit confirm button focus (0 = Yep!, 1 = Nope)
-	quitConfirmFocused int
-
-	// Keybindings
-	keys KeyMap
-
-	// Server port for display
-	ServerPort int
-	ServerHost string
-	IsRemote   bool
-
-	// Update check
-	UpdateInfo     *version.UpdateInfo // Update information (nil if no update available)
-	CurrentVersion string              // Current version of Surge
-
-	InitialDarkBackground bool // Captured at startup for "System" theme
-
-	logoCache string // Cached logo with gradient applied
-
-	enqueueCtx    context.Context
-	cancelEnqueue context.CancelFunc
-	shuttingDown  bool
-
-	spinner spinner.Model
+	catMgrEditing          bool
+	pendingIsDefaultPath   bool
+	IsRemote               bool
+	logFocused             bool
+	catMgrIsNew            bool
+	InitialDarkBackground  bool
+	searchActive           bool
+	SettingsIsEditing      bool
+	ExtensionTokenCopied   bool
+	shuttingDown           bool
+	ManualTabSwitch        bool
 }
 
-// NewDownloadModel creates a new download model
+// NewDownloadModel creates a new download model.
 func NewDownloadModel(id string, url string, filename string, total int64) *DownloadModel {
 	// Create dummy state container for compatibility if needed
 	state := types.NewProgressState(id, total)
@@ -483,7 +439,7 @@ func (m RootModel) Init() tea.Cmd {
 	return tea.Batch(cmds...)
 }
 
-// FindDownloadByID finds a download by its ID
+// FindDownloadByID finds a download by its ID.
 func (m *RootModel) FindDownloadByID(id string) *DownloadModel {
 	for _, d := range m.downloads {
 		if d.ID == id {
@@ -493,7 +449,7 @@ func (m *RootModel) FindDownloadByID(id string) *DownloadModel {
 	return nil
 }
 
-// Helper to get downloads for the current tab
+// Helper to get downloads for the current tab.
 func (m RootModel) getFilteredDownloads() []*DownloadModel {
 	var filtered []*DownloadModel
 	searchLower := strings.ToLower(m.searchQuery)
@@ -588,7 +544,7 @@ func newFilepicker(currentDir string) filepicker.Model {
 	return fp
 }
 
-// ApplyTheme applies the selected theme mode
+// ApplyTheme applies the selected theme mode.
 func (m *RootModel) ApplyTheme(mode int, path string) {
 	applyColorModeForTheme(mode, path, m.InitialDarkBackground)
 	m.refreshThemeCaches()

--- a/internal/tui/polling_test.go
+++ b/internal/tui/polling_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+
 	"github.com/SurgeDM/Surge/internal/core"
 	"github.com/SurgeDM/Surge/internal/download"
 	"github.com/SurgeDM/Surge/internal/engine/events"

--- a/internal/tui/process.go
+++ b/internal/tui/process.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+
 	"github.com/SurgeDM/Surge/internal/engine/events"
 	"github.com/SurgeDM/Surge/internal/processing"
 	"github.com/SurgeDM/Surge/internal/utils"
@@ -76,7 +77,7 @@ func (m *RootModel) processProgressMsg(msg events.ProgressMsg) tea.Cmd {
 	return cmd
 }
 
-// startDownload initiates a new download
+// startDownload initiates a new download.
 func (m RootModel) startDownload(url string, mirrors []string, headers map[string]string, path string, isDefaultPath bool, filename, id string) (RootModel, tea.Cmd) {
 	if m.Service == nil {
 		m.addLogEntry(LogStyleError.Render("\u2716 Service unavailable"))

--- a/internal/tui/startup_test.go
+++ b/internal/tui/startup_test.go
@@ -164,7 +164,7 @@ func TestTUI_Startup_LoadsErroredDownloadsIntoDoneTab(t *testing.T) {
 	}
 }
 
-// Helper functions (duplicated from cmd/startup_test.go because packages differ)
+// Helper functions (duplicated from cmd/startup_test.go because packages differ).
 func setupTestEnv(t *testing.T, tmpDir string) {
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 	t.Setenv("APPDATA", tmpDir)

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -8,7 +8,7 @@ import (
 	"charm.land/lipgloss/v2"
 )
 
-// === Layout Styles ===
+// === Layout Styles ===.
 var (
 	AppStyle          lipgloss.Style
 	PaneStyle         lipgloss.Style

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -10,7 +10,6 @@ import (
 )
 
 func (m RootModel) updatePaste(msg tea.PasteMsg) (tea.Model, tea.Cmd) {
-
 	if m.state == DashboardState && m.searchActive {
 		var cmd tea.Cmd
 		m.searchInput, cmd = m.searchInput.Update(msg)
@@ -47,9 +46,8 @@ func (m RootModel) updatePaste(msg tea.PasteMsg) (tea.Model, tea.Cmd) {
 	}
 }
 
-// Update handles messages and updates the model
+// Update handles messages and updates the model.
 func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-
 	if m.Settings == nil {
 		m.Settings = config.DefaultSettings()
 	}
@@ -71,7 +69,6 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	switch msg := msg.(type) {
-
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
@@ -180,7 +177,6 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyPressMsg:
 		switch m.state {
-
 		case DashboardState:
 			return m.updateDashboard(msg)
 

--- a/internal/tui/update_category.go
+++ b/internal/tui/update_category.go
@@ -8,6 +8,7 @@ import (
 
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
+
 	"github.com/SurgeDM/Surge/internal/config"
 )
 

--- a/internal/tui/update_dashboard.go
+++ b/internal/tui/update_dashboard.go
@@ -4,13 +4,13 @@ import (
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/list"
 	tea "charm.land/bubbletea/v2"
+
 	"github.com/SurgeDM/Surge/internal/clipboard"
 	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/engine/types"
 )
 
 func (m RootModel) updateDashboard(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-
 	// Handle search input FIRST when active (intercepts ALL keys)
 	if m.searchActive {
 		switch msg.String() {

--- a/internal/tui/update_events.go
+++ b/internal/tui/update_events.go
@@ -7,6 +7,7 @@ import (
 
 	"charm.land/bubbles/v2/spinner"
 	tea "charm.land/bubbletea/v2"
+
 	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/engine/events"
 	"github.com/SurgeDM/Surge/internal/tui/components"
@@ -14,9 +15,7 @@ import (
 )
 
 func (m RootModel) updateEvents(msg tea.Msg) (tea.Model, tea.Cmd) {
-
 	switch msg := msg.(type) {
-
 	case spinner.TickMsg:
 		var cmd tea.Cmd
 		m.spinner, cmd = m.spinner.Update(msg)

--- a/internal/tui/update_filepicker.go
+++ b/internal/tui/update_filepicker.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
+
 	"github.com/SurgeDM/Surge/internal/utils"
 )
 

--- a/internal/tui/update_input.go
+++ b/internal/tui/update_input.go
@@ -5,6 +5,7 @@ import (
 
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
+
 	"github.com/SurgeDM/Surge/internal/utils"
 )
 

--- a/internal/tui/update_modals.go
+++ b/internal/tui/update_modals.go
@@ -34,7 +34,6 @@ func (m RootModel) updateDuplicateWarning(msg tea.KeyPressMsg) (tea.Model, tea.C
 }
 
 func (m RootModel) updateQuitConfirm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-
 	confirmQuit := func() (tea.Model, tea.Cmd) {
 		if m.cancelEnqueue != nil {
 			m.cancelEnqueue()
@@ -70,7 +69,6 @@ func (m RootModel) updateQuitConfirm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m RootModel) updateBatchConfirm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-
 	if key.Matches(msg, m.keys.BatchConfirm.Confirm) {
 		// Add all URLs as downloads, skipping duplicates
 		path := m.Settings.General.DefaultDownloadDir
@@ -115,7 +113,6 @@ func (m RootModel) updateBatchConfirm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 }
 
 func (m RootModel) updateURLUpdate(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-
 	if key.Matches(msg, m.keys.Input.Esc) {
 		m.state = DashboardState
 		m.urlUpdateInput.SetValue("")

--- a/internal/tui/update_settings.go
+++ b/internal/tui/update_settings.go
@@ -7,6 +7,7 @@ import (
 
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
+
 	"github.com/SurgeDM/Surge/internal/clipboard"
 	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/utils"

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -12,6 +12,7 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
+
 	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/core"
 	"github.com/SurgeDM/Surge/internal/download"

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -15,7 +16,7 @@ import (
 	"charm.land/lipgloss/v2"
 )
 
-// Viewport layout
+// Viewport layout.
 const maxUIDuration = 30 * 24 * time.Hour
 
 // formatDurationForUI formats a duration as a human-readable clock string.
@@ -49,7 +50,7 @@ func formatDurationForUI(d time.Duration) string {
 	return fmt.Sprintf("%d:%02d", mins, secs)
 }
 
-// renderModalWithOverlay renders a modal centered on screen with a dark overlay effect
+// renderModalWithOverlay renders a modal centered on screen with a dark overlay effect.
 func (m RootModel) renderModalWithOverlay(modal string) string {
 	// Place modal centered with dark gray background fill for overlay effect
 	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, modal,
@@ -381,11 +382,9 @@ func (m RootModel) View() tea.View {
 			detailBox := m.renderDetailsBox(layout.LeftWidth, layout.DetailHeight, detailContent)
 			body = lipgloss.JoinVertical(lipgloss.Left, headerBox, listBox, detailBox)
 		} else {
-
 			body = lipgloss.JoinVertical(lipgloss.Left, headerBox, listBox)
 		}
 	} else {
-
 		leftColumn := lipgloss.JoinVertical(lipgloss.Left, headerBox, listBox)
 		body = lipgloss.JoinHorizontal(lipgloss.Top, leftColumn, rightColumn)
 	}
@@ -402,7 +401,7 @@ func (m RootModel) View() tea.View {
 	return m.wrapView(lipgloss.Place(layout.AvailableWidth, m.height, lipgloss.Center, lipgloss.Top, fullView))
 }
 
-// Helper to render the detailed info pane
+// Helper to render the detailed info pane.
 func renderFocusedDetails(d *DownloadModel, w int, spinnerView string) string {
 	pct := 0.0
 	if d.Total > 0 {
@@ -580,7 +579,7 @@ func renderFocusedDetails(d *DownloadModel, w int, spinnerView string) string {
 		if conns == 0 {
 			conns = 1 // Single-connection download (range requests not supported)
 		}
-		connStr := fmt.Sprintf("%d", conns)
+		connStr := strconv.Itoa(conns)
 		leftColItems = append(leftColItems, lipgloss.JoinHorizontal(lipgloss.Left, StatsLabelStyle.Width(7).Render("Conns:"), StatsValueStyle.Render(connStr)))
 	}
 	leftCol := lipgloss.JoinVertical(lipgloss.Left, leftColItems...)
@@ -819,5 +818,5 @@ func (m RootModel) viewQuitConfirm() string {
 // Supports left and right titles (e.g., search on left, pane name on right)
 // Accepts pre-styled title strings
 // Example: ╭─ 🔍 Search... ─────────── Downloads ─╮
-// Delegates to components.RenderBtopBox for the actual rendering
+// Delegates to components.RenderBtopBox for the actual rendering.
 var renderBtopBox = components.RenderBtopBox

--- a/internal/tui/view_category.go
+++ b/internal/tui/view_category.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
+
 	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/tui/colors"
 )

--- a/internal/tui/view_dashboard_chunkmap.go
+++ b/internal/tui/view_dashboard_chunkmap.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"charm.land/lipgloss/v2"
+
 	"github.com/SurgeDM/Surge/internal/tui/colors"
 	"github.com/SurgeDM/Surge/internal/tui/components"
 )
@@ -22,7 +23,6 @@ func (m *RootModel) renderChunkMapBox(width, height int, selected *DownloadModel
 	if len(bitmap) == 0 || bitmapWidth == 0 {
 		innerContent = renderEmptyMessage(contentWidth, contentHeight, "Chunk visualization not available")
 	} else {
-
 		targetRows := contentHeight
 		if targetRows < 3 {
 			targetRows = 3
@@ -46,7 +46,6 @@ func (m *RootModel) renderChunkMapBox(width, height int, selected *DownloadModel
 		chunkContentWrapper := chunkMapPadding.Render(chunkMap.View())
 
 		innerContent = lipgloss.Place(contentWidth, contentHeight, lipgloss.Center, lipgloss.Top, chunkContentWrapper)
-
 	}
 
 	return renderBtopBox("", PaneTitleStyle.Render(" Chunk Map "), innerContent, width, height, colors.Gray())

--- a/internal/tui/view_dashboard_header.go
+++ b/internal/tui/view_dashboard_header.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"charm.land/lipgloss/v2"
+
 	"github.com/SurgeDM/Surge/internal/tui/colors"
 	"github.com/SurgeDM/Surge/internal/tui/components"
 )

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -14,7 +14,7 @@ import (
 	"charm.land/lipgloss/v2"
 )
 
-// viewSettings renders the Btop-style settings page
+// viewSettings renders the Btop-style settings page.
 func (m RootModel) viewSettings() string {
 	if m.width <= 0 || m.height <= 0 {
 		return ""
@@ -496,7 +496,7 @@ func (m *RootModel) updateSettingsInputWidthForViewport() {
 	m.SettingsInput.SetWidth(targetWidth)
 }
 
-// getSettingsValues returns a map of setting key -> value for a category
+// getSettingsValues returns a map of setting key -> value for a category.
 func (m RootModel) getSettingsValues(category string) map[string]interface{} {
 	values := make(map[string]interface{})
 
@@ -541,7 +541,7 @@ func (m RootModel) getSettingsValues(category string) map[string]interface{} {
 	return values
 }
 
-// setSettingValue sets a setting value from string input
+// setSettingValue sets a setting value from string input.
 func (m *RootModel) setSettingValue(category, key, value string) error {
 	val := reflect.ValueOf(m.Settings).Elem()
 	typ := val.Type()
@@ -675,7 +675,7 @@ func (m *RootModel) persistSettings() error {
 	return nil
 }
 
-// getCurrentSettingKey returns the key of the currently selected setting
+// getCurrentSettingKey returns the key of the currently selected setting.
 func (m RootModel) getCurrentSettingKey() string {
 	meta := m.getCurrentSettingMeta()
 	if meta != nil {
@@ -684,7 +684,7 @@ func (m RootModel) getCurrentSettingKey() string {
 	return ""
 }
 
-// getCurrentSettingMeta returns the metadata for the currently selected setting
+// getCurrentSettingMeta returns the metadata for the currently selected setting.
 func (m RootModel) getCurrentSettingMeta() *config.SettingMeta {
 	categories := config.CategoryOrder()
 	if m.SettingsActiveTab < 0 || m.SettingsActiveTab >= len(categories) {
@@ -700,7 +700,7 @@ func (m RootModel) getCurrentSettingMeta() *config.SettingMeta {
 	return &settingsList[m.SettingsSelectedRow]
 }
 
-// getCurrentSettingType returns the type of the currently selected setting
+// getCurrentSettingType returns the type of the currently selected setting.
 func (m RootModel) getCurrentSettingType() string {
 	meta := m.getCurrentSettingMeta()
 	if meta != nil {
@@ -709,7 +709,7 @@ func (m RootModel) getCurrentSettingType() string {
 	return "string"
 }
 
-// getSettingsCount returns the number of settings in the current category
+// getSettingsCount returns the number of settings in the current category.
 func (m RootModel) getSettingsCount() int {
 	categories := config.CategoryOrder()
 	if m.SettingsActiveTab >= 0 && m.SettingsActiveTab < len(categories) {
@@ -723,7 +723,7 @@ func (m RootModel) getSettingsCount() int {
 	return 0
 }
 
-// getSettingUnit returns the unit suffix for the currently selected setting
+// getSettingUnit returns the unit suffix for the currently selected setting.
 func (m RootModel) getSettingUnit() string {
 	key := m.getCurrentSettingKey()
 	switch key {
@@ -744,7 +744,7 @@ func (m RootModel) getSettingUnit() string {
 	}
 }
 
-// formatSettingValueForEdit returns a plain value without units for editing
+// formatSettingValueForEdit returns a plain value without units for editing.
 func formatSettingValueForEdit(value interface{}, typ, key string, truncate bool) string {
 	switch key {
 	case "min_chunk_size":
@@ -782,7 +782,7 @@ func formatSettingValueForEdit(value interface{}, typ, key string, truncate bool
 	return formatSettingValue(value, typ, truncate)
 }
 
-// formatSettingValue formats a setting value for display
+// formatSettingValue formats a setting value for display.
 func formatSettingValue(value interface{}, typ string, truncate bool) string {
 	if value == nil {
 		return "-"
@@ -803,12 +803,12 @@ func formatSettingValue(value interface{}, typ string, truncate bool) string {
 	case "int64":
 		if v, ok := value.(int64); ok {
 			// Just display the raw number - units handled by getSettingUnit
-			return fmt.Sprintf("%d", v)
+			return strconv.FormatInt(v, 10)
 		}
 	case "int":
 		v := reflect.ValueOf(value)
 		if v.Kind() == reflect.Int {
-			return fmt.Sprintf("%d", v.Int())
+			return strconv.FormatInt(v.Int(), 10)
 		}
 	case "float64":
 		if v, ok := value.(float64); ok {
@@ -832,7 +832,7 @@ func formatSettingValue(value interface{}, typ string, truncate bool) string {
 	v := reflect.ValueOf(value)
 	switch v.Kind() {
 	case reflect.Int, reflect.Int64:
-		return fmt.Sprintf("%d", v.Int())
+		return strconv.FormatInt(v.Int(), 10)
 	case reflect.Float64:
 		return fmt.Sprintf("%.2f", v.Float())
 	default:
@@ -840,7 +840,7 @@ func formatSettingValue(value interface{}, typ string, truncate bool) string {
 	}
 }
 
-// resetSettingToDefault resets a specific setting to its default value
+// resetSettingToDefault resets a specific setting to its default value.
 func (m *RootModel) resetSettingToDefault(category, key string, defaults *config.Settings) {
 	switch category {
 	case "General":

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -11,6 +11,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+
 	"github.com/SurgeDM/Surge/internal/tui/colors"
 )
 

--- a/internal/utils/debug.go
+++ b/internal/utils/debug.go
@@ -18,13 +18,13 @@ var (
 	logsDir   atomic.Value // string
 )
 
-// ConfigureDebug sets the directory for debug logs
+// ConfigureDebug sets the directory for debug logs.
 func ConfigureDebug(dir string) {
 	logsDir.Store(dir)
 }
 
 // IsLoggingEnabled returns true if debug logging is configured
-// This allows callers to skip expensive argument evaluation
+// This allows callers to skip expensive argument evaluation.
 func IsLoggingEnabled() bool {
 	val := logsDir.Load()
 	if val == nil {
@@ -34,7 +34,7 @@ func IsLoggingEnabled() bool {
 	return ok && dir != ""
 }
 
-// Debug writes a message to debug.log file in the configured directory
+// Debug writes a message to debug.log file in the configured directory.
 func Debug(format string, args ...any) {
 	// Internal fast path check without lock
 	val := logsDir.Load()
@@ -60,7 +60,7 @@ func Debug(format string, args ...any) {
 	}
 }
 
-// CleanupLogs removes old log files, keeping only the most recent retentionCount files
+// CleanupLogs removes old log files, keeping only the most recent retentionCount files.
 func CleanupLogs(retentionCount int) {
 	if retentionCount < 0 {
 		return // Keep all logs

--- a/internal/utils/filename_test.go
+++ b/internal/utils/filename_test.go
@@ -77,11 +77,11 @@ func TestDetermineFilename_PriorityOrder(t *testing.T) {
 	pdfContent := []byte("%PDF-1.4\n") // Magic bytes for PDF
 
 	tests := []struct {
+		headers  http.Header
 		name     string
 		url      string
-		headers  http.Header
-		body     []byte
 		expected string
+		body     []byte
 	}{
 		{
 			name: "Priority 1: Content-Disposition beats all",

--- a/internal/utils/notify.go
+++ b/internal/utils/notify.go
@@ -5,8 +5,9 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/SurgeDM/Surge/assets"
 	"github.com/gen2brain/beeep"
+
+	"github.com/SurgeDM/Surge/assets"
 )
 
 const NotificationAppName = "Surge"

--- a/internal/utils/open.go
+++ b/internal/utils/open.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -10,7 +11,7 @@ import (
 
 func OpenFile(path string) error {
 	if path == "" {
-		return fmt.Errorf("path is empty")
+		return errors.New("path is empty")
 	}
 
 	info, err := os.Stat(path)
@@ -27,7 +28,7 @@ func OpenFile(path string) error {
 
 func OpenContainingFolder(path string) error {
 	if path == "" {
-		return fmt.Errorf("path is empty")
+		return errors.New("path is empty")
 	}
 
 	targetPath := path
@@ -75,7 +76,7 @@ func buildOpenCommand(path string) *exec.Cmd {
 // OpenBrowser opens a URL in the system's default web browser.
 func OpenBrowser(url string) error {
 	if url == "" {
-		return fmt.Errorf("url is empty")
+		return errors.New("url is empty")
 	}
 	return openWithSystem(url)
 }

--- a/internal/utils/url_reader.go
+++ b/internal/utils/url_reader.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -55,7 +56,7 @@ func ReadURLsFromFile(filepath string) ([]string, error) {
 		return nil, err
 	}
 	if len(urls) == 0 {
-		return nil, fmt.Errorf("no valid URLs found in file")
+		return nil, errors.New("no valid URLs found in file")
 	}
 	return urls, nil
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -12,13 +12,13 @@ import (
 )
 
 const (
-	// GitHubAPIURL is the endpoint for fetching the latest release
+	// GitHubAPIURL is the endpoint for fetching the latest release.
 	GitHubAPIURL = "https://api.github.com/repos/SurgeDM/Surge/releases/latest"
-	// RequestTimeout is the timeout for the GitHub API request
+	// RequestTimeout is the timeout for the GitHub API request.
 	RequestTimeout = 10 * time.Second
 )
 
-// UpdateInfo contains information about an available update
+// UpdateInfo contains information about an available update.
 type UpdateInfo struct {
 	CurrentVersion  string // The current version of Surge
 	LatestVersion   string // The latest version available on GitHub
@@ -26,7 +26,7 @@ type UpdateInfo struct {
 	UpdateAvailable bool   // Whether an update is available
 }
 
-// GitHubRelease represents the relevant fields from the GitHub API response
+// GitHubRelease represents the relevant fields from the GitHub API response.
 type GitHubRelease struct {
 	TagName string `json:"tag_name"`
 	HTMLURL string `json:"html_url"`
@@ -87,7 +87,7 @@ func CheckForUpdate(currentVersion string) (*UpdateInfo, error) {
 	return updateInfo, nil
 }
 
-// normalizeVersion removes the 'v' prefix and trims whitespace
+// normalizeVersion removes the 'v' prefix and trims whitespace.
 func normalizeVersion(version string) string {
 	version = strings.TrimSpace(version)
 	version = strings.TrimPrefix(version, "v")
@@ -95,7 +95,7 @@ func normalizeVersion(version string) string {
 }
 
 // isNewerVersion compares two semver strings and returns true if latest > current
-// Assumes format: MAJOR.MINOR.PATCH (e.g., "1.2.3")
+// Assumes format: MAJOR.MINOR.PATCH (e.g., "1.2.3").
 func isNewerVersion(latest, current string) bool {
 	latestParts := parseVersion(latest)
 	currentParts := parseVersion(current)
@@ -111,7 +111,7 @@ func isNewerVersion(latest, current string) bool {
 	return false // Versions are equal
 }
 
-// parseVersion parses a semver string into [major, minor, patch]
+// parseVersion parses a semver string into [major, minor, patch].
 func parseVersion(version string) [3]int {
 	var parts [3]int
 


### PR DESCRIPTION
- **feat: add .golangci.yml configuration for project linting**
- **golangci-lint run --fix**
- **chore: update golangci-lint workflow to use official action and dynamic Go versioning**

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `.golangci.yml` v2 configuration, upgrades the CI workflow to the official `golangci/golangci-lint-action@v9` with dynamic Go versioning, and applies `golangci-lint run --fix` across 116 files. The automated fixes are broadly safe: `errors.New` replaces static `fmt.Errorf` calls, `errors.Is` replaces direct `context.Canceled` equality checks, doc-comment periods are added, US-spelling ("canceled") is enforced, and struct fields are reordered for padding alignment. The only notable side effect is that the `fieldalignment` auto-reorder stripped inline documentation comments from several critical structs in the concurrent engine and types packages.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are automated lint fixes with no logic modifications; the only open finding is a P2 documentation concern.

All remaining findings are P2 style/documentation suggestions. No logic, serialization, or correctness issues were introduced; JSON tags are preserved through the struct reordering, and the errors.Is conversion is strictly more correct than the previous equality check.

internal/engine/concurrent/task.go and internal/engine/types/models.go lost inline field documentation through fieldalignment auto-fix.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .golangci.yml | New golangci-lint v2 config with 30+ linters enabled; `unparam` duplicated in enable list (already flagged); some settings (funlen: 80 lines) may be quite strict for this codebase |
| .github/workflows/core-lint.yml | Switches from ad-hoc `go run golangci-lint@latest` to official `golangci/golangci-lint-action@v9` with pinned v2.11 and dynamic Go version from go.mod; missing trailing newline (already flagged) |
| internal/engine/types/models.go | Struct fields reordered for padding optimization by fieldalignment; inline documentation comments stripped from DownloadConfig, DownloadState, DownloadEntry, DownloadStatus, Task, CancelResult |
| internal/engine/concurrent/task.go | ActiveTask struct fields reordered for padding; all helpful inline comments explaining field semantics (hedged tracking, health monitoring, sliding window) were removed by the auto-fix |
| internal/engine/concurrent/downloader.go | Static fmt.Errorf → errors.New, err != context.Canceled → errors.Is, struct fields reordered, inline comments stripped, doc comment periods added; logic unchanged |
| internal/engine/concurrent/worker.go | errors.Is used for context.Canceled check, static errors.New replacements, "cancelled" → "canceled" in comments/debug strings; no logic changes |
| internal/engine/state/db.go | Static fmt.Errorf → errors.New for database not configured/initialized errors; doc comment periods added; no logic changes |
| internal/processing/probe.go | Static fmt.Errorf → errors.New, ProbeResult and mirrorProbeResult fields reordered, doc comment periods added; no logic changes |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/engine/concurrent/task.go
Line: 12-29

Comment:
**fieldalignment auto-fix stripped field-level documentation**

The `fieldalignment` reorder removed all inline comments that explained the purpose of each field group — e.g. `// Used to deduplicate byte counting in hedged requests` on `SharedMaxOffset`, the `// Health monitoring fields` section header, and `// Sliding window for recent speed tracking`. These comments are not derivable from the field names alone and carry meaningful semantic context for anyone reasoning about the health monitor or hedged-request logic.

The same pattern occurs in `DownloadConfig`, `DownloadState`, `DownloadEntry`, `DownloadStatus`, and `ConcurrentDownloader`. Consider restoring the most load-bearing comments (even as a preceding block comment on the struct or a `//nolint:govet` field note) so reviewers of the concurrent engine don't lose that context.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["chore: update golangci-lint workflow to ..."](https://github.com/surgedm/surge/commit/c0dd20ccfe07a8ea3542ff36f4965004c4a9139f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29239504)</sub>

<!-- /greptile_comment -->