### PR TITLE
chore: update GitHub Actions to latest versions, add commit linting, and configure native GitHub changelog generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,18 @@
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+    authors:
+      - dependabot[bot]
+  categories:
+    - title: "Features"
+      labels:
+        - feat
+        - enhancement
+    - title: "Bug Fixes"
+      labels:
+        - fix
+        - bug
+    - title: "Internal Changes"
+      labels:
+        - "*"

--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get Surge version
         id: surge-version
@@ -72,7 +72,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -80,7 +80,7 @@ jobs:
 
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -88,7 +88,7 @@ jobs:
             type=raw,value=latest,enable=${{ steps.latest-tag.outputs.enable }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: docker
           file: docker/Dockerfile

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -11,6 +11,9 @@ on:
       - reopened
       - synchronize
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,24 @@
+name: "Conventional Commits"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check commits
+        uses: webiny/action-conventional-commits@v1.3.1

--- a/.github/workflows/core-binary-size-compare.yml
+++ b/.github/workflows/core-binary-size-compare.yml
@@ -19,12 +19,12 @@ jobs:
     name: Compare Binary Size
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.25.0"
           check-latest: false
@@ -61,7 +61,7 @@ jobs:
           echo "${{ github.event.pull_request.number }}" > pr_number.txt
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: binary-size-data
           path: |

--- a/.github/workflows/core-build.yml
+++ b/.github/workflows/core-build.yml
@@ -29,9 +29,9 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.25.0"
           check-latest: false
@@ -49,7 +49,7 @@ jobs:
           fi
           gotestsum --junitfile test-results.xml --format testdox $cover_arg ./...
       - name: Upload Test Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: test-results-${{ matrix.os }}
@@ -69,15 +69,15 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v') && !startsWith(github.ref, 'refs/tags/ext-v')
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.25.0"
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser-pro
           version: latest

--- a/.github/workflows/core-lint.yml
+++ b/.github/workflows/core-lint.yml
@@ -22,8 +22,8 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.25.0'
       - name: golangci-lint

--- a/.github/workflows/extension-checks.yml
+++ b/.github/workflows/extension-checks.yml
@@ -14,9 +14,9 @@ jobs:
       run:
         working-directory: extension
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"
@@ -32,9 +32,9 @@ jobs:
       run:
         working-directory: extension
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"
@@ -50,9 +50,9 @@ jobs:
       run:
         working-directory: extension
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/extension.yml
+++ b/.github/workflows/extension.yml
@@ -36,9 +36,9 @@ jobs:
       run:
         working-directory: extension
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"
@@ -54,7 +54,7 @@ jobs:
         run: |
           npm run zip -- -b ${{ matrix.browser }}
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: extension-${{ matrix.browser }}
           path: extension/output/*.zip
@@ -76,15 +76,15 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/ext-v')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           pattern: extension-*
           merge-multiple: true
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: artifacts/*.zip
           generate_release_notes: true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,10 +33,10 @@ jobs:
     name: Extension ↔ Surge Backend
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.25.0"
           check-latest: false
@@ -45,7 +45,7 @@ jobs:
         run: go build -o surge .
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,6 +21,7 @@ before:
     - ./scripts/package-themes.sh
 
 release:
+  header: "## Changelog"
   footer: |
     ---
     **Enjoying Surge?** Consider supporting the project to keep it blazing fast!
@@ -32,12 +33,7 @@ release:
     - glob: .goreleaser-extra/themes.zip
 
 changelog:
-  sort: asc
-
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"
+  use: github-native
 
 archives:
   - formats: [ tar.gz ]


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps all GitHub Actions to their latest major versions across 8 workflow files, introduces a new conventional-commits linting workflow, and switches changelog generation to GitHub's native system (backed by a new `.github/release.yml` label-based config and `goreleaser`'s `use: github-native`).

- **P1 — `extension.yml`**: `actions/upload-artifact@v7` (build job) and `actions/download-artifact@v8` (release job) are on different major versions; they share an artifact format contract that may break across majors, causing the `ext-v*` release job to fail when downloading artifacts.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the upload/download-artifact version mismatch, which would silently break extension releases.

One P1 finding: the upload-artifact@v7 / download-artifact@v8 mismatch in the connected build→release jobs in extension.yml will cause the release pipeline to fail on ext-v* tag pushes. All other changes are straightforward action version bumps that look correct.

.github/workflows/extension.yml — verify upload-artifact and download-artifact are on the same major version.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/extension.yml | Bumps checkout, setup-node, upload-artifact, download-artifact, and softprops action versions; upload-artifact@v7 / download-artifact@v8 version mismatch may break release job artifact retrieval. |
| .github/workflows/commit-lint.yml | New workflow enforcing conventional commits on PRs and pushes to main using webiny/action-conventional-commits@v1.3.1; looks correct. |
| .github/release.yml | New GitHub-native changelog config categorising PRs by label with a catch-all "Internal Changes" bucket; looks correct. |
| .goreleaser.yaml | Switches goreleaser changelog to github-native, delegates to .github/release.yml; consistent with new release config. |
| .github/workflows/build-push-images.yml | Bumps checkout, docker/login-action, docker/metadata-action, and docker/build-push-action to latest major versions; straightforward update. |
| .github/workflows/core-binary-size-compare.yml | Bumps checkout, setup-go, and upload-artifact; no download-artifact counterpart in this file so no version mismatch concern. |
| .github/workflows/core-build.yml | Bumps checkout, setup-go, upload-artifact, and goreleaser-action to latest major versions; consistent updates. |
| .github/workflows/core-lint.yml | Bumps checkout and setup-go; straightforward update. |
| .github/workflows/extension-checks.yml | Bumps checkout and setup-node across three jobs; straightforward update. |
| .github/workflows/integration.yml | Bumps checkout, setup-go, and setup-node; straightforward update. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/extension.yml
Line: 57-81

Comment:
**upload-artifact/download-artifact major-version mismatch**

The `build` job uploads with `actions/upload-artifact@v7` while the `release` job downloads with `actions/download-artifact@v8`. These two actions use a shared internal artifact format, and different major versions are not guaranteed to be cross-compatible — a v7-produced artifact may not be correctly read by the v8 client, causing the release job to fail silently or error out on `ext-v*` tag pushes.

Both actions should be pinned to the same major version. Either downgrade the download to `@v7` or upgrade the upload to `@v8`.

```suggestion
        uses: actions/upload-artifact@v8
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Potential fix for pull request finding &#39;..."](https://github.com/surgedm/surge/commit/262e55c710e57afc7a5fba7b651a2bc8d88bf1d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29629206)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->