### PR TITLE
fix settings tui cutoff

### DIFF
--- a/internal/tui/components/add_download_modal.go
+++ b/internal/tui/components/add_download_modal.go
@@ -4,6 +4,7 @@ import (
 	"image/color"
 
 	"github.com/SurgeDM/Surge/internal/tui/colors"
+	"github.com/SurgeDM/Surge/internal/utils"
 
 	"charm.land/bubbles/v2/help"
 	"charm.land/bubbles/v2/textinput"
@@ -33,8 +34,11 @@ func (m AddDownloadModal) View() string {
 	content := []string{""}
 
 	if m.ShowURL && m.URL != "" {
+		horizontalPadding := lipgloss.NewStyle().Padding(0, 2).GetHorizontalFrameSize()
+		innerWidth := m.Width - BorderFrameWidth - horizontalPadding
+		wrappedURL := utils.WrapText(m.URL, innerWidth-5) // Offset for "URL: "
 		content = append(content,
-			lipgloss.NewStyle().Foreground(colors.LightGray()).Render("URL: "+m.URL),
+			lipgloss.NewStyle().Foreground(colors.LightGray()).Render("URL: "+wrappedURL),
 			"",
 		)
 	}

--- a/internal/tui/components/confirmation_modal.go
+++ b/internal/tui/components/confirmation_modal.go
@@ -4,6 +4,7 @@ import (
 	"image/color"
 
 	"github.com/SurgeDM/Surge/internal/tui/colors"
+	"github.com/SurgeDM/Surge/internal/utils"
 
 	"charm.land/bubbles/v2/help"
 	"charm.land/bubbles/v2/key"
@@ -35,6 +36,7 @@ func (m ConfirmationModal) view() string {
 		Bold(true)
 
 	// Build content - just message and detail (no help)
+	// We wrap these manually to the modal width in RenderWithBtopBox
 	content := m.Message
 
 	if m.Detail != "" {
@@ -70,6 +72,27 @@ func (m ConfirmationModal) RenderWithBtopBox(
 		Width(innerWidth).
 		Align(lipgloss.Center)
 	helpText := helpStyle.Render(m.Help.View(m.Keys))
+
+	detailStyle := lipgloss.NewStyle().
+		Foreground(colors.Magenta()).
+		Bold(true)
+
+	// Ensure message and detail are wrapped to innerWidth
+	wrappedMessage := utils.WrapText(m.Message, innerWidth)
+	wrappedDetail := ""
+	if m.Detail != "" {
+		wrappedDetail = utils.WrapText(m.Detail, innerWidth)
+	}
+
+	// Re-build content with wrapped text
+	mainContent = wrappedMessage
+	if wrappedDetail != "" {
+		mainContent = lipgloss.JoinVertical(lipgloss.Center,
+			mainContent,
+			"",
+			detailStyle.Render(wrappedDetail),
+		)
+	}
 
 	// Calculate heights
 	mainContentHeight := lipgloss.Height(mainContent)

--- a/internal/tui/components/confirmation_modal.go
+++ b/internal/tui/components/confirmation_modal.go
@@ -31,19 +31,27 @@ func (NoKeys) FullHelp() [][]key.Binding { return nil }
 
 // View renders the confirmation modal content (without the box wrapper or help text)
 func (m ConfirmationModal) view() string {
-	detailStyle := lipgloss.NewStyle().
-		Foreground(colors.Magenta()).
-		Bold(true)
+	return m.renderBody(0)
+}
 
-	// Build content - just message and detail (no help)
-	// We wrap these manually to the modal width in RenderWithBtopBox
-	content := m.Message
+// renderBody handles joining message and detail with a gap and optional wrapping.
+func (m ConfirmationModal) renderBody(width int) string {
+	msg := m.Message
+	det := m.Detail
 
-	if m.Detail != "" {
+	if width > 0 {
+		msg = utils.WrapText(msg, width)
+		if det != "" {
+			det = utils.WrapText(det, width)
+		}
+	}
+
+	content := msg
+	if det != "" {
 		content = lipgloss.JoinVertical(lipgloss.Center,
 			content,
 			"",
-			detailStyle.Render(m.Detail),
+			getDetailStyle().Render(det),
 		)
 	}
 
@@ -73,26 +81,8 @@ func (m ConfirmationModal) RenderWithBtopBox(
 		Align(lipgloss.Center)
 	helpText := helpStyle.Render(m.Help.View(m.Keys))
 
-	detailStyle := lipgloss.NewStyle().
-		Foreground(colors.Magenta()).
-		Bold(true)
-
-	// Ensure message and detail are wrapped to innerWidth
-	wrappedMessage := utils.WrapText(m.Message, innerWidth)
-	wrappedDetail := ""
-	if m.Detail != "" {
-		wrappedDetail = utils.WrapText(m.Detail, innerWidth)
-	}
-
-	// Re-build content with wrapped text
-	mainContent := wrappedMessage
-	if wrappedDetail != "" {
-		mainContent = lipgloss.JoinVertical(lipgloss.Center,
-			mainContent,
-			"",
-			detailStyle.Render(wrappedDetail),
-		)
-	}
+	// Ensure message and detail are wrapped to innerWidth and joined
+	mainContent := m.renderBody(innerWidth)
 
 	// Calculate heights
 	mainContentHeight := lipgloss.Height(mainContent)
@@ -159,4 +149,10 @@ func (m ConfirmationModal) Centered(width, height int) string {
 
 	return lipgloss.Place(width, height, lipgloss.Center, lipgloss.Center,
 		boxStyle.Render(fullContent))
+}
+
+func getDetailStyle() lipgloss.Style {
+	return lipgloss.NewStyle().
+		Foreground(colors.Magenta()).
+		Bold(true)
 }

--- a/internal/tui/components/confirmation_modal.go
+++ b/internal/tui/components/confirmation_modal.go
@@ -64,7 +64,7 @@ func (m ConfirmationModal) RenderWithBtopBox(
 	innerHeight := m.Height - boxFrameY
 
 	// Get content without help
-	mainContent := m.view()
+	// mainContent is defined and populated lower down after wrapping
 
 	// Style and center help text
 	helpStyle := lipgloss.NewStyle().
@@ -85,7 +85,7 @@ func (m ConfirmationModal) RenderWithBtopBox(
 	}
 
 	// Re-build content with wrapped text
-	mainContent = wrappedMessage
+	mainContent := wrappedMessage
 	if wrappedDetail != "" {
 		mainContent = lipgloss.JoinVertical(lipgloss.Center,
 			mainContent,

--- a/internal/tui/helpers.go
+++ b/internal/tui/helpers.go
@@ -40,7 +40,7 @@ func (m *RootModel) refreshLogViewportContent() {
 	}
 
 	// Render each entry at the viewport width so the content fills the pane.
-	// Lines wider than the viewport will be clipped during rendering.
+	// WrapText pre-wraps lines so no content is clipped during rendering.
 	wrapStyle := lipgloss.NewStyle().Width(width).Align(lipgloss.Left)
 
 	var wrappedEntries []string

--- a/internal/tui/helpers.go
+++ b/internal/tui/helpers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/engine/types"
 	"github.com/SurgeDM/Surge/internal/processing"
+	"github.com/SurgeDM/Surge/internal/utils"
 )
 
 // addLogEntry adds a log entry to the log viewport
@@ -44,8 +45,9 @@ func (m *RootModel) refreshLogViewportContent() {
 
 	var wrappedEntries []string
 	for _, entry := range m.logEntries {
-		wrapped := wrapStyle.Render(entry)
-		wrappedEntries = append(wrappedEntries, strings.Split(wrapped, "\n")...)
+		wrapped := utils.WrapText(entry, width)
+		rendered := wrapStyle.Render(wrapped)
+		wrappedEntries = append(wrappedEntries, strings.Split(rendered, "\n")...)
 	}
 
 	// Bottom-align entries if they don't fill the viewport

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -149,8 +149,8 @@ func (d downloadDelegate) Render(w io.Writer, m list.Model, index int, listItem 
 		availableWidth = 10
 	}
 
-	title := truncateString(i.Title(), availableWidth)
-	description := truncateString(i.Description(), availableWidth)
+	title := utils.Truncate(i.Title(), availableWidth)
+	description := utils.Truncate(i.Description(), availableWidth)
 
 	// Render lines
 	line1 := prefix + titleStyle.Render(title)

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -144,7 +144,7 @@ func (m RootModel) View() tea.View {
 		modal := components.ConfirmationModal{
 			Title:       "\u26a0 Duplicate Detected",
 			Message:     "A download with this URL already exists",
-			Detail:      utils.WrapText(m.duplicateInfo, 50),
+			Detail:      m.duplicateInfo,
 			Keys:        m.keys.Duplicate,
 			Help:        m.help,
 			BorderColor: colors.Pink(),
@@ -178,7 +178,7 @@ func (m RootModel) View() tea.View {
 			Labels:          []string{"Path:", "Filename:"},
 			FocusedInput:    focused,
 			ShowURL:         true,
-			URL:             utils.WrapText(m.pendingURL, 68),
+			URL:             m.pendingURL,
 			BrowseHintIndex: 0,
 			Help:            m.help,
 			HelpKeys:        m.keys.Extension,
@@ -217,7 +217,7 @@ func (m RootModel) View() tea.View {
 		modal := components.ConfirmationModal{
 			Title:       "Batch Import",
 			Message:     fmt.Sprintf("Add %d downloads?", urlCount),
-			Detail:      utils.WrapText(m.batchFilePath, 50),
+			Detail:      m.batchFilePath,
 			Keys:        m.keys.BatchConfirm,
 			Help:        m.help,
 			BorderColor: colors.Cyan(),
@@ -687,42 +687,6 @@ func (m RootModel) ComputeViewStats() ViewStats {
 		stats.TotalDownloaded += d.Downloaded
 	}
 	return stats
-}
-
-func truncateString(s string, i int) string {
-	if i <= 0 {
-		return ""
-	}
-	if lipgloss.Width(s) <= i {
-		return s
-	}
-	if i <= 1 {
-		return "\u2026"
-	}
-	return lipgloss.NewStyle().MaxWidth(i-1).Render(s) + "\u2026"
-}
-
-func truncateMiddle(s string, i int) string {
-	if i <= 0 {
-		return ""
-	}
-	if lipgloss.Width(s) <= i {
-		return s
-	}
-	if i <= 5 {
-		return truncateString(s, i)
-	}
-
-	runes := []rune(s)
-	// We use i-1 because \u2026 is one character
-	start := (i - 1) / 2
-	end := i - 1 - start
-
-	if start+end+1 > len(runes) {
-		return s
-	}
-
-	return string(runes[:start]) + "\u2026" + string(runes[len(runes)-end:])
 }
 
 func renderTabs(activeTab, activeCount, queuedCount, doneCount int) string {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -144,7 +144,7 @@ func (m RootModel) View() tea.View {
 		modal := components.ConfirmationModal{
 			Title:       "\u26a0 Duplicate Detected",
 			Message:     "A download with this URL already exists",
-			Detail:      truncateString(m.duplicateInfo, 50),
+			Detail:      utils.WrapText(m.duplicateInfo, 50),
 			Keys:        m.keys.Duplicate,
 			Help:        m.help,
 			BorderColor: colors.Pink(),
@@ -178,7 +178,7 @@ func (m RootModel) View() tea.View {
 			Labels:          []string{"Path:", "Filename:"},
 			FocusedInput:    focused,
 			ShowURL:         true,
-			URL:             truncateString(m.pendingURL, 68),
+			URL:             utils.WrapText(m.pendingURL, 68),
 			BrowseHintIndex: 0,
 			Help:            m.help,
 			HelpKeys:        m.keys.Extension,
@@ -217,7 +217,7 @@ func (m RootModel) View() tea.View {
 		modal := components.ConfirmationModal{
 			Title:       "Batch Import",
 			Message:     fmt.Sprintf("Add %d downloads?", urlCount),
-			Detail:      truncateString(m.batchFilePath, 50),
+			Detail:      utils.WrapText(m.batchFilePath, 50),
 			Keys:        m.keys.BatchConfirm,
 			Help:        m.help,
 			BorderColor: colors.Cyan(),
@@ -458,10 +458,10 @@ func renderFocusedDetails(d *DownloadModel, w int, spinnerView string) string {
 	}
 
 	fileInfoContent := lipgloss.JoinVertical(lipgloss.Left,
-		lipgloss.JoinHorizontal(lipgloss.Left, StatsLabelStyle.Render("URL: "), StatsValueStyle.Render(truncateMiddle(d.URL, valueWidth))),
-		lipgloss.JoinHorizontal(lipgloss.Left, StatsLabelStyle.Render("File: "), StatsValueStyle.Render(truncateString(displayFilename, valueWidth))),
-		lipgloss.JoinHorizontal(lipgloss.Left, StatsLabelStyle.Render("Path: "), StatsValueStyle.Render(truncateMiddle(displayPath, valueWidth))),
-		lipgloss.JoinHorizontal(lipgloss.Left, StatsLabelStyle.Render("ID:   "), lipgloss.NewStyle().Foreground(colors.LightGray()).Render(truncateString(d.ID, valueWidth))),
+		lipgloss.JoinHorizontal(lipgloss.Top, StatsLabelStyle.Render("URL: "), StatsValueStyle.Width(valueWidth).MaxWidth(valueWidth).Render(utils.WrapText(d.URL, valueWidth))),
+		lipgloss.JoinHorizontal(lipgloss.Top, StatsLabelStyle.Render("File: "), StatsValueStyle.Width(valueWidth).MaxWidth(valueWidth).Render(utils.WrapText(displayFilename, valueWidth))),
+		lipgloss.JoinHorizontal(lipgloss.Top, StatsLabelStyle.Render("Path: "), StatsValueStyle.Width(valueWidth).MaxWidth(valueWidth).Render(utils.WrapText(displayPath, valueWidth))),
+		lipgloss.JoinHorizontal(lipgloss.Top, StatsLabelStyle.Render("ID:   "), lipgloss.NewStyle().Foreground(colors.LightGray()).Width(valueWidth).MaxWidth(valueWidth).Render(utils.WrapText(d.ID, valueWidth))),
 	)
 	fileSection := sectionStyle.Render(fileInfoContent)
 

--- a/internal/tui/view_category.go
+++ b/internal/tui/view_category.go
@@ -7,6 +7,7 @@ import (
 	"charm.land/lipgloss/v2"
 	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/tui/colors"
+	"github.com/SurgeDM/Surge/internal/utils"
 )
 
 // viewCategoryManager renders the category management screen.
@@ -216,18 +217,18 @@ func (m RootModel) renderCategoryDetailView(cats []config.Category, cursor, inne
 	divider := dimStyle.Render(strings.Repeat("\u2500", innerWidth))
 
 	content := lipgloss.JoinVertical(lipgloss.Left,
-		labelStyle.Render("Name: ")+valueStyle.Width(innerWidth-6).Render(cat.Name),
+		labelStyle.Render("Name: ")+valueStyle.Width(innerWidth-6).MaxWidth(innerWidth-6).Render(utils.WrapText(cat.Name, innerWidth-6)),
 		"",
 		labelStyle.Render("Description:"),
-		valueStyle.Width(innerWidth).Render(cat.Description),
+		valueStyle.Width(innerWidth).MaxWidth(innerWidth).Render(utils.WrapText(cat.Description, innerWidth)),
 		"",
 		divider,
 		"",
 		labelStyle.Render("Pattern (Regex):"),
-		valueStyle.Width(innerWidth).Render(cat.Pattern),
+		valueStyle.Width(innerWidth).MaxWidth(innerWidth).Render(utils.WrapText(cat.Pattern, innerWidth)),
 		"",
 		labelStyle.Render("Path:"),
-		valueStyle.Width(innerWidth).Render(cat.Path),
+		valueStyle.Width(innerWidth).MaxWidth(innerWidth).Render(utils.WrapText(cat.Path, innerWidth)),
 	)
 
 	return formatSettingsBlock(content, innerWidth, rows)

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -268,13 +268,7 @@ func renderSettingsListViewport(settingsMeta []config.SettingMeta, selectedRow, 
 		}
 
 		// Truncate to avoid line wrapping which breaks parent height constraints
-		if len(label) > maxLabelLen {
-			if maxLabelLen > 3 {
-				label = label[:maxLabelLen-3] + "..."
-			} else {
-				label = label[:maxLabelLen]
-			}
-		}
+		label = utils.Truncate(label, maxLabelLen)
 
 		lines = append(lines, style.Width(innerWidth).MaxWidth(innerWidth).Render(prefix+label))
 	}
@@ -827,8 +821,8 @@ func formatSettingValue(value interface{}, typ string, truncate bool) string {
 			if s == "" {
 				return "(default)"
 			}
-			if truncate && len(s) > 30 {
-				return s[:27] + "..."
+			if truncate {
+				return utils.Truncate(s, 30)
 			}
 			return s
 		}

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -10,6 +10,7 @@ import (
 	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/tui/colors"
 	"github.com/SurgeDM/Surge/internal/tui/components"
+	"github.com/SurgeDM/Surge/internal/utils"
 
 	"charm.land/lipgloss/v2"
 )
@@ -342,11 +343,12 @@ func (m RootModel) renderSettingsDetailBlock(settingsMeta []config.SettingMeta, 
 
 	divider := lipgloss.NewStyle().Foreground(colors.Gray()).Render(strings.Repeat("\u2500", innerWidth))
 
+	wrappedDesc := utils.WrapText(meta.Description, innerWidth)
 	descDisplay := lipgloss.NewStyle().
 		Foreground(colors.LightGray()).
 		Width(innerWidth).
 		MaxWidth(innerWidth).
-		Render(meta.Description)
+		Render(wrappedDesc)
 
 	detail := lipgloss.JoinVertical(lipgloss.Left,
 		valueDisplay,

--- a/internal/utils/text.go
+++ b/internal/utils/text.go
@@ -3,10 +3,12 @@ package utils
 import (
 	"strings"
 	"unicode"
+
+	"github.com/mattn/go-runewidth"
 )
 
 // WrapText wraps a string to a specified maximum width.
-// It tries to wrap at word boundaries (spaces).
+// It tries to wrap at word boundaries (spaces) and handles multi-byte runes and visual width.
 func WrapText(text string, width int) string {
 	if width <= 0 {
 		return text
@@ -16,33 +18,48 @@ func WrapText(text string, width int) string {
 	var result []string
 
 	for _, line := range lines {
-		if len(line) <= width {
+		if runewidth.StringWidth(line) <= width {
 			result = append(result, line)
 			continue
 		}
 
 		var currentLine strings.Builder
+		currentLineWidth := 0
 		words := strings.FieldsFunc(line, unicode.IsSpace)
 
 		for _, word := range words {
+			wordWidth := runewidth.StringWidth(word)
+
 			// If adding the word plus a space exceeds width
-			if currentLine.Len()+len(word)+1 > width {
-				if currentLine.Len() > 0 {
+			spaceWidth := 0
+			if currentLineWidth > 0 {
+				spaceWidth = 1
+			}
+
+			if currentLineWidth+wordWidth+spaceWidth > width {
+				if currentLineWidth > 0 {
 					result = append(result, currentLine.String())
 					currentLine.Reset()
+					currentLineWidth = 0
 				}
 
 				// Handle words longer than width by hard-wrapping them
-				for len(word) > width {
-					result = append(result, word[:width])
-					word = word[width:]
+				for runewidth.StringWidth(word) > width {
+					// Find where to break
+					sub, w := truncateToWidth(word, width)
+					result = append(result, sub)
+					word = word[len(sub):]
+					_ = w
 				}
 				currentLine.WriteString(word)
+				currentLineWidth = runewidth.StringWidth(word)
 			} else {
-				if currentLine.Len() > 0 {
+				if currentLineWidth > 0 {
 					currentLine.WriteByte(' ')
+					currentLineWidth++
 				}
 				currentLine.WriteString(word)
+				currentLineWidth += wordWidth
 			}
 		}
 
@@ -52,4 +69,68 @@ func WrapText(text string, width int) string {
 	}
 
 	return strings.Join(result, "\n")
+}
+
+// truncateToWidth truncates a string to a visual width and returns the truncated string and its actual width.
+func truncateToWidth(s string, width int) (string, int) {
+	var res strings.Builder
+	var w int
+	for _, r := range s {
+		rw := runewidth.RuneWidth(r)
+		if w+rw > width {
+			break
+		}
+		res.WriteRune(r)
+		w += rw
+	}
+	return res.String(), w
+}
+
+// Truncate truncates a string to a maximum visual width and adds an ellipsis if needed.
+func Truncate(s string, limit int) string {
+	if limit <= 0 {
+		return ""
+	}
+	if runewidth.StringWidth(s) <= limit {
+		return s
+	}
+	if limit <= 1 {
+		return "…"
+	}
+
+	sub, _ := truncateToWidth(s, limit-1)
+	return sub + "…"
+}
+
+// TruncateMiddle truncates a string in the middle to a maximum visual width.
+func TruncateMiddle(s string, limit int) string {
+	if limit <= 0 {
+		return ""
+	}
+	if runewidth.StringWidth(s) <= limit {
+		return s
+	}
+	if limit < 3 {
+		return Truncate(s, limit)
+	}
+
+	leftLimit := (limit - 1) / 2
+	rightLimit := limit - 1 - leftLimit
+
+	left, _ := truncateToWidth(s, leftLimit)
+
+	// For the right part, we need to find how many characters from the end fit in rightLimit
+	runes := []rune(s)
+	right := ""
+	rightWidth := 0
+	for i := len(runes) - 1; i >= 0; i-- {
+		rw := runewidth.RuneWidth(runes[i])
+		if rightWidth+rw > rightLimit {
+			break
+		}
+		right = string(runes[i]) + right
+		rightWidth += rw
+	}
+
+	return left + "…" + right
 }

--- a/internal/utils/text.go
+++ b/internal/utils/text.go
@@ -1,0 +1,55 @@
+package utils
+
+import (
+	"strings"
+	"unicode"
+)
+
+// WrapText wraps a string to a specified maximum width.
+// It tries to wrap at word boundaries (spaces).
+func WrapText(text string, width int) string {
+	if width <= 0 {
+		return text
+	}
+
+	lines := strings.Split(text, "\n")
+	var result []string
+
+	for _, line := range lines {
+		if len(line) <= width {
+			result = append(result, line)
+			continue
+		}
+
+		var currentLine strings.Builder
+		words := strings.FieldsFunc(line, unicode.IsSpace)
+
+		for _, word := range words {
+			// If adding the word plus a space exceeds width
+			if currentLine.Len()+len(word)+1 > width {
+				if currentLine.Len() > 0 {
+					result = append(result, currentLine.String())
+					currentLine.Reset()
+				}
+
+				// Handle words longer than width by hard-wrapping them
+				for len(word) > width {
+					result = append(result, word[:width])
+					word = word[width:]
+				}
+				currentLine.WriteString(word)
+			} else {
+				if currentLine.Len() > 0 {
+					currentLine.WriteByte(' ')
+				}
+				currentLine.WriteString(word)
+			}
+		}
+
+		if currentLine.Len() > 0 {
+			result = append(result, currentLine.String())
+		}
+	}
+
+	return strings.Join(result, "\n")
+}

--- a/internal/utils/text.go
+++ b/internal/utils/text.go
@@ -40,7 +40,6 @@ func WrapText(text string, width int) string {
 				if currentLineWidth > 0 {
 					result = append(result, currentLine.String())
 					currentLine.Reset()
-					currentLineWidth = 0
 				}
 
 				// Handle words longer than width by hard-wrapping them

--- a/internal/utils/text.go
+++ b/internal/utils/text.go
@@ -45,10 +45,9 @@ func WrapText(text string, width int) string {
 				// Handle words longer than width by hard-wrapping them
 				for runewidth.StringWidth(word) > width {
 					// Find where to break
-					sub, w := truncateToWidth(word, width)
+					sub := truncateToWidth(word, width)
 					result = append(result, sub)
 					word = word[len(sub):]
-					_ = w
 				}
 				currentLine.WriteString(word)
 				currentLineWidth = runewidth.StringWidth(word)
@@ -70,8 +69,8 @@ func WrapText(text string, width int) string {
 	return strings.Join(result, "\n")
 }
 
-// truncateToWidth truncates a string to a visual width and returns the truncated string and its actual width.
-func truncateToWidth(s string, width int) (string, int) {
+// truncateToWidth truncates a string to a visual width and returns the truncated string.
+func truncateToWidth(s string, width int) string {
 	var res strings.Builder
 	var w int
 	for _, r := range s {
@@ -82,7 +81,7 @@ func truncateToWidth(s string, width int) (string, int) {
 		res.WriteRune(r)
 		w += rw
 	}
-	return res.String(), w
+	return res.String()
 }
 
 // Truncate truncates a string to a maximum visual width and adds an ellipsis if needed.
@@ -97,12 +96,12 @@ func Truncate(s string, limit int) string {
 		return "…"
 	}
 
-	sub, _ := truncateToWidth(s, limit-1)
+	sub := truncateToWidth(s, limit-1)
 	return sub + "…"
 }
 
-// TruncateMiddle truncates a string in the middle to a maximum visual width.
-func TruncateMiddle(s string, limit int) string {
+// truncateMiddle truncates a string in the middle to a maximum visual width.
+func truncateMiddle(s string, limit int) string {
 	if limit <= 0 {
 		return ""
 	}
@@ -116,7 +115,7 @@ func TruncateMiddle(s string, limit int) string {
 	leftLimit := (limit - 1) / 2
 	rightLimit := limit - 1 - leftLimit
 
-	left, _ := truncateToWidth(s, leftLimit)
+	left := truncateToWidth(s, leftLimit)
 
 	// For the right part, we need to find how many characters from the end fit in rightLimit
 	runes := []rune(s)

--- a/internal/utils/text_test.go
+++ b/internal/utils/text_test.go
@@ -72,6 +72,18 @@ func TestWrapText(t *testing.T) {
 			width:    8,
 			expected: "hello 🌟\nworld",
 		},
+		{
+			name:     "Hard wrap mid-sentence",
+			text:     "short supercalifragilisticexpialidocious",
+			width:    10,
+			expected: "short\nsupercalif\nragilistic\nexpialidoc\nious",
+		},
+		{
+			name:     "Width 1",
+			text:     "abc",
+			width:    1,
+			expected: "a\nb\nc",
+		},
 	}
 
 	for _, tt := range tests {
@@ -91,6 +103,7 @@ func TestTruncate(t *testing.T) {
 		{"ASCII", "hello world", 5, "hell…"},
 		{"Emoji", "🌟🌟🌟", 4, "🌟…"}, // 🌟 is width 2, so 🌟 is 2, next 🌟 would make it 4, but limit-1 is 3. So only one 🌟 fits.
 		{"CJK", "你好世界", 5, "你好…"}, // 你是2, 好的2, 总共4. 世是2, 总共6 > 5. 所以只有你好.
+		{"Limit 1", "hello", 1, "…"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -111,7 +124,25 @@ func TestTruncateMiddle(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, TruncateMiddle(tt.text, tt.limit))
+			assert.Equal(t, tt.expected, truncateMiddle(tt.text, tt.limit))
+		})
+	}
+}
+
+func TestTruncateMiddleEdgeCases(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		limit    int
+		expected string
+	}{
+		{"Limit 1", "hello", 1, "…"},
+		{"Limit 2", "hello", 2, "h…"},
+		{"Limit 3", "hello", 3, "h…o"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, truncateMiddle(tt.text, tt.limit))
 		})
 	}
 }

--- a/internal/utils/text_test.go
+++ b/internal/utils/text_test.go
@@ -54,11 +54,64 @@ func TestWrapText(t *testing.T) {
 			width:    0,
 			expected: "hello",
 		},
+		{
+			name:     "Multi-byte runes (emojis)",
+			text:     "🌟🌟🌟🌟🌟",
+			width:    4, // Each emoji is width 2
+			expected: "🌟🌟\n🌟🌟\n🌟",
+		},
+		{
+			name:     "CJK characters",
+			text:     "你好世界",
+			width:    4, // Each character is width 2
+			expected: "你好\n世界",
+		},
+		{
+			name:     "Mixed ASCII and runes",
+			text:     "hello 🌟 world",
+			width:    8,
+			expected: "hello 🌟\nworld",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.expected, WrapText(tt.text, tt.width))
+		})
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		limit    int
+		expected string
+	}{
+		{"ASCII", "hello world", 5, "hell…"},
+		{"Emoji", "🌟🌟🌟", 4, "🌟…"}, // 🌟 is width 2, so 🌟 is 2, next 🌟 would make it 4, but limit-1 is 3. So only one 🌟 fits.
+		{"CJK", "你好世界", 5, "你好…"}, // 你是2, 好的2, 总共4. 世是2, 总共6 > 5. 所以只有你好.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, Truncate(tt.text, tt.limit))
+		})
+	}
+}
+
+func TestTruncateMiddle(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		limit    int
+		expected string
+	}{
+		{"ASCII", "1234567890", 5, "12…90"},
+		{"Mixed", "abc🌟def", 6, "ab…def"}, // abc(3) 🌟(2) def(3). limit 6.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, TruncateMiddle(tt.text, tt.limit))
 		})
 	}
 }

--- a/internal/utils/text_test.go
+++ b/internal/utils/text_test.go
@@ -1,0 +1,64 @@
+package utils
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestWrapText(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		width    int
+		expected string
+	}{
+		{
+			name:     "Simple wrap",
+			text:     "hello world",
+			width:    5,
+			expected: "hello\nworld",
+		},
+		{
+			name:     "No wrap needed",
+			text:     "hello",
+			width:    10,
+			expected: "hello",
+		},
+		{
+			name:     "Hard wrap long word",
+			text:     "supercalifragilisticexpialidocious",
+			width:    10,
+			expected: "supercalif\nragilistic\nexpialidoc\nious",
+		},
+		{
+			name:     "Wrap with multiple spaces",
+			text:     "hello   world",
+			width:    5,
+			expected: "hello\nworld",
+		},
+		{
+			name:     "Wrap with existing newlines",
+			text:     "hello\nworld",
+			width:    10,
+			expected: "hello\nworld",
+		},
+		{
+			name:     "Empty string",
+			text:     "",
+			width:    10,
+			expected: "",
+		},
+		{
+			name:     "Zero width",
+			text:     "hello",
+			width:    0,
+			expected: "hello",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, WrapText(tt.text, tt.width))
+		})
+	}
+}


### PR DESCRIPTION
- **refactor: introduce utility for text wrapping and replace manual truncation in TUI components**
- **refactor: centralize string truncation logic into utils package and remove redundant local implementations**

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralizes text truncation and wrapping into `internal/utils/text.go` and replaces ad-hoc, byte-based truncation logic across several TUI components with the new runewidth-aware `WrapText` and `Truncate` helpers. The core utility implementation is correct — hard-wrap byte-slicing, empty-line preservation, and multi-byte/CJK handling all look sound — and the test suite covers the important edge cases.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all remaining findings are cosmetic P2 suggestions.

The new utility functions are correct and well-tested. All truncation and wrapping call sites have been updated consistently. The one open comment (URL continuation-line indentation) is a visual imperfection, not a correctness issue.

internal/tui/components/add_download_modal.go — minor visual alignment issue with wrapped URL continuation lines.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/utils/text.go | New utility file centralizing WrapText, Truncate, and truncateMiddle — logic is correct, runewidth-aware, and handles multi-byte/CJK characters properly. |
| internal/utils/text_test.go | Good coverage of happy-path and edge cases including width=1, hard-wrap mid-sentence, emoji/CJK, and truncateMiddle edge cases (limit 1/2/3). |
| internal/tui/components/add_download_modal.go | Uses WrapText for URL display, but continuation lines after wrapping will not be indented to align with the "URL: " prefix. |
| internal/tui/components/confirmation_modal.go | Refactored to renderBody(width) pattern; RenderWithBtopBox now correctly wraps to innerWidth; getDetailStyle() extracted to avoid duplication. |
| internal/tui/view.go | renderFocusedDetails now uses WrapText+lipgloss.Top for multi-line values; local truncateString/truncateMiddle helpers removed; pre-truncation of Detail/URL removed in favour of component-level wrapping. |
| internal/tui/view_settings.go | Settings list truncation now uses utils.Truncate; settings detail description now uses WrapText; formatSettingValue uses utils.Truncate properly. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/tui/helpers.go`, line 42-44 ([link](https://github.com/surgedm/surge/blob/c153d882f53df4da943a21d4bcbd35373d49b04a/internal/tui/helpers.go#L42-L44)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Stale comment after wrapping strategy change**

   The comment says "Lines wider than the viewport will be clipped during rendering," but the code now uses `utils.WrapText` so lines are wrapped, not clipped. The comment should be updated to reflect the new approach.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/tui/helpers.go
   Line: 42-44

   Comment:
   **Stale comment after wrapping strategy change**

   The comment says "Lines wider than the viewport will be clipped during rendering," but the code now uses `utils.WrapText` so lines are wrapped, not clipped. The comment should be updated to reflect the new approach.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/tui/components/add_download_modal.go
Line: 39-43

Comment:
**Wrapped URL continuation lines lack "URL: " indentation**

`WrapText` is called with `innerWidth-5` to reserve space for the `"URL: "` prefix, but that prefix is only prepended to the first line. Continuation lines start at column 0 with no indentation, so a wrapped URL renders like:

```
URL: https://very-long-url-
that-wraps-here
```

Consider rendering each wrapped line separately with the appropriate indentation on the first line and spaces on the rest, or omit the label from the wrap width calculation and let a style with `Width`/`MaxWidth` handle clipping.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor: consolidate text wrapping logi..."](https://github.com/surgedm/surge/commit/05accf62a1ebd310b99bda0038c4770410b28a13) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29379889)</sub>

<!-- /greptile_comment -->