### PR TITLE
refactor: unify download progress state management using SessionReset and effective total size passing

### DIFF
--- a/internal/download/manager.go
+++ b/internal/download/manager.go
@@ -186,13 +186,11 @@ func TUIDownload(ctx context.Context, cfg *types.DownloadConfig) error {
 		d := concurrent.NewConcurrentDownloader(cfg.ID, cfg.ProgressCh, cfg.State, cfg.Runtime)
 		d.Headers = cfg.Headers // Forward custom headers from browser extension
 		utils.Debug("Calling Download with mirrors: %v", mirrors)
-		downloadErr = d.Download(ctx, cfg.URL, mirrors, activeMirrors, finalDestPath, cfg.TotalSize)
+		// Pass effectiveTotalSize to avoid unnecessary bootstrap if state already knows the size
+		downloadErr = d.Download(ctx, cfg.URL, mirrors, activeMirrors, finalDestPath, effectiveTotalSize)
 		if d.TotalSize > 0 {
 			cfg.TotalSize = d.TotalSize
 			effectiveTotalSize = d.TotalSize
-			if cfg.State != nil {
-				cfg.State.SetTotalSize(d.TotalSize)
-			}
 		}
 
 		// Determine if we should attempt a fallback to single-threaded mode.
@@ -201,11 +199,9 @@ func TUIDownload(ctx context.Context, cfg *types.DownloadConfig) error {
 			utils.Debug("Concurrent download failed: %v — falling back to single-threaded", downloadErr)
 			useConcurrent = false // Trigger sequential block below
 
-			// Reset progress state for single-stream restart from byte 0
+			// Reset progress state cleanly for single-stream restart from byte 0
 			if cfg.State != nil {
-				cfg.State.Downloaded.Store(0)
-				cfg.State.VerifiedProgress.Store(0)
-				cfg.State.SyncSessionStart()
+				cfg.State.SessionReset()
 			}
 
 			// Truncate the working file to zero to prevent stale tail bytes
@@ -220,7 +216,8 @@ func TUIDownload(ctx context.Context, cfg *types.DownloadConfig) error {
 		utils.Debug("Using single-threaded downloader")
 		d := single.NewSingleDownloader(cfg.ID, cfg.ProgressCh, cfg.State, cfg.Runtime)
 		d.Headers = cfg.Headers // Forward custom headers from browser extension
-		downloadErr = d.Download(ctx, cfg.URL, finalDestPath, cfg.TotalSize, finalFilename)
+		// Pass effectiveTotalSize here as well
+		downloadErr = d.Download(ctx, cfg.URL, finalDestPath, effectiveTotalSize, finalFilename)
 		if d.TotalSize > 0 {
 			cfg.TotalSize = d.TotalSize
 			effectiveTotalSize = d.TotalSize

--- a/internal/engine/types/progress.go
+++ b/internal/engine/types/progress.go
@@ -92,6 +92,13 @@ func NewProgressState(id string, totalSize int64) *ProgressState {
 func (ps *ProgressState) SetTotalSize(size int64) {
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
+
+	// If size is already set and timer is running, don't reset the clock.
+	// This prevents post-download updates from erasing the session duration.
+	if ps.TotalSize == size && !ps.StartTime.IsZero() {
+		return
+	}
+
 	ps.TotalSize = size
 	ps.SessionStartBytes = ps.VerifiedProgress.Load()
 	ps.StartTime = time.Now()
@@ -214,6 +221,33 @@ func (ps *ProgressState) FinalizeSession(downloaded int64) (time.Duration, time.
 	ps.VerifiedProgress.Store(downloaded)
 
 	return sessionElapsed, totalElapsed
+}
+
+// SessionReset wipes the current progress and session state, allowing for a fresh start (e.g. fallback).
+func (ps *ProgressState) SessionReset() {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+
+	ps.Downloaded.Store(0)
+	ps.VerifiedProgress.Store(0)
+	ps.SessionStartBytes = 0
+	ps.StartTime = time.Now()
+	ps.SavedElapsed = 0
+	ps.Done.Store(false)
+	ps.Paused.Store(false)
+	ps.Pausing.Store(false)
+	ps.Error.Store(nil)
+
+	// Clear mirrors error status
+	for i := range ps.Mirrors {
+		ps.Mirrors[i].Error = false
+	}
+
+	// Reset chunk tracking if initialized
+	if ps.BitmapWidth > 0 {
+		ps.ChunkBitmap = make([]byte, len(ps.ChunkBitmap))
+		ps.ChunkProgress = make([]int64, ps.BitmapWidth)
+	}
 }
 
 // FinalizePauseSession finalizes the current session for a pause transition.

--- a/internal/engine/types/progress_test.go
+++ b/internal/engine/types/progress_test.go
@@ -44,6 +44,30 @@ func TestProgressState_SetTotalSize(t *testing.T) {
 	}
 }
 
+func TestProgressState_SetTotalSize_Idempotent(t *testing.T) {
+	ps := NewProgressState("test-idempotent", 100)
+
+	// Simulate a session that started 5 seconds ago
+	originalStartTime := time.Now().Add(-5 * time.Second)
+	ps.StartTime = originalStartTime
+
+	// Call SetTotalSize with the SAME size
+	ps.SetTotalSize(100)
+
+	// Verify StartTime was NOT reset to Now
+	if !ps.StartTime.Equal(originalStartTime) {
+		t.Errorf("StartTime was reset despite same size: got %v, want %v", ps.StartTime, originalStartTime)
+	}
+
+	// Call SetTotalSize with a DIFFERENT size
+	ps.SetTotalSize(200)
+
+	// Verify StartTime WAS reset (should be later than original)
+	if !ps.StartTime.After(originalStartTime) {
+		t.Errorf("StartTime was NOT reset for new size: got %v, want > %v", ps.StartTime, originalStartTime)
+	}
+}
+
 func TestProgressState_SyncSessionStart(t *testing.T) {
 	ps := NewProgressState("test", 100)
 	ps.Downloaded.Store(75)
@@ -252,5 +276,51 @@ func TestProgressState_FinalizePauseSession_UsesVerifiedWhenDownloadedUnknown(t 
 	}
 	if ps.VerifiedProgress.Load() != 55 {
 		t.Fatalf("VerifiedProgress = %d, want 55", ps.VerifiedProgress.Load())
+	}
+}
+
+func TestProgressState_SessionReset(t *testing.T) {
+	ps := NewProgressState("test-reset", 1000)
+	ps.Downloaded.Store(500)
+	ps.VerifiedProgress.Store(450)
+	ps.SessionStartBytes = 100
+	ps.SavedElapsed = 10 * time.Second
+	ps.Done.Store(true)
+	ps.InitBitmap(1000, 100)
+
+	// Simulate some activity
+	ps.UpdateChunkStatus(0, 100, ChunkCompleted)
+
+	ps.SessionReset()
+
+	if ps.Downloaded.Load() != 0 {
+		t.Errorf("Downloaded = %d, want 0", ps.Downloaded.Load())
+	}
+	if ps.VerifiedProgress.Load() != 0 {
+		t.Errorf("VerifiedProgress = %d, want 0", ps.VerifiedProgress.Load())
+	}
+	if ps.SessionStartBytes != 0 {
+		t.Errorf("SessionStartBytes = %d, want 0", ps.SessionStartBytes)
+	}
+	if ps.SavedElapsed != 0 {
+		t.Errorf("SavedElapsed = %v, want 0", ps.SavedElapsed)
+	}
+	if ps.Done.Load() {
+		t.Error("Done should be false after reset")
+	}
+
+	// Verify bitmap was cleared
+	bitmap, _, _, _, progress := ps.GetBitmap()
+	for _, b := range bitmap {
+		if b != 0 {
+			t.Error("Bitmap should be all zeros after reset")
+			break
+		}
+	}
+	for _, p := range progress {
+		if p != 0 {
+			t.Error("ChunkProgress should be all zeros after reset")
+			break
+		}
 	}
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR unifies download progress state management by introducing a `SessionReset()` method (replacing ad-hoc three-field resets), adding an idempotency guard to `SetTotalSize` (preventing clock reset when the confirmed size matches the known size), and threading `effectiveTotalSize` consistently to both concurrent and single-threaded downloaders. The removal of the post-download `cfg.State.SetTotalSize` call is safe because the concurrent downloader already calls `SetTotalSize` internally when it receives response headers.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are minor style/hardening suggestions with no blocking correctness issues.

The core logic changes are correct and well-tested. The removed `SetTotalSize` call was verified to be redundant (the concurrent downloader updates state internally). The only open items are a missing `ActiveWorkers` reset in `SessionReset()` (practically safe since workers exit before the fallback) and inconsistent mutex usage in the new tests.

internal/engine/types/progress.go — consider resetting `ActiveWorkers` in `SessionReset()`

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/download/manager.go | Passes `effectiveTotalSize` instead of `cfg.TotalSize` to both downloaders and replaces the three-line manual reset with `SessionReset()`. Removal of the post-download `cfg.State.SetTotalSize` call is safe — the concurrent downloader already calls `SetTotalSize` internally (line 672 of concurrent/downloader.go), so the post-download call was redundant. |
| internal/engine/types/progress.go | Adds `SessionReset()` (comprehensive state wipe for fallback) and an idempotency guard to `SetTotalSize` (prevents clock reset when the same size is re-confirmed). Minor gap: `ActiveWorkers` is not reset in `SessionReset()`. |
| internal/engine/types/progress_test.go | Adds `TestProgressState_SetTotalSize_Idempotent` and `TestProgressState_SessionReset` with good coverage. Tests directly access mutex-protected struct fields without holding the lock, which is inconsistent with the struct's locking discipline. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/engine/types/progress.go
Line: 227-251

Comment:
**`SessionReset` does not reset `ActiveWorkers`**

After a failed concurrent download, `ActiveWorkers` may be non-zero if workers haven't fully decremented by the time `d.Download()` returns (e.g. via a deferred cleanup race). Leaving `ActiveWorkers` un-reset means the TUI could briefly display a stale connection count between the fallback detection and the moment the single-threaded downloader sets its own `ActiveWorkers`.

```suggestion
func (ps *ProgressState) SessionReset() {
	ps.mu.Lock()
	defer ps.mu.Unlock()

	ps.Downloaded.Store(0)
	ps.VerifiedProgress.Store(0)
	ps.SessionStartBytes = 0
	ps.StartTime = time.Now()
	ps.SavedElapsed = 0
	ps.Done.Store(false)
	ps.Paused.Store(false)
	ps.Pausing.Store(false)
	ps.Error.Store(nil)
	ps.ActiveWorkers.Store(0)
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/engine/types/progress_test.go
Line: 51-68

Comment:
**Direct access to mutex-protected field in test**

`ps.StartTime` is protected by `ps.mu` (as documented in the struct comment). The test writes to it directly (`ps.StartTime = originalStartTime`) and reads it back without holding the lock. While safe in a sequential test, Go's `-race` detector can flag unsynchronized accesses even when no goroutine is concurrently running, and it sets an inconsistent precedent for future test authors.

Consider adding a helper or a lock-guarded setter, or at minimum using `ps.mu.Lock()`/`ps.mu.Unlock()` around the direct field accesses in the test to align with the struct's locking discipline.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add idempotency tests for SetTotal..."](https://github.com/surgedm/surge/commit/11177331449c06c8017e2e3d08c5e23dce6d6bb7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29460878)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->