### PR TITLE
fix worker buffer size

### DIFF
--- a/internal/tui/settings_unit_test.go
+++ b/internal/tui/settings_unit_test.go
@@ -1,0 +1,115 @@
+package tui
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/SurgeDM/Surge/internal/config"
+)
+
+func TestSettingsUnitConversion(t *testing.T) {
+	m := RootModel{
+		Settings: config.DefaultSettings(),
+	}
+
+	tests := []struct {
+		name          string
+		category      string
+		key           string
+		typ           string
+		internalValue interface{}
+		uiInput       string
+		expectedValue interface{}
+	}{
+		{
+			name:          "MinChunkSize MB Conversion",
+			category:      "Network",
+			key:           "min_chunk_size",
+			typ:           "int64",
+			internalValue: int64(4 * config.MB),
+			uiInput:       "4.0",
+			expectedValue: int64(4 * config.MB),
+		},
+		{
+			name:          "WorkerBufferSize KB Conversion",
+			category:      "Network",
+			key:           "worker_buffer_size",
+			typ:           "int",
+			internalValue: 1024 * config.KB,
+			uiInput:       "1024",
+			expectedValue: 1024 * config.KB,
+		},
+		{
+			name:          "SlowWorkerGracePeriod seconds Conversion",
+			category:      "Performance",
+			key:           "slow_worker_grace_period",
+			typ:           "duration",
+			internalValue: 10 * time.Second,
+			uiInput:       "10",
+			expectedValue: 10 * time.Second,
+		},
+		{
+			name:          "StallTimeout seconds Conversion",
+			category:      "Performance",
+			key:           "stall_timeout",
+			typ:           "duration",
+			internalValue: 5 * time.Second,
+			uiInput:       "5",
+			expectedValue: 5 * time.Second,
+		},
+		{
+			name:          "SlowWorkerThreshold float Comparison",
+			category:      "Performance",
+			key:           "slow_worker_threshold",
+			typ:           "float64",
+			internalValue: 0.35,
+			uiInput:       "0.35",
+			expectedValue: 0.35,
+		},
+		{
+			name:          "SpeedEmaAlpha float Comparison",
+			category:      "Performance",
+			key:           "speed_ema_alpha",
+			typ:           "float64",
+			internalValue: 0.5,
+			uiInput:       "0.50",
+			expectedValue: 0.5,
+		},
+		{
+			name:          "MaxTaskRetries int Comparison",
+			category:      "Performance",
+			key:           "max_task_retries",
+			typ:           "int",
+			internalValue: 5,
+			uiInput:       "5",
+			expectedValue: 5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// 1. Test Internal -> UI String (formatSettingValueForEdit)
+			gotUI := formatSettingValueForEdit(tt.internalValue, tt.typ, tt.key, false)
+			// For floats like 4.0 vs 4, we normalize by parsing back
+			if gotUI != tt.uiInput {
+				t.Errorf("%s: formatSettingValueForEdit() = %q, want %q", tt.name, gotUI, tt.uiInput)
+			}
+
+			// 2. Test UI String -> Internal (setSettingValue)
+			err := m.setSettingValue(tt.category, tt.key, tt.uiInput)
+			if err != nil {
+				t.Fatalf("%s: setSettingValue() returned error: %v", tt.name, err)
+			}
+
+			// Read back the value using reflection similar to how the app does
+			values := m.getSettingsValues(tt.category)
+			gotInternal := values[tt.key]
+
+			if !reflect.DeepEqual(gotInternal, tt.expectedValue) {
+				t.Errorf("%s: Value after setSettingValue() = %v (%T), want %v (%T)",
+					tt.name, gotInternal, gotInternal, tt.expectedValue, tt.expectedValue)
+			}
+		})
+	}
+}

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -625,8 +625,14 @@ func (m *RootModel) setSettingValue(category, key, value string) error {
 			case reflect.String:
 				targetField.SetString(value)
 			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32:
-				if v, err := strconv.Atoi(value); err == nil {
-					targetField.SetInt(int64(v))
+				if key == "worker_buffer_size" {
+					if v, err := strconv.ParseFloat(value, 64); err == nil {
+						targetField.SetInt(int64(v * float64(config.KB)))
+					}
+				} else {
+					if v, err := strconv.Atoi(value); err == nil {
+						targetField.SetInt(int64(v))
+					}
 				}
 			case reflect.Int64:
 				if targetField.Type().String() == "time.Duration" {


### PR DESCRIPTION
- **feat: add support for KB-scaled float values to worker_buffer_size setting**
- **test: add unit tests for TUI settings value conversion and validation**

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds KB-scaled input support for the `worker_buffer_size` TUI setting, converting the user-entered KB value to bytes via `ParseFloat` before storing it — mirroring the existing MB conversion for `min_chunk_size`. A new test file covers the round-trip conversion for several settings, including `worker_buffer_size`.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the conversion logic is correct and consistent with the existing pattern for `min_chunk_size`.

The only finding is a P2 suggestion to extend the new test with edge-case inputs (zero, invalid string, fractional KB). No logic errors or breaking changes were identified.

internal/tui/settings_unit_test.go — consider adding edge-case tests for the `worker_buffer_size` conversion.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/tui/view_settings.go | Adds KB-to-bytes conversion for `worker_buffer_size` in `setSettingValue`; logic is correct but parse errors are silently swallowed (consistent with surrounding code). |
| internal/tui/settings_unit_test.go | New test file covering several settings conversions; `worker_buffer_size` test only covers the happy path, missing edge cases (zero, invalid string, fractional input). |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/tui/settings_unit_test.go
Line: 33-47

Comment:
**Missing edge-case tests for the new KB conversion path**

The `WorkerBufferSize` test case only exercises the happy path (`1024 KB` → valid positive integer). The custom rule for edge-case coverage requires testing boundary inputs as well. Notably:

- `"0"` → sets the field to `0` bytes, silently relying on `GetWorkerBufferSize()` to fall back to the default; there is no user-visible error.
- `"abc"` (non-numeric) → `ParseFloat` fails, the field is silently left unchanged, and `setSettingValue` still returns `nil`.
- Fractional input like `"1.5"` → accepted and silently truncated to `1536` bytes without feedback.

Adding tests for these cases would verify both the conversion logic and the error-handling (or lack thereof) behaviour.

**Rule Used:** What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add unit tests for TUI settings va..."](https://github.com/surgedm/surge/commit/822a3a07b88f0701537a7c57c98d106b7bb55ef2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29379084)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))

<!-- /greptile_comment -->