### PR TITLE
fix: drain response body before signaling readiness in concurrent downloader to ensure connection reuse

### DIFF
--- a/internal/engine/concurrent/downloader.go
+++ b/internal/engine/concurrent/downloader.go
@@ -721,9 +721,10 @@ func (d *ConcurrentDownloader) prewarmConnections(ctx context.Context, client *h
 			}
 
 			// Connection is now hot in the pool.
-			// Signal readiness and IMMEDIATELY close body to release to IdleConn pool.
-			ready <- struct{}{}
+			// Drain body to ensure it can be returned to idle pool, then signal readiness.
+			_, _ = io.Copy(io.Discard, resp.Body)
 			_ = resp.Body.Close()
+			ready <- struct{}{}
 		}(i)
 	}
 

--- a/internal/engine/concurrent/downloader.go
+++ b/internal/engine/concurrent/downloader.go
@@ -720,8 +720,7 @@ func (d *ConcurrentDownloader) prewarmConnections(ctx context.Context, client *h
 				return
 			}
 
-			// Connection is now hot in the pool.
-			// Drain body to ensure it can be returned to idle pool, then signal readiness.
+			// Drain body and close to return connection to idle pool, then signal readiness.
 			_, _ = io.Copy(io.Discard, resp.Body)
 			_ = resp.Body.Close()
 			ready <- struct{}{}

--- a/internal/engine/concurrent/prewarm_reuse_test.go
+++ b/internal/engine/concurrent/prewarm_reuse_test.go
@@ -44,7 +44,10 @@ func TestPrewarmConnections_Reuse(t *testing.T) {
 		},
 	}
 
-	req, _ := http.NewRequestWithContext(httptrace.WithClientTrace(ctx, trace), http.MethodGet, server.URL(), nil)
+	req, err := http.NewRequestWithContext(httptrace.WithClientTrace(ctx, trace), http.MethodGet, server.URL(), nil)
+	if err != nil {
+		t.Fatalf("Failed to build request: %v", err)
+	}
 	req.Header.Set("Range", "bytes=0-0")
 	resp, err := client.Do(req)
 	if err != nil {

--- a/internal/engine/concurrent/prewarm_reuse_test.go
+++ b/internal/engine/concurrent/prewarm_reuse_test.go
@@ -1,0 +1,59 @@
+package concurrent
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptrace"
+	"testing"
+
+	"github.com/SurgeDM/Surge/internal/engine/types"
+	"github.com/SurgeDM/Surge/internal/testutil"
+)
+
+func TestPrewarmConnections_Reuse(t *testing.T) {
+	fileSize := int64(1 * types.KB)
+	server := testutil.NewMockServerT(t,
+		testutil.WithFileSize(fileSize),
+		testutil.WithRangeSupport(true),
+	)
+	defer server.Close()
+
+	runtime := &types.RuntimeConfig{
+		MaxConnectionsPerHost: 2,
+		DialHedgeCount:        0,
+	}
+
+	downloader := NewConcurrentDownloader("test-reuse", nil, nil, runtime)
+	client := downloader.newConcurrentClient(1)
+
+	ctx := context.Background()
+	mirrors := []string{server.URL()}
+
+	// 1. Prewarm connections
+	// This should populate the idle pool with one connection
+	downloader.prewarmConnections(ctx, client, 1, 0, mirrors)
+
+	// 2. Perform a request and check for reuse
+	reused := false
+	trace := &httptrace.ClientTrace{
+		GotConn: func(info httptrace.GotConnInfo) {
+			if info.Reused {
+				reused = true
+			}
+		},
+	}
+
+	req, _ := http.NewRequestWithContext(httptrace.WithClientTrace(ctx, trace), http.MethodGet, server.URL(), nil)
+	req.Header.Set("Range", "bytes=0-0")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Request failed: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	if !reused {
+		t.Error("Expected connection to be reused after prewarming, but it was not. Handshake leak likely present.")
+	}
+}

--- a/internal/engine/concurrent/prewarm_reuse_test.go
+++ b/internal/engine/concurrent/prewarm_reuse_test.go
@@ -51,7 +51,7 @@ func TestPrewarmConnections_Reuse(t *testing.T) {
 		t.Fatalf("Request failed: %v", err)
 	}
 	_, _ = io.Copy(io.Discard, resp.Body)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 
 	if !reused {
 		t.Error("Expected connection to be reused after prewarming, but it was not. Handshake leak likely present.")


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a connection-reuse bug in `prewarmConnections` where `ready` was signalled before the response body was drained and closed. Go's `net/http` transport only returns a connection to the idle pool after the body is fully consumed and closed, so signalling first meant consumers could start new requests before the connection was actually available, defeating prewarming. The fix drains and closes the body first, then signals — and the new `TestPrewarmConnections_Reuse` test validates this with `httptrace`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is minimal, correct, and directly validated by the new test.

The fix is a two-line reorder with a clear rationale backed by Go's transport contract. The prewarm request already uses bytes=0-0, so the body drained is a single byte and blocking the goroutine is negligible. The new test uses httptrace to confirm end-to-end connection reuse. No P0 or P1 issues found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/engine/concurrent/downloader.go | Reorders body drain and close before the ready signal so the connection is guaranteed to be in the idle pool before consumers start making requests — correct fix for the connection-reuse bug. |
| internal/engine/concurrent/prewarm_reuse_test.go | New test that uses httptrace.GotConnInfo.Reused to verify a prewarmed connection is actually reused by the next request; errors are properly handled with t.Fatalf. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: comments"](https://github.com/surgedm/surge/commit/67739d20ccdf763b7992718dfc02560b2eb83fc8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29378724)</sub>

<!-- /greptile_comment -->