### PR TITLE
unified worker pool

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -223,6 +223,7 @@ func ensureGlobalLocalServiceAndLifecycle() error {
 			UpdateURL:           GlobalPool.UpdateURL,
 			PublishEvent:        localService.Publish,
 		})
+		lifecycle.SetConnectionManager(GlobalPool.GetConnectionManager())
 
 		localService.SetLifecycleHooks(core.LifecycleHooks{
 			Pause:       lifecycle.Pause,

--- a/internal/core/pause_resume_integration_test.go
+++ b/internal/core/pause_resume_integration_test.go
@@ -144,7 +144,7 @@ func forceSingleConnectionRuntime(svc *LocalDownloadService) {
 	// Keep integration behavior deterministic:
 	// - single worker connection (no hedging/stealing overlap effects),
 	// - conservative health settings to avoid synthetic task cancellation.
-	svc.settings.Network.MaxConnectionsPerHost = 1
+	svc.settings.Network.MaxConnectionsPerHost = 10
 	svc.settings.Performance.SlowWorkerGracePeriod = 60 * time.Second
 	svc.settings.Performance.StallTimeout = 60 * time.Second
 }
@@ -721,7 +721,7 @@ func TestIntegration_PauseResumeBatch_ColdPath(t *testing.T) {
 	state.Configure(dbPath)
 	defer state.CloseDB()
 
-	const fileSize = int64(16 * 1024 * 1024)
+	const fileSize = int64(128 * 1024 * 1024)
 	server := newDeterministicStreamingServer(t, fileSize)
 	defer server.Close()
 

--- a/internal/core/pause_resume_integration_test.go
+++ b/internal/core/pause_resume_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -144,7 +145,7 @@ func forceSingleConnectionRuntime(svc *LocalDownloadService) {
 	// Keep integration behavior deterministic:
 	// - single worker connection (no hedging/stealing overlap effects),
 	// - conservative health settings to avoid synthetic task cancellation.
-	svc.settings.Network.MaxConnectionsPerHost = 10
+	svc.settings.Network.MaxConnectionsPerHost = 1
 	svc.settings.Performance.SlowWorkerGracePeriod = 60 * time.Second
 	svc.settings.Performance.StallTimeout = 60 * time.Second
 }
@@ -747,16 +748,17 @@ func TestIntegration_PauseResumeBatch_ColdPath(t *testing.T) {
 	if f, err := os.Create(destPath2 + ".surge"); err == nil {
 		_ = f.Close()
 	}
-	id2, err := svc1.Add(server.URL(), outputDir, "cold2.bin", nil, nil, false, fileSize, true)
+	url2 := strings.Replace(server.URL(), "127.0.0.1", "localhost", 1)
+	id2, err := svc1.Add(url2, outputDir, "cold2.bin", nil, nil, false, fileSize, true)
 	if err != nil {
 		t.Fatalf("add 2 failed: %v", err)
 	}
 
 	waitForDownloadStatus(t, svc1, id1, 25*time.Second, func(st *types.DownloadStatus) bool {
-		return (st.Status == "downloading" || st.Status == "completed") && st.Downloaded > 1024*512
+		return st.Status == "downloading" && st.Downloaded > 1024*512
 	})
 	waitForDownloadStatus(t, svc1, id2, 25*time.Second, func(st *types.DownloadStatus) bool {
-		return (st.Status == "downloading" || st.Status == "completed") && st.Downloaded > 1024*512
+		return st.Status == "downloading" && st.Downloaded > 1024*512
 	})
 
 	if err := svc1.Pause(id1); err != nil {

--- a/internal/core/pause_resume_integration_test.go
+++ b/internal/core/pause_resume_integration_test.go
@@ -753,10 +753,10 @@ func TestIntegration_PauseResumeBatch_ColdPath(t *testing.T) {
 	}
 
 	waitForDownloadStatus(t, svc1, id1, 25*time.Second, func(st *types.DownloadStatus) bool {
-		return st.Status == "downloading" && st.Downloaded > 1024*512
+		return (st.Status == "downloading" || st.Status == "completed") && st.Downloaded > 1024*512
 	})
 	waitForDownloadStatus(t, svc1, id2, 25*time.Second, func(st *types.DownloadStatus) bool {
-		return st.Status == "downloading" && st.Downloaded > 1024*512
+		return (st.Status == "downloading" || st.Status == "completed") && st.Downloaded > 1024*512
 	})
 
 	if err := svc1.Pause(id1); err != nil {

--- a/internal/download/manager.go
+++ b/internal/download/manager.go
@@ -220,6 +220,7 @@ func TUIDownload(ctx context.Context, cfg *types.DownloadConfig) error {
 		// Fallback to single-threaded downloader
 		utils.Debug("Using single-threaded downloader")
 		d := single.NewSingleDownloader(cfg.ID, cfg.ProgressCh, cfg.State, cfg.Runtime)
+		d.Execution = cfg.Execution
 		d.Headers = cfg.Headers // Forward custom headers from browser extension
 		downloadErr = d.Download(ctx, cfg.URL, finalDestPath, cfg.TotalSize, finalFilename)
 		if d.TotalSize > 0 {

--- a/internal/download/manager.go
+++ b/internal/download/manager.go
@@ -185,6 +185,7 @@ func TUIDownload(ctx context.Context, cfg *types.DownloadConfig) error {
 
 		d := concurrent.NewConcurrentDownloader(cfg.ID, cfg.ProgressCh, cfg.State, cfg.Runtime)
 		d.Headers = cfg.Headers // Forward custom headers from browser extension
+		d.Execution = cfg.Execution
 		utils.Debug("Calling Download with mirrors: %v", mirrors)
 		downloadErr = d.Download(ctx, cfg.URL, mirrors, activeMirrors, finalDestPath, cfg.TotalSize)
 		if d.TotalSize > 0 {

--- a/internal/download/pool.go
+++ b/internal/download/pool.go
@@ -507,6 +507,11 @@ func (p *TaskPool) GetStatus(id string) *types.DownloadStatus {
 }
 
 // GetConnectionManager returns the shared connection pool for this task pool.
+//
+// NOTE: This performs a type assertion to the concrete *network.ConnectionManager.
+// If a non-standard HTTPClientFactory implementation is injected into the pool,
+// this will return nil and wiring (e.g. in LifecycleManager) will fall back to
+// isolated connection pools.
 func (p *TaskPool) GetConnectionManager() *network.ConnectionManager {
 	if p.execution == nil {
 		return nil

--- a/internal/download/pool.go
+++ b/internal/download/pool.go
@@ -574,6 +574,9 @@ drainLoop:
 
 	p.wg.Wait() // Blocks until all workers call Done()
 
+	// Shutdown the global execution layers. This is safe to do here because
+	// wg.Wait() above ensures all download goroutines have returned, meaning
+	// no more calls to Run() or HTTPClients can occur.
 	if p.execution != nil && p.execution.NetworkWorkers != nil {
 		p.execution.NetworkWorkers.Shutdown()
 	}

--- a/internal/download/pool.go
+++ b/internal/download/pool.go
@@ -11,7 +11,6 @@ import (
 	"github.com/SurgeDM/Surge/internal/engine/concurrent"
 	"github.com/SurgeDM/Surge/internal/engine/network"
 	"github.com/SurgeDM/Surge/internal/engine/types"
-	"github.com/SurgeDM/Surge/internal/processing"
 	"github.com/SurgeDM/Surge/internal/utils"
 )
 
@@ -74,7 +73,6 @@ func NewTaskPool(progressCh chan<- any, maxDownloads int) *TaskPool {
 			NetworkWorkers: networkWorkers,
 		},
 	}
-	processing.SetProbeConnectionManager(connections)
 	for i := 0; i < maxDownloads; i++ {
 		go pool.worker()
 	}
@@ -506,6 +504,17 @@ func (p *TaskPool) GetStatus(id string) *types.DownloadStatus {
 	}
 
 	return status
+}
+
+// GetConnectionManager returns the shared connection pool for this task pool.
+func (p *TaskPool) GetConnectionManager() *network.ConnectionManager {
+	if p.execution == nil {
+		return nil
+	}
+	if mgr, ok := p.execution.HTTPClients.(*network.ConnectionManager); ok {
+		return mgr
+	}
+	return nil
 }
 
 // GracefulShutdown pauses all downloads and waits for them to save state

--- a/internal/download/pool.go
+++ b/internal/download/pool.go
@@ -8,7 +8,10 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/SurgeDM/Surge/internal/engine/concurrent"
+	"github.com/SurgeDM/Surge/internal/engine/network"
 	"github.com/SurgeDM/Surge/internal/engine/types"
+	"github.com/SurgeDM/Surge/internal/processing"
 	"github.com/SurgeDM/Surge/internal/utils"
 )
 
@@ -20,7 +23,7 @@ type activeDownload struct {
 	running atomic.Bool
 }
 
-type WorkerPool struct {
+type TaskPool struct {
 	taskChan     chan types.DownloadConfig
 	progressCh   chan<- any
 	progressDone chan struct{}                   // closed when progressCh must no longer be sent to
@@ -29,7 +32,11 @@ type WorkerPool struct {
 	mu           sync.RWMutex
 	wg           sync.WaitGroup // We use this to wait for all active downloads to pause before exiting the program
 	maxDownloads int
+	execution    *types.ExecutionDeps
 }
+
+// WorkerPool is a temporary compatibility alias during the TaskPool migration.
+type WorkerPool = TaskPool
 
 var (
 	// gracefulShutdownPauseSoftTimeout controls when we emit a warning that
@@ -46,22 +53,36 @@ var (
 	cancelStopPollInterval = 10 * time.Millisecond
 )
 
-func NewWorkerPool(progressCh chan<- any, maxDownloads int) *WorkerPool {
+func NewTaskPool(progressCh chan<- any, maxDownloads int) *TaskPool {
 	if maxDownloads < 1 {
 		maxDownloads = 3 // Default to 3 if invalid
 	}
-	pool := &WorkerPool{
+	connections := network.NewConnectionManager()
+	buffers := network.NewBufferPoolManager()
+	networkWorkers := concurrent.NewNetworkWorkerPool(maxDownloads * types.PerHostMax)
+
+	pool := &TaskPool{
 		taskChan:     make(chan types.DownloadConfig, 100), // We make it buffered to avoid blocking add
 		progressCh:   progressCh,
 		progressDone: make(chan struct{}),
 		downloads:    make(map[string]*activeDownload),
 		queued:       make(map[string]types.DownloadConfig),
 		maxDownloads: maxDownloads,
+		execution: &types.ExecutionDeps{
+			HTTPClients:    connections,
+			BufferPools:    buffers,
+			NetworkWorkers: networkWorkers,
+		},
 	}
+	processing.SetProbeConnectionManager(connections)
 	for i := 0; i < maxDownloads; i++ {
 		go pool.worker()
 	}
 	return pool
+}
+
+func NewWorkerPool(progressCh chan<- any, maxDownloads int) *WorkerPool {
+	return NewTaskPool(progressCh, maxDownloads)
 }
 
 // syncConfigFromState syncs Filename, DestPath, and Mirrors from the associated state.
@@ -101,9 +122,12 @@ func resolveDestPath(cfg *types.DownloadConfig) string {
 
 // Add adds a new download task to the pool. The caller (LifecycleManager) is
 // responsible for emitting any lifecycle events (e.g. DownloadQueuedMsg).
-func (p *WorkerPool) Add(cfg types.DownloadConfig) {
+func (p *TaskPool) Add(cfg types.DownloadConfig) {
 	if cfg.ProgressCh == nil {
 		cfg.ProgressCh = p.progressCh
+	}
+	if cfg.Execution == nil {
+		cfg.Execution = p.execution
 	}
 	p.mu.Lock()
 	p.queued[cfg.ID] = cfg
@@ -113,7 +137,7 @@ func (p *WorkerPool) Add(cfg types.DownloadConfig) {
 }
 
 // HasDownload reports whether a download with the given URL is currently active or queued in the pool.
-func (p *WorkerPool) HasDownload(url string) bool {
+func (p *TaskPool) HasDownload(url string) bool {
 	p.mu.RLock()
 	for _, ad := range p.downloads {
 		if ad.config.URL == url {
@@ -133,7 +157,7 @@ func (p *WorkerPool) HasDownload(url string) bool {
 }
 
 // ActiveCount returns the number of currently active (downloading/pausing) downloads
-func (p *WorkerPool) ActiveCount() int {
+func (p *TaskPool) ActiveCount() int {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 
@@ -150,7 +174,7 @@ func (p *WorkerPool) ActiveCount() int {
 }
 
 // GetAll returns all active download configs (for listing)
-func (p *WorkerPool) GetAll() []types.DownloadConfig {
+func (p *TaskPool) GetAll() []types.DownloadConfig {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 
@@ -168,7 +192,7 @@ func (p *WorkerPool) GetAll() []types.DownloadConfig {
 
 // Pause pauses a specific download by ID. Returns true if found and pause initiated
 // (or already paused), false otherwise. Pure mechanical operation — no events emitted.
-func (p *WorkerPool) Pause(downloadID string) bool {
+func (p *TaskPool) Pause(downloadID string) bool {
 	p.mu.RLock()
 	ad, exists := p.downloads[downloadID]
 	p.mu.RUnlock()
@@ -204,7 +228,7 @@ func (p *WorkerPool) Pause(downloadID string) bool {
 }
 
 // PauseAll pauses all active downloads (for graceful shutdown)
-func (p *WorkerPool) PauseAll() {
+func (p *TaskPool) PauseAll() {
 	p.mu.RLock()
 	ids := make([]string, 0, len(p.downloads)) // This stores the uuids of the downloads to be paused
 	for id, ad := range p.downloads {
@@ -223,7 +247,7 @@ func (p *WorkerPool) PauseAll() {
 // Cancel cancels and removes a download by ID. Returns metadata about what was
 // removed so the caller (LifecycleManager) can emit events and handle cleanup.
 // No events are emitted by the pool itself.
-func (p *WorkerPool) Cancel(downloadID string) types.CancelResult {
+func (p *TaskPool) Cancel(downloadID string) types.CancelResult {
 	p.mu.Lock()
 	ad, activeExists := p.downloads[downloadID]
 	qCfg, queuedExists := p.queued[downloadID]
@@ -273,7 +297,7 @@ func (p *WorkerPool) Cancel(downloadID string) types.CancelResult {
 // ExtractPausedConfig atomically removes a paused download from the pool and returns
 // its config (with state cleared for re-enqueue) so the LifecycleManager can resume it.
 // Returns nil if the download is not found, not paused, or still transitioning (pausing).
-func (p *WorkerPool) ExtractPausedConfig(downloadID string) *types.DownloadConfig {
+func (p *TaskPool) ExtractPausedConfig(downloadID string) *types.DownloadConfig {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
@@ -301,7 +325,7 @@ func (p *WorkerPool) ExtractPausedConfig(downloadID string) *types.DownloadConfi
 // UpdateURL updates the in-memory URL of a download by ID.
 // The caller (LifecycleManager) is responsible for persisting the change to the DB.
 // It fails if the download is actively downloading (not paused or errored).
-func (p *WorkerPool) UpdateURL(downloadID string, newURL string) error {
+func (p *TaskPool) UpdateURL(downloadID string, newURL string) error {
 	p.mu.Lock()
 	ad, exists := p.downloads[downloadID]
 	_, qExists := p.queued[downloadID]
@@ -328,8 +352,11 @@ func (p *WorkerPool) UpdateURL(downloadID string, newURL string) error {
 	return nil
 }
 
-func (p *WorkerPool) worker() {
+func (p *TaskPool) worker() {
 	for cfg := range p.taskChan {
+		if cfg.Execution == nil {
+			cfg.Execution = p.execution
+		}
 		p.mu.RLock()
 		_, stillQueued := p.queued[cfg.ID]
 		p.mu.RUnlock()
@@ -371,7 +398,7 @@ func (p *WorkerPool) worker() {
 		}
 
 		if isPaused {
-			utils.Debug("WorkerPool: Download %s paused cleanly", cfg.ID)
+			utils.Debug("TaskPool: Download %s paused cleanly", cfg.ID)
 			// If paused, we keep it in downloads map for potential resume via ExtractPausedConfig
 		} else if err != nil {
 			if cfg.State != nil {
@@ -401,7 +428,7 @@ func (p *WorkerPool) worker() {
 }
 
 // GetStatus returns the status of an active download
-func (p *WorkerPool) GetStatus(id string) *types.DownloadStatus {
+func (p *TaskPool) GetStatus(id string) *types.DownloadStatus {
 	p.mu.RLock()
 	ad, exists := p.downloads[id]
 	qCfg, qExists := p.queued[id]
@@ -482,7 +509,7 @@ func (p *WorkerPool) GetStatus(id string) *types.DownloadStatus {
 }
 
 // GracefulShutdown pauses all downloads and waits for them to save state
-func (p *WorkerPool) GracefulShutdown() {
+func (p *TaskPool) GracefulShutdown() {
 	p.PauseAll()
 
 	// Discard all queued-but-not-yet-started downloads so that idle workers
@@ -546,6 +573,15 @@ drainLoop:
 	}
 
 	p.wg.Wait() // Blocks until all workers call Done()
+
+	if p.execution != nil && p.execution.NetworkWorkers != nil {
+		p.execution.NetworkWorkers.Shutdown()
+	}
+	if p.execution != nil {
+		if connections, ok := p.execution.HTTPClients.(*network.ConnectionManager); ok {
+			connections.Shutdown()
+		}
+	}
 
 	// Signal that progressCh must no longer be sent to, then close taskChan
 	// so worker goroutines exit their range loop.

--- a/internal/engine/concurrent/downloader.go
+++ b/internal/engine/concurrent/downloader.go
@@ -20,10 +20,29 @@ import (
 	"github.com/SurgeDM/Surge/internal/utils"
 )
 
-var defaultExecution = &types.ExecutionDeps{
-	HTTPClients:    network.NewConnectionManager(),
-	BufferPools:    network.NewBufferPoolManager(),
-	NetworkWorkers: NewNetworkWorkerPool(types.PerHostMax),
+var (
+	defaultExec     *types.ExecutionDeps
+	defaultExecOnce sync.Once
+)
+
+func getDefaultExecution() *types.ExecutionDeps {
+	defaultExecOnce.Do(func() {
+		defaultExec = &types.ExecutionDeps{
+			HTTPClients:    network.NewConnectionManager(),
+			BufferPools:    network.NewBufferPoolManager(),
+			NetworkWorkers: NewNetworkWorkerPool(types.PerHostMax),
+		}
+	})
+	return defaultExec
+}
+
+// ShutdownDefaultExecution releases global resources owned by the default execution layer.
+// Primarily used for clean test teardown to avoid goroutine leaks.
+func ShutdownDefaultExecution() {
+	if defaultExec != nil {
+		defaultExec.NetworkWorkers.Shutdown()
+		defaultExec.HTTPClients.Shutdown()
+	}
 }
 
 // ConcurrentDownloader handles multi-connection downloads
@@ -58,7 +77,7 @@ func NewConcurrentDownloader(id string, progressCh chan<- any, progState *types.
 		State:        progState,
 		activeTasks:  make(map[int]*ActiveTask),
 		Runtime:      runtime,
-		Execution:    defaultExecution,
+		Execution:    getDefaultExecution(),
 	}
 }
 
@@ -189,7 +208,7 @@ func (d *ConcurrentDownloader) execution() *types.ExecutionDeps {
 	if d.Execution != nil {
 		return d.Execution
 	}
-	return defaultExecution
+	return getDefaultExecution()
 }
 
 func (d *ConcurrentDownloader) bufferPool() *sync.Pool {

--- a/internal/engine/concurrent/downloader.go
+++ b/internal/engine/concurrent/downloader.go
@@ -2,13 +2,10 @@ package concurrent
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"io"
 	"math"
-	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -17,10 +14,17 @@ import (
 	"time"
 
 	"github.com/SurgeDM/Surge/internal/engine/events"
+	"github.com/SurgeDM/Surge/internal/engine/network"
 	"github.com/SurgeDM/Surge/internal/engine/state"
 	"github.com/SurgeDM/Surge/internal/engine/types"
 	"github.com/SurgeDM/Surge/internal/utils"
 )
+
+var defaultExecution = &types.ExecutionDeps{
+	HTTPClients:    network.NewConnectionManager(),
+	BufferPools:    network.NewBufferPoolManager(),
+	NetworkWorkers: NewNetworkWorkerPool(types.PerHostMax),
+}
 
 // ConcurrentDownloader handles multi-connection downloads
 type ConcurrentDownloader struct {
@@ -33,8 +37,8 @@ type ConcurrentDownloader struct {
 	DestPath     string // For pause/resume
 	Runtime      *types.RuntimeConfig
 	TotalSize    int64
-	bufPool      sync.Pool
 	Headers      map[string]string // Custom HTTP headers from browser (cookies, auth, etc.)
+	Execution    *types.ExecutionDeps
 }
 
 // NewConcurrentDownloader creates a new concurrent downloader with all required parameters
@@ -54,14 +58,7 @@ func NewConcurrentDownloader(id string, progressCh chan<- any, progState *types.
 		State:        progState,
 		activeTasks:  make(map[int]*ActiveTask),
 		Runtime:      runtime,
-		bufPool: sync.Pool{
-			New: func() any {
-				// Use configured buffer size
-				size := runtime.GetWorkerBufferSize()
-				buf := make([]byte, size)
-				return &buf
-			},
-		},
+		Execution:    defaultExecution,
 	}
 }
 
@@ -188,76 +185,23 @@ func createTasks(fileSize, chunkSize int64) []types.Task {
 	return tasks
 }
 
-// newConcurrentClient creates an http.Client tuned for concurrent downloads
-func (d *ConcurrentDownloader) newConcurrentClient(numConns int) *http.Client {
-	// Ensure we have enough connections per host
-	maxConns := d.Runtime.GetMaxConnectionsPerHost()
-	if numConns > maxConns {
-		maxConns = numConns
+func (d *ConcurrentDownloader) execution() *types.ExecutionDeps {
+	if d.Execution != nil {
+		return d.Execution
 	}
+	return defaultExecution
+}
 
-	var proxyFunc func(*http.Request) (*url.URL, error)
-	if d.Runtime.ProxyURL != "" {
-		if parsedURL, err := url.Parse(d.Runtime.ProxyURL); err == nil {
-			proxyFunc = http.ProxyURL(parsedURL)
-		} else {
-			// Fallback or log error? For now fallback to environment
-			utils.Debug("Invalid proxy URL %s: %v", d.Runtime.ProxyURL, err)
-			proxyFunc = http.ProxyFromEnvironment
-		}
-	} else {
-		proxyFunc = http.ProxyFromEnvironment
-	}
+func (d *ConcurrentDownloader) bufferPool() *sync.Pool {
+	return d.execution().BufferPools.Get(d.Runtime.GetWorkerBufferSize())
+}
 
-	transport := &http.Transport{
-		// Connection pooling
-		MaxIdleConns:        types.DefaultMaxIdleConns,
-		MaxIdleConnsPerHost: maxConns + d.Runtime.GetDialHedgeCount() + 2, // Host buffer for hedges
-		MaxConnsPerHost:     maxConns,
-		Proxy:               proxyFunc,
+func (d *ConcurrentDownloader) concurrentClient() *http.Client {
+	return d.execution().HTTPClients.ConcurrentClient(d.Runtime)
+}
 
-		// Timeouts to prevent hung connections
-		IdleConnTimeout:       types.DefaultIdleConnTimeout,
-		TLSHandshakeTimeout:   types.DefaultTLSHandshakeTimeout,
-		ResponseHeaderTimeout: types.DefaultResponseHeaderTimeout,
-		ExpectContinueTimeout: types.DefaultExpectContinueTimeout,
-
-		// Performance tuning
-		DisableCompression: true,  // Files are usually already compressed
-		ForceAttemptHTTP2:  false, // FORCE HTTP/1.1 for multiple TCP connections
-		TLSNextProto:       make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
-	}
-
-	dialer := &net.Dialer{
-		Timeout:   types.DialTimeout,
-		KeepAlive: types.KeepAliveDuration,
-	}
-
-	utils.ConfigureDialer(dialer, d.Runtime.CustomDNS)
-	transport.DialContext = dialer.DialContext
-
-	return &http.Client{
-		Transport: transport,
-		// Preserve headers on redirects for authenticated downloads
-		// By default, Go strips sensitive headers (Cookie, Authorization) on cross-domain redirects.
-		// Since these headers were explicitly provided by the browser for this download, we forward them.
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			if len(via) >= 10 {
-				return fmt.Errorf("stopped after 10 redirects")
-			}
-			// Copy headers from original request to redirect request
-			if len(via) > 0 {
-				utils.CopyRedirectHeaders(req, via[0])
-			}
-			// Re-apply explicit custom headers down the redirect chain
-			for key, val := range d.Headers {
-				if key != "Range" {
-					req.Header.Set(key, val)
-				}
-			}
-			return nil
-		},
-	}
+func (d *ConcurrentDownloader) workerRunner() types.NetworkWorkerRunner {
+	return d.execution().NetworkWorkers
 }
 
 // Download downloads a file using multiple concurrent connections
@@ -314,12 +258,9 @@ func (d *ConcurrentDownloader) Download(ctx context.Context, rawurl string, cand
 		d.State.SetCancelFunc(cancel)
 	}
 
-	bootstrapClient := d.newConcurrentClient(1)
-	defer bootstrapClient.CloseIdleConnections()
-
 	// Determine connections and chunk size
 	if fileSize <= 0 {
-		discoveredSize, err := d.bootstrapMetadata(downloadCtx, bootstrapClient, rawurl)
+		discoveredSize, err := d.bootstrapMetadata(downloadCtx, d.concurrentClient(), rawurl)
 		if err != nil {
 			return err
 		}
@@ -331,8 +272,7 @@ func (d *ConcurrentDownloader) Download(ctx context.Context, rawurl string, cand
 	chunkSize := d.determineChunkSize(fileSize, numConns)
 
 	// Create tuned HTTP client for concurrent downloads
-	client := d.newConcurrentClient(numConns)
-	defer client.CloseIdleConnections()
+	client := d.concurrentClient()
 
 	// Initialize chunk visualization
 	if d.State != nil {
@@ -511,27 +451,9 @@ func (d *ConcurrentDownloader) Download(ctx context.Context, rawurl string, cand
 		}
 	}()
 
-	// Start workers
-	var wg sync.WaitGroup
-	workerErrors := make(chan error, numConns)
-
-	for i := 0; i < numConns; i++ {
-		wg.Add(1)
-		go func(workerID int) {
-			defer wg.Done()
-			err := d.worker(downloadCtx, workerID, workerMirrors, outFile, queue, fileSize, client)
-			if err != nil && err != context.Canceled {
-				workerErrors <- err
-			}
-		}(i)
-	}
-
-	// Wait for all workers to complete
-	go func() {
-		wg.Wait()
-		close(workerErrors)
-		queue.Close()
-	}()
+	workerErrors := d.workerRunner().Run(downloadCtx, numConns, func(workerID int) error {
+		return d.worker(downloadCtx, workerID, workerMirrors, outFile, queue, fileSize, client)
+	})
 
 	// Check for errors or pause
 	var downloadErr error
@@ -696,7 +618,7 @@ func (d *ConcurrentDownloader) prewarmConnections(ctx context.Context, client *h
 			mirror := mirrors[idx%len(mirrors)]
 
 			// Use a fast Range request to ensure the handshake completes
-			req, err := http.NewRequestWithContext(pingCtx, http.MethodGet, mirror, nil)
+			req, err := http.NewRequestWithContext(network.WithRequestHeaders(pingCtx, d.Headers), http.MethodGet, mirror, nil)
 			if err != nil {
 				return
 			}

--- a/internal/engine/concurrent/downloader.go
+++ b/internal/engine/concurrent/downloader.go
@@ -483,6 +483,12 @@ func (d *ConcurrentDownloader) Download(ctx context.Context, rawurl string, cand
 		}
 	}()
 
+	// Start a watcher to unblock workers if context is cancelled (via pause, shutdown, or fatal error)
+	go func() {
+		<-downloadCtx.Done()
+		queue.Close()
+	}()
+
 	workerErrors := d.workerRunner().Run(downloadCtx, numConns, func(workerID int) error {
 		return d.worker(downloadCtx, workerID, workerMirrors, outFile, queue, fileSize, client)
 	})
@@ -492,6 +498,8 @@ func (d *ConcurrentDownloader) Download(ctx context.Context, rawurl string, cand
 	for err := range workerErrors {
 		if err != nil {
 			downloadErr = err
+			// Trigger context cancellation on first fatal error to unblock other workers
+			cancel()
 		}
 	}
 

--- a/internal/engine/concurrent/downloader.go
+++ b/internal/engine/concurrent/downloader.go
@@ -22,26 +22,38 @@ import (
 )
 
 var (
-	defaultExec     atomic.Pointer[types.ExecutionDeps]
-	defaultExecOnce sync.Once
+	defaultExec atomic.Pointer[types.ExecutionDeps]
+	defaultMu   sync.Mutex
 )
 
 func GetDefaultExecution() *types.ExecutionDeps {
-	defaultExecOnce.Do(func() {
-		exec := &types.ExecutionDeps{
-			HTTPClients:    network.NewConnectionManager(),
-			BufferPools:    network.NewBufferPoolManager(),
-			NetworkWorkers: NewNetworkWorkerPool(types.PerHostMax),
-		}
-		defaultExec.Store(exec)
-	})
-	return defaultExec.Load()
+	if exec := defaultExec.Load(); exec != nil {
+		return exec
+	}
+
+	defaultMu.Lock()
+	defer defaultMu.Unlock()
+
+	if exec := defaultExec.Load(); exec != nil {
+		return exec
+	}
+
+	exec := &types.ExecutionDeps{
+		HTTPClients:    network.NewConnectionManager(),
+		BufferPools:    network.NewBufferPoolManager(),
+		NetworkWorkers: NewNetworkWorkerPool(types.PerHostMax),
+	}
+	defaultExec.Store(exec)
+	return exec
 }
 
 // ShutdownDefaultExecution releases global resources owned by the default execution layer.
 // Primarily used for clean test teardown to avoid goroutine leaks.
 func ShutdownDefaultExecution() {
-	if exec := defaultExec.Load(); exec != nil {
+	defaultMu.Lock()
+	defer defaultMu.Unlock()
+
+	if exec := defaultExec.Swap(nil); exec != nil {
 		exec.NetworkWorkers.Shutdown()
 		exec.HTTPClients.Shutdown()
 	}
@@ -662,11 +674,14 @@ func (d *ConcurrentDownloader) prewarmConnections(ctx context.Context, client *h
 				return
 			}
 
-			// Connection is now hot in the pool.
-			// Signal readiness and IMMEDIATELY close body to release to IdleConn pool.
-			ready <- struct{}{}
+			// Drain a small prefix to trigger server-side connection reuse, then close.
+			// This ensures the connection is actually in the idle pool and available
+			// for the first real worker before we signal readiness.
 			_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 32*types.KB))
 			_ = resp.Body.Close()
+
+			// Signal readiness now that the connection is hot in the pool.
+			ready <- struct{}{}
 		}(i)
 	}
 

--- a/internal/engine/concurrent/downloader.go
+++ b/internal/engine/concurrent/downloader.go
@@ -77,7 +77,6 @@ func NewConcurrentDownloader(id string, progressCh chan<- any, progState *types.
 		State:        progState,
 		activeTasks:  make(map[int]*ActiveTask),
 		Runtime:      runtime,
-		Execution:    getDefaultExecution(),
 	}
 }
 

--- a/internal/engine/concurrent/downloader.go
+++ b/internal/engine/concurrent/downloader.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/SurgeDM/Surge/internal/engine/events"
@@ -21,27 +22,28 @@ import (
 )
 
 var (
-	defaultExec     *types.ExecutionDeps
+	defaultExec     atomic.Pointer[types.ExecutionDeps]
 	defaultExecOnce sync.Once
 )
 
-func getDefaultExecution() *types.ExecutionDeps {
+func GetDefaultExecution() *types.ExecutionDeps {
 	defaultExecOnce.Do(func() {
-		defaultExec = &types.ExecutionDeps{
+		exec := &types.ExecutionDeps{
 			HTTPClients:    network.NewConnectionManager(),
 			BufferPools:    network.NewBufferPoolManager(),
 			NetworkWorkers: NewNetworkWorkerPool(types.PerHostMax),
 		}
+		defaultExec.Store(exec)
 	})
-	return defaultExec
+	return defaultExec.Load()
 }
 
 // ShutdownDefaultExecution releases global resources owned by the default execution layer.
 // Primarily used for clean test teardown to avoid goroutine leaks.
 func ShutdownDefaultExecution() {
-	if defaultExec != nil {
-		defaultExec.NetworkWorkers.Shutdown()
-		defaultExec.HTTPClients.Shutdown()
+	if exec := defaultExec.Load(); exec != nil {
+		exec.NetworkWorkers.Shutdown()
+		exec.HTTPClients.Shutdown()
 	}
 }
 
@@ -207,7 +209,7 @@ func (d *ConcurrentDownloader) execution() *types.ExecutionDeps {
 	if d.Execution != nil {
 		return d.Execution
 	}
-	return getDefaultExecution()
+	return GetDefaultExecution()
 }
 
 func (d *ConcurrentDownloader) bufferPool() *sync.Pool {
@@ -663,6 +665,7 @@ func (d *ConcurrentDownloader) prewarmConnections(ctx context.Context, client *h
 			// Connection is now hot in the pool.
 			// Signal readiness and IMMEDIATELY close body to release to IdleConn pool.
 			ready <- struct{}{}
+			_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 32*types.KB))
 			_ = resp.Body.Close()
 		}(i)
 	}

--- a/internal/engine/concurrent/network_worker_pool.go
+++ b/internal/engine/concurrent/network_worker_pool.go
@@ -115,4 +115,3 @@ func (p *NetworkWorkerPool) worker() {
 		}
 	}
 }
-

--- a/internal/engine/concurrent/network_worker_pool.go
+++ b/internal/engine/concurrent/network_worker_pool.go
@@ -1,0 +1,94 @@
+package concurrent
+
+import (
+	"context"
+	"sync"
+)
+
+type networkWorkerJob struct {
+	ctx      context.Context
+	workerID int
+	fn       func(workerID int) error
+	results  chan error
+	done     *sync.WaitGroup
+}
+
+// NetworkWorkerPool reuses a fixed set of goroutines for chunk execution across downloads.
+type NetworkWorkerPool struct {
+	size     int
+	jobs     chan networkWorkerJob
+	stopOnce sync.Once
+}
+
+func NewNetworkWorkerPool(size int) *NetworkWorkerPool {
+	if size < 1 {
+		size = 1
+	}
+
+	pool := &NetworkWorkerPool{
+		size: size,
+		jobs: make(chan networkWorkerJob),
+	}
+
+	for i := 0; i < size; i++ {
+		go pool.worker()
+	}
+
+	return pool
+}
+
+func (p *NetworkWorkerPool) Run(ctx context.Context, workerCount int, fn func(workerID int) error) <-chan error {
+	if workerCount < 1 {
+		workerCount = 1
+	}
+	if workerCount > p.size {
+		workerCount = p.size
+	}
+
+	results := make(chan error, workerCount)
+	var done sync.WaitGroup
+
+	for i := 0; i < workerCount; i++ {
+		done.Add(1)
+		job := networkWorkerJob{
+			ctx:      ctx,
+			workerID: i,
+			fn:       fn,
+			results:  results,
+			done:     &done,
+		}
+
+		select {
+		case p.jobs <- job:
+		case <-ctx.Done():
+			done.Done()
+		}
+	}
+
+	go func() {
+		done.Wait()
+		close(results)
+	}()
+
+	return results
+}
+
+func (p *NetworkWorkerPool) Size() int {
+	return p.size
+}
+
+func (p *NetworkWorkerPool) Shutdown() {
+	p.stopOnce.Do(func() {
+		close(p.jobs)
+	})
+}
+
+func (p *NetworkWorkerPool) worker() {
+	for job := range p.jobs {
+		err := job.fn(job.workerID)
+		if err != nil && err != context.Canceled {
+			job.results <- err
+		}
+		job.done.Done()
+	}
+}

--- a/internal/engine/concurrent/network_worker_pool.go
+++ b/internal/engine/concurrent/network_worker_pool.go
@@ -18,6 +18,7 @@ type networkWorkerJob struct {
 type NetworkWorkerPool struct {
 	size     int
 	jobs     chan networkWorkerJob
+	stop     chan struct{}
 	stopOnce sync.Once
 	stopped  atomic.Bool
 }
@@ -30,6 +31,7 @@ func NewNetworkWorkerPool(size int) *NetworkWorkerPool {
 	pool := &NetworkWorkerPool{
 		size: size,
 		jobs: make(chan networkWorkerJob),
+		stop: make(chan struct{}),
 	}
 
 	for i := 0; i < size; i++ {
@@ -69,6 +71,8 @@ func (p *NetworkWorkerPool) Run(ctx context.Context, workerCount int, fn func(wo
 		case p.jobs <- job:
 		case <-ctx.Done():
 			done.Done()
+		case <-p.stop:
+			done.Done()
 		}
 	}
 
@@ -87,16 +91,27 @@ func (p *NetworkWorkerPool) Size() int {
 func (p *NetworkWorkerPool) Shutdown() {
 	p.stopOnce.Do(func() {
 		p.stopped.Store(true)
-		close(p.jobs)
+		close(p.stop)
+		// We don't close p.jobs here to avoid panics in Run's send.
+		// Workers will exit when p.stop is closed.
 	})
 }
 
 func (p *NetworkWorkerPool) worker() {
-	for job := range p.jobs {
-		err := job.fn(job.workerID)
-		if err != nil && err != context.Canceled {
-			job.results <- err
+	for {
+		select {
+		case job, ok := <-p.jobs:
+			if !ok {
+				return
+			}
+			err := job.fn(job.workerID)
+			if err != nil && err != context.Canceled {
+				job.results <- err
+			}
+			job.done.Done()
+		case <-p.stop:
+			return
 		}
-		job.done.Done()
 	}
 }
+

--- a/internal/engine/concurrent/network_worker_pool.go
+++ b/internal/engine/concurrent/network_worker_pool.go
@@ -55,6 +55,7 @@ func (p *NetworkWorkerPool) Run(ctx context.Context, workerCount int, fn func(wo
 		workerCount = p.size
 	}
 
+	// Ensure results channel is sized to the effective workerCount after capping
 	results := make(chan error, workerCount)
 	var done sync.WaitGroup
 

--- a/internal/engine/concurrent/network_worker_pool.go
+++ b/internal/engine/concurrent/network_worker_pool.go
@@ -2,7 +2,9 @@ package concurrent
 
 import (
 	"context"
+	"fmt"
 	"sync"
+	"sync/atomic"
 )
 
 type networkWorkerJob struct {
@@ -18,6 +20,7 @@ type NetworkWorkerPool struct {
 	size     int
 	jobs     chan networkWorkerJob
 	stopOnce sync.Once
+	stopped  atomic.Bool
 }
 
 func NewNetworkWorkerPool(size int) *NetworkWorkerPool {
@@ -38,6 +41,12 @@ func NewNetworkWorkerPool(size int) *NetworkWorkerPool {
 }
 
 func (p *NetworkWorkerPool) Run(ctx context.Context, workerCount int, fn func(workerID int) error) <-chan error {
+	if p.stopped.Load() {
+		errs := make(chan error, 1)
+		errs <- fmt.Errorf("network worker pool is stopped")
+		close(errs)
+		return errs
+	}
 	if workerCount < 1 {
 		workerCount = 1
 	}
@@ -79,6 +88,7 @@ func (p *NetworkWorkerPool) Size() int {
 
 func (p *NetworkWorkerPool) Shutdown() {
 	p.stopOnce.Do(func() {
+		p.stopped.Store(true)
 		close(p.jobs)
 	})
 }

--- a/internal/engine/concurrent/network_worker_pool.go
+++ b/internal/engine/concurrent/network_worker_pool.go
@@ -8,7 +8,6 @@ import (
 )
 
 type networkWorkerJob struct {
-	ctx      context.Context
 	workerID int
 	fn       func(workerID int) error
 	results  chan error
@@ -60,7 +59,6 @@ func (p *NetworkWorkerPool) Run(ctx context.Context, workerCount int, fn func(wo
 	for i := 0; i < workerCount; i++ {
 		done.Add(1)
 		job := networkWorkerJob{
-			ctx:      ctx,
 			workerID: i,
 			fn:       fn,
 			results:  results,

--- a/internal/engine/concurrent/network_worker_pool_test.go
+++ b/internal/engine/concurrent/network_worker_pool_test.go
@@ -1,0 +1,36 @@
+package concurrent
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestNetworkWorkerPool_ReusesWorkersAcrossRuns(t *testing.T) {
+	pool := NewNetworkWorkerPool(1)
+	defer pool.Shutdown()
+
+	var runs atomic.Int32
+
+	for i := 0; i < 2; i++ {
+		results := pool.Run(context.Background(), 1, func(workerID int) error {
+			if workerID != 0 {
+				t.Fatalf("workerID = %d, want 0", workerID)
+			}
+			runs.Add(1)
+			time.Sleep(10 * time.Millisecond)
+			return nil
+		})
+
+		for err := range results {
+			if err != nil {
+				t.Fatalf("run %d returned error: %v", i, err)
+			}
+		}
+	}
+
+	if got := runs.Load(); got != 2 {
+		t.Fatalf("runs = %d, want 2", got)
+	}
+}

--- a/internal/engine/concurrent/reuse_test.go
+++ b/internal/engine/concurrent/reuse_test.go
@@ -85,7 +85,6 @@ func TestConcurrentDownloader_ProbeAndDownloadShareTransport(t *testing.T) {
 	defer cleanup()
 
 	manager := network.NewConnectionManager()
-	processing.SetProbeConnectionManager(manager)
 
 	exec := &types.ExecutionDeps{
 		HTTPClients:    manager,
@@ -95,7 +94,7 @@ func TestConcurrentDownloader_ProbeAndDownloadShareTransport(t *testing.T) {
 	defer exec.NetworkWorkers.Shutdown()
 
 	probeCfg := &config.RuntimeConfig{MaxConnectionsPerHost: 1}
-	if _, err := processing.ProbeServerWithProxy(context.Background(), server.URL(), "", nil, probeCfg); err != nil {
+	if _, err := processing.ProbeServerWithProxy(context.Background(), server.URL(), "", nil, probeCfg, manager); err != nil {
 		t.Fatalf("probe failed: %v", err)
 	}
 

--- a/internal/engine/concurrent/reuse_test.go
+++ b/internal/engine/concurrent/reuse_test.go
@@ -1,0 +1,124 @@
+package concurrent
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/SurgeDM/Surge/internal/config"
+	"github.com/SurgeDM/Surge/internal/engine/network"
+	"github.com/SurgeDM/Surge/internal/engine/types"
+	"github.com/SurgeDM/Surge/internal/processing"
+	"github.com/SurgeDM/Surge/internal/testutil"
+)
+
+func TestConcurrentDownloader_ReusesConnectionAcrossDownloads(t *testing.T) {
+	var newConnections atomic.Int32
+
+	server := testutil.NewHTTPServerT(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.ServeContent(w, r, "reuse.bin", time.Now(), bytes.NewReader(make([]byte, 128*types.KB)))
+	}))
+	server.Config.ConnState = func(conn net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			newConnections.Add(1)
+		}
+	}
+
+	tmpDir, cleanup := initTestState(t)
+	defer cleanup()
+
+	exec := &types.ExecutionDeps{
+		HTTPClients:    network.NewConnectionManager(),
+		BufferPools:    network.NewBufferPoolManager(),
+		NetworkWorkers: NewNetworkWorkerPool(1),
+	}
+	defer exec.NetworkWorkers.Shutdown()
+
+	runtime := &types.RuntimeConfig{
+		MaxConnectionsPerHost: 1,
+		MinChunkSize:          32 * types.KB,
+		WorkerBufferSize:      32 * types.KB,
+	}
+
+	for i := 0; i < 2; i++ {
+		destPath := filepath.Join(tmpDir, "reuse-"+string(rune('a'+i))+".bin")
+		if f, err := os.Create(destPath + types.IncompleteSuffix); err == nil {
+			_ = f.Close()
+		}
+
+		d := NewConcurrentDownloader("reuse-id", nil, types.NewProgressState("reuse", 128*types.KB), runtime)
+		d.Execution = exec
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		err := d.Download(ctx, server.URL, []string{server.URL}, []string{server.URL}, destPath, 128*types.KB)
+		cancel()
+		if err != nil {
+			t.Fatalf("download %d failed: %v", i, err)
+		}
+	}
+
+	if got := newConnections.Load(); got != 1 {
+		t.Fatalf("new connections = %d, want 1", got)
+	}
+}
+
+func TestConcurrentDownloader_ProbeAndDownloadShareTransport(t *testing.T) {
+	var newConnections atomic.Int32
+
+	server := testutil.NewMockServerT(t,
+		testutil.WithFileSize(128*types.KB),
+		testutil.WithRangeSupport(true),
+	)
+	server.Server.Config.ConnState = func(conn net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			newConnections.Add(1)
+		}
+	}
+
+	tmpDir, cleanup := initTestState(t)
+	defer cleanup()
+
+	manager := network.NewConnectionManager()
+	processing.SetProbeConnectionManager(manager)
+
+	exec := &types.ExecutionDeps{
+		HTTPClients:    manager,
+		BufferPools:    network.NewBufferPoolManager(),
+		NetworkWorkers: NewNetworkWorkerPool(1),
+	}
+	defer exec.NetworkWorkers.Shutdown()
+
+	probeCfg := &config.RuntimeConfig{MaxConnectionsPerHost: 1}
+	if _, err := processing.ProbeServerWithProxy(context.Background(), server.URL(), "", nil, probeCfg); err != nil {
+		t.Fatalf("probe failed: %v", err)
+	}
+
+	destPath := filepath.Join(tmpDir, "probe-reuse.bin")
+	if f, err := os.Create(destPath + types.IncompleteSuffix); err == nil {
+		_ = f.Close()
+	}
+
+	d := NewConcurrentDownloader("probe-reuse", nil, types.NewProgressState("probe-reuse", 128*types.KB), &types.RuntimeConfig{
+		MaxConnectionsPerHost: 1,
+		MinChunkSize:          32 * types.KB,
+		WorkerBufferSize:      32 * types.KB,
+	})
+	d.Execution = exec
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := d.Download(ctx, server.URL(), []string{server.URL()}, []string{server.URL()}, destPath, 128*types.KB); err != nil {
+		t.Fatalf("download failed: %v", err)
+	}
+
+	if got := newConnections.Load(); got != 1 {
+		t.Fatalf("new connections = %d, want 1", got)
+	}
+}

--- a/internal/engine/concurrent/worker.go
+++ b/internal/engine/concurrent/worker.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/SurgeDM/Surge/internal/engine/network"
 	"github.com/SurgeDM/Surge/internal/engine/types"
 	"github.com/SurgeDM/Surge/internal/utils"
 )
@@ -16,8 +17,9 @@ import (
 // worker downloads tasks from the queue
 func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []string, file *os.File, queue *TaskQueue, totalSize int64, client *http.Client) error {
 	// Get pooled buffer
-	bufPtr := d.bufPool.Get().(*[]byte)
-	defer d.bufPool.Put(bufPtr)
+	bufPool := d.bufferPool()
+	bufPtr := bufPool.Get().(*[]byte)
+	defer bufPool.Put(bufPtr)
 	buf := *bufPtr
 
 	utils.Debug("Worker %d started", id)
@@ -181,7 +183,7 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 
 // downloadTask downloads a single byte range and writes to file at offset
 func (d *ConcurrentDownloader) downloadTask(ctx context.Context, rawurl string, file *os.File, activeTask *ActiveTask, buf []byte, client *http.Client, totalSize int64) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawurl, nil)
+	req, err := http.NewRequestWithContext(network.WithRequestHeaders(ctx, d.Headers), http.MethodGet, rawurl, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/engine/network/buffer_pool.go
+++ b/internal/engine/network/buffer_pool.go
@@ -1,0 +1,37 @@
+package network
+
+import "sync"
+
+// BufferPoolManager shares byte buffers across downloads while preserving size isolation.
+type BufferPoolManager struct {
+	mu    sync.Mutex
+	pools map[int]*sync.Pool
+}
+
+func NewBufferPoolManager() *BufferPoolManager {
+	return &BufferPoolManager{
+		pools: make(map[int]*sync.Pool),
+	}
+}
+
+func (m *BufferPoolManager) Get(size int) *sync.Pool {
+	if size <= 0 {
+		size = 1
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if pool, ok := m.pools[size]; ok {
+		return pool
+	}
+
+	pool := &sync.Pool{
+		New: func() any {
+			buf := make([]byte, size)
+			return &buf
+		},
+	}
+	m.pools[size] = pool
+	return pool
+}

--- a/internal/engine/network/buffer_pool_test.go
+++ b/internal/engine/network/buffer_pool_test.go
@@ -1,0 +1,30 @@
+package network
+
+import "testing"
+
+func TestBufferPoolManager_IsolatesBySize(t *testing.T) {
+	manager := NewBufferPoolManager()
+
+	small := manager.Get(1024)
+	sameSmall := manager.Get(1024)
+	large := manager.Get(2048)
+
+	if small != sameSmall {
+		t.Fatal("expected same-size requests to reuse the same pool")
+	}
+	if small == large {
+		t.Fatal("expected different-size requests to use different pools")
+	}
+
+	buf := small.Get().(*[]byte)
+	if got := len(*buf); got != 1024 {
+		t.Fatalf("buffer len = %d, want 1024", got)
+	}
+	small.Put(buf)
+
+	buf = large.Get().(*[]byte)
+	if got := len(*buf); got != 2048 {
+		t.Fatalf("buffer len = %d, want 2048", got)
+	}
+	large.Put(buf)
+}

--- a/internal/engine/network/connection_manager.go
+++ b/internal/engine/network/connection_manager.go
@@ -18,11 +18,12 @@ import (
 type requestHeadersContextKey struct{}
 
 type transportProfile struct {
-	ProxyURL   string
-	CustomDNS  string
-	MaxConns   int
-	ForceTCP4  bool
-	ForceHTTP1 bool
+	ProxyURL       string
+	CustomDNS      string
+	MaxConns       int
+	DialHedgeCount int
+	ForceTCP4      bool
+	ForceHTTP1     bool
 }
 
 type clientProfile struct {
@@ -58,11 +59,12 @@ func (m *ConnectionManager) ConcurrentClient(runtime *enginetypes.RuntimeConfig)
 	}
 
 	transportProfile := transportProfile{
-		ProxyURL:   strings.TrimSpace(runtime.ProxyURL),
-		CustomDNS:  strings.TrimSpace(runtime.CustomDNS),
-		MaxConns:   runtime.GetMaxConnectionsPerHost(),
-		ForceHTTP1: true,
-		ForceTCP4:  true,
+		ProxyURL:       strings.TrimSpace(runtime.ProxyURL),
+		CustomDNS:      strings.TrimSpace(runtime.CustomDNS),
+		MaxConns:       runtime.GetMaxConnectionsPerHost(),
+		DialHedgeCount: runtime.GetDialHedgeCount(),
+		ForceHTTP1:     true,
+		ForceTCP4:      true,
 	}
 	clientProfile := clientProfile{
 		Transport: transportProfile,
@@ -78,11 +80,12 @@ func (m *ConnectionManager) ProbeClient(runtime *config.RuntimeConfig) *http.Cli
 	}
 
 	transportProfile := transportProfile{
-		ProxyURL:   strings.TrimSpace(runtime.ProxyURL),
-		CustomDNS:  strings.TrimSpace(runtime.CustomDNS),
-		MaxConns:   runtime.MaxConnectionsPerHost,
-		ForceHTTP1: true,
-		ForceTCP4:  true,
+		ProxyURL:       strings.TrimSpace(runtime.ProxyURL),
+		CustomDNS:      strings.TrimSpace(runtime.CustomDNS),
+		MaxConns:       runtime.MaxConnectionsPerHost,
+		DialHedgeCount: 0, // Probing doesn't use hedged dialing
+		ForceHTTP1:     true,
+		ForceTCP4:      true,
 	}
 	if transportProfile.MaxConns <= 0 {
 		transportProfile.MaxConns = enginetypes.PerHostMax
@@ -169,7 +172,7 @@ func (m *ConnectionManager) transportLocked(profile transportProfile) *http.Tran
 
 	transport := &http.Transport{
 		MaxIdleConns:          enginetypes.DefaultMaxIdleConns,
-		MaxIdleConnsPerHost:   maxConns + enginetypes.DialHedgeCount + 2,
+		MaxIdleConnsPerHost:   maxConns + profile.DialHedgeCount + 2,
 		MaxConnsPerHost:       maxConns,
 		Proxy:                 proxyFunc,
 		IdleConnTimeout:       enginetypes.DefaultIdleConnTimeout,

--- a/internal/engine/network/connection_manager.go
+++ b/internal/engine/network/connection_manager.go
@@ -81,6 +81,7 @@ func (m *ConnectionManager) ProbeClient(runtime *config.RuntimeConfig) *http.Cli
 		CustomDNS:  strings.TrimSpace(runtime.CustomDNS),
 		MaxConns:   runtime.MaxConnectionsPerHost,
 		ForceHTTP1: true,
+		ForceTCP4:  true,
 	}
 	if transportProfile.MaxConns <= 0 {
 		transportProfile.MaxConns = enginetypes.PerHostMax

--- a/internal/engine/network/connection_manager.go
+++ b/internal/engine/network/connection_manager.go
@@ -18,10 +18,10 @@ import (
 type requestHeadersContextKey struct{}
 
 type transportProfile struct {
-	ProxyURL  string
-	CustomDNS string
-	MaxConns  int
-	ForceTCP4 bool
+	ProxyURL   string
+	CustomDNS  string
+	MaxConns   int
+	ForceTCP4  bool
 	ForceHTTP1 bool
 }
 

--- a/internal/engine/network/connection_manager.go
+++ b/internal/engine/network/connection_manager.go
@@ -62,6 +62,7 @@ func (m *ConnectionManager) ConcurrentClient(runtime *enginetypes.RuntimeConfig)
 		CustomDNS:  strings.TrimSpace(runtime.CustomDNS),
 		MaxConns:   runtime.GetMaxConnectionsPerHost(),
 		ForceHTTP1: true,
+		ForceTCP4:  true,
 	}
 	clientProfile := clientProfile{
 		Transport: transportProfile,

--- a/internal/engine/network/connection_manager.go
+++ b/internal/engine/network/connection_manager.go
@@ -1,0 +1,205 @@
+package network
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	neturl "net/url"
+	"strings"
+	"sync"
+
+	"github.com/SurgeDM/Surge/internal/config"
+	enginetypes "github.com/SurgeDM/Surge/internal/engine/types"
+	"github.com/SurgeDM/Surge/internal/utils"
+)
+
+type requestHeadersContextKey struct{}
+
+type transportProfile struct {
+	ProxyURL  string
+	CustomDNS string
+	MaxConns  int
+	ForceTCP4 bool
+	ForceHTTP1 bool
+}
+
+type clientProfile struct {
+	Transport transportProfile
+	Mode      string
+	UserAgent string
+}
+
+// ConnectionManager owns shared transports and clients for download/probe traffic.
+type ConnectionManager struct {
+	mu         sync.Mutex
+	transports map[transportProfile]*http.Transport
+	clients    map[clientProfile]*http.Client
+}
+
+func NewConnectionManager() *ConnectionManager {
+	return &ConnectionManager{
+		transports: make(map[transportProfile]*http.Transport),
+		clients:    make(map[clientProfile]*http.Client),
+	}
+}
+
+func WithRequestHeaders(ctx context.Context, headers map[string]string) context.Context {
+	if len(headers) == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, requestHeadersContextKey{}, headers)
+}
+
+func (m *ConnectionManager) ConcurrentClient(runtime *enginetypes.RuntimeConfig) *http.Client {
+	if runtime == nil {
+		runtime = &enginetypes.RuntimeConfig{}
+	}
+
+	transportProfile := transportProfile{
+		ProxyURL:   strings.TrimSpace(runtime.ProxyURL),
+		CustomDNS:  strings.TrimSpace(runtime.CustomDNS),
+		MaxConns:   runtime.GetMaxConnectionsPerHost(),
+		ForceHTTP1: true,
+	}
+	clientProfile := clientProfile{
+		Transport: transportProfile,
+		Mode:      "concurrent",
+		UserAgent: runtime.GetUserAgent(),
+	}
+	return m.client(clientProfile)
+}
+
+func (m *ConnectionManager) ProbeClient(runtime *config.RuntimeConfig) *http.Client {
+	if runtime == nil {
+		runtime = &config.RuntimeConfig{}
+	}
+
+	transportProfile := transportProfile{
+		ProxyURL:   strings.TrimSpace(runtime.ProxyURL),
+		CustomDNS:  strings.TrimSpace(runtime.CustomDNS),
+		MaxConns:   runtime.MaxConnectionsPerHost,
+		ForceHTTP1: true,
+	}
+	if transportProfile.MaxConns <= 0 {
+		transportProfile.MaxConns = enginetypes.PerHostMax
+	}
+
+	clientProfile := clientProfile{
+		Transport: transportProfile,
+		Mode:      "probe",
+		UserAgent: defaultUserAgent(runtime.UserAgent),
+	}
+	return m.client(clientProfile)
+}
+
+func (m *ConnectionManager) CloseIdleConnections() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, client := range m.clients {
+		client.CloseIdleConnections()
+	}
+}
+
+func (m *ConnectionManager) Shutdown() {
+	m.CloseIdleConnections()
+}
+
+func (m *ConnectionManager) client(profile clientProfile) *http.Client {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if client, ok := m.clients[profile]; ok {
+		return client
+	}
+
+	transport := m.transportLocked(profile.Transport)
+	client := &http.Client{
+		Transport: transport,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return fmt.Errorf("stopped after 10 redirects")
+			}
+			if len(via) > 0 {
+				utils.CopyRedirectHeaders(req, via[0])
+			}
+			if customHeaders, ok := req.Context().Value(requestHeadersContextKey{}).(map[string]string); ok {
+				for k, v := range customHeaders {
+					if !strings.EqualFold(k, "Range") {
+						req.Header.Set(k, v)
+					}
+				}
+			}
+			return nil
+		},
+	}
+
+	m.clients[profile] = client
+	return client
+}
+
+func (m *ConnectionManager) transportLocked(profile transportProfile) *http.Transport {
+	if transport, ok := m.transports[profile]; ok {
+		return transport
+	}
+
+	proxyFunc := http.ProxyFromEnvironment
+	if profile.ProxyURL != "" {
+		if parsedURL, err := neturl.Parse(profile.ProxyURL); err == nil {
+			proxyFunc = http.ProxyURL(parsedURL)
+		} else {
+			utils.Debug("Invalid proxy URL %s: %v", profile.ProxyURL, err)
+		}
+	}
+
+	dialer := &net.Dialer{
+		Timeout:   enginetypes.DialTimeout,
+		KeepAlive: enginetypes.KeepAliveDuration,
+	}
+	utils.ConfigureDialer(dialer, profile.CustomDNS)
+
+	maxConns := profile.MaxConns
+	if maxConns <= 0 {
+		maxConns = enginetypes.PerHostMax
+	}
+
+	transport := &http.Transport{
+		MaxIdleConns:          enginetypes.DefaultMaxIdleConns,
+		MaxIdleConnsPerHost:   maxConns + enginetypes.DialHedgeCount + 2,
+		MaxConnsPerHost:       maxConns,
+		Proxy:                 proxyFunc,
+		IdleConnTimeout:       enginetypes.DefaultIdleConnTimeout,
+		TLSHandshakeTimeout:   enginetypes.DefaultTLSHandshakeTimeout,
+		ResponseHeaderTimeout: enginetypes.DefaultResponseHeaderTimeout,
+		ExpectContinueTimeout: enginetypes.DefaultExpectContinueTimeout,
+		DisableCompression:    true,
+	}
+
+	if profile.ForceHTTP1 {
+		transport.ForceAttemptHTTP2 = false
+		transport.TLSNextProto = make(map[string]func(string, *tls.Conn) http.RoundTripper)
+	}
+
+	if profile.ForceTCP4 {
+		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			if network == "tcp" {
+				network = "tcp4"
+			}
+			return dialer.DialContext(ctx, network, addr)
+		}
+	} else {
+		transport.DialContext = dialer.DialContext
+	}
+
+	m.transports[profile] = transport
+	return transport
+}
+
+func defaultUserAgent(ua string) string {
+	if strings.TrimSpace(ua) != "" {
+		return ua
+	}
+	return "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+}

--- a/internal/engine/network/connection_manager_test.go
+++ b/internal/engine/network/connection_manager_test.go
@@ -1,0 +1,81 @@
+package network
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/SurgeDM/Surge/internal/config"
+	"github.com/SurgeDM/Surge/internal/engine/types"
+)
+
+func TestConnectionManager_TransportReuse(t *testing.T) {
+	mgr := NewConnectionManager()
+	runtime := &types.RuntimeConfig{MaxConnectionsPerHost: 8}
+
+	c1 := mgr.ConcurrentClient(runtime)
+	c2 := mgr.ConcurrentClient(runtime)
+
+	t1, ok := c1.Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("expected client transport to be *http.Transport")
+	}
+	t2, ok := c2.Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("expected client transport to be *http.Transport")
+	}
+
+	if t1 != t2 {
+		t.Fatal("expected transport reuse for identical runtime config")
+	}
+}
+
+func TestConnectionManager_TransportIsolationByProxy(t *testing.T) {
+	mgr := NewConnectionManager()
+
+	c1 := mgr.ConcurrentClient(&types.RuntimeConfig{ProxyURL: "http://127.0.0.1:8080"})
+	c2 := mgr.ConcurrentClient(&types.RuntimeConfig{ProxyURL: "http://127.0.0.1:9090"})
+
+	t1 := c1.Transport.(*http.Transport)
+	t2 := c2.Transport.(*http.Transport)
+
+	if t1 == t2 {
+		t.Fatal("expected different transports for different proxy settings")
+	}
+}
+
+func TestConnectionManager_TransportIsolationByHedgeCount(t *testing.T) {
+	mgr := NewConnectionManager()
+
+	c1 := mgr.ConcurrentClient(&types.RuntimeConfig{DialHedgeCount: 2})
+	c2 := mgr.ConcurrentClient(&types.RuntimeConfig{DialHedgeCount: 5})
+
+	t1 := c1.Transport.(*http.Transport)
+	t2 := c2.Transport.(*http.Transport)
+
+	if t1 == t2 {
+		t.Fatal("expected different transports for different hedge counts")
+	}
+}
+
+func TestConnectionManager_ProbeVsConcurrentReuse(t *testing.T) {
+	mgr := NewConnectionManager()
+	
+	downloadRuntime := &types.RuntimeConfig{
+		MaxConnectionsPerHost: 8,
+		ProxyURL: "http://proxy:8080",
+	}
+	probeRuntime := &config.RuntimeConfig{
+		MaxConnectionsPerHost: 8,
+		ProxyURL: "http://proxy:8080",
+	}
+
+	cConcurrent := mgr.ConcurrentClient(downloadRuntime)
+	cProbe := mgr.ProbeClient(probeRuntime)
+
+	tConcurrent := cConcurrent.Transport.(*http.Transport)
+	tProbe := cProbe.Transport.(*http.Transport)
+
+	if tConcurrent != tProbe {
+		t.Fatal("expected transport reuse between probe and concurrent clients with matching network profiles")
+	}
+}

--- a/internal/engine/network/connection_manager_test.go
+++ b/internal/engine/network/connection_manager_test.go
@@ -73,14 +73,14 @@ func TestConnectionManager_TransportIsolationByHedgeCount(t *testing.T) {
 
 func TestConnectionManager_ProbeVsConcurrentReuse(t *testing.T) {
 	mgr := NewConnectionManager()
-	
+
 	downloadRuntime := &types.RuntimeConfig{
 		MaxConnectionsPerHost: 8,
-		ProxyURL: "http://proxy:8080",
+		ProxyURL:              "http://proxy:8080",
 	}
 	probeRuntime := &config.RuntimeConfig{
 		MaxConnectionsPerHost: 8,
-		ProxyURL: "http://proxy:8080",
+		ProxyURL:              "http://proxy:8080",
 	}
 
 	cConcurrent := mgr.ConcurrentClient(downloadRuntime)

--- a/internal/engine/network/connection_manager_test.go
+++ b/internal/engine/network/connection_manager_test.go
@@ -77,6 +77,7 @@ func TestConnectionManager_ProbeVsConcurrentReuse(t *testing.T) {
 	downloadRuntime := &types.RuntimeConfig{
 		MaxConnectionsPerHost: 8,
 		ProxyURL:              "http://proxy:8080",
+		DialHedgeCount:        0, // Explicitly match probe's default for reuse assertion
 	}
 	probeRuntime := &config.RuntimeConfig{
 		MaxConnectionsPerHost: 8,

--- a/internal/engine/network/connection_manager_test.go
+++ b/internal/engine/network/connection_manager_test.go
@@ -43,6 +43,20 @@ func TestConnectionManager_TransportIsolationByProxy(t *testing.T) {
 	}
 }
 
+func TestConnectionManager_ProbeClient_ProxyIsolation(t *testing.T) {
+	mgr := NewConnectionManager()
+
+	c1 := mgr.ProbeClient(&config.RuntimeConfig{ProxyURL: "http://127.0.0.1:8080"})
+	c2 := mgr.ProbeClient(&config.RuntimeConfig{ProxyURL: "http://127.0.0.1:9090"})
+
+	t1 := c1.Transport.(*http.Transport)
+	t2 := c2.Transport.(*http.Transport)
+
+	if t1 == t2 {
+		t.Fatal("expected different transports for different proxy settings in probe client")
+	}
+}
+
 func TestConnectionManager_TransportIsolationByHedgeCount(t *testing.T) {
 	mgr := NewConnectionManager()
 

--- a/internal/engine/single/downloader.go
+++ b/internal/engine/single/downloader.go
@@ -4,43 +4,24 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
-	"net/url"
 	"os"
-	"sync"
 	"time"
 
+	"github.com/SurgeDM/Surge/internal/config"
+	"github.com/SurgeDM/Surge/internal/engine/concurrent"
 	"github.com/SurgeDM/Surge/internal/engine/types"
 	"github.com/SurgeDM/Surge/internal/utils"
 )
 
-// SingleDownloader handles single-threaded downloads for servers that don't support range requests.
-// NOTE: Pause/resume is NOT supported because this downloader is only used when
-// the server doesn't support Range headers. If interrupted, the download must restart.
 type SingleDownloader struct {
-	Client       *http.Client
 	ProgressChan chan<- any           // Channel for events (start/complete/error)
 	ID           string               // Download ID
 	State        *types.ProgressState // Shared state for TUI polling
 	Runtime      *types.RuntimeConfig
 	TotalSize    int64
 	Headers      map[string]string // Custom HTTP headers (cookies, auth, etc.)
-}
-
-type singleTransportKey struct {
-	proxyURL  string
-	maxConns  int
-	customDNS string
-}
-
-var singleTransportCache sync.Map // map[singleTransportKey]*http.Transport
-
-var bufPool = sync.Pool{
-	New: func() any {
-		b := make([]byte, 32*types.KB)
-		return &b
-	},
+	Execution    *types.ExecutionDeps
 }
 
 // NewSingleDownloader creates a new single-threaded downloader with all required parameters
@@ -49,94 +30,41 @@ func NewSingleDownloader(id string, progressCh chan<- any, state *types.Progress
 		runtime = &types.RuntimeConfig{}
 	}
 
-	sd := &SingleDownloader{
+	return &SingleDownloader{
 		ProgressChan: progressCh,
 		ID:           id,
 		State:        state,
 		Runtime:      runtime,
 	}
-	sd.Client = newSingleClient(runtime, sd)
-	return sd
 }
 
-func newSingleClient(runtime *types.RuntimeConfig, sd *SingleDownloader) *http.Client {
-	transport := getSharedSingleTransport(runtime)
-
-	return &http.Client{
-		Transport: transport,
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			if len(via) >= 10 {
-				return fmt.Errorf("stopped after 10 redirects")
-			}
-			if len(via) > 0 {
-				utils.CopyRedirectHeaders(req, via[0])
-			}
-			if sd != nil && sd.Headers != nil {
-				for key, val := range sd.Headers {
-					if key != "Range" {
-						req.Header.Set(key, val)
-					}
-				}
-			}
-			return nil
-		},
+func (d *SingleDownloader) execution() *types.ExecutionDeps {
+	if d.Execution != nil {
+		return d.Execution
 	}
+	// Note: Fallback to global default if no specific deps provided.
+	// This maintains backward compatibility for callers not using the pool.
+	return concurrent.GetDefaultExecution()
 }
 
-func getSharedSingleTransport(runtime *types.RuntimeConfig) *http.Transport {
-	key := singleTransportKey{
-		proxyURL:  runtime.ProxyURL,
-		maxConns:  runtime.GetMaxConnectionsPerHost(),
-		customDNS: runtime.CustomDNS,
+func (d *SingleDownloader) probeClient() *http.Client {
+	// For single-threaded downloads, we use the probe client profile as it's
+	// optimized for single connections and honors the same profile-based pooling.
+	// We convert enginetypes.RuntimeConfig to config.RuntimeConfig for compatibility.
+	cfg := &config.RuntimeConfig{
+		ProxyURL:              d.Runtime.ProxyURL,
+		CustomDNS:             d.Runtime.CustomDNS,
+		MaxConnectionsPerHost: d.Runtime.GetMaxConnectionsPerHost(),
+		UserAgent:             d.Runtime.UserAgent,
 	}
-
-	if cached, ok := singleTransportCache.Load(key); ok {
-		return cached.(*http.Transport)
-	}
-
-	transport := newSingleTransport(runtime)
-	actual, _ := singleTransportCache.LoadOrStore(key, transport)
-	return actual.(*http.Transport)
-}
-
-func newSingleTransport(runtime *types.RuntimeConfig) *http.Transport {
-	proxyFunc := http.ProxyFromEnvironment
-	if runtime.ProxyURL != "" {
-		if parsedURL, err := url.Parse(runtime.ProxyURL); err == nil {
-			proxyFunc = http.ProxyURL(parsedURL)
-		} else {
-			utils.Debug("Invalid proxy URL %s: %v", runtime.ProxyURL, err)
-		}
-	}
-
-	dialer := &net.Dialer{
-		Timeout:   types.DialTimeout,
-		KeepAlive: types.KeepAliveDuration,
-	}
-
-	utils.ConfigureDialer(dialer, runtime.CustomDNS)
-
-	return &http.Transport{
-		MaxIdleConns:        types.DefaultMaxIdleConns,
-		MaxIdleConnsPerHost: runtime.GetMaxConnectionsPerHost(),
-		MaxConnsPerHost:     runtime.GetMaxConnectionsPerHost(),
-		Proxy:               proxyFunc,
-
-		IdleConnTimeout:       types.DefaultIdleConnTimeout,
-		TLSHandshakeTimeout:   types.DefaultTLSHandshakeTimeout,
-		ResponseHeaderTimeout: types.DefaultResponseHeaderTimeout,
-		ExpectContinueTimeout: types.DefaultExpectContinueTimeout,
-
-		DisableCompression: true,
-		DialContext:        dialer.DialContext,
-	}
+	return d.execution().HTTPClients.ProbeClient(cfg)
 }
 
 // Download downloads a file using a single connection.
 // This is used for servers that don't support Range requests.
 // If interrupted, the download cannot be resumed and must restart from the beginning.
 func (d *SingleDownloader) Download(ctx context.Context, rawurl, destPath string, fileSize int64, filename string) (err error) {
-	defer d.Client.CloseIdleConnections()
+	client := d.probeClient()
 
 	if d.State != nil {
 		d.State.SetURL(rawurl)
@@ -153,7 +81,7 @@ func (d *SingleDownloader) Download(ctx context.Context, rawurl, destPath string
 	}
 	req.Header.Set("User-Agent", d.Runtime.GetUserAgent())
 
-	resp, err := d.Client.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return err
 	}
@@ -198,6 +126,7 @@ func (d *SingleDownloader) Download(ctx context.Context, rawurl, destPath string
 	start := time.Now()
 	var written int64
 
+	bufPool := d.execution().BufferPools.Get(d.Runtime.GetWorkerBufferSize())
 	bufPtr := bufPool.Get().(*[]byte)
 	buf := *bufPtr
 	defer bufPool.Put(bufPtr)

--- a/internal/engine/single/downloader_test.go
+++ b/internal/engine/single/downloader_test.go
@@ -307,7 +307,6 @@ func TestNewSingleDownloader(t *testing.T) {
 	}
 }
 
-
 func TestSingleDownloader_Download_Success(t *testing.T) {
 	tmpDir, cleanup, err := testutil.TempDir("surge-single-test")
 	if err != nil {

--- a/internal/engine/single/downloader_test.go
+++ b/internal/engine/single/downloader_test.go
@@ -307,40 +307,6 @@ func TestNewSingleDownloader(t *testing.T) {
 	}
 }
 
-func TestNewSingleDownloader_TransportReuse(t *testing.T) {
-	runtime := &types.RuntimeConfig{MaxConnectionsPerHost: 8}
-	d1 := NewSingleDownloader("test-id-1", nil, nil, runtime)
-	d2 := NewSingleDownloader("test-id-2", nil, nil, runtime)
-
-	t1, ok := d1.probeClient().Transport.(*http.Transport)
-	if !ok {
-		t.Fatal("expected downloader client transport to be *http.Transport")
-	}
-	t2, ok := d2.probeClient().Transport.(*http.Transport)
-	if !ok {
-		t.Fatal("expected downloader client transport to be *http.Transport")
-	}
-	if t1 != t2 {
-		t.Fatal("expected transport reuse for identical runtime config")
-	}
-}
-
-func TestNewSingleDownloader_TransportIsolationByProxy(t *testing.T) {
-	d1 := NewSingleDownloader("test-id-1", nil, nil, &types.RuntimeConfig{ProxyURL: "http://127.0.0.1:8080"})
-	d2 := NewSingleDownloader("test-id-2", nil, nil, &types.RuntimeConfig{ProxyURL: "http://127.0.0.1:9090"})
-
-	t1, ok := d1.probeClient().Transport.(*http.Transport)
-	if !ok {
-		t.Fatal("expected downloader client transport to be *http.Transport")
-	}
-	t2, ok := d2.probeClient().Transport.(*http.Transport)
-	if !ok {
-		t.Fatal("expected downloader client transport to be *http.Transport")
-	}
-	if t1 == t2 {
-		t.Fatal("expected different transports for different proxy settings")
-	}
-}
 
 func TestSingleDownloader_Download_Success(t *testing.T) {
 	tmpDir, cleanup, err := testutil.TempDir("surge-single-test")

--- a/internal/engine/single/downloader_test.go
+++ b/internal/engine/single/downloader_test.go
@@ -312,11 +312,11 @@ func TestNewSingleDownloader_TransportReuse(t *testing.T) {
 	d1 := NewSingleDownloader("test-id-1", nil, nil, runtime)
 	d2 := NewSingleDownloader("test-id-2", nil, nil, runtime)
 
-	t1, ok := d1.Client.Transport.(*http.Transport)
+	t1, ok := d1.probeClient().Transport.(*http.Transport)
 	if !ok {
 		t.Fatal("expected downloader client transport to be *http.Transport")
 	}
-	t2, ok := d2.Client.Transport.(*http.Transport)
+	t2, ok := d2.probeClient().Transport.(*http.Transport)
 	if !ok {
 		t.Fatal("expected downloader client transport to be *http.Transport")
 	}
@@ -329,11 +329,11 @@ func TestNewSingleDownloader_TransportIsolationByProxy(t *testing.T) {
 	d1 := NewSingleDownloader("test-id-1", nil, nil, &types.RuntimeConfig{ProxyURL: "http://127.0.0.1:8080"})
 	d2 := NewSingleDownloader("test-id-2", nil, nil, &types.RuntimeConfig{ProxyURL: "http://127.0.0.1:9090"})
 
-	t1, ok := d1.Client.Transport.(*http.Transport)
+	t1, ok := d1.probeClient().Transport.(*http.Transport)
 	if !ok {
 		t.Fatal("expected downloader client transport to be *http.Transport")
 	}
-	t2, ok := d2.Client.Transport.(*http.Transport)
+	t2, ok := d2.probeClient().Transport.(*http.Transport)
 	if !ok {
 		t.Fatal("expected downloader client transport to be *http.Transport")
 	}

--- a/internal/engine/types/config.go
+++ b/internal/engine/types/config.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/SurgeDM/Surge/internal/config"
 )
 
 // Size constants
@@ -74,6 +76,7 @@ type DownloadConfig struct {
 // HTTPClientFactory provides shared HTTP clients for concurrent downloads.
 type HTTPClientFactory interface {
 	ConcurrentClient(runtime *RuntimeConfig) *http.Client
+	ProbeClient(runtime *config.RuntimeConfig) *http.Client
 	Shutdown()
 }
 

--- a/internal/engine/types/config.go
+++ b/internal/engine/types/config.go
@@ -1,6 +1,9 @@
 package types
 
 import (
+	"context"
+	"net/http"
+	"sync"
 	"time"
 )
 
@@ -65,6 +68,31 @@ type DownloadConfig struct {
 	IsExplicitCategory bool              // Used to override category routing from TUI
 	TotalSize          int64             // Total size in bytes of the required download
 	SupportsRange      bool              // Indicates whether the server supports range requests for concurrency
+	Execution          *ExecutionDeps    // Shared execution dependencies owned by the service/engine layer
+}
+
+// HTTPClientFactory provides shared HTTP clients for concurrent downloads.
+type HTTPClientFactory interface {
+	ConcurrentClient(runtime *RuntimeConfig) *http.Client
+}
+
+// BufferPoolFactory provides shared byte-buffer pools keyed by buffer size.
+type BufferPoolFactory interface {
+	Get(size int) *sync.Pool
+}
+
+// NetworkWorkerRunner executes logical download workers on a persistent worker pool.
+type NetworkWorkerRunner interface {
+	Run(ctx context.Context, workerCount int, fn func(workerID int) error) <-chan error
+	Size() int
+	Shutdown()
+}
+
+// ExecutionDeps groups shared runtime-scoped execution resources for concurrent downloads.
+type ExecutionDeps struct {
+	HTTPClients    HTTPClientFactory
+	BufferPools    BufferPoolFactory
+	NetworkWorkers NetworkWorkerRunner
 }
 
 // RuntimeConfig holds dynamic settings that can override defaults

--- a/internal/engine/types/config.go
+++ b/internal/engine/types/config.go
@@ -74,6 +74,7 @@ type DownloadConfig struct {
 // HTTPClientFactory provides shared HTTP clients for concurrent downloads.
 type HTTPClientFactory interface {
 	ConcurrentClient(runtime *RuntimeConfig) *http.Client
+	Shutdown()
 }
 
 // BufferPoolFactory provides shared byte-buffer pools keyed by buffer size.

--- a/internal/processing/manager.go
+++ b/internal/processing/manager.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/engine/events"
+	"github.com/SurgeDM/Surge/internal/engine/network"
 	"github.com/SurgeDM/Surge/internal/engine/types"
 	"github.com/SurgeDM/Surge/internal/utils"
 )
@@ -40,6 +41,7 @@ type LifecycleManager struct {
 	// probeSem caps the number of simultaneous server probes so adding a
 	// large batch of downloads does not flood the network with HEAD requests.
 	probeSem chan struct{}
+	connMgr  *network.ConnectionManager
 }
 
 const (
@@ -111,6 +113,7 @@ func NewLifecycleManager(addFunc AddDownloadFunc, addWithIDFunc AddDownloadWithI
 		addWithIDFunc:       addWithIDFunc,
 		isNameActive:        activeCheck,
 		probeSem:            sem,
+		connMgr:             network.NewConnectionManager(),
 	}
 }
 
@@ -127,6 +130,14 @@ func (mgr *LifecycleManager) getEngineHooks() EngineHooks {
 	mgr.hooksMu.RLock()
 	defer mgr.hooksMu.RUnlock()
 	return mgr.engineHooks
+}
+
+// SetConnectionManager overrides the default connection manager.
+// Used to align probing traffic with the engine's global connection pool.
+func (mgr *LifecycleManager) SetConnectionManager(mgr2 *network.ConnectionManager) {
+	if mgr2 != nil {
+		mgr.connMgr = mgr2
+	}
 }
 
 // GetSettings reloads disk-backed routing rules opportunistically so a long-lived
@@ -258,7 +269,7 @@ func (mgr *LifecycleManager) enqueueResolved(ctx context.Context, req *DownloadR
 		defer func() { mgr.probeSem <- struct{}{} }()
 	}
 
-	probe, probeErr := ProbeServerWithProxy(ctx, req.URL, req.Filename, req.Headers, settings.ToRuntimeConfig())
+	probe, probeErr := ProbeServerWithProxy(ctx, req.URL, req.Filename, req.Headers, settings.ToRuntimeConfig(), mgr.connMgr)
 	if probeErr != nil {
 		// Distinguish between terminal client errors (invalid scheme, etc) and
 		// server-side rejections or timeouts that we can optimistically ignore.

--- a/internal/processing/probe.go
+++ b/internal/processing/probe.go
@@ -23,7 +23,6 @@ var ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
 	"Chrome/120.0.0.0 Safari/537.36"
 
 var (
-	probeConnMu sync.RWMutex
 	// defaultProbeConnMgr is used as a fallback if no explicit manager is provided to a probe.
 	defaultProbeConnMgr = network.NewConnectionManager()
 )
@@ -100,7 +99,7 @@ func ProbeServerWithProxy(ctx context.Context, rawurl string, filenameHint strin
 	} else {
 		mgr = defaultProbeConnMgr
 	}
-	client := getProbeClient(runCfg, mgr)
+	client := mgr.ProbeClient(runCfg)
 
 	// Sequentialize probes to the same host to prevent rate limiting (e.g., Google Drive)
 	hostLock := getProbeHostLock(rawurl)
@@ -262,10 +261,6 @@ func applyProbeHeaders(req *http.Request, headers map[string]string, includeRang
 	if req.Header.Get("User-Agent") == "" {
 		req.Header.Set("User-Agent", ua)
 	}
-}
-
-func getProbeClient(runCfg *config.RuntimeConfig, connMgr *network.ConnectionManager) *http.Client {
-	return connMgr.ProbeClient(runCfg)
 }
 
 // ProbeMirrors is the convenience wrapper for callers that need mirror probing

--- a/internal/processing/probe.go
+++ b/internal/processing/probe.go
@@ -259,35 +259,6 @@ func getProbeClient(runCfg *config.RuntimeConfig) *http.Client {
 	return probeConnectionManager.ProbeClient(runCfg)
 }
 
-func copyProbeRedirectHeaders(dst, src *http.Request) {
-	if dst == nil || src == nil {
-		return
-	}
-
-	if sameProbeRedirectOrigin(dst.URL, src.URL) {
-		for key, vals := range src.Header {
-			dst.Header[key] = append([]string(nil), vals...)
-		}
-		return
-	}
-
-	for key := range dst.Header {
-		delete(dst.Header, key)
-	}
-
-	for _, key := range []string{"Range", "User-Agent"} {
-		if vals := src.Header.Values(key); len(vals) > 0 {
-			dst.Header[key] = append([]string(nil), vals...)
-		}
-	}
-}
-
-func sameProbeRedirectOrigin(a, b *neturl.URL) bool {
-	if a == nil || b == nil {
-		return false
-	}
-	return strings.EqualFold(a.Scheme, b.Scheme) && strings.EqualFold(a.Host, b.Host)
-}
 
 // ProbeMirrors is the convenience wrapper for callers that need mirror probing
 // to honor the saved proxy setting but do not already hold a live settings snapshot.

--- a/internal/processing/probe.go
+++ b/internal/processing/probe.go
@@ -23,8 +23,9 @@ var ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
 	"Chrome/120.0.0.0 Safari/537.36"
 
 var (
-	probeConnMu            sync.RWMutex
-	probeConnectionManager = network.NewConnectionManager()
+	probeConnMu sync.RWMutex
+	// defaultProbeConnMgr is used as a fallback if no explicit manager is provided to a probe.
+	defaultProbeConnMgr = network.NewConnectionManager()
 )
 
 // ErrProbeRequestCreation is returned when a probe request cannot be initialized.
@@ -39,14 +40,10 @@ type ProbeResult struct {
 	ContentType      string
 }
 
-func SetProbeConnectionManager(manager *network.ConnectionManager) {
-	probeConnMu.Lock()
-	defer probeConnMu.Unlock()
-	if manager == nil {
-		probeConnectionManager = network.NewConnectionManager()
-		return
-	}
-	probeConnectionManager = manager
+// GetDefaultProbeConnectionManager returns the shared connection manager used for probes
+// when no explicit manager is provided.
+func GetDefaultProbeConnectionManager() *network.ConnectionManager {
+	return defaultProbeConnMgr
 }
 
 func resolveRuntimeConfig() *config.RuntimeConfig {
@@ -85,8 +82,9 @@ func getProbeHostLock(rawurl string) *sync.Mutex {
 
 // ProbeServerWithProxy is the hot-path variant for callers that already know
 // the effective proxy and want probe traffic to match the eventual download path
-// without re-reading settings from disk.
-func ProbeServerWithProxy(ctx context.Context, rawurl string, filenameHint string, headers map[string]string, runCfg *config.RuntimeConfig) (*ProbeResult, error) {
+// without re-reading settings from disk. Optional connMgr allows sharing
+// connection pools with the downloader.
+func ProbeServerWithProxy(ctx context.Context, rawurl string, filenameHint string, headers map[string]string, runCfg *config.RuntimeConfig, connMgr ...*network.ConnectionManager) (*ProbeResult, error) {
 	utils.Debug("Probing server: %s", rawurl)
 
 	// Embed custom headers in context so CheckRedirect can use them
@@ -96,7 +94,13 @@ func ProbeServerWithProxy(ctx context.Context, rawurl string, filenameHint strin
 
 	var resp *http.Response
 
-	client := getProbeClient(runCfg)
+	var mgr *network.ConnectionManager
+	if len(connMgr) > 0 && connMgr[0] != nil {
+		mgr = connMgr[0]
+	} else {
+		mgr = defaultProbeConnMgr
+	}
+	client := getProbeClient(runCfg, mgr)
 
 	// Sequentialize probes to the same host to prevent rate limiting (e.g., Google Drive)
 	hostLock := getProbeHostLock(rawurl)
@@ -260,10 +264,8 @@ func applyProbeHeaders(req *http.Request, headers map[string]string, includeRang
 	}
 }
 
-func getProbeClient(runCfg *config.RuntimeConfig) *http.Client {
-	probeConnMu.RLock()
-	defer probeConnMu.RUnlock()
-	return probeConnectionManager.ProbeClient(runCfg)
+func getProbeClient(runCfg *config.RuntimeConfig, connMgr *network.ConnectionManager) *http.Client {
+	return connMgr.ProbeClient(runCfg)
 }
 
 
@@ -274,7 +276,7 @@ func ProbeMirrors(ctx context.Context, mirrors []string) (valid []string, errs m
 }
 
 // ProbeMirrorsWithProxy preserves caller order so mirror priority remains stable.
-func ProbeMirrorsWithProxy(ctx context.Context, mirrors []string, runCfg *config.RuntimeConfig) (valid []string, errs map[string]error) {
+func ProbeMirrorsWithProxy(ctx context.Context, mirrors []string, runCfg *config.RuntimeConfig, connMgr ...*network.ConnectionManager) (valid []string, errs map[string]error) {
 	candidates := orderedUniqueMirrors(mirrors)
 	utils.Debug("Probing %d mirrors...", len(candidates))
 
@@ -299,7 +301,7 @@ func ProbeMirrorsWithProxy(ctx context.Context, mirrors []string, runCfg *config
 			probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 			defer cancel()
 
-			result, err := ProbeServerWithProxy(probeCtx, target, "", nil, runCfg)
+			result, err := ProbeServerWithProxy(probeCtx, target, "", nil, runCfg, connMgr...)
 
 			outcome := mirrorProbeResult{}
 			if err != nil {

--- a/internal/processing/probe.go
+++ b/internal/processing/probe.go
@@ -22,7 +22,10 @@ var ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
 	"AppleWebKit/537.36 (KHTML, like Gecko) " +
 	"Chrome/120.0.0.0 Safari/537.36"
 
-var probeConnectionManager = network.NewConnectionManager()
+var (
+	probeConnMu            sync.RWMutex
+	probeConnectionManager = network.NewConnectionManager()
+)
 
 // ErrProbeRequestCreation is returned when a probe request cannot be initialized.
 var ErrProbeRequestCreation = errors.New("failed to create probe request")
@@ -37,6 +40,8 @@ type ProbeResult struct {
 }
 
 func SetProbeConnectionManager(manager *network.ConnectionManager) {
+	probeConnMu.Lock()
+	defer probeConnMu.Unlock()
 	if manager == nil {
 		probeConnectionManager = network.NewConnectionManager()
 		return
@@ -256,6 +261,8 @@ func applyProbeHeaders(req *http.Request, headers map[string]string, includeRang
 }
 
 func getProbeClient(runCfg *config.RuntimeConfig) *http.Client {
+	probeConnMu.RLock()
+	defer probeConnMu.RUnlock()
 	return probeConnectionManager.ProbeClient(runCfg)
 }
 

--- a/internal/processing/probe.go
+++ b/internal/processing/probe.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	neturl "net/url"
 	"strconv"
@@ -14,6 +13,7 @@ import (
 	"time"
 
 	"github.com/SurgeDM/Surge/internal/config"
+	"github.com/SurgeDM/Surge/internal/engine/network"
 	"github.com/SurgeDM/Surge/internal/engine/types"
 	"github.com/SurgeDM/Surge/internal/utils"
 )
@@ -22,13 +22,7 @@ var ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
 	"AppleWebKit/537.36 (KHTML, like Gecko) " +
 	"Chrome/120.0.0.0 Safari/537.36"
 
-var (
-	probeClientsMu   sync.Mutex
-	probeClients     = make(map[string]*http.Client)
-	probeClientOrder []string
-)
-
-const maxProbeClients = 8
+var probeConnectionManager = network.NewConnectionManager()
 
 // ErrProbeRequestCreation is returned when a probe request cannot be initialized.
 var ErrProbeRequestCreation = errors.New("failed to create probe request")
@@ -42,8 +36,13 @@ type ProbeResult struct {
 	ContentType      string
 }
 
-// probeHeadersContextKey is used to pass custom headers to the HTTP client's CheckRedirect function
-type probeHeadersContextKey struct{}
+func SetProbeConnectionManager(manager *network.ConnectionManager) {
+	if manager == nil {
+		probeConnectionManager = network.NewConnectionManager()
+		return
+	}
+	probeConnectionManager = manager
+}
 
 func resolveRuntimeConfig() *config.RuntimeConfig {
 	settings, err := config.LoadSettings()
@@ -87,7 +86,7 @@ func ProbeServerWithProxy(ctx context.Context, rawurl string, filenameHint strin
 
 	// Embed custom headers in context so CheckRedirect can use them
 	if headers != nil {
-		ctx = context.WithValue(ctx, probeHeadersContextKey{}, headers)
+		ctx = network.WithRequestHeaders(ctx, headers)
 	}
 
 	var resp *http.Response
@@ -257,94 +256,7 @@ func applyProbeHeaders(req *http.Request, headers map[string]string, includeRang
 }
 
 func getProbeClient(runCfg *config.RuntimeConfig) *http.Client {
-	probeClientsMu.Lock()
-	defer probeClientsMu.Unlock()
-
-	key := ""
-	if runCfg != nil {
-		// Quote values to prevent ambiguity when one value contains the separator
-		key = fmt.Sprintf("%q|%q", runCfg.ProxyURL, runCfg.CustomDNS)
-	}
-
-	if cached, ok := probeClients[key]; ok {
-		return cached
-	}
-
-	client := &http.Client{
-		Transport: newProbeTransport(runCfg),
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			if len(via) >= 10 {
-				return fmt.Errorf("stopped after 10 redirects")
-			}
-			if len(via) > 0 {
-				copyProbeRedirectHeaders(req, via[0])
-			}
-
-			// Re-apply custom explicitly provided headers on cross-origin redirects
-			if customHeaders, ok := req.Context().Value(probeHeadersContextKey{}).(map[string]string); ok {
-				for k, v := range customHeaders {
-					if !strings.EqualFold(k, "Range") {
-						req.Header.Set(k, v)
-					}
-				}
-			}
-			return nil
-		},
-	}
-
-	if len(probeClients) >= maxProbeClients && len(probeClientOrder) > 0 {
-		evictedKey := probeClientOrder[0]
-		probeClientOrder = probeClientOrder[1:]
-		if evictedClient, ok := probeClients[evictedKey]; ok {
-			evictedClient.CloseIdleConnections()
-			delete(probeClients, evictedKey)
-		}
-	}
-
-	probeClients[key] = client
-	probeClientOrder = append(probeClientOrder, key)
-	return client
-}
-
-func newProbeTransport(runCfg *config.RuntimeConfig) *http.Transport {
-	proxyFunc := http.ProxyFromEnvironment
-	var customDNS string
-	if runCfg != nil {
-		customDNS = runCfg.CustomDNS
-		if strings.TrimSpace(runCfg.ProxyURL) != "" {
-			if parsedURL, err := neturl.Parse(runCfg.ProxyURL); err == nil {
-				proxyFunc = http.ProxyURL(parsedURL)
-			} else {
-				utils.Debug("Invalid probe proxy URL %s: %v", runCfg.ProxyURL, err)
-			}
-		}
-	}
-
-	dialer := &net.Dialer{
-		Timeout:   types.DialTimeout,
-		KeepAlive: types.KeepAliveDuration,
-	}
-
-	utils.ConfigureDialer(dialer, customDNS)
-
-	return &http.Transport{
-		Proxy:                 proxyFunc,
-		MaxIdleConns:          types.DefaultMaxIdleConns,
-		MaxIdleConnsPerHost:   types.PerHostMax,
-		IdleConnTimeout:       types.DefaultIdleConnTimeout,
-		TLSHandshakeTimeout:   types.DefaultTLSHandshakeTimeout,
-		ResponseHeaderTimeout: types.DefaultResponseHeaderTimeout,
-		ExpectContinueTimeout: types.DefaultExpectContinueTimeout,
-		// Use tcp4 to prefer IPv4 when connecting to CDN hosts.
-		// Some CDN nodes resolve to IPv6 addresses that are unreachable
-		// on networks that have IPv6 assigned but no working IPv6 path.
-		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			if network == "tcp" {
-				network = "tcp4"
-			}
-			return dialer.DialContext(ctx, network, addr)
-		},
-	}
+	return probeConnectionManager.ProbeClient(runCfg)
 }
 
 func copyProbeRedirectHeaders(dst, src *http.Request) {

--- a/internal/processing/probe.go
+++ b/internal/processing/probe.go
@@ -268,7 +268,6 @@ func getProbeClient(runCfg *config.RuntimeConfig, connMgr *network.ConnectionMan
 	return connMgr.ProbeClient(runCfg)
 }
 
-
 // ProbeMirrors is the convenience wrapper for callers that need mirror probing
 // to honor the saved proxy setting but do not already hold a live settings snapshot.
 func ProbeMirrors(ctx context.Context, mirrors []string) (valid []string, errs map[string]error) {


### PR DESCRIPTION
- **add shared network execution primitives**
- **reuse concurrent network workers and buffers**
- **rename worker pool to task pool**
- **add network reuse regression tests**

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a unified worker pool that shares HTTP transports, byte-buffer pools, and a fixed goroutine pool (`NetworkWorkerPool`) across all concurrent downloads, replacing per-download allocations. The `WorkerPool` is renamed to `TaskPool` (with a compatibility alias) and now owns an `ExecutionDeps` struct that is injected into each download. Probe traffic is wired through the same `ConnectionManager` so probe connections can be reused by subsequent downloads.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the partial-dispatch workerID gap in NetworkWorkerPool.Run().

All previously flagged concurrency and data-race issues have been resolved (atomic.Pointer for defaultExec, stopped bool before Run(), ForceTCP4 restored, probeConnectionManager replaced). One new P1 remains: partial context cancellation during job dispatch in Run() produces non-contiguous workerID sequences without any signal to callers, which can silently affect workloads that rely on workerID for routing or task assignment.

internal/engine/concurrent/network_worker_pool.go — partial dispatch / workerID gap; internal/download/pool.go — unnecessary type assertion in GracefulShutdown

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/engine/concurrent/network_worker_pool.go | New shared worker pool reuses goroutines across downloads. `stopped` atomic check prevents panic on post-shutdown `Run()`. Partial-dispatch path leaves non-contiguous workerIDs silently; dead `!ok` branch in worker(). |
| internal/engine/network/connection_manager.go | New shared transport/client registry keyed by profile structs. Both ConcurrentClient and ProbeClient now set ForceTCP4=true; redirect headers flow via context; properly addresses prior review concerns. |
| internal/download/pool.go | WorkerPool renamed to TaskPool with alias; shared ExecutionDeps wired in; GracefulShutdown shuts down network workers after wg.Wait(). Unnecessary type assertion in shutdown path bypasses the HTTPClientFactory.Shutdown() interface method. |
| internal/engine/concurrent/downloader.go | Replaces per-download HTTP client and buffer pool with shared ExecutionDeps; default execution uses atomic.Pointer + mutex for safe initialization and shutdown; prewarm now drains 32 KB before signaling to ensure connection is truly idle. |
| internal/engine/single/downloader.go | Removes per-downloader transport cache; now delegates to ExecutionDeps.HTTPClients.ProbeClient(). Custom headers still not embedded in request context, leaving redirect auth forwarding incomplete (pre-existing issue from prior review). |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `internal/core/pause_resume_integration_test.go`, line 9-10 ([link](https://github.com/surgedm/surge/blob/b1ac376d1827690d218115cc9c8cd7ecd1af3a83/internal/core/pause_resume_integration_test.go#L9-L10)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`forceSingleConnectionRuntime` now allows 10 connections, breaking stated determinism**

   The function comment says "single worker connection (no hedging/stealing overlap effects)" but the new value is `10`. If the intent was to allow the shared pool to have more connections available, the comment must be updated. More critically, the test that calls this function (`TestIntegration_PauseResumeBatch_ColdPath`) relies on slow, single-connection behaviour to give the pause signal time to land before the download completes — 10 connections may speed the transfer enough to make the test flaky.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/core/pause_resume_integration_test.go
   Line: 9-10

   Comment:
   **`forceSingleConnectionRuntime` now allows 10 connections, breaking stated determinism**

   The function comment says "single worker connection (no hedging/stealing overlap effects)" but the new value is `10`. If the intent was to allow the shared pool to have more connections available, the comment must be updated. More critically, the test that calls this function (`TestIntegration_PauseResumeBatch_ColdPath`) relies on slow, single-connection behaviour to give the pause signal time to land before the download completes — 10 connections may speed the transfer enough to make the test flaky.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `internal/engine/single/downloader.go`, line 74 ([link](https://github.com/surgedm/surge/blob/707fd06369fbf5e9bad106dc69533506aeb0ac52/internal/engine/single/downloader.go#L74)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Custom headers not embedded in context — redirects drop auth/cookies**

   The request is created with a plain `ctx`, so `requestHeadersContextKey{}` is never set. The shared `ConnectionManager.client()` `CheckRedirect` handler looks up headers exclusively from `req.Context().Value(requestHeadersContextKey{})`, meaning `d.Headers` (cookies, auth tokens) will not be forwarded on any redirect. The concurrent downloader wraps `ctx` with `network.WithRequestHeaders(ctx, d.Headers)` at every request site — the single downloader must do the same.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/engine/single/downloader.go
   Line: 74

   Comment:
   **Custom headers not embedded in context — redirects drop auth/cookies**

   The request is created with a plain `ctx`, so `requestHeadersContextKey{}` is never set. The shared `ConnectionManager.client()` `CheckRedirect` handler looks up headers exclusively from `req.Context().Value(requestHeadersContextKey{})`, meaning `d.Headers` (cookies, auth tokens) will not be forwarded on any redirect. The concurrent downloader wraps `ctx` with `network.WithRequestHeaders(ctx, d.Headers)` at every request site — the single downloader must do the same.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

3. `internal/engine/concurrent/network_worker_pool.go`, line 648-664 ([link](https://github.com/surgedm/surge/blob/106d3189ea2eb10a19fa94535e50caf80860e9d8/internal/engine/concurrent/network_worker_pool.go#L648-L664)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Partial dispatch leaves non-contiguous workerIDs silently**

   When `ctx.Done()` or `p.stop` fires partway through the submission loop, the remaining iterations call `done.Done()` without submitting a job. Meanwhile, jobs that *were* successfully sent to workers are still executing with their original `workerID` values, leaving gaps in the ID sequence (e.g., workers 0 and 1 run but workers 2–N are skipped). Callers using `workerID` for index-based task routing or logging will see non-contiguous IDs with no indication that some slots were never dispatched.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/engine/concurrent/network_worker_pool.go
   Line: 648-664

   Comment:
   **Partial dispatch leaves non-contiguous workerIDs silently**

   When `ctx.Done()` or `p.stop` fires partway through the submission loop, the remaining iterations call `done.Done()` without submitting a job. Meanwhile, jobs that *were* successfully sent to workers are still executing with their original `workerID` values, leaving gaps in the ID sequence (e.g., workers 0 and 1 run but workers 2–N are skipped). Callers using `workerID` for index-based task routing or logging will see non-contiguous IDs with no indication that some slots were never dispatched.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/download/pool.go
Line: 294-297

Comment:
**Unnecessary type assertion — `Shutdown()` is on the interface**

`HTTPClientFactory` already declares `Shutdown()`, so the `(*network.ConnectionManager)` type assertion is redundant and couples the shutdown path to a concrete type. A future injected implementation won't be shut down here if the assertion fails silently.

```suggestion
	if p.execution != nil {
		if p.execution.NetworkWorkers != nil {
			p.execution.NetworkWorkers.Shutdown()
		}
		p.execution.HTTPClients.Shutdown()
	}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/engine/concurrent/network_worker_pool.go
Line: 690-693

Comment:
**Dead `!ok` branch — `jobs` is never closed**

The `Shutdown()` method explicitly avoids closing `p.jobs` (the comment there says so), so `!ok` can never be true. The branch is unreachable and silently misleads readers into thinking there's a clean-close path for the channel.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/engine/concurrent/network_worker_pool.go
Line: 648-664

Comment:
**Partial dispatch leaves non-contiguous workerIDs silently**

When `ctx.Done()` or `p.stop` fires partway through the submission loop, the remaining iterations call `done.Done()` without submitting a job. Meanwhile, jobs that *were* successfully sent to workers are still executing with their original `workerID` values, leaving gaps in the ID sequence (e.g., workers 0 and 1 run but workers 2–N are skipped). Callers using `workerID` for index-based task routing or logging will see non-contiguous IDs with no indication that some slots were never dispatched.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (5): Last reviewed commit: ["docs: add documentation regarding type a..."](https://github.com/surgedm/surge/commit/106d3189ea2eb10a19fa94535e50caf80860e9d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29368703)</sub>

<!-- /greptile_comment -->