### PR TITLE
refactor: introduce shared NetworkPool to manage and reuse HTTP transports across downloaders

### DIFF
--- a/internal/engine/concurrent/downloader.go
+++ b/internal/engine/concurrent/downloader.go
@@ -262,11 +262,18 @@ func (d *ConcurrentDownloader) Download(ctx context.Context, rawurl string, cand
 		d.State.SetCancelFunc(cancel)
 	}
 
-	// 1. Bootstrap Phase: Acquire transport with standard limit for metadata discovery
-	bootstrapTransport := engine.DefaultNetworkPool.AcquireTransport(d.Runtime.ProxyURL, d.Runtime.CustomDNS, d.Runtime.GetMaxConnectionsPerHost())
-	defer engine.DefaultNetworkPool.ReleaseTransport(bootstrapTransport)
+	// Acquire a single stable transport for the entire download session.
+	var proxyURL, customDNS string
+	if d.Runtime != nil {
+		proxyURL = d.Runtime.ProxyURL
+		customDNS = d.Runtime.CustomDNS
+	}
 
-	bootstrapClient := &http.Client{Transport: bootstrapTransport}
+	// Standardize on PoolMaxConnsPerHost for probes to match the eventual download path
+	transport := engine.DefaultNetworkPool.AcquireTransport(proxyURL, customDNS, types.PoolMaxConnsPerHost)
+	defer engine.DefaultNetworkPool.ReleaseTransport(transport)
+
+	bootstrapClient := &http.Client{Transport: transport}
 	d.applyClientSettings(bootstrapClient)
 
 	// Determine connections and chunk size
@@ -282,17 +289,7 @@ func (d *ConcurrentDownloader) Download(ctx context.Context, rawurl string, cand
 	numConns := d.getInitialConnections(fileSize)
 	chunkSize := d.determineChunkSize(fileSize, numConns)
 
-	// 2. Download Phase: Acquire transport with a limit that accounts for actual workers + hedging
-	hedgeCount := d.Runtime.GetDialHedgeCount()
-	requiredLimit := numConns + hedgeCount
-	if requiredLimit < d.Runtime.GetMaxConnectionsPerHost() {
-		requiredLimit = d.Runtime.GetMaxConnectionsPerHost()
-	}
-
-	transport := engine.DefaultNetworkPool.AcquireTransport(d.Runtime.ProxyURL, d.Runtime.CustomDNS, requiredLimit)
-	defer engine.DefaultNetworkPool.ReleaseTransport(transport)
-
-	// Create tuned HTTP client for concurrent downloads
+	// Create tuned HTTP client for concurrent downloads reusing the same transport
 	client := &http.Client{Transport: transport}
 	d.applyClientSettings(client)
 
@@ -314,6 +311,7 @@ func (d *ConcurrentDownloader) Download(ctx context.Context, rawurl string, cand
 	}
 
 	// HEDGED DIALING: Pre-warm connections to bypass slow dials
+	hedgeCount := d.Runtime.GetDialHedgeCount()
 	if hedgeCount > 0 {
 		utils.Debug("Pre-warming %d connections (hedge=%d)", numConns, hedgeCount)
 		d.prewarmConnections(downloadCtx, client, numConns, hedgeCount, workerMirrors)

--- a/internal/engine/concurrent/downloader.go
+++ b/internal/engine/concurrent/downloader.go
@@ -2,13 +2,10 @@ package concurrent
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"io"
 	"math"
-	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -16,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/SurgeDM/Surge/internal/engine"
 	"github.com/SurgeDM/Surge/internal/engine/events"
 	"github.com/SurgeDM/Surge/internal/engine/state"
 	"github.com/SurgeDM/Surge/internal/engine/types"
@@ -188,75 +186,25 @@ func createTasks(fileSize, chunkSize int64) []types.Task {
 	return tasks
 }
 
-// newConcurrentClient creates an http.Client tuned for concurrent downloads
-func (d *ConcurrentDownloader) newConcurrentClient(numConns int) *http.Client {
-	// Ensure we have enough connections per host
-	maxConns := d.Runtime.GetMaxConnectionsPerHost()
-	if numConns > maxConns {
-		maxConns = numConns
-	}
-
-	var proxyFunc func(*http.Request) (*url.URL, error)
-	if d.Runtime.ProxyURL != "" {
-		if parsedURL, err := url.Parse(d.Runtime.ProxyURL); err == nil {
-			proxyFunc = http.ProxyURL(parsedURL)
-		} else {
-			// Fallback or log error? For now fallback to environment
-			utils.Debug("Invalid proxy URL %s: %v", d.Runtime.ProxyURL, err)
-			proxyFunc = http.ProxyFromEnvironment
+func (d *ConcurrentDownloader) applyClientSettings(client *http.Client) {
+	// Preserve headers on redirects for authenticated downloads
+	// By default, Go strips sensitive headers (Cookie, Authorization) on cross-domain redirects.
+	// Since these headers were explicitly provided by the browser for this download, we forward them.
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) >= 10 {
+			return fmt.Errorf("stopped after 10 redirects")
 		}
-	} else {
-		proxyFunc = http.ProxyFromEnvironment
-	}
-
-	transport := &http.Transport{
-		// Connection pooling
-		MaxIdleConns:        types.DefaultMaxIdleConns,
-		MaxIdleConnsPerHost: maxConns + d.Runtime.GetDialHedgeCount() + 2, // Host buffer for hedges
-		MaxConnsPerHost:     maxConns,
-		Proxy:               proxyFunc,
-
-		// Timeouts to prevent hung connections
-		IdleConnTimeout:       types.DefaultIdleConnTimeout,
-		TLSHandshakeTimeout:   types.DefaultTLSHandshakeTimeout,
-		ResponseHeaderTimeout: types.DefaultResponseHeaderTimeout,
-		ExpectContinueTimeout: types.DefaultExpectContinueTimeout,
-
-		// Performance tuning
-		DisableCompression: true,  // Files are usually already compressed
-		ForceAttemptHTTP2:  false, // FORCE HTTP/1.1 for multiple TCP connections
-		TLSNextProto:       make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
-	}
-
-	dialer := &net.Dialer{
-		Timeout:   types.DialTimeout,
-		KeepAlive: types.KeepAliveDuration,
-	}
-
-	utils.ConfigureDialer(dialer, d.Runtime.CustomDNS)
-	transport.DialContext = dialer.DialContext
-
-	return &http.Client{
-		Transport: transport,
-		// Preserve headers on redirects for authenticated downloads
-		// By default, Go strips sensitive headers (Cookie, Authorization) on cross-domain redirects.
-		// Since these headers were explicitly provided by the browser for this download, we forward them.
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			if len(via) >= 10 {
-				return fmt.Errorf("stopped after 10 redirects")
+		// Copy headers from original request to redirect request
+		if len(via) > 0 {
+			utils.CopyRedirectHeaders(req, via[0])
+		}
+		// Re-apply explicit custom headers down the redirect chain
+		for key, val := range d.Headers {
+			if key != "Range" {
+				req.Header.Set(key, val)
 			}
-			// Copy headers from original request to redirect request
-			if len(via) > 0 {
-				utils.CopyRedirectHeaders(req, via[0])
-			}
-			// Re-apply explicit custom headers down the redirect chain
-			for key, val := range d.Headers {
-				if key != "Range" {
-					req.Header.Set(key, val)
-				}
-			}
-			return nil
-		},
+		}
+		return nil
 	}
 }
 
@@ -314,8 +262,12 @@ func (d *ConcurrentDownloader) Download(ctx context.Context, rawurl string, cand
 		d.State.SetCancelFunc(cancel)
 	}
 
-	bootstrapClient := d.newConcurrentClient(1)
-	defer bootstrapClient.CloseIdleConnections()
+	// 1. Bootstrap Phase: Acquire transport with standard limit for metadata discovery
+	bootstrapTransport := engine.DefaultNetworkPool.AcquireTransport(d.Runtime.ProxyURL, d.Runtime.CustomDNS, d.Runtime.GetMaxConnectionsPerHost())
+	defer engine.DefaultNetworkPool.ReleaseTransport(bootstrapTransport)
+
+	bootstrapClient := &http.Client{Transport: bootstrapTransport}
+	d.applyClientSettings(bootstrapClient)
 
 	// Determine connections and chunk size
 	if fileSize <= 0 {
@@ -330,9 +282,19 @@ func (d *ConcurrentDownloader) Download(ctx context.Context, rawurl string, cand
 	numConns := d.getInitialConnections(fileSize)
 	chunkSize := d.determineChunkSize(fileSize, numConns)
 
+	// 2. Download Phase: Acquire transport with a limit that accounts for actual workers + hedging
+	hedgeCount := d.Runtime.GetDialHedgeCount()
+	requiredLimit := numConns + hedgeCount
+	if requiredLimit < d.Runtime.GetMaxConnectionsPerHost() {
+		requiredLimit = d.Runtime.GetMaxConnectionsPerHost()
+	}
+
+	transport := engine.DefaultNetworkPool.AcquireTransport(d.Runtime.ProxyURL, d.Runtime.CustomDNS, requiredLimit)
+	defer engine.DefaultNetworkPool.ReleaseTransport(transport)
+
 	// Create tuned HTTP client for concurrent downloads
-	client := d.newConcurrentClient(numConns)
-	defer client.CloseIdleConnections()
+	client := &http.Client{Transport: transport}
+	d.applyClientSettings(client)
 
 	// Initialize chunk visualization
 	if d.State != nil {
@@ -352,7 +314,6 @@ func (d *ConcurrentDownloader) Download(ctx context.Context, rawurl string, cand
 	}
 
 	// HEDGED DIALING: Pre-warm connections to bypass slow dials
-	hedgeCount := d.Runtime.GetDialHedgeCount()
 	if hedgeCount > 0 {
 		utils.Debug("Pre-warming %d connections (hedge=%d)", numConns, hedgeCount)
 		d.prewarmConnections(downloadCtx, client, numConns, hedgeCount, workerMirrors)

--- a/internal/engine/concurrent/prewarm_reuse_test.go
+++ b/internal/engine/concurrent/prewarm_reuse_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptrace"
 	"testing"
 
+	"github.com/SurgeDM/Surge/internal/engine"
 	"github.com/SurgeDM/Surge/internal/engine/types"
 	"github.com/SurgeDM/Surge/internal/testutil"
 )
@@ -25,7 +26,9 @@ func TestPrewarmConnections_Reuse(t *testing.T) {
 	}
 
 	downloader := NewConcurrentDownloader("test-reuse", nil, nil, runtime)
-	client := downloader.newConcurrentClient(1)
+	transport := engine.DefaultNetworkPool.AcquireTransport(runtime.ProxyURL, runtime.CustomDNS, runtime.GetMaxConnectionsPerHost())
+	defer engine.DefaultNetworkPool.ReleaseTransport(transport)
+	client := &http.Client{Transport: transport}
 
 	ctx := context.Background()
 	mirrors := []string{server.URL()}

--- a/internal/engine/network.go
+++ b/internal/engine/network.go
@@ -1,0 +1,161 @@
+package engine
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/SurgeDM/Surge/internal/engine/types"
+	"github.com/SurgeDM/Surge/internal/utils"
+)
+
+type poolKey struct {
+	proxyURL  string
+	customDNS string
+	maxConns  int
+}
+
+// transportLease tracks a specific transport's usage and cleanup lifecycle.
+type transportLease struct {
+	transport *http.Transport
+	refs      int
+	idleTimer *time.Timer
+	timerGen  int
+	key       poolKey
+}
+
+// NetworkPool manages shared HTTP transports for TCP connection reuse.
+type NetworkPool struct {
+	mu           sync.Mutex
+	configMap    map[poolKey]*transportLease
+	transportMap map[*http.Transport]*transportLease
+}
+
+// DefaultNetworkPool is the global instance managed by the engine layer.
+var DefaultNetworkPool = &NetworkPool{
+	configMap:    make(map[poolKey]*transportLease),
+	transportMap: make(map[*http.Transport]*transportLease),
+}
+
+// AcquireTransport returns a shared transport for the given configuration.
+func (p *NetworkPool) AcquireTransport(proxyURL, customDNS string, maxConns int) *http.Transport {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.configMap == nil {
+		p.configMap = make(map[poolKey]*transportLease)
+	}
+	if p.transportMap == nil {
+		p.transportMap = make(map[*http.Transport]*transportLease)
+	}
+
+	key := poolKey{proxyURL, customDNS, maxConns}
+
+	lease, ok := p.configMap[key]
+	if !ok {
+		t := p.createNewTransport(proxyURL, customDNS, maxConns)
+		lease = &transportLease{
+			transport: t,
+			key:       key,
+		}
+		p.configMap[key] = lease
+		p.transportMap[t] = lease
+	}
+
+	if lease.idleTimer != nil {
+		lease.idleTimer.Stop()
+		lease.idleTimer = nil
+		lease.timerGen++
+	}
+
+	lease.refs++
+	utils.Debug("NetworkPool: AcquireTransport (key=%+v, refs=%d)", key, lease.refs)
+
+	return lease.transport
+}
+
+// ReleaseTransport marks a specific transport lease as returned.
+func (p *NetworkPool) ReleaseTransport(t *http.Transport) {
+	if t == nil {
+		return
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	lease, ok := p.transportMap[t]
+	if !ok {
+		utils.Debug("NetworkPool: ReleaseTransport called for unmanaged transport")
+		return
+	}
+
+	lease.refs--
+	if lease.refs < 0 {
+		lease.refs = 0
+	}
+	utils.Debug("NetworkPool: ReleaseTransport (key=%+v, refs=%d)", lease.key, lease.refs)
+
+	if lease.refs == 0 {
+		lease.timerGen++
+		gen := lease.timerGen
+		lease.idleTimer = time.AfterFunc(10*time.Second, func() {
+			p.mu.Lock()
+			defer p.mu.Unlock()
+
+			if lease.refs == 0 && lease.timerGen == gen {
+				utils.Debug("NetworkPool: idle timeout reached, evicting transport")
+				lease.transport.CloseIdleConnections()
+				delete(p.configMap, lease.key)
+				delete(p.transportMap, lease.transport)
+			}
+		})
+	}
+}
+
+func (p *NetworkPool) createNewTransport(proxyURL, customDNS string, maxConns int) *http.Transport {
+	utils.Debug("NetworkPool: creating new shared transport (proxy=%s, limit=%d)", proxyURL, maxConns)
+
+	dialer := &net.Dialer{
+		Timeout:   types.DialTimeout,
+		KeepAlive: types.KeepAliveDuration,
+	}
+	utils.ConfigureDialer(dialer, customDNS)
+
+	proxyFunc := http.ProxyFromEnvironment
+	if proxyURL != "" {
+		if parsed, err := url.Parse(proxyURL); err == nil {
+			proxyFunc = http.ProxyURL(parsed)
+		} else {
+			utils.Debug("NetworkPool: invalid proxy URL %s: %v", proxyURL, err)
+		}
+	}
+
+	finalMaxConns := maxConns
+	if finalMaxConns <= 0 {
+		finalMaxConns = types.PoolMaxConnsPerHost
+	}
+
+	return &http.Transport{
+		Proxy: proxyFunc,
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return dialer.DialContext(ctx, network, addr)
+		},
+
+		MaxIdleConns:        types.PoolMaxIdleConns,
+		MaxIdleConnsPerHost: types.PoolMaxIdleConnsPerHost,
+		MaxConnsPerHost:     finalMaxConns,
+
+		IdleConnTimeout:       types.DefaultIdleConnTimeout,
+		TLSHandshakeTimeout:   types.DefaultTLSHandshakeTimeout,
+		ResponseHeaderTimeout: types.DefaultResponseHeaderTimeout,
+		ExpectContinueTimeout: types.DefaultExpectContinueTimeout,
+
+		DisableCompression: true,
+		ForceAttemptHTTP2:  false,
+		TLSNextProto:       make(map[string]func(string, *tls.Conn) http.RoundTripper),
+	}
+}

--- a/internal/engine/network_test.go
+++ b/internal/engine/network_test.go
@@ -1,0 +1,112 @@
+package engine
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httptrace"
+	"testing"
+
+	"github.com/SurgeDM/Surge/internal/engine/types"
+)
+
+func TestNetworkPool_Reuse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	pool := &NetworkPool{}
+	runtime := &types.RuntimeConfig{}
+
+	// First request
+	transport1 := pool.AcquireTransport(runtime.ProxyURL, runtime.CustomDNS, 0)
+	client1 := &http.Client{Transport: transport1}
+	req1, _ := http.NewRequest("GET", server.URL, nil)
+	resp1, err := client1.Do(req1)
+	if err != nil {
+		t.Fatalf("First request failed: %v", err)
+	}
+	_ = resp1.Body.Close()
+	pool.ReleaseTransport(transport1)
+
+	// Second request with trace
+	transport2 := pool.AcquireTransport(runtime.ProxyURL, runtime.CustomDNS, 0)
+	client2 := &http.Client{Transport: transport2}
+	reused := false
+	trace := &httptrace.ClientTrace{
+		GotConn: func(info httptrace.GotConnInfo) {
+			if info.Reused {
+				reused = true
+			}
+		},
+	}
+	req2, _ := http.NewRequestWithContext(httptrace.WithClientTrace(context.Background(), trace), "GET", server.URL, nil)
+	resp2, err := client2.Do(req2)
+	if err != nil {
+		t.Fatalf("Second request failed: %v", err)
+	}
+	_ = resp2.Body.Close()
+	pool.ReleaseTransport(transport2)
+
+	if !reused {
+		t.Error("Expected connection to be reused")
+	}
+}
+
+func TestNetworkPool_IdleCleanup(t *testing.T) {
+	pool := &NetworkPool{}
+	runtime := &types.RuntimeConfig{}
+
+	transport := pool.AcquireTransport(runtime.ProxyURL, runtime.CustomDNS, 0)
+	lease, ok := pool.transportMap[transport]
+	if !ok {
+		t.Fatal("Expected transport to be in transportMap")
+	}
+
+	if lease.refs != 1 {
+		t.Errorf("Expected refs=1, got %d", lease.refs)
+	}
+	if lease.idleTimer != nil {
+		t.Error("Expected no idle timer when refs > 0")
+	}
+
+	pool.ReleaseTransport(transport)
+	if lease.refs != 0 {
+		t.Errorf("Expected refs=0, got %d", lease.refs)
+	}
+	if lease.idleTimer == nil {
+		t.Error("Expected idle timer to be started after ReleaseTransport()")
+	}
+
+	// Calling AcquireTransport again should stop the timer
+	pool.AcquireTransport(runtime.ProxyURL, runtime.CustomDNS, 0)
+	if lease.idleTimer != nil {
+		t.Error("Expected idle timer to be stopped after AcquireTransport()")
+	}
+	pool.ReleaseTransport(transport)
+}
+
+func TestNetworkPool_ConfigChange(t *testing.T) {
+	pool := &NetworkPool{}
+
+	r1 := &types.RuntimeConfig{ProxyURL: "http://proxy1"}
+	t1 := pool.AcquireTransport(r1.ProxyURL, r1.CustomDNS, 0)
+	pool.ReleaseTransport(t1)
+
+	r2 := &types.RuntimeConfig{ProxyURL: "http://proxy2"}
+	t2 := pool.AcquireTransport(r2.ProxyURL, r2.CustomDNS, 0)
+	pool.ReleaseTransport(t2)
+
+	if t1 == t2 {
+		t.Error("Expected different transport after config change")
+	}
+
+	// Get with same config should reuse
+	t3 := pool.AcquireTransport(r2.ProxyURL, r2.CustomDNS, 0)
+	pool.ReleaseTransport(t3)
+
+	if t2 != t3 {
+		t.Error("Expected transport reuse for identical config")
+	}
+}

--- a/internal/engine/single/downloader.go
+++ b/internal/engine/single/downloader.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"sync"
 	"time"
 
+	"github.com/SurgeDM/Surge/internal/engine"
 	"github.com/SurgeDM/Surge/internal/engine/types"
 	"github.com/SurgeDM/Surge/internal/utils"
 )
@@ -19,7 +18,6 @@ import (
 // NOTE: Pause/resume is NOT supported because this downloader is only used when
 // the server doesn't support Range headers. If interrupted, the download must restart.
 type SingleDownloader struct {
-	Client       *http.Client
 	ProgressChan chan<- any           // Channel for events (start/complete/error)
 	ID           string               // Download ID
 	State        *types.ProgressState // Shared state for TUI polling
@@ -27,14 +25,6 @@ type SingleDownloader struct {
 	TotalSize    int64
 	Headers      map[string]string // Custom HTTP headers (cookies, auth, etc.)
 }
-
-type singleTransportKey struct {
-	proxyURL  string
-	maxConns  int
-	customDNS string
-}
-
-var singleTransportCache sync.Map // map[singleTransportKey]*http.Transport
 
 var bufPool = sync.Pool{
 	New: func() any {
@@ -49,86 +39,30 @@ func NewSingleDownloader(id string, progressCh chan<- any, state *types.Progress
 		runtime = &types.RuntimeConfig{}
 	}
 
-	sd := &SingleDownloader{
+	return &SingleDownloader{
 		ProgressChan: progressCh,
 		ID:           id,
 		State:        state,
 		Runtime:      runtime,
 	}
-	sd.Client = newSingleClient(runtime, sd)
-	return sd
 }
 
-func newSingleClient(runtime *types.RuntimeConfig, sd *SingleDownloader) *http.Client {
-	transport := getSharedSingleTransport(runtime)
-
-	return &http.Client{
-		Transport: transport,
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			if len(via) >= 10 {
-				return fmt.Errorf("stopped after 10 redirects")
-			}
-			if len(via) > 0 {
-				utils.CopyRedirectHeaders(req, via[0])
-			}
-			if sd != nil && sd.Headers != nil {
-				for key, val := range sd.Headers {
-					if key != "Range" {
-						req.Header.Set(key, val)
-					}
+func (d *SingleDownloader) applyClientSettings(client *http.Client) {
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) >= 10 {
+			return fmt.Errorf("stopped after 10 redirects")
+		}
+		if len(via) > 0 {
+			utils.CopyRedirectHeaders(req, via[0])
+		}
+		if d.Headers != nil {
+			for key, val := range d.Headers {
+				if key != "Range" {
+					req.Header.Set(key, val)
 				}
 			}
-			return nil
-		},
-	}
-}
-
-func getSharedSingleTransport(runtime *types.RuntimeConfig) *http.Transport {
-	key := singleTransportKey{
-		proxyURL:  runtime.ProxyURL,
-		maxConns:  runtime.GetMaxConnectionsPerHost(),
-		customDNS: runtime.CustomDNS,
-	}
-
-	if cached, ok := singleTransportCache.Load(key); ok {
-		return cached.(*http.Transport)
-	}
-
-	transport := newSingleTransport(runtime)
-	actual, _ := singleTransportCache.LoadOrStore(key, transport)
-	return actual.(*http.Transport)
-}
-
-func newSingleTransport(runtime *types.RuntimeConfig) *http.Transport {
-	proxyFunc := http.ProxyFromEnvironment
-	if runtime.ProxyURL != "" {
-		if parsedURL, err := url.Parse(runtime.ProxyURL); err == nil {
-			proxyFunc = http.ProxyURL(parsedURL)
-		} else {
-			utils.Debug("Invalid proxy URL %s: %v", runtime.ProxyURL, err)
 		}
-	}
-
-	dialer := &net.Dialer{
-		Timeout:   types.DialTimeout,
-		KeepAlive: types.KeepAliveDuration,
-	}
-
-	utils.ConfigureDialer(dialer, runtime.CustomDNS)
-
-	return &http.Transport{
-		MaxIdleConns:        types.DefaultMaxIdleConns,
-		MaxIdleConnsPerHost: runtime.GetMaxConnectionsPerHost(),
-		MaxConnsPerHost:     runtime.GetMaxConnectionsPerHost(),
-		Proxy:               proxyFunc,
-
-		IdleConnTimeout:       types.DefaultIdleConnTimeout,
-		TLSHandshakeTimeout:   types.DefaultTLSHandshakeTimeout,
-		ResponseHeaderTimeout: types.DefaultResponseHeaderTimeout,
-		ExpectContinueTimeout: types.DefaultExpectContinueTimeout,
-
-		DisableCompression: true,
-		DialContext:        dialer.DialContext,
+		return nil
 	}
 }
 
@@ -136,7 +70,11 @@ func newSingleTransport(runtime *types.RuntimeConfig) *http.Transport {
 // This is used for servers that don't support Range requests.
 // If interrupted, the download cannot be resumed and must restart from the beginning.
 func (d *SingleDownloader) Download(ctx context.Context, rawurl, destPath string, fileSize int64, filename string) (err error) {
-	defer d.Client.CloseIdleConnections()
+	transport := engine.DefaultNetworkPool.AcquireTransport(d.Runtime.ProxyURL, d.Runtime.CustomDNS, d.Runtime.GetMaxConnectionsPerHost())
+	defer engine.DefaultNetworkPool.ReleaseTransport(transport)
+
+	client := &http.Client{Transport: transport}
+	d.applyClientSettings(client)
 
 	if d.State != nil {
 		d.State.SetURL(rawurl)
@@ -153,7 +91,7 @@ func (d *SingleDownloader) Download(ctx context.Context, rawurl, destPath string
 	}
 	req.Header.Set("User-Agent", d.Runtime.GetUserAgent())
 
-	resp, err := d.Client.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return err
 	}

--- a/internal/engine/single/downloader.go
+++ b/internal/engine/single/downloader.go
@@ -70,7 +70,7 @@ func (d *SingleDownloader) applyClientSettings(client *http.Client) {
 // This is used for servers that don't support Range requests.
 // If interrupted, the download cannot be resumed and must restart from the beginning.
 func (d *SingleDownloader) Download(ctx context.Context, rawurl, destPath string, fileSize int64, filename string) (err error) {
-	transport := engine.DefaultNetworkPool.AcquireTransport(d.Runtime.ProxyURL, d.Runtime.CustomDNS, d.Runtime.GetMaxConnectionsPerHost())
+	transport := engine.DefaultNetworkPool.AcquireTransport(d.Runtime.ProxyURL, d.Runtime.CustomDNS, types.PoolMaxConnsPerHost)
 	defer engine.DefaultNetworkPool.ReleaseTransport(transport)
 
 	client := &http.Client{Transport: transport}

--- a/internal/engine/single/downloader_test.go
+++ b/internal/engine/single/downloader_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/SurgeDM/Surge/internal/engine"
 	"github.com/SurgeDM/Surge/internal/engine/types"
 	"github.com/SurgeDM/Surge/internal/testutil"
 	"github.com/SurgeDM/Surge/internal/utils"
@@ -309,34 +310,27 @@ func TestNewSingleDownloader(t *testing.T) {
 
 func TestNewSingleDownloader_TransportReuse(t *testing.T) {
 	runtime := &types.RuntimeConfig{MaxConnectionsPerHost: 8}
-	d1 := NewSingleDownloader("test-id-1", nil, nil, runtime)
-	d2 := NewSingleDownloader("test-id-2", nil, nil, runtime)
+	t1 := engine.DefaultNetworkPool.AcquireTransport(runtime.ProxyURL, runtime.CustomDNS, runtime.GetMaxConnectionsPerHost())
+	defer engine.DefaultNetworkPool.ReleaseTransport(t1)
 
-	t1, ok := d1.Client.Transport.(*http.Transport)
-	if !ok {
-		t.Fatal("expected downloader client transport to be *http.Transport")
-	}
-	t2, ok := d2.Client.Transport.(*http.Transport)
-	if !ok {
-		t.Fatal("expected downloader client transport to be *http.Transport")
-	}
+	t2 := engine.DefaultNetworkPool.AcquireTransport(runtime.ProxyURL, runtime.CustomDNS, runtime.GetMaxConnectionsPerHost())
+	defer engine.DefaultNetworkPool.ReleaseTransport(t2)
+
 	if t1 != t2 {
 		t.Fatal("expected transport reuse for identical runtime config")
 	}
 }
 
 func TestNewSingleDownloader_TransportIsolationByProxy(t *testing.T) {
-	d1 := NewSingleDownloader("test-id-1", nil, nil, &types.RuntimeConfig{ProxyURL: "http://127.0.0.1:8080"})
-	d2 := NewSingleDownloader("test-id-2", nil, nil, &types.RuntimeConfig{ProxyURL: "http://127.0.0.1:9090"})
+	r1 := &types.RuntimeConfig{ProxyURL: "http://127.0.0.1:8080"}
+	r2 := &types.RuntimeConfig{ProxyURL: "http://127.0.0.1:9090"}
 
-	t1, ok := d1.Client.Transport.(*http.Transport)
-	if !ok {
-		t.Fatal("expected downloader client transport to be *http.Transport")
-	}
-	t2, ok := d2.Client.Transport.(*http.Transport)
-	if !ok {
-		t.Fatal("expected downloader client transport to be *http.Transport")
-	}
+	t1 := engine.DefaultNetworkPool.AcquireTransport(r1.ProxyURL, r1.CustomDNS, r1.GetMaxConnectionsPerHost())
+	defer engine.DefaultNetworkPool.ReleaseTransport(t1)
+
+	t2 := engine.DefaultNetworkPool.AcquireTransport(r2.ProxyURL, r2.CustomDNS, r2.GetMaxConnectionsPerHost())
+	defer engine.DefaultNetworkPool.ReleaseTransport(t2)
+
 	if t1 == t2 {
 		t.Fatal("expected different transports for different proxy settings")
 	}

--- a/internal/engine/types/config.go
+++ b/internal/engine/types/config.go
@@ -33,7 +33,7 @@ const (
 
 // HTTP Client Tuning
 const (
-	DefaultMaxIdleConns          = 100
+	DefaultMaxIdleConns          = 100 // Standard fallback
 	DefaultIdleConnTimeout       = 90 * time.Second
 	DefaultTLSHandshakeTimeout   = 10 * time.Second
 	DefaultResponseHeaderTimeout = 15 * time.Second
@@ -41,6 +41,11 @@ const (
 	DialTimeout                  = 10 * time.Second
 	KeepAliveDuration            = 30 * time.Second
 	ProbeTimeout                 = 30 * time.Second
+
+	// NetworkPool Tuning
+	PoolMaxIdleConns        = 512
+	PoolMaxIdleConnsPerHost = 128
+	PoolMaxConnsPerHost     = 512
 )
 
 // Channel buffer sizes

--- a/internal/processing/probe.go
+++ b/internal/processing/probe.go
@@ -85,16 +85,13 @@ func ProbeServerWithProxy(ctx context.Context, rawurl string, filenameHint strin
 	var resp *http.Response
 
 	var proxyURL, customDNS string
-	maxConns := types.PerHostMax
 	if runCfg != nil {
 		proxyURL = runCfg.ProxyURL
 		customDNS = runCfg.CustomDNS
-		if runCfg.MaxConnectionsPerHost > 0 {
-			maxConns = runCfg.MaxConnectionsPerHost
-		}
 	}
 
-	transport := engine.DefaultNetworkPool.AcquireTransport(proxyURL, customDNS, maxConns)
+	// Standardize on PoolMaxConnsPerHost for probes to match the eventual download path
+	transport := engine.DefaultNetworkPool.AcquireTransport(proxyURL, customDNS, types.PoolMaxConnsPerHost)
 	defer engine.DefaultNetworkPool.ReleaseTransport(transport)
 
 	client := &http.Client{

--- a/internal/processing/probe.go
+++ b/internal/processing/probe.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	neturl "net/url"
 	"strconv"
@@ -14,6 +13,7 @@ import (
 	"time"
 
 	"github.com/SurgeDM/Surge/internal/config"
+	"github.com/SurgeDM/Surge/internal/engine"
 	"github.com/SurgeDM/Surge/internal/engine/types"
 	"github.com/SurgeDM/Surge/internal/utils"
 )
@@ -23,12 +23,8 @@ var ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
 	"Chrome/120.0.0.0 Safari/537.36"
 
 var (
-	probeClientsMu   sync.Mutex
-	probeClients     = make(map[string]*http.Client)
-	probeClientOrder []string
+	probeHostLocks sync.Map // map[string]*sync.Mutex
 )
-
-const maxProbeClients = 8
 
 // ErrProbeRequestCreation is returned when a probe request cannot be initialized.
 var ErrProbeRequestCreation = errors.New("failed to create probe request")
@@ -63,10 +59,6 @@ func ProbeServer(ctx context.Context, rawurl string, filenameHint string, header
 	return ProbeServerWithProxy(ctx, rawurl, filenameHint, headers, resolveRuntimeConfig())
 }
 
-var (
-	probeHostLocks sync.Map // map[string]*sync.Mutex
-)
-
 // getProbeHostLock returns a mutex for a specific host to sequentialize probes
 func getProbeHostLock(rawurl string) *sync.Mutex {
 	parsed, err := neturl.Parse(rawurl)
@@ -92,7 +84,40 @@ func ProbeServerWithProxy(ctx context.Context, rawurl string, filenameHint strin
 
 	var resp *http.Response
 
-	client := getProbeClient(runCfg)
+	var proxyURL, customDNS string
+	maxConns := types.PerHostMax
+	if runCfg != nil {
+		proxyURL = runCfg.ProxyURL
+		customDNS = runCfg.CustomDNS
+		if runCfg.MaxConnectionsPerHost > 0 {
+			maxConns = runCfg.MaxConnectionsPerHost
+		}
+	}
+
+	transport := engine.DefaultNetworkPool.AcquireTransport(proxyURL, customDNS, maxConns)
+	defer engine.DefaultNetworkPool.ReleaseTransport(transport)
+
+	client := &http.Client{
+		Transport: transport,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return fmt.Errorf("stopped after 10 redirects")
+			}
+			if len(via) > 0 {
+				copyProbeRedirectHeaders(req, via[0])
+			}
+
+			// Re-apply custom explicitly provided headers on cross-origin redirects
+			if customHeaders, ok := req.Context().Value(probeHeadersContextKey{}).(map[string]string); ok {
+				for k, v := range customHeaders {
+					if !strings.EqualFold(k, "Range") {
+						req.Header.Set(k, v)
+					}
+				}
+			}
+			return nil
+		},
+	}
 
 	// Sequentialize probes to the same host to prevent rate limiting (e.g., Google Drive)
 	hostLock := getProbeHostLock(rawurl)
@@ -253,97 +278,6 @@ func applyProbeHeaders(req *http.Request, headers map[string]string, includeRang
 	}
 	if req.Header.Get("User-Agent") == "" {
 		req.Header.Set("User-Agent", ua)
-	}
-}
-
-func getProbeClient(runCfg *config.RuntimeConfig) *http.Client {
-	probeClientsMu.Lock()
-	defer probeClientsMu.Unlock()
-
-	key := ""
-	if runCfg != nil {
-		// Quote values to prevent ambiguity when one value contains the separator
-		key = fmt.Sprintf("%q|%q", runCfg.ProxyURL, runCfg.CustomDNS)
-	}
-
-	if cached, ok := probeClients[key]; ok {
-		return cached
-	}
-
-	client := &http.Client{
-		Transport: newProbeTransport(runCfg),
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			if len(via) >= 10 {
-				return fmt.Errorf("stopped after 10 redirects")
-			}
-			if len(via) > 0 {
-				copyProbeRedirectHeaders(req, via[0])
-			}
-
-			// Re-apply custom explicitly provided headers on cross-origin redirects
-			if customHeaders, ok := req.Context().Value(probeHeadersContextKey{}).(map[string]string); ok {
-				for k, v := range customHeaders {
-					if !strings.EqualFold(k, "Range") {
-						req.Header.Set(k, v)
-					}
-				}
-			}
-			return nil
-		},
-	}
-
-	if len(probeClients) >= maxProbeClients && len(probeClientOrder) > 0 {
-		evictedKey := probeClientOrder[0]
-		probeClientOrder = probeClientOrder[1:]
-		if evictedClient, ok := probeClients[evictedKey]; ok {
-			evictedClient.CloseIdleConnections()
-			delete(probeClients, evictedKey)
-		}
-	}
-
-	probeClients[key] = client
-	probeClientOrder = append(probeClientOrder, key)
-	return client
-}
-
-func newProbeTransport(runCfg *config.RuntimeConfig) *http.Transport {
-	proxyFunc := http.ProxyFromEnvironment
-	var customDNS string
-	if runCfg != nil {
-		customDNS = runCfg.CustomDNS
-		if strings.TrimSpace(runCfg.ProxyURL) != "" {
-			if parsedURL, err := neturl.Parse(runCfg.ProxyURL); err == nil {
-				proxyFunc = http.ProxyURL(parsedURL)
-			} else {
-				utils.Debug("Invalid probe proxy URL %s: %v", runCfg.ProxyURL, err)
-			}
-		}
-	}
-
-	dialer := &net.Dialer{
-		Timeout:   types.DialTimeout,
-		KeepAlive: types.KeepAliveDuration,
-	}
-
-	utils.ConfigureDialer(dialer, customDNS)
-
-	return &http.Transport{
-		Proxy:                 proxyFunc,
-		MaxIdleConns:          types.DefaultMaxIdleConns,
-		MaxIdleConnsPerHost:   types.PerHostMax,
-		IdleConnTimeout:       types.DefaultIdleConnTimeout,
-		TLSHandshakeTimeout:   types.DefaultTLSHandshakeTimeout,
-		ResponseHeaderTimeout: types.DefaultResponseHeaderTimeout,
-		ExpectContinueTimeout: types.DefaultExpectContinueTimeout,
-		// Use tcp4 to prefer IPv4 when connecting to CDN hosts.
-		// Some CDN nodes resolve to IPv6 addresses that are unreachable
-		// on networks that have IPv6 assigned but no working IPv6 path.
-		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			if network == "tcp" {
-				network = "tcp4"
-			}
-			return dialer.DialContext(ctx, network, addr)
-		},
 	}
 }
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the per-downloader transport construction (and the old per-config `sync.Map` cache in the single downloader) with a centralized `NetworkPool` that ref-counts leases and evicts idle transports after 10 seconds. Bootstrap and download clients in the concurrent downloader now share the same pool entry (both use `PoolMaxConnsPerHost`), resolving the previous key-mismatch concern. The probe layer drops its LRU client cache and acquires from the same pool per call.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the one remaining finding is a minor test consistency issue that does not affect correctness.

All previously raised P0/P1 concerns (IPv4 preference, test race, bootstrap/download key mismatch) are addressed or intentionally resolved. The only new finding is a P2 pool-key inconsistency in the prewarm test that doesn't affect production behavior.

internal/engine/concurrent/prewarm_reuse_test.go — pool key should match the one used in Download().

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/engine/network.go | New file — implements NetworkPool with ref-counted leases, idle eviction via time.AfterFunc, and a timerGen guard to avoid double-eviction. Logic is correct and thread-safe. |
| internal/engine/network_test.go | New tests cover reuse, idle cleanup, and config isolation; TestNetworkPool_IdleCleanup reads lease fields without the pool mutex (noted in previous threads). |
| internal/engine/concurrent/downloader.go | Removes newConcurrentClient; both bootstrap and download clients now share the same pool transport (PoolMaxConnsPerHost), fixing the prior key mismatch concern. |
| internal/engine/concurrent/prewarm_reuse_test.go | Updated to use NetworkPool directly; acquires transport with GetMaxConnectionsPerHost() (64) while Download() uses PoolMaxConnsPerHost (512) — different pool key, so the test exercises a different transport config than production. |
| internal/engine/single/downloader.go | Removes the per-instance singleTransportCache; transport is now acquired from the shared NetworkPool per Download() call with a deferred release. |
| internal/processing/probe.go | Replaces the LRU probe client cache with a per-call NetworkPool acquire/release; CheckRedirect logic is preserved verbatim. |
| internal/engine/types/config.go | Adds PoolMaxIdleConns (512), PoolMaxIdleConnsPerHost (128), and PoolMaxConnsPerHost (512) constants for the new shared pool. |
| internal/engine/single/downloader_test.go | Transport reuse and isolation tests updated to acquire directly from NetworkPool; assertions are equivalent to the removed test. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/engine/concurrent/prewarm_reuse_test.go
Line: 27-29

Comment:
**Pool key mismatch between test and production code**

`AcquireTransport` is called here with `runtime.GetMaxConnectionsPerHost()` (64 by default), but `Download()` always passes `types.PoolMaxConnsPerHost` (512). These resolve to different `poolKey` entries, so the transport acquired in the test has `MaxConnsPerHost = 64` while the one used in production has `MaxConnsPerHost = 512`. The prewarm→reuse assertion still passes because both use the same client object, but the test is no longer exercising the transport configuration that actually runs in production. Consider passing `types.PoolMaxConnsPerHost` here to stay in sync with `Download()`.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (5): Last reviewed commit: ["refactor: standardize network transport ..."](https://github.com/surgedm/surge/commit/0aa6f7332d14f38609e96ce9ff265616d8c99a01) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29451134)</sub>

<!-- /greptile_comment -->