### PR TITLE
long urls break tui

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	charm.land/bubbles/v2 v2.1.0
 	charm.land/bubbletea/v2 v2.0.6
 	charm.land/lipgloss/v2 v2.0.3
+	github.com/BurntSushi/toml v1.6.0
 	github.com/adrg/xdg v0.5.3
 	github.com/atotto/clipboard v0.1.4
 	github.com/dustin/go-humanize v1.0.1
@@ -13,6 +14,7 @@ require (
 	github.com/gofrs/flock v0.13.0
 	github.com/google/uuid v1.6.0
 	github.com/h2non/filetype v1.1.3
+	github.com/mattn/go-runewidth v0.0.23
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/vfaronov/httpheader v0.1.0
@@ -21,7 +23,6 @@ require (
 
 require (
 	git.sr.ht/~jackmordaunt/go-toast v1.1.2 // indirect
-	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/harmonica v0.2.0 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260416155717-489999b90468 // indirect
@@ -40,7 +41,6 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/mattn/go-runewidth v0.0.23 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect

--- a/internal/tui/components/add_download_modal.go
+++ b/internal/tui/components/add_download_modal.go
@@ -36,7 +36,7 @@ func (m AddDownloadModal) View() string {
 	if m.ShowURL && m.URL != "" {
 		horizontalPadding := lipgloss.NewStyle().Padding(0, 2).GetHorizontalFrameSize()
 		innerWidth := m.Width - BorderFrameWidth - horizontalPadding
-		wrappedURL := utils.WrapText(m.URL, innerWidth-5) // Offset for "URL: "
+		wrappedURL := utils.TruncateTwoLines(m.URL, innerWidth-5) // Offset for "URL: "
 		content = append(content,
 			lipgloss.NewStyle().Foreground(colors.LightGray()).Render("URL: "+wrappedURL),
 			"",

--- a/internal/tui/components/box.go
+++ b/internal/tui/components/box.go
@@ -43,6 +43,36 @@ func RenderBtopBox(leftTitle, rightTitle string, content string, width, height i
 	leftTitleWidth := lipgloss.Width(leftTitle)
 	rightTitleWidth := lipgloss.Width(rightTitle)
 
+	// Truncate titles so they can never push the top border wider than innerWidth.
+	// We always reserve at least one horizontal dash (the one after ╭) so the
+	// border looks correct even on very narrow terminals.
+	const minBorderDashes = 1
+	maxTitleSpace := innerWidth - minBorderDashes
+	if maxTitleSpace <= 0 {
+		// No room for any title at this width — suppress both
+		leftTitle = ""
+		leftTitleWidth = 0
+		rightTitle = ""
+		rightTitleWidth = 0
+	} else if leftTitleWidth+rightTitleWidth > maxTitleSpace {
+		// Shorten left title first; if still too wide, also shorten right.
+		half := maxTitleSpace / 2
+		if leftTitleWidth > half {
+			leftTitle = lipgloss.NewStyle().MaxWidth(half).Render(leftTitle)
+			leftTitleWidth = lipgloss.Width(leftTitle)
+		}
+		if leftTitleWidth+rightTitleWidth > maxTitleSpace {
+			rightRemaining := maxTitleSpace - leftTitleWidth
+			if rightRemaining <= 0 {
+				rightTitle = ""
+				rightTitleWidth = 0
+			} else {
+				rightTitle = lipgloss.NewStyle().MaxWidth(rightRemaining).Render(rightTitle)
+				rightTitleWidth = lipgloss.Width(rightTitle)
+			}
+		}
+	}
+
 	// Calculate remaining horizontal space for the border
 	// Structure: ╭ + horizontal*? + leftTitle + horizontal*? + rightTitle + horizontal*? + ╮
 	// Basic structure we want:
@@ -55,8 +85,8 @@ func RenderBtopBox(leftTitle, rightTitle string, content string, width, height i
 	// Case 1: Both Titles
 	if leftTitle != "" && rightTitle != "" {
 		remainingWidth := innerWidth - leftTitleWidth - rightTitleWidth - lipgloss.Width(horizontal)
-		if remainingWidth < 1 {
-			remainingWidth = 1 // overflow mitigation (might break layout but prevents crash)
+		if remainingWidth < 0 {
+			remainingWidth = 0
 		}
 
 		topBorder = borderStyler.Render(topLeft+horizontal) +
@@ -100,6 +130,9 @@ func RenderBtopBox(leftTitle, rightTitle string, content string, width, height i
 	// Wrap content lines with vertical borders
 	contentLines := strings.Split(content, "\n")
 	innerHeight := height - BorderFrameHeight // Account for top and bottom borders
+	if innerHeight < 0 {
+		innerHeight = 0
+	}
 
 	// Style for truncation
 	truncStyle := lipgloss.NewStyle().MaxWidth(innerWidth)

--- a/internal/tui/components/confirmation_modal.go
+++ b/internal/tui/components/confirmation_modal.go
@@ -47,7 +47,7 @@ func (m ConfirmationModal) renderBody(width int) string {
 	if width > 0 {
 		msg = utils.WrapText(msg, width)
 		if det != "" {
-			det = utils.WrapText(det, width)
+			det = utils.TruncateTwoLines(det, width)
 		}
 	}
 

--- a/internal/tui/helpers.go
+++ b/internal/tui/helpers.go
@@ -40,7 +40,7 @@ func (m *RootModel) refreshLogViewportContent() {
 	}
 
 	// Render each entry at the viewport width so the content fills the pane.
-	// WrapText pre-wraps lines so no content is clipped during rendering.
+	// TruncateTwoLines ensures long messages don't overflow the UI.
 
 	var wrappedEntries []string
 	for _, entry := range m.logEntries {

--- a/internal/tui/helpers.go
+++ b/internal/tui/helpers.go
@@ -41,13 +41,11 @@ func (m *RootModel) refreshLogViewportContent() {
 
 	// Render each entry at the viewport width so the content fills the pane.
 	// WrapText pre-wraps lines so no content is clipped during rendering.
-	wrapStyle := lipgloss.NewStyle().Width(width).Align(lipgloss.Left)
 
 	var wrappedEntries []string
 	for _, entry := range m.logEntries {
-		wrapped := utils.WrapText(entry, width)
-		rendered := wrapStyle.Render(wrapped)
-		wrappedEntries = append(wrappedEntries, strings.Split(rendered, "\n")...)
+		wrapped := utils.TruncateTwoLines(entry, width)
+		wrappedEntries = append(wrappedEntries, strings.Split(wrapped, "\n")...)
 	}
 
 	// Bottom-align entries if they don't fill the viewport

--- a/internal/tui/layout_helpers.go
+++ b/internal/tui/layout_helpers.go
@@ -215,16 +215,10 @@ func CalculateDashboardLayout(termW, termH int) DashboardLayout {
 			targetGraphH = l.MinGraphHeight
 		}
 
-		// Adjust heights for detail and chunk map
-		targetDetailH := l.AvailableHeight - targetGraphH
-
-		// If we show chunk map, check if there's enough room for details
-		if l.ShowChunkMap {
-			potentialDetailH := targetDetailH - (5 + components.BorderFrameHeight)
-			if potentialDetailH < 14 {
-				l.ShowChunkMap = false
-			}
-		}
+		// Compute heights assuming chunk map may be shown.
+		// The actual decision to render the chunk map is made dynamically
+		// in View() by measuring the rendered detail content against the
+		// allocated DetailHeight. This avoids any hardcoded height guesses.
 
 		if l.ShowChunkMap {
 			l.ChunkMapHeight = 5 + components.BorderFrameHeight // 5 rows of content + 2 for borders

--- a/internal/tui/layout_regression_test.go
+++ b/internal/tui/layout_regression_test.go
@@ -1,0 +1,475 @@
+package tui
+
+// layout_regression_test.go – enforces that no TUI component ever produces
+// output that exceeds the terminal width or height it was given.
+//
+// These tests are the authoritative "no cutting off" regression suite.
+// Any future change that causes a line to exceed the terminal width OR adds
+// more rendered lines than the terminal height will break these tests.
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"charm.land/bubbles/v2/list"
+	"charm.land/lipgloss/v2"
+	"github.com/SurgeDM/Surge/internal/processing"
+	"github.com/SurgeDM/Surge/internal/tui/components"
+	"github.com/SurgeDM/Surge/internal/version"
+)
+
+var stripANSI = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+// plainLines strips ANSI codes and splits on newlines.
+func plainLines(s string) []string {
+	return strings.Split(stripANSI.ReplaceAllString(s, ""), "\n")
+}
+
+// assertNoLineExceedsWidth fails if any rendered line is wider than wantWidth.
+func assertNoLineExceedsWidth(t *testing.T, label string, output string, wantWidth int) {
+	t.Helper()
+	for i, line := range plainLines(output) {
+		if w := lipgloss.Width(line); w > wantWidth {
+			// Show a helpful excerpt of the offending line.
+			excerpt := line
+			if len(excerpt) > 120 {
+				excerpt = excerpt[:120] + "…"
+			}
+			t.Errorf("[%s] line %d: width %d > max %d\n  %q", label, i, w, wantWidth, excerpt)
+		}
+	}
+}
+
+// assertHeightNotExceeded fails if the rendered output has more non-trailing lines
+// than wantHeight allows (trailing empty lines are excluded from the count).
+func assertHeightNotExceeded(t *testing.T, label string, output string, wantHeight int) {
+	t.Helper()
+	lines := plainLines(strings.TrimRight(output, "\n"))
+	if len(lines) > wantHeight {
+		t.Errorf("[%s] height %d > max %d", label, len(lines), wantHeight)
+	}
+}
+
+// termSizes covers a representative range of terminal geometries including
+// corner cases that historically produced overflows.
+var termSizes = []struct{ width, height int }{
+	{160, 50}, // extra wide, tall
+	{140, 40}, // full layout
+	{120, 35}, // standard large
+	{100, 30}, // medium
+	{80, 24},  // classic 80×24
+	{72, 20},  // narrow modal threshold
+	{60, 20},  // right column hidden
+	{50, 16},  // very narrow
+	{46, 14},  // minimum useful width
+	{45, 12},  // MinTermWidth boundary
+}
+
+// ─────────────────────────────────────────────────────────────
+// 1. Dashboard – all sizes
+// ─────────────────────────────────────────────────────────────
+
+func TestLayout_DashboardWidthNeverExceeds(t *testing.T) {
+	m := InitialRootModel(1701, "test", nil, processing.NewLifecycleManager(nil, nil), false)
+	for _, tc := range termSizes {
+		m.width = tc.width
+		m.height = tc.height
+		label := fmt.Sprintf("dashboard %dx%d", tc.width, tc.height)
+		view := m.View()
+		assertNoLineExceedsWidth(t, label, view.Content, tc.width)
+	}
+}
+
+func TestLayout_DashboardHeightNeverExceeds(t *testing.T) {
+	m := InitialRootModel(1701, "test", nil, processing.NewLifecycleManager(nil, nil), false)
+	for _, tc := range termSizes {
+		m.width = tc.width
+		m.height = tc.height
+		label := fmt.Sprintf("dashboard %dx%d", tc.width, tc.height)
+		view := m.View()
+		assertHeightNotExceeded(t, label, view.Content, tc.height)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────
+// 2. Dashboard with a selected download that has a very long URL
+// ─────────────────────────────────────────────────────────────
+
+func TestLayout_DashboardLongURLWidthNeverExceeds(t *testing.T) {
+	longURL := "https://cdn.example.com/releases/v1.2.3/" + strings.Repeat("a", 300) + "/ubuntu-22.04.iso"
+	m := InitialRootModel(1701, "test", nil, processing.NewLifecycleManager(nil, nil), false)
+	m.downloads = []*DownloadModel{
+		{
+			ID:          "dl-1",
+			URL:         longURL,
+			Filename:    strings.Repeat("very-long-filename-", 10) + ".iso",
+			Destination: "/home/user/" + strings.Repeat("deep/nested/path/", 8),
+			Total:       1 << 30,
+			Downloaded:  512 << 20,
+			Speed:       10 * MB,
+		},
+	}
+
+	for _, tc := range termSizes {
+		m.width = tc.width
+		m.height = tc.height
+		m.UpdateListItems()
+		label := fmt.Sprintf("dashboard+longURL %dx%d", tc.width, tc.height)
+		view := m.View()
+		assertNoLineExceedsWidth(t, label, view.Content, tc.width)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────
+// 3. All modal states – width & height
+// ─────────────────────────────────────────────────────────────
+
+var modalStates = []struct {
+	name  string
+	state UIState
+}{
+	{"QuitConfirm", QuitConfirmState},
+	{"HelpModal", HelpModalState},
+	{"DuplicateWarning", DuplicateWarningState},
+	{"BatchConfirm", BatchConfirmState},
+	{"UpdateAvailable", UpdateAvailableState},
+	{"BugReportTarget", BugReportTargetState},
+	{"BugReportSystemDetails", BugReportSystemDetailsState},
+	{"BugReportLogPath", BugReportLogPathState},
+}
+
+func TestLayout_AllModalsWidthNeverExceeds(t *testing.T) {
+	for _, ms := range modalStates {
+		for _, tc := range termSizes {
+			t.Run(fmt.Sprintf("%s_%dx%d", ms.name, tc.width, tc.height), func(t *testing.T) {
+				m := InitialRootModel(1701, "test", nil, processing.NewLifecycleManager(nil, nil), false)
+				m.width = tc.width
+				m.height = tc.height
+				m.state = ms.state
+
+				// UpdateAvailableState requires UpdateInfo
+				if ms.state == UpdateAvailableState {
+					m.UpdateInfo = &version.UpdateInfo{LatestVersion: "9.9.9", CurrentVersion: "1.0.0"}
+				}
+				// DuplicateWarningState benefits from a long detail string
+				if ms.state == DuplicateWarningState {
+					m.duplicateInfo = "https://very.long.domain.example.com/path/to/very/deep/file.iso"
+				}
+				// BatchConfirm needs pending URLs
+				if ms.state == BatchConfirmState {
+					m.pendingBatchURLs = []string{"url1", "url2"}
+					m.batchFilePath = "/very/long/path/to/" + strings.Repeat("dir/", 10) + "urls.txt"
+				}
+
+				view := m.View()
+				assertNoLineExceedsWidth(t,
+					fmt.Sprintf("%s %dx%d", ms.name, tc.width, tc.height),
+					view.Content, tc.width)
+			})
+		}
+	}
+}
+
+func TestLayout_AllModalsHeightNeverExceeds(t *testing.T) {
+	for _, ms := range modalStates {
+		for _, tc := range termSizes {
+			t.Run(fmt.Sprintf("%s_%dx%d", ms.name, tc.width, tc.height), func(t *testing.T) {
+				m := InitialRootModel(1701, "test", nil, processing.NewLifecycleManager(nil, nil), false)
+				m.width = tc.width
+				m.height = tc.height
+				m.state = ms.state
+
+				if ms.state == UpdateAvailableState {
+					m.UpdateInfo = &version.UpdateInfo{LatestVersion: "9.9.9", CurrentVersion: "1.0.0"}
+				}
+				if ms.state == DuplicateWarningState {
+					m.duplicateInfo = "https://very.long.domain.example.com/very/deep/path/file.iso"
+				}
+				if ms.state == BatchConfirmState {
+					m.pendingBatchURLs = []string{"url1", "url2"}
+				}
+
+				view := m.View()
+				assertHeightNotExceeded(t,
+					fmt.Sprintf("%s %dx%d", ms.name, tc.width, tc.height),
+					view.Content, tc.height)
+			})
+		}
+	}
+}
+
+// ─────────────────────────────────────────────────────────────
+// 4. Settings & Category Manager – width & height
+// ─────────────────────────────────────────────────────────────
+
+func TestLayout_SettingsWidthNeverExceeds(t *testing.T) {
+	m := InitialRootModel(1701, "test", nil, processing.NewLifecycleManager(nil, nil), false)
+	m.state = SettingsState
+	for _, tc := range termSizes {
+		m.width = tc.width
+		m.height = tc.height
+		label := fmt.Sprintf("settings %dx%d", tc.width, tc.height)
+		view := m.View()
+		assertNoLineExceedsWidth(t, label, view.Content, tc.width)
+	}
+}
+
+func TestLayout_SettingsHeightNeverExceeds(t *testing.T) {
+	m := InitialRootModel(1701, "test", nil, processing.NewLifecycleManager(nil, nil), false)
+	m.state = SettingsState
+	for _, tc := range termSizes {
+		m.width = tc.width
+		m.height = tc.height
+		label := fmt.Sprintf("settings %dx%d", tc.width, tc.height)
+		view := m.View()
+		assertHeightNotExceeded(t, label, view.Content, tc.height)
+	}
+}
+
+func TestLayout_CategoryManagerWidthNeverExceeds(t *testing.T) {
+	m := InitialRootModel(1701, "test", nil, processing.NewLifecycleManager(nil, nil), false)
+	m.state = CategoryManagerState
+	for _, tc := range termSizes {
+		m.width = tc.width
+		m.height = tc.height
+		label := fmt.Sprintf("catmgr %dx%d", tc.width, tc.height)
+		view := m.View()
+		assertNoLineExceedsWidth(t, label, view.Content, tc.width)
+	}
+}
+
+func TestLayout_CategoryManagerHeightNeverExceeds(t *testing.T) {
+	m := InitialRootModel(1701, "test", nil, processing.NewLifecycleManager(nil, nil), false)
+	m.state = CategoryManagerState
+	for _, tc := range termSizes {
+		m.width = tc.width
+		m.height = tc.height
+		label := fmt.Sprintf("catmgr %dx%d", tc.width, tc.height)
+		view := m.View()
+		assertHeightNotExceeded(t, label, view.Content, tc.height)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────
+// 5. Download list delegate – Render width enforcement
+// ─────────────────────────────────────────────────────────────
+
+func TestLayout_DelegateRenderNeverExceedsWidth(t *testing.T) {
+	d := newDownloadDelegate()
+
+	widths := []int{200, 120, 80, 60, 45, 30}
+	for _, w := range widths {
+		t.Run(fmt.Sprintf("width_%d", w), func(t *testing.T) {
+			m := list.New([]list.Item{}, d, w, 20)
+			di := DownloadItem{
+				download: &DownloadModel{
+					ID:       "dl-abc",
+					Filename: strings.Repeat("very-long-filename-", 12) + ".iso",
+					URL:      "https://example.com/" + strings.Repeat("a", 400),
+					Total:    1 << 30,
+					Speed:    5 * MB,
+				},
+				spinnerView: "⠋",
+			}
+
+			var buf bytes.Buffer
+			d.Render(&buf, m, 0, di)
+			rendered := stripANSI.ReplaceAllString(buf.String(), "")
+			for i, line := range strings.Split(rendered, "\n") {
+				if lw := lipgloss.Width(line); lw > w {
+					t.Errorf("line %d: width %d > max %d in rendered delegate at width %d", i, lw, w, w)
+				}
+			}
+		})
+	}
+}
+
+// ─────────────────────────────────────────────────────────────
+// 6. RenderBtopBox – width invariant at all widths
+// ─────────────────────────────────────────────────────────────
+
+func TestLayout_RenderBtopBoxWidthInvariant(t *testing.T) {
+	longLeft := " " + strings.Repeat("Left Title Text ", 8) + " "
+	longRight := " " + strings.Repeat("Right Title ", 8) + " "
+	content := strings.Repeat("x", 400)
+
+	widths := []int{200, 120, 80, 60, 45, 30, 15, 5, 3}
+	heights := []int{20, 10, 5, 3, 1}
+
+	for _, w := range widths {
+		for _, h := range heights {
+			for _, tc := range []struct {
+				name, left, right string
+			}{
+				{"no-titles", "", ""},
+				{"left-only", longLeft, ""},
+				{"right-only", "", longRight},
+				{"both-long", longLeft, longRight},
+				{"both-short", " L ", " R "},
+			} {
+				label := fmt.Sprintf("box_%s_%dx%d", tc.name, w, h)
+				out := components.RenderBtopBox(tc.left, tc.right, content, w, h, nil)
+				plain := stripANSI.ReplaceAllString(out, "")
+				for i, line := range strings.Split(plain, "\n") {
+					if lw := lipgloss.Width(line); lw > w {
+						t.Errorf("[%s] line %d width=%d > box width=%d", label, i, lw, w)
+					}
+				}
+				// Height: top border + content rows + bottom border
+				outLines := strings.Split(plain, "\n")
+				// Strip trailing empty line that JoinVertical may add
+				for len(outLines) > 0 && outLines[len(outLines)-1] == "" {
+					outLines = outLines[:len(outLines)-1]
+				}
+				// RenderBtopBox always produces exactly h lines.
+				// A box has a minimum of 3 lines (top border, content rows, bottom border),
+				// so for h < 3 the output will be 3 lines — that is expected behaviour.
+				expectedLines := h
+				if expectedLines < 3 {
+					expectedLines = 3
+				}
+				if len(outLines) != expectedLines {
+					t.Errorf("[%s] height=%d != expected=%d", label, len(outLines), expectedLines)
+				}
+			}
+		}
+	}
+}
+
+// ─────────────────────────────────────────────────────────────
+// 7. Extreme sizes – no panic
+// ─────────────────────────────────────────────────────────────
+
+func TestLayout_ExtremeSizesNoPanic(t *testing.T) {
+	extremes := []struct{ w, h int }{
+		{1, 1},
+		{2, 2},
+		{45, 1},
+		{1, 50},
+		{0, 0},
+		{500, 200},
+	}
+
+	allStates := append(modalStates,
+		struct {
+			name  string
+			state UIState
+		}{"Dashboard", DashboardState},
+		struct {
+			name  string
+			state UIState
+		}{"Settings", SettingsState},
+		struct {
+			name  string
+			state UIState
+		}{"CategoryManager", CategoryManagerState},
+	)
+
+	for _, tc := range extremes {
+		for _, ms := range allStates {
+			t.Run(fmt.Sprintf("%s_%dx%d", ms.name, tc.w, tc.h), func(t *testing.T) {
+				m := InitialRootModel(1701, "test", nil, processing.NewLifecycleManager(nil, nil), false)
+				m.width = tc.w
+				m.height = tc.h
+				m.state = ms.state
+				if ms.state == UpdateAvailableState {
+					m.UpdateInfo = &version.UpdateInfo{LatestVersion: "9.9.9", CurrentVersion: "1.0.0"}
+				}
+				// Must not panic
+				defer func() {
+					if r := recover(); r != nil {
+						t.Errorf("panic for state=%s at %dx%d: %v", ms.name, tc.w, tc.h, r)
+					}
+				}()
+				_ = m.View()
+			})
+		}
+	}
+}
+
+// ─────────────────────────────────────────────────────────────
+// 8. CalculateDashboardLayout – sum invariants
+// ─────────────────────────────────────────────────────────────
+
+func TestLayout_CalculateDashboardLayout_SumInvariants(t *testing.T) {
+	sizes := []struct{ w, h int }{
+		{160, 50}, {120, 35}, {80, 24}, {60, 20}, {46, 14},
+	}
+	for _, tc := range sizes {
+		l := CalculateDashboardLayout(tc.w, tc.h)
+		label := fmt.Sprintf("%dx%d", tc.w, tc.h)
+
+		// Left + Right should equal AvailableWidth (when right column is shown)
+		if !l.HideRightColumn {
+			if l.LeftWidth+l.RightWidth != l.AvailableWidth {
+				t.Errorf("[%s] LeftWidth(%d)+RightWidth(%d) != AvailableWidth(%d)",
+					label, l.LeftWidth, l.RightWidth, l.AvailableWidth)
+			}
+		}
+
+		// ListHeight should not exceed AvailableHeight
+		if l.ListHeight > l.AvailableHeight {
+			t.Errorf("[%s] ListHeight(%d) > AvailableHeight(%d)", label, l.ListHeight, l.AvailableHeight)
+		}
+
+		// GraphHeight + DetailHeight (+ ChunkMapHeight) should not exceed AvailableHeight
+		if !l.HideRightColumn {
+			total := l.GraphHeight + l.DetailHeight
+			if l.ShowChunkMap {
+				total += l.ChunkMapHeight
+			}
+			if total > l.AvailableHeight {
+				t.Errorf("[%s] right column heights sum(%d) > AvailableHeight(%d)",
+					label, total, l.AvailableHeight)
+			}
+		}
+
+		// All dimensions must be non-negative
+		for name, val := range map[string]int{
+			"AvailableWidth":  l.AvailableWidth,
+			"AvailableHeight": l.AvailableHeight,
+			"LeftWidth":       l.LeftWidth,
+			"ListHeight":      l.ListHeight,
+			"HeaderHeight":    l.HeaderHeight,
+		} {
+			if val < 0 {
+				t.Errorf("[%s] %s is negative: %d", label, name, val)
+			}
+		}
+	}
+}
+
+// ─────────────────────────────────────────────────────────────
+// 9. GetDynamicModalDimensions – output never exceeds terminal
+// ─────────────────────────────────────────────────────────────
+
+func TestLayout_GetDynamicModalDimensions_BoundedByTerminal(t *testing.T) {
+	cases := []struct {
+		termW, termH, minW, minH, prefW, contentH int
+	}{
+		{120, 35, 40, 8, 80, 20},
+		{60, 20, 40, 8, 80, 20}, // pref > term
+		{45, 12, 40, 8, 80, 20}, // very narrow
+		{10, 5, 40, 8, 80, 20},  // smaller than min (should still not exceed term)
+		{200, 60, 50, 10, 72, 15},
+	}
+	for _, tc := range cases {
+		w, h := GetDynamicModalDimensions(tc.termW, tc.termH, tc.minW, tc.minH, tc.prefW, tc.contentH)
+		label := fmt.Sprintf("term=%dx%d pref=%dx%d", tc.termW, tc.termH, tc.prefW, tc.contentH)
+		if tc.termW > 0 && w > tc.termW {
+			t.Errorf("[%s] modal width %d > termW %d", label, w, tc.termW)
+		}
+		if tc.termH > 0 && h > tc.termH {
+			t.Errorf("[%s] modal height %d > termH %d", label, h, tc.termH)
+		}
+		if w < 1 {
+			t.Errorf("[%s] modal width %d < 1", label, w)
+		}
+		if h < 1 {
+			t.Errorf("[%s] modal height %d < 1", label, h)
+		}
+	}
+}

--- a/internal/tui/layout_regression_test.go
+++ b/internal/tui/layout_regression_test.go
@@ -16,6 +16,7 @@ import (
 
 	"charm.land/bubbles/v2/list"
 	"charm.land/lipgloss/v2"
+	"github.com/SurgeDM/Surge/internal/engine/types"
 	"github.com/SurgeDM/Surge/internal/processing"
 	"github.com/SurgeDM/Surge/internal/tui/components"
 	"github.com/SurgeDM/Surge/internal/version"
@@ -471,5 +472,227 @@ func TestLayout_GetDynamicModalDimensions_BoundedByTerminal(t *testing.T) {
 		if h < 1 {
 			t.Errorf("[%s] modal height %d < 1", label, h)
 		}
+	}
+}
+
+// ─────────────────────────────────────────────────────────────
+// 10. Right column height – graph + details + chunkmap ≤ available
+// ─────────────────────────────────────────────────────────────
+
+// makeDownloadWithChunks creates a download model that has an active bitmap,
+// mirrors, an error, and verbose fields — everything that makes the detail
+// pane as tall as possible.
+func makeDownloadWithChunks(longURL bool) *DownloadModel {
+	url := "https://cdn.example.com/releases/v1.2.3/file.iso"
+	filename := "file.iso"
+	dest := "/home/user/Downloads/file.iso"
+	if longURL {
+		url = "https://cdn.example.com/releases/v1.2.3/" + strings.Repeat("segment/", 20) + "ubuntu-22.04.iso"
+		filename = strings.Repeat("very-long-filename-", 6) + ".iso"
+		dest = "/home/user/" + strings.Repeat("deep/nested/path/", 6) + "file.iso"
+	}
+
+	dm := NewDownloadModel("dl-chunked", url, filename, 500*MB)
+	dm.Destination = dest
+	dm.Downloaded = 200 * MB
+	dm.Speed = 10 * MB
+	dm.Connections = 8
+
+	// Initialize the bitmap so GetBitmap() returns data
+	dm.state.InitBitmap(500*MB, 10*MB) // 50 chunks
+	// Mark some chunks as downloading/completed
+	for i := 0; i < 20; i++ {
+		dm.state.SetChunkState(i, 2) // ChunkCompleted
+	}
+	for i := 20; i < 28; i++ {
+		dm.state.SetChunkState(i, 1) // ChunkDownloading
+	}
+
+	// Add mirrors and an error to make the detail pane taller
+	dm.state.SetMirrors([]types.MirrorStatus{
+		{URL: "https://mirror1.example.com", Active: true},
+		{URL: "https://mirror2.example.com", Active: true},
+		{URL: "https://mirror3.example.com", Error: true},
+	})
+	dm.err = fmt.Errorf("connection reset by peer (retrying)")
+
+	return dm
+}
+
+func TestLayout_RightColumnHeightNeverExceedsAvailable(t *testing.T) {
+	// Test across a wide range of heights — the invariant must hold for ALL of them.
+	for termH := 18; termH <= 60; termH++ {
+		for _, termW := range []int{200, 160, 140} {
+			t.Run(fmt.Sprintf("%dx%d", termW, termH), func(t *testing.T) {
+				m := InitialRootModel(1701, "test", nil, processing.NewLifecycleManager(nil, nil), false)
+				m.width = termW
+				m.height = termH
+				m.activeTab = TabActive // download has Speed > 0
+
+				dm := makeDownloadWithChunks(true)
+				m.downloads = []*DownloadModel{dm}
+				m.UpdateListItems()
+
+				view := m.View()
+				assertNoLineExceedsWidth(t, fmt.Sprintf("%dx%d", termW, termH), view.Content, termW)
+				assertHeightNotExceeded(t, fmt.Sprintf("%dx%d", termW, termH), view.Content, termH)
+			})
+		}
+	}
+}
+
+// ─────────────────────────────────────────────────────────────
+// 11. Chunk map suppression – when details is big, chunk map must NOT render
+// ─────────────────────────────────────────────────────────────
+
+func TestLayout_ChunkMapSuppressedWhenDetailsTall(t *testing.T) {
+	// At various "medium" terminal heights where the chunk map might try to
+	// render, verify it is dynamically suppressed when the detail content
+	// is too tall to fit alongside it.
+	for termH := 18; termH <= 45; termH++ {
+		t.Run(fmt.Sprintf("h%d", termH), func(t *testing.T) {
+			m := InitialRootModel(1701, "test", nil, processing.NewLifecycleManager(nil, nil), false)
+			m.width = 160
+			m.height = termH
+			m.activeTab = TabActive
+
+			dm := makeDownloadWithChunks(true) // long URL + mirrors + error = very tall detail
+			m.downloads = []*DownloadModel{dm}
+			m.UpdateListItems()
+
+			layout := CalculateDashboardLayout(m.width, m.height)
+
+			if layout.HideRightColumn {
+				t.Skip("right column hidden at this size, chunk map irrelevant")
+			}
+
+			// Measure what the detail content would look like
+			selected := m.GetSelectedDownload()
+			if selected == nil {
+				t.Skip("no selected download")
+			}
+			detailContent := renderFocusedDetails(
+				selected,
+				layout.RightWidth-components.BorderFrameWidth,
+				"⠋",
+			)
+			contentH := lipgloss.Height(detailContent)
+
+			// Compute the inner height if chunk map IS shown
+			detailInnerH := layout.DetailHeight - components.BorderFrameHeight
+
+			if contentH > detailInnerH {
+				// Content is taller than what chunk map allocation allows.
+				// The view MUST suppress the chunk map in this case.
+				view := m.View()
+				rendered := view.Content
+
+				// "Chunk Map" title must NOT appear in the rendered output
+				if strings.Contains(rendered, "Chunk Map") {
+					t.Errorf("h=%d: chunk map rendered but detail content (%d lines) exceeds allocated inner height (%d lines)",
+						termH, contentH, detailInnerH)
+				}
+			}
+		})
+	}
+}
+
+// ─────────────────────────────────────────────────────────────
+// 12. Detail content NOT clipped – every section must be visible
+// ─────────────────────────────────────────────────────────────
+
+func TestLayout_DetailContentNotClippedByChunkMap(t *testing.T) {
+	// Render the dashboard at every height from 18..50 and verify that
+	// when the detail pane has enough room for the full content,
+	// all key sections are visible — none cut off by the chunk map.
+	for termH := 18; termH <= 50; termH++ {
+		t.Run(fmt.Sprintf("h%d", termH), func(t *testing.T) {
+			m := InitialRootModel(1701, "test", nil, processing.NewLifecycleManager(nil, nil), false)
+			m.width = 160
+			m.height = termH
+			m.activeTab = TabActive
+
+			dm := makeDownloadWithChunks(false) // normal URL, with mirrors + error
+			m.downloads = []*DownloadModel{dm}
+			m.UpdateListItems()
+
+			layout := CalculateDashboardLayout(m.width, m.height)
+			if layout.HideRightColumn {
+				t.Skip("right column hidden")
+			}
+
+			// Measure the actual detail content height
+			selected := m.GetSelectedDownload()
+			if selected == nil {
+				t.Skip("no selected download")
+			}
+			detailContent := renderFocusedDetails(
+				selected,
+				layout.RightWidth-components.BorderFrameWidth,
+				"⠋",
+			)
+			contentH := lipgloss.Height(detailContent)
+
+			// The maximum possible detail height (no chunk map) is
+			// AvailableHeight - GraphHeight, minus the border frame.
+			maxDetailInnerH := layout.AvailableHeight - layout.GraphHeight - components.BorderFrameHeight
+
+			if contentH > maxDetailInnerH {
+				// Even at full allocation (no chunk map), the content is
+				// taller than the detail pane. Clipping is expected — skip.
+				t.Skipf("content (%d lines) exceeds max detail inner height (%d) — terminal too short", contentH, maxDetailInnerH)
+			}
+
+			view := m.View()
+			rendered := stripANSI.ReplaceAllString(view.Content, "")
+
+			// These key labels must always be present in the rendered output
+			// when the detail pane has enough room. If any is missing,
+			// the chunk map stole space that should have gone to details.
+			requiredLabels := []string{
+				"URL:",
+				"File:",
+				"Path:",
+				"Speed:",
+				"ETA:",
+			}
+			for _, label := range requiredLabels {
+				if !strings.Contains(rendered, label) {
+					t.Errorf("h=%d: label %q not found in rendered view — detail content was clipped (contentH=%d, maxInnerH=%d)",
+						termH, label, contentH, maxDetailInnerH)
+				}
+			}
+		})
+	}
+}
+
+// ─────────────────────────────────────────────────────────────
+// 13. Dynamic suppression sweep – chunk map space always reclaimed
+// ─────────────────────────────────────────────────────────────
+
+func TestLayout_ChunkMapSpaceReclaimedForDetails(t *testing.T) {
+	// At every height where CalculateDashboardLayout says ShowChunkMap=true,
+	// verify that the final rendered right column still fits within
+	// AvailableHeight — proving that either the chunk map rendered within
+	// budget or was suppressed and its space reclaimed.
+	for termH := 18; termH <= 60; termH++ {
+		t.Run(fmt.Sprintf("h%d", termH), func(t *testing.T) {
+			m := InitialRootModel(1701, "test", nil, processing.NewLifecycleManager(nil, nil), false)
+			m.width = 160
+			m.height = termH
+			m.activeTab = TabActive
+
+			dm := makeDownloadWithChunks(true)
+			m.downloads = []*DownloadModel{dm}
+			m.UpdateListItems()
+
+			layout := CalculateDashboardLayout(m.width, m.height)
+			if layout.HideRightColumn {
+				t.Skip("right column hidden")
+			}
+
+			view := m.View()
+			assertHeightNotExceeded(t, fmt.Sprintf("h%d", termH), view.Content, termH)
+		})
 	}
 }

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -149,7 +149,7 @@ func (d downloadDelegate) Render(w io.Writer, m list.Model, index int, listItem 
 		availableWidth = 10
 	}
 
-	title := utils.Truncate(i.Title(), availableWidth)
+	title := utils.TruncateMiddle(i.Title(), availableWidth)
 	description := utils.Truncate(i.Description(), availableWidth)
 
 	// Render lines

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -142,11 +142,23 @@ func (d downloadDelegate) Render(w io.Writer, m list.Model, index int, listItem 
 		prefix = d.prefixNormal
 	}
 
-	// Truncate title and description if needed
-	// m.Width() is the available space for the list item
-	availableWidth := m.Width() - (components.BorderFrameWidth * 2) // Account for prefix and some padding
-	if availableWidth < 10 {
-		availableWidth = 10
+	// Measure the prefix so we can subtract it from the allowed content width.
+	prefixWidth := lipgloss.Width(prefix)
+
+	// Compute the content width available for title/description.
+	// We subtract the border frame allowance AND the prefix so the total
+	// rendered line (prefix + content) never exceeds m.Width().
+	availableWidth := m.Width() - prefixWidth - (components.BorderFrameWidth * 2)
+	if availableWidth < 1 {
+		availableWidth = 1
+	}
+	// Absolute cap at list width (minus prefix) to prevent any overflow.
+	maxContent := m.Width() - prefixWidth
+	if maxContent < 1 {
+		maxContent = 1
+	}
+	if availableWidth > maxContent {
+		availableWidth = maxContent
 	}
 
 	title := utils.TruncateMiddle(i.Title(), availableWidth)

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -152,14 +152,6 @@ func (d downloadDelegate) Render(w io.Writer, m list.Model, index int, listItem 
 	if availableWidth < 1 {
 		availableWidth = 1
 	}
-	// Absolute cap at list width (minus prefix) to prevent any overflow.
-	maxContent := m.Width() - prefixWidth
-	if maxContent < 1 {
-		maxContent = 1
-	}
-	if availableWidth > maxContent {
-		availableWidth = maxContent
-	}
 
 	title := utils.TruncateMiddle(i.Title(), availableWidth)
 	description := utils.Truncate(i.Description(), availableWidth)

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -507,9 +507,9 @@ func renderFocusedDetails(d *DownloadModel, w int, spinnerView string) string {
 	}
 
 	fileInfoContent := lipgloss.JoinVertical(lipgloss.Left,
-		lipgloss.JoinHorizontal(lipgloss.Top, StatsLabelStyle.Render("URL: "), StatsValueStyle.Width(valueWidth).MaxWidth(valueWidth).Render(utils.WrapText(d.URL, valueWidth))),
-		lipgloss.JoinHorizontal(lipgloss.Top, StatsLabelStyle.Render("File: "), StatsValueStyle.Width(valueWidth).MaxWidth(valueWidth).Render(utils.WrapText(displayFilename, valueWidth))),
-		lipgloss.JoinHorizontal(lipgloss.Top, StatsLabelStyle.Render("Path: "), StatsValueStyle.Width(valueWidth).MaxWidth(valueWidth).Render(utils.WrapText(displayPath, valueWidth))),
+		lipgloss.JoinHorizontal(lipgloss.Top, StatsLabelStyle.Render("URL: "), StatsValueStyle.Width(valueWidth).MaxWidth(valueWidth).Render(utils.TruncateTwoLines(d.URL, valueWidth))),
+		lipgloss.JoinHorizontal(lipgloss.Top, StatsLabelStyle.Render("File: "), StatsValueStyle.Width(valueWidth).MaxWidth(valueWidth).Render(utils.TruncateTwoLines(displayFilename, valueWidth))),
+		lipgloss.JoinHorizontal(lipgloss.Top, StatsLabelStyle.Render("Path: "), StatsValueStyle.Width(valueWidth).MaxWidth(valueWidth).Render(utils.TruncateTwoLines(displayPath, valueWidth))),
 		lipgloss.JoinHorizontal(lipgloss.Top, StatsLabelStyle.Render("ID:   "), lipgloss.NewStyle().Foreground(colors.LightGray()).Width(valueWidth).MaxWidth(valueWidth).Render(utils.WrapText(d.ID, valueWidth))),
 	)
 	fileSection := sectionStyle.Render(fileInfoContent)

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -405,6 +405,22 @@ func (m RootModel) View() tea.View {
 		hasChunks := len(bitmap) > 0 && bitmapWidth > 0
 		showActualChunkMap := layout.ShowChunkMap && hasChunks && selected != nil && !selected.done
 
+		// Measure whether the detail content actually fits in the allocated
+		// DetailHeight. If it doesn't, the chunk map would cause details to
+		// be clipped — so give the chunk map's space back to details.
+		if showActualChunkMap {
+			detailInnerH := layout.DetailHeight - components.BorderFrameHeight
+			if detailInnerH < 1 {
+				detailInnerH = 1
+			}
+			contentH := lipgloss.Height(detailContent)
+			if contentH > detailInnerH {
+				// Detail content is taller than what's allocated; reclaim
+				// chunk map space so nothing gets cut off.
+				showActualChunkMap = false
+			}
+		}
+
 		// If we reserved space for chunk map but aren't showing it, give it to details
 		if !showActualChunkMap && layout.ShowChunkMap {
 			layout.DetailHeight += layout.ChunkMapHeight

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -233,6 +233,7 @@ func (m RootModel) View() tea.View {
 	}
 
 	if m.state == BugReportTargetState {
+		w, h := GetDynamicModalDimensions(m.width, m.height, 40, 8, 64, 12)
 		modal := components.ConfirmationModal{
 			Title:       "Bug Report",
 			Message:     "What would you like to report?",
@@ -240,14 +241,15 @@ func (m RootModel) View() tea.View {
 			Keys:        m.keys.BugReport,
 			Help:        m.help,
 			BorderColor: colors.Cyan(),
-			Width:       64,
-			Height:      12,
+			Width:       w,
+			Height:      h,
 		}
 		box := modal.RenderWithBtopBox(renderBtopBox, PaneTitleStyle)
 		return m.wrapView(m.renderModalWithOverlay(box))
 	}
 
 	if m.state == BugReportSystemDetailsState {
+		w, h := GetDynamicModalDimensions(m.width, m.height, 40, 8, 66, 12)
 		modal := components.ConfirmationModal{
 			Title:            "Core Bug Report",
 			Message:          "Include system details in issue body?",
@@ -255,8 +257,8 @@ func (m RootModel) View() tea.View {
 			Keys:             m.keys.QuitConfirm,
 			Help:             m.help,
 			BorderColor:      colors.Cyan(),
-			Width:            66,
-			Height:           12,
+			Width:            w,
+			Height:           h,
 			ShowYesNoButtons: true,
 			YesNoFocused:     m.quitConfirmFocused,
 		}
@@ -265,6 +267,7 @@ func (m RootModel) View() tea.View {
 	}
 
 	if m.state == BugReportLogPathState {
+		w, h := GetDynamicModalDimensions(m.width, m.height, 40, 8, 72, 12)
 		modal := components.ConfirmationModal{
 			Title:            "Core Bug Report",
 			Message:          "Include latest debug log path in issue body?",
@@ -272,8 +275,8 @@ func (m RootModel) View() tea.View {
 			Keys:             m.keys.QuitConfirm,
 			Help:             m.help,
 			BorderColor:      colors.Cyan(),
-			Width:            72,
-			Height:           12,
+			Width:            w,
+			Height:           h,
 			ShowYesNoButtons: true,
 			YesNoFocused:     m.quitConfirmFocused,
 		}

--- a/internal/tui/view_category.go
+++ b/internal/tui/view_category.go
@@ -217,18 +217,18 @@ func (m RootModel) renderCategoryDetailView(cats []config.Category, cursor, inne
 	divider := dimStyle.Render(strings.Repeat("\u2500", innerWidth))
 
 	content := lipgloss.JoinVertical(lipgloss.Left,
-		labelStyle.Render("Name: ")+valueStyle.Width(innerWidth-6).MaxWidth(innerWidth-6).Render(utils.WrapText(cat.Name, innerWidth-6)),
+		labelStyle.Render("Name: ")+valueStyle.Width(innerWidth-6).MaxWidth(innerWidth-6).Render(utils.TruncateTwoLines(cat.Name, innerWidth-6)),
 		"",
 		labelStyle.Render("Description:"),
-		valueStyle.Width(innerWidth).MaxWidth(innerWidth).Render(utils.WrapText(cat.Description, innerWidth)),
+		valueStyle.Width(innerWidth).MaxWidth(innerWidth).Render(utils.TruncateTwoLines(cat.Description, innerWidth)),
 		"",
 		divider,
 		"",
 		labelStyle.Render("Pattern (Regex):"),
-		valueStyle.Width(innerWidth).MaxWidth(innerWidth).Render(utils.WrapText(cat.Pattern, innerWidth)),
+		valueStyle.Width(innerWidth).MaxWidth(innerWidth).Render(utils.TruncateTwoLines(cat.Pattern, innerWidth)),
 		"",
 		labelStyle.Render("Path:"),
-		valueStyle.Width(innerWidth).MaxWidth(innerWidth).Render(utils.WrapText(cat.Path, innerWidth)),
+		valueStyle.Width(innerWidth).MaxWidth(innerWidth).Render(utils.TruncateTwoLines(cat.Path, innerWidth)),
 	)
 
 	return formatSettingsBlock(content, innerWidth, rows)

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -332,13 +332,13 @@ func (m RootModel) renderSettingsDetailBlock(settingsMeta []config.SettingMeta, 
 
 	valueLabelStyle := lipgloss.NewStyle().Foreground(colors.Cyan()).Bold(true)
 	valueContentStyle := lipgloss.NewStyle().Foreground(colors.White())
-	
+
 	labelRendered := valueLabelStyle.Render(valueLabel)
 	availableValueWidth := innerWidth - lipgloss.Width(labelRendered)
 	if availableValueWidth < 5 {
 		availableValueWidth = 5
 	}
-	
+
 	valueDisplay := lipgloss.JoinHorizontal(lipgloss.Top,
 		labelRendered,
 		valueContentStyle.Render(utils.TruncateTwoLines(valueStr, availableValueWidth)),

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -268,7 +268,7 @@ func renderSettingsListViewport(settingsMeta []config.SettingMeta, selectedRow, 
 		}
 
 		// Truncate to avoid line wrapping which breaks parent height constraints
-		label = utils.Truncate(label, maxLabelLen)
+		label = utils.TruncateMiddle(label, maxLabelLen)
 
 		lines = append(lines, style.Width(innerWidth).MaxWidth(innerWidth).Render(prefix+label))
 	}
@@ -332,12 +332,22 @@ func (m RootModel) renderSettingsDetailBlock(settingsMeta []config.SettingMeta, 
 
 	valueLabelStyle := lipgloss.NewStyle().Foreground(colors.Cyan()).Bold(true)
 	valueContentStyle := lipgloss.NewStyle().Foreground(colors.White())
-	valueDisplay := valueLabelStyle.Render(valueLabel) + valueContentStyle.Render(valueStr)
+	
+	labelRendered := valueLabelStyle.Render(valueLabel)
+	availableValueWidth := innerWidth - lipgloss.Width(labelRendered)
+	if availableValueWidth < 5 {
+		availableValueWidth = 5
+	}
+	
+	valueDisplay := lipgloss.JoinHorizontal(lipgloss.Top,
+		labelRendered,
+		valueContentStyle.Render(utils.TruncateTwoLines(valueStr, availableValueWidth)),
+	)
 	valueDisplay = lipgloss.NewStyle().Width(innerWidth).MaxWidth(innerWidth).Render(valueDisplay)
 
 	divider := lipgloss.NewStyle().Foreground(colors.Gray()).Render(strings.Repeat("\u2500", innerWidth))
 
-	wrappedDesc := utils.WrapText(meta.Description, innerWidth)
+	wrappedDesc := utils.TruncateTwoLines(meta.Description, innerWidth)
 	descDisplay := lipgloss.NewStyle().
 		Foreground(colors.LightGray()).
 		Width(innerWidth).
@@ -822,7 +832,7 @@ func formatSettingValue(value interface{}, typ string, truncate bool) string {
 				return "(default)"
 			}
 			if truncate {
-				return utils.Truncate(s, 30)
+				return utils.TruncateMiddle(s, 30)
 			}
 			return s
 		}

--- a/internal/utils/text.go
+++ b/internal/utils/text.go
@@ -5,7 +5,6 @@ import (
 	"unicode"
 
 	"github.com/mattn/go-runewidth"
-	"charm.land/lipgloss/v2"
 )
 
 // WrapText wraps a string to a specified maximum width.
@@ -88,7 +87,7 @@ func truncateToWidth(s string, width int) string {
 		res.WriteRune(info.r)
 		currentW += info.w
 	}
-	
+
 	return res.String()
 }
 
@@ -150,7 +149,11 @@ func getAnsiState(infos []charInfo, endIdx int) string {
 }
 
 func stringWidth(s string) int {
-	return lipgloss.Width(s)
+	var width int
+	for _, info := range getCharInfos(s) {
+		width += info.w
+	}
+	return width
 }
 
 // Truncate truncates a string to a maximum visual width and adds an ellipsis if needed.
@@ -158,7 +161,7 @@ func Truncate(s string, limit int) string {
 	if limit <= 0 {
 		return ""
 	}
-	if runewidth.StringWidth(s) <= limit {
+	if stringWidth(s) <= limit {
 		return s
 	}
 	if limit <= 1 {
@@ -244,12 +247,17 @@ func TruncateTwoLines(s string, width int) string {
 	var lines []string
 	var currentLine strings.Builder
 	currentW := 0
-	
-	for _, info := range infos {
+
+	for i, info := range infos {
 		if info.w > 0 && currentW+info.w > width {
 			if len(lines) < 1 { // We only need 2 lines max
+				state := getAnsiState(infos, i)
+				if state != "" {
+					currentLine.WriteString("\x1b[0m")
+				}
 				lines = append(lines, currentLine.String())
 				currentLine.Reset()
+				currentLine.WriteString(state)
 				currentW = 0
 			} else {
 				// We already have one line and this would start a third line

--- a/internal/utils/text.go
+++ b/internal/utils/text.go
@@ -76,15 +76,19 @@ func truncateToWidth(s string, width int) string {
 	infos := getCharInfos(s)
 	var res strings.Builder
 	var currentW int
-	for _, info := range infos {
+	for i, info := range infos {
 		if info.w > 0 && currentW+info.w > width {
-			break
+			// Check if we need to add a reset
+			state := getAnsiState(infos, i)
+			if state != "" {
+				res.WriteString("\x1b[0m")
+			}
+			return res.String()
 		}
 		res.WriteRune(info.r)
 		currentW += info.w
 	}
 	
-	// Return the result as-is to allow ANSI states (colors) to bleed into the next line
 	return res.String()
 }
 
@@ -114,6 +118,35 @@ func getCharInfos(s string) []charInfo {
 		}
 	}
 	return infos
+}
+
+func getAnsiState(infos []charInfo, endIdx int) string {
+	var state strings.Builder
+	var currentAnsi strings.Builder
+	inAnsi := false
+	for i := 0; i < endIdx && i < len(infos); i++ {
+		r := infos[i].r
+		if r == '\x1b' {
+			inAnsi = true
+			currentAnsi.WriteRune(r)
+			continue
+		}
+		if inAnsi {
+			currentAnsi.WriteRune(r)
+			if r == 'm' {
+				inAnsi = false
+				seq := currentAnsi.String()
+				if seq == "\x1b[0m" || seq == "\x1b[m" {
+					state.Reset()
+				} else {
+					state.WriteString(seq)
+				}
+				currentAnsi.Reset()
+			}
+			continue
+		}
+	}
+	return state.String()
 }
 
 func stringWidth(s string) int {
@@ -156,12 +189,14 @@ func TruncateMiddle(s string, limit int) string {
 	infos := getCharInfos(s)
 	var left strings.Builder
 	currentW := 0
-	for _, info := range infos {
+	leftEndIdx := 0
+	for i, info := range infos {
 		if info.w > 0 && currentW+info.w > leftLimit {
 			break
 		}
 		left.WriteRune(info.r)
 		currentW += info.w
+		leftEndIdx = i + 1
 	}
 
 	var right strings.Builder
@@ -183,8 +218,12 @@ func TruncateMiddle(s string, limit int) string {
 	}
 
 	lStr := left.String()
-	if strings.Contains(lStr, "\x1b[") && !strings.HasSuffix(lStr, "\x1b[0m") {
-		lStr += "\x1b[0m"
+	state := getAnsiState(infos, leftEndIdx)
+	if state != "" {
+		if !strings.HasSuffix(lStr, "\x1b[0m") {
+			lStr += "\x1b[0m"
+		}
+		return lStr + "…" + state + right.String()
 	}
 
 	return lStr + "…" + right.String()

--- a/internal/utils/text.go
+++ b/internal/utils/text.go
@@ -5,6 +5,7 @@ import (
 	"unicode"
 
 	"github.com/mattn/go-runewidth"
+	"charm.land/lipgloss/v2"
 )
 
 // WrapText wraps a string to a specified maximum width.
@@ -70,18 +71,53 @@ func WrapText(text string, width int) string {
 }
 
 // truncateToWidth truncates a string to a visual width and returns the truncated string.
+// It is ANSI-aware and will include escape codes without counting them towards width.
 func truncateToWidth(s string, width int) string {
+	infos := getCharInfos(s)
 	var res strings.Builder
-	var w int
-	for _, r := range s {
-		rw := runewidth.RuneWidth(r)
-		if w+rw > width {
+	var currentW int
+	for _, info := range infos {
+		if info.w > 0 && currentW+info.w > width {
 			break
 		}
-		res.WriteRune(r)
-		w += rw
+		res.WriteRune(info.r)
+		currentW += info.w
 	}
+	
+	// Return the result as-is to allow ANSI states (colors) to bleed into the next line
 	return res.String()
+}
+
+type charInfo struct {
+	r rune
+	w int
+}
+
+func getCharInfos(s string) []charInfo {
+	var infos []charInfo
+	inAnsi := false
+	for _, r := range s {
+		if r == '\x1b' {
+			inAnsi = true
+		}
+
+		w := 0
+		if !inAnsi {
+			w = runewidth.RuneWidth(r)
+		}
+
+		infos = append(infos, charInfo{r, w})
+
+		// Simple SGR sequence end detection
+		if inAnsi && r == 'm' {
+			inAnsi = false
+		}
+	}
+	return infos
+}
+
+func stringWidth(s string) int {
+	return lipgloss.Width(s)
 }
 
 // Truncate truncates a string to a maximum visual width and adds an ellipsis if needed.
@@ -101,11 +137,13 @@ func Truncate(s string, limit int) string {
 }
 
 // TruncateMiddle truncates a string in the middle to a maximum visual width.
+// It is ANSI-aware.
 func TruncateMiddle(s string, limit int) string {
 	if limit <= 0 {
 		return ""
 	}
-	if runewidth.StringWidth(s) <= limit {
+	totalW := stringWidth(s)
+	if totalW <= limit {
 		return s
 	}
 	if limit < 3 {
@@ -115,22 +153,41 @@ func TruncateMiddle(s string, limit int) string {
 	leftLimit := (limit - 1) / 2
 	rightLimit := limit - 1 - leftLimit
 
-	left := truncateToWidth(s, leftLimit)
-
-	// For the right part, we need to find how many characters from the end fit in rightLimit
-	runes := []rune(s)
-	right := ""
-	rightWidth := 0
-	for i := len(runes) - 1; i >= 0; i-- {
-		rw := runewidth.RuneWidth(runes[i])
-		if rightWidth+rw > rightLimit {
+	infos := getCharInfos(s)
+	var left strings.Builder
+	currentW := 0
+	for _, info := range infos {
+		if info.w > 0 && currentW+info.w > leftLimit {
 			break
 		}
-		right = string(runes[i]) + right
-		rightWidth += rw
+		left.WriteRune(info.r)
+		currentW += info.w
 	}
 
-	return left + "…" + right
+	var right strings.Builder
+	currentW = 0
+	rightStartIdx := -1
+	for i := len(infos) - 1; i >= 0; i-- {
+		info := infos[i]
+		if info.w > 0 && currentW+info.w > rightLimit {
+			break
+		}
+		currentW += info.w
+		rightStartIdx = i
+	}
+
+	if rightStartIdx != -1 {
+		for i := rightStartIdx; i < len(infos); i++ {
+			right.WriteRune(infos[i].r)
+		}
+	}
+
+	lStr := left.String()
+	if strings.Contains(lStr, "\x1b[") && !strings.HasSuffix(lStr, "\x1b[0m") {
+		lStr += "\x1b[0m"
+	}
+
+	return lStr + "…" + right.String()
 }
 
 // TruncateTwoLines middle-truncates a string to fit in at most 2 lines of a given width.
@@ -143,16 +200,34 @@ func TruncateTwoLines(s string, width int) string {
 	// 1. Truncate in the middle if it exceeds 2 lines of visual width
 	truncated := TruncateMiddle(s, 2*width)
 
-	// 2. Wrap based on characters (visual width)
+	// 2. Wrap based on characters (visual width) by building lines rune by rune
+	infos := getCharInfos(truncated)
 	var lines []string
-	current := truncated
-	for i := 0; i < 2 && current != ""; i++ {
-		sub := truncateToWidth(current, width)
-		if sub == "" {
-			break
+	var currentLine strings.Builder
+	currentW := 0
+	
+	for _, info := range infos {
+		if info.w > 0 && currentW+info.w > width {
+			if len(lines) < 1 { // We only need 2 lines max
+				lines = append(lines, currentLine.String())
+				currentLine.Reset()
+				currentW = 0
+			} else {
+				// We already have one line and this would start a third line
+				// So we stop here.
+				currentLine.Reset()
+				currentW = -1 // Mark as finished
+				break
+			}
 		}
-		lines = append(lines, sub)
-		current = current[len(sub):]
+		if currentW != -1 {
+			currentLine.WriteRune(info.r)
+			currentW += info.w
+		}
+	}
+
+	if currentW != -1 && currentLine.Len() > 0 {
+		lines = append(lines, currentLine.String())
 	}
 
 	return strings.Join(lines, "\n")

--- a/internal/utils/text.go
+++ b/internal/utils/text.go
@@ -100,8 +100,8 @@ func Truncate(s string, limit int) string {
 	return sub + "…"
 }
 
-// truncateMiddle truncates a string in the middle to a maximum visual width.
-func truncateMiddle(s string, limit int) string {
+// TruncateMiddle truncates a string in the middle to a maximum visual width.
+func TruncateMiddle(s string, limit int) string {
 	if limit <= 0 {
 		return ""
 	}
@@ -131,4 +131,18 @@ func truncateMiddle(s string, limit int) string {
 	}
 
 	return left + "…" + right
+}
+
+// TruncateTwoLines middle-truncates a string to fit in at most 2 lines of a given width.
+func TruncateTwoLines(s string, width int) string {
+	if width <= 0 {
+		return s
+	}
+	truncated := TruncateMiddle(s, 2*width)
+	wrapped := WrapText(truncated, width)
+	lines := strings.Split(wrapped, "\n")
+	if len(lines) > 2 {
+		lines = lines[:2]
+	}
+	return strings.Join(lines, "\n")
 }

--- a/internal/utils/text.go
+++ b/internal/utils/text.go
@@ -247,7 +247,7 @@ func TruncateTwoLines(s string, width int) string {
 	var lines []string
 	var currentLine strings.Builder
 	currentW := 0
-
+	done := false
 	for i, info := range infos {
 		if info.w > 0 && currentW+info.w > width {
 			if len(lines) < 1 { // We only need 2 lines max
@@ -262,18 +262,15 @@ func TruncateTwoLines(s string, width int) string {
 			} else {
 				// We already have one line and this would start a third line
 				// So we stop here.
-				currentLine.Reset()
-				currentW = -1 // Mark as finished
+				done = true
 				break
 			}
 		}
-		if currentW != -1 {
-			currentLine.WriteRune(info.r)
-			currentW += info.w
-		}
+		currentLine.WriteRune(info.r)
+		currentW += info.w
 	}
 
-	if currentW != -1 && currentLine.Len() > 0 {
+	if !done && currentLine.Len() > 0 {
 		lines = append(lines, currentLine.String())
 	}
 

--- a/internal/utils/text.go
+++ b/internal/utils/text.go
@@ -134,15 +134,26 @@ func TruncateMiddle(s string, limit int) string {
 }
 
 // TruncateTwoLines middle-truncates a string to fit in at most 2 lines of a given width.
+// It uses character-based wrapping (ignoring word boundaries) to maximize space usage.
 func TruncateTwoLines(s string, width int) string {
 	if width <= 0 {
 		return s
 	}
+
+	// 1. Truncate in the middle if it exceeds 2 lines of visual width
 	truncated := TruncateMiddle(s, 2*width)
-	wrapped := WrapText(truncated, width)
-	lines := strings.Split(wrapped, "\n")
-	if len(lines) > 2 {
-		lines = lines[:2]
+
+	// 2. Wrap based on characters (visual width)
+	var lines []string
+	current := truncated
+	for i := 0; i < 2 && current != ""; i++ {
+		sub := truncateToWidth(current, width)
+		if sub == "" {
+			break
+		}
+		lines = append(lines, sub)
+		current = current[len(sub):]
 	}
+
 	return strings.Join(lines, "\n")
 }

--- a/internal/utils/text.go
+++ b/internal/utils/text.go
@@ -111,8 +111,7 @@ func getCharInfos(s string) []charInfo {
 
 		infos = append(infos, charInfo{r, w})
 
-		// Simple SGR sequence end detection
-		if inAnsi && r == 'm' {
+		if inAnsi && r != '\x1b' && r != '[' && r >= 0x40 && r <= 0x7E {
 			inAnsi = false
 		}
 	}
@@ -132,7 +131,7 @@ func getAnsiState(infos []charInfo, endIdx int) string {
 		}
 		if inAnsi {
 			currentAnsi.WriteRune(r)
-			if r == 'm' {
+			if r != '\x1b' && r != '[' && r >= 0x40 && r <= 0x7E {
 				inAnsi = false
 				seq := currentAnsi.String()
 				if seq == "\x1b[0m" || seq == "\x1b[m" {

--- a/internal/utils/text_test.go
+++ b/internal/utils/text_test.go
@@ -169,13 +169,27 @@ func TestAnsiAwareness(t *testing.T) {
 	red := "\x1b[31m"
 	reset := "\x1b[0m"
 	text := red + "hello" + reset // visual width 5
-	
+
 	t.Run("truncateToWidth", func(t *testing.T) {
 		assert.Equal(t, red+"hel"+reset, truncateToWidth(text, 3))
 	})
-	
+
 	t.Run("TruncateMiddle", func(t *testing.T) {
 		// limit 4: left 1, right 2
 		assert.Equal(t, red+"h"+reset+"…"+red+"lo"+reset, TruncateMiddle(text, 4))
+	})
+
+	t.Run("Truncate ANSI Guard", func(t *testing.T) {
+		// This should not be truncated because visual width is 5
+		assert.Equal(t, text, Truncate(text, 10))
+		// This should be truncated
+		assert.Equal(t, red+"hel"+reset+"…", Truncate(text, 4))
+	})
+
+	t.Run("TruncateTwoLines ANSI carry-over", func(t *testing.T) {
+		// width 3: first line "hel", second line should have "lo" with red color
+		// Expected: red+"hel"+reset + "\n" + red+"lo"+reset
+		expected := red + "hel" + reset + "\n" + red + "lo" + reset
+		assert.Equal(t, expected, TruncateTwoLines(text, 3))
 	})
 }

--- a/internal/utils/text_test.go
+++ b/internal/utils/text_test.go
@@ -146,3 +146,21 @@ func TestTruncateMiddleEdgeCases(t *testing.T) {
 		})
 	}
 }
+
+func TestTruncateTwoLines(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		width    int
+		expected string
+	}{
+		{"Single Line", "abc", 10, "abc"},
+		{"Exactly Two Lines", "abcdefghij", 5, "abcde\nfghij"},
+		{"With Spaces", "abc def", 4, "abc \ndef"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, TruncateTwoLines(tt.text, tt.width))
+		})
+	}
+}

--- a/internal/utils/text_test.go
+++ b/internal/utils/text_test.go
@@ -192,4 +192,12 @@ func TestAnsiAwareness(t *testing.T) {
 		expected := red + "hel" + reset + "\n" + red + "lo" + reset
 		assert.Equal(t, expected, TruncateTwoLines(text, 3))
 	})
+
+	t.Run("Non-SGR ANSI", func(t *testing.T) {
+		// \x1b[A is cursor up (width 0)
+		cursorUp := "\x1b[A"
+		text := "abc" + cursorUp + "def"
+		assert.Equal(t, 6, stringWidth(text))
+		assert.Equal(t, "abc"+cursorUp+"d"+"\x1b[0m"+"…", Truncate(text, 5))
+	})
 }

--- a/internal/utils/text_test.go
+++ b/internal/utils/text_test.go
@@ -164,3 +164,18 @@ func TestTruncateTwoLines(t *testing.T) {
 		})
 	}
 }
+
+func TestAnsiAwareness(t *testing.T) {
+	red := "\x1b[31m"
+	reset := "\x1b[0m"
+	text := red + "hello" + reset // visual width 5
+	
+	t.Run("truncateToWidth", func(t *testing.T) {
+		assert.Equal(t, red+"hel"+reset, truncateToWidth(text, 3))
+	})
+	
+	t.Run("TruncateMiddle", func(t *testing.T) {
+		// limit 4: left 1, right 2
+		assert.Equal(t, red+"h"+reset+"…"+red+"lo"+reset, TruncateMiddle(text, 4))
+	})
+}

--- a/internal/utils/text_test.go
+++ b/internal/utils/text_test.go
@@ -124,7 +124,7 @@ func TestTruncateMiddle(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, truncateMiddle(tt.text, tt.limit))
+			assert.Equal(t, tt.expected, TruncateMiddle(tt.text, tt.limit))
 		})
 	}
 }
@@ -142,7 +142,7 @@ func TestTruncateMiddleEdgeCases(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, truncateMiddle(tt.text, tt.limit))
+			assert.Equal(t, tt.expected, TruncateMiddle(tt.text, tt.limit))
 		})
 	}
 }


### PR DESCRIPTION
- **refactor: export TruncateMiddle and implement TruncateTwoLines for TUI layout consistency**
- **refactor: truncate detail text to two lines instead of wrapping in confirmation modal**
- **refactor: replace text wrapping with two-line truncation and improve string truncation logic across TUI views**
- **refactor: update TruncateTwoLines to use character-based wrapping and add unit tests**
- **chore: go mod tidy**
- **feat: make text truncation utilities ANSI-aware and add support for visual width calculations**
- **feat: implement dynamic modal sizing and improve TUI layout robustness by adding title truncation and overflow safety checksd**
- **refactor: transition chunk map visibility logic from hardcoded height thresholds to dynamic content measurement**

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes long URLs breaking the TUI and extension by introducing ANSI-aware two-line truncation (`TruncateTwoLines`, `TruncateMiddle` exported) across detail panes, modals, the download list, settings, and the category manager, replacing unbounded `WrapText` calls. It also adds dynamic chunk-map suppression, modal size clamping, and a comprehensive 698-line layout regression test suite covering all terminal sizes and modal states.

<h3>Confidence Score: 5/5</h3>

Safe to merge — only P2 findings, no runtime breakage identified.

All findings are P2 (the done=true dead-code path in TruncateTwoLines and the WrapText inconsistency on the ID field). Core truncation logic and ANSI handling are correct as verified by analysis and backed by a thorough regression suite.

internal/utils/text.go (latent done=true bug at line 272); internal/tui/view.go (ID field WrapText inconsistency at line 532)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/utils/text.go | Adds ANSI-aware truncation utilities (TruncateMiddle exported, TruncateTwoLines, getCharInfos, getAnsiState, stringWidth). Core logic is correct; one latent bug where done=true silently drops partially-built line-2 content. |
| internal/utils/text_test.go | Adds TestTruncateTwoLines (3 cases) and TestAnsiAwareness (4 sub-tests). ANSI assertions are correct for the new implementation. Missing edge-case coverage (width≤0, content>2*width) was flagged in a prior review. |
| internal/tui/view.go | Switches URL/File/Path detail fields to TruncateTwoLines; adds dynamic chunk-map suppression logic; applies GetDynamicModalDimensions to three bug-report modals. ID field inconsistently left using WrapText. |
| internal/tui/layout_regression_test.go | New regression suite (698 lines, 13 test groups) enforcing width/height invariants across all terminal sizes, modal states, and extreme edge cases. Comprehensive coverage of the core layout contract. |
| internal/tui/components/box.go | Adds title overflow guards (truncate left then right via MaxWidth, suppress both when width is too small) and clamps innerHeight to ≥0. Logic is sound and tested by the regression suite. |
| internal/tui/layout_helpers.go | Removes hardcoded height threshold for chunk-map visibility; decision deferred to View() via dynamic content measurement. Clean refactor with no correctness issues. |
| internal/tui/view_settings.go | Switches setting-value and description rendering to TruncateTwoLines, computes available value width dynamically, and changes label truncation to TruncateMiddle. No issues found. |
| internal/tui/view_category.go | Switches all four category-detail fields (Name, Description, Pattern, Path) from WrapText to TruncateTwoLines. Straightforward and consistent. |
| internal/tui/helpers.go | Log entries now truncated to two lines instead of fully wrapped; intentional trade-off confirmed by author reply in prior thread. |
| internal/tui/list.go | Prefix width now subtracted from available content width, title uses TruncateMiddle instead of Truncate. Fixes the root cause of URL overflow in the download list. |
| go.mod | Promotes go-runewidth and BurntSushi/toml from indirect to direct dependencies, matching their actual direct usage. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `internal/utils/text_test.go`, line 1313-1321 ([link](https://github.com/surgedm/surge/blob/8a9d139780a4038dc4c0d9749c59c2bb38543441/internal/utils/text_test.go#L1313-L1321)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **ANSI test assertions don't match implementation behavior**

   Both assertions in `TestAnsiAwareness` are incorrect and will fail.

   1. `truncateToWidth` explicitly does **not** append a reset (comment: "allow ANSI states (colors) to bleed into the next line"), so the actual output for `truncateToWidth(text, 3)` is `"\x1b[31mhel"`, not `"\x1b[31mhel\x1b[0m"`.

   2. `TruncateMiddle` builds the right portion from the *tail* of the original string. For `text = "\x1b[31mhello\x1b[0m"` with `limit=4`, the right portion is the last 2 visible chars: `"lo\x1b[0m"` — it does not re-apply the leading `\x1b[31m`. The actual result is `"\x1b[31mh\x1b[0m…lo\x1b[0m"`, not `"\x1b[31mh\x1b[0m…\x1b[31mlo\x1b[0m"`.

   These tests will fail CI.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/utils/text_test.go
   Line: 1313-1321

   Comment:
   **ANSI test assertions don't match implementation behavior**

   Both assertions in `TestAnsiAwareness` are incorrect and will fail.

   1. `truncateToWidth` explicitly does **not** append a reset (comment: "allow ANSI states (colors) to bleed into the next line"), so the actual output for `truncateToWidth(text, 3)` is `"\x1b[31mhel"`, not `"\x1b[31mhel\x1b[0m"`.

   2. `TruncateMiddle` builds the right portion from the *tail* of the original string. For `text = "\x1b[31mhello\x1b[0m"` with `limit=4`, the right portion is the last 2 visible chars: `"lo\x1b[0m"` — it does not re-apply the leading `\x1b[31m`. The actual result is `"\x1b[31mh\x1b[0m…lo\x1b[0m"`, not `"\x1b[31mh\x1b[0m…\x1b[31mlo\x1b[0m"`.

   These tests will fail CI.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `internal/utils/text_test.go`, line 1290-1305 ([link](https://github.com/surgedm/surge/blob/8a9d139780a4038dc4c0d9749c59c2bb38543441/internal/utils/text_test.go#L1290-L1305)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`TruncateTwoLines` tests missing key edge cases**

   The three cases cover a happy path and basic wrapping, but are missing:
   - `width <= 0` (function currently returns the unchanged string, which could pass a very long URL through)
   - A string whose total length exceeds `2*width` (verifying the `TruncateMiddle` truncation actually fires)
   - ANSI-containing input (the function calls `getCharInfos` internally)

   Per the team rule, edge cases and integration points should always be tested.

   **Rule Used:** What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: internal/utils/text_test.go
   Line: 1290-1305
   
   Comment:
   **`TruncateTwoLines` tests missing key edge cases**
   
   The three cases cover a happy path and basic wrapping, but are missing:
   - `width <= 0` (function currently returns the unchanged string, which could pass a very long URL through)
   - A string whose total length exceeds `2*width` (verifying the `TruncateMiddle` truncation actually fires)
   - ANSI-containing input (the function calls `getCharInfos` internally)
   
   Per the team rule, edge cases and integration points should always be tested.
   
   **Rule Used:** What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/utils/text.go
Line: 272-274

Comment:
**Second line content dropped when `done=true`**

When `done` is `true`, `currentLine` holds the valid, partially-built content of line 2 (everything that fit within `width` before the overflow was detected), but the `!done` guard prevents it from being appended to `lines`. In the current code this path is unreachable — `TruncateMiddle(s, 2*width)` guarantees the content never needs a third line — but if the invariant is ever broken (direct call with un-truncated input, or a future refactor), the second line is silently discarded. Appending unconditionally is safer:

```suggestion
	if currentLine.Len() > 0 {
		lines = append(lines, currentLine.String())
	}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/tui/view.go
Line: 532

Comment:
**`ID` field still uses `WrapText` while sibling fields use `TruncateTwoLines`**

`URL`, `File`, and `Path` were all switched to `TruncateTwoLines`, but `ID` (a UUID) still calls `WrapText`. UUIDs are 36 chars so this won't overflow in practice, but the inconsistency means a theoretical future change to the ID format (e.g. a long custom ID) would break layout while the others would not.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix: improve ANSI sequence parsing in te..."](https://github.com/surgedm/surge/commit/9a34dd459073259fa1474b94e249207dcad2afe2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29693473)</sub>

<!-- /greptile_comment -->