### PR TITLE
feat(tui): mark restart-required settings and add confirmation modal

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"runtime/debug"
 	"strings"
 	"sync"
@@ -564,9 +565,11 @@ func performRestart() error {
 		return fmt.Errorf("could not get executable path: %w", err)
 	}
 
-	// Use syscall.Exec to replace the current process with a fresh instance.
-	// This ensures settings requiring restart take effect immediately.
-	return syscall.Exec(executable, os.Args, os.Environ())
+	if runtime.GOOS == "windows" {
+		_ = ReleaseLock()
+	}
+
+	return utils.Run(executable, os.Args, os.Environ())
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -543,12 +543,30 @@ func startTUI(port int, exitWhenDone bool, noResume bool) error {
 	}()
 
 	// Run TUI
-	if _, err := p.Run(); err != nil {
+	finalModel, err := p.Run()
+	if err != nil {
 		_ = executeGlobalShutdown("tui: p.Run failed")
 		return fmt.Errorf("error running program: %w", err)
 	}
 	_ = executeGlobalShutdown("tui: program exited")
+
+	// Check if restart was requested (e.g. from settings changed)
+	if m, ok := finalModel.(tui.RootModel); ok && m.RestartRequested {
+		return performRestart()
+	}
+
 	return nil
+}
+
+func performRestart() error {
+	executable, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("could not get executable path: %w", err)
+	}
+
+	// Use syscall.Exec to replace the current process with a fresh instance.
+	// This ensures settings requiring restart take effect immediately.
+	return syscall.Exec(executable, os.Args, os.Environ())
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -24,14 +24,14 @@ type GeneralSettings struct {
 	DefaultDownloadDir           string `json:"default_download_dir" ui_label:"Default Download Dir" ui_desc:"Default directory for new downloads. Leave empty to use current directory."`
 	WarnOnDuplicate              bool   `json:"warn_on_duplicate" ui_label:"Warn on Duplicate" ui_desc:"Show warning when adding a download that already exists."`
 	DownloadCompleteNotification bool   `json:"download_complete_notification" ui_label:"Download Complete Notification" ui_desc:"Show system notification when a download finishes."`
-	AllowRemoteOpenActions       bool   `json:"allow_remote_open_actions" ui_label:"Allow Remote Open Actions" ui_desc:"Allow /open-file and /open-folder API calls from non-loopback clients. Disabled by default for security."`
-	AutoResume                   bool   `json:"auto_resume" ui_label:"Auto Resume" ui_desc:"Automatically resume paused downloads on startup."`
-	SkipUpdateCheck              bool   `json:"skip_update_check" ui_label:"Skip Update Check" ui_desc:"Disable automatic check for new versions on startup."`
+	AllowRemoteOpenActions       bool   `json:"allow_remote_open_actions" ui_label:"Allow Remote Open Actions" ui_desc:"Allow /open-file and /open-folder API calls from non-loopback clients. Disabled by default for security." ui_restart:"true"`
+	AutoResume                   bool   `json:"auto_resume" ui_label:"Auto Resume" ui_desc:"Automatically resume paused downloads on startup." ui_restart:"true"`
+	SkipUpdateCheck              bool   `json:"skip_update_check" ui_label:"Skip Update Check" ui_desc:"Disable automatic check for new versions on startup." ui_restart:"true"`
 
-	ClipboardMonitor  bool   `json:"clipboard_monitor" ui_label:"Clipboard Monitor" ui_desc:"Watch clipboard for URLs and prompt to download them."`
+	ClipboardMonitor  bool   `json:"clipboard_monitor" ui_label:"Clipboard Monitor" ui_desc:"Watch clipboard for URLs and prompt to download them." ui_restart:"true"`
 	Theme             int    `json:"theme" ui_label:"App Theme" ui_desc:"UI Theme (System, Light, Dark)."`
 	ThemePath         string `json:"theme_path" ui_label:"Theme File" ui_desc:"Path to a custom .toml color scheme."`
-	LogRetentionCount int    `json:"log_retention_count" ui_label:"Log Retention Count" ui_desc:"Number of recent log files to keep."`
+	LogRetentionCount int    `json:"log_retention_count" ui_label:"Log Retention Count" ui_desc:"Number of recent log files to keep." ui_restart:"true"`
 	LiveSpeedGraph    bool   `json:"live_speed_graph" ui_label:"Live Speed Graph" ui_desc:"Use live speed for graph instead of EMA smoothed speed."`
 }
 
@@ -59,8 +59,8 @@ type ExtensionSettings struct {
 // NetworkSettings contains network connection parameters.
 type NetworkSettings struct {
 	MaxConnectionsPerHost  int    `json:"max_connections_per_host" ui_label:"Max Connections/Host" ui_desc:"Maximum concurrent connections per host (1-64)."`
-	MaxConcurrentDownloads int    `json:"max_concurrent_downloads" ui_label:"Max Concurrent Downloads" ui_desc:"Maximum number of downloads running at once (1-10). Requires restart."`
-	MaxConcurrentProbes    int    `json:"max_concurrent_probes" ui_label:"Max Concurrent Probes" ui_desc:"Maximum number of simultaneous server probes when adding many downloads at once (1-10)."`
+	MaxConcurrentDownloads int    `json:"max_concurrent_downloads" ui_label:"Max Concurrent Downloads" ui_desc:"Maximum number of downloads running at once (1-10)." ui_restart:"true"`
+	MaxConcurrentProbes    int    `json:"max_concurrent_probes" ui_label:"Max Concurrent Probes" ui_desc:"Maximum number of simultaneous server probes when adding many downloads at once (1-10)." ui_restart:"true"`
 	UserAgent              string `json:"user_agent" ui_label:"User Agent" ui_desc:"Custom User-Agent string for HTTP requests. Leave empty for default."`
 	ProxyURL               string `json:"proxy_url" ui_label:"Proxy URL" ui_desc:"HTTP/HTTPS proxy URL (e.g. http://127.0.0.1:1700). Leave empty to use system default."`
 	CustomDNS              string `json:"custom_dns" ui_label:"Custom DNS Server" ui_desc:"Set custom DNS (e.g., 1.1.1.1:53, 94.140.14.14:53). Leave empty for system."`
@@ -81,10 +81,11 @@ type PerformanceSettings struct {
 
 // SettingMeta provides metadata for a single setting (for UI rendering).
 type SettingMeta struct {
-	Key         string // JSON key name
-	Label       string // Human-readable label
-	Description string // Help text displayed in right pane
-	Type        string // "string", "int", "int64", "bool", "duration", "float64", "auth_token", "link"
+	Key             string // JSON key name
+	Label           string // Human-readable label
+	Description     string // Help text displayed in right pane
+	Type            string // "string", "int", "int64", "bool", "duration", "float64", "auth_token", "link"
+	RequiresRestart bool   // Whether changing this setting requires an application restart
 }
 
 // GetSettingsMetadata returns metadata for all settings organized by category.
@@ -141,10 +142,11 @@ func GetSettingsMetadata() map[string][]SettingMeta {
 				}
 
 				catMetas = append(catMetas, SettingMeta{
-					Key:         key,
-					Label:       label,
-					Description: desc,
-					Type:        typStr,
+					Key:             key,
+					Label:           label,
+					Description:     desc,
+					Type:            typStr,
+					RequiresRestart: settingField.Tag.Get("ui_restart") == "true",
 				})
 			}
 		}

--- a/internal/tui/helpers.go
+++ b/internal/tui/helpers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"time"
 
@@ -178,4 +179,45 @@ func renderEmptyMessage(width, height int, message string) string {
 	}
 	return lipgloss.Place(width, height, lipgloss.Center, lipgloss.Center,
 		EmptyMessageStyle.Render(message))
+}
+
+func (m *RootModel) snapshotSettings() {
+	if m.Settings == nil {
+		return
+	}
+	// Shallow copy settings to compare restart-required fields later.
+	// Since Settings is a pointer, we clone the underlying struct.
+	baseline := *m.Settings
+	m.SettingsBaseline = &baseline
+}
+
+func (m *RootModel) checkRestartRequirement() bool {
+	if m.Settings == nil || m.SettingsBaseline == nil {
+		return false
+	}
+
+	val1 := reflect.ValueOf(m.Settings).Elem()
+	val2 := reflect.ValueOf(m.SettingsBaseline).Elem()
+	typ := val1.Type()
+
+	for i := 0; i < typ.NumField(); i++ {
+		catField1 := val1.Field(i)
+		catField2 := val2.Field(i)
+		if catField1.Kind() != reflect.Struct {
+			continue
+		}
+
+		catTyp := catField1.Type()
+		for j := 0; j < catTyp.NumField(); j++ {
+			field := catTyp.Field(j)
+			if field.Tag.Get("ui_restart") == "true" {
+				f1 := catField1.Field(j)
+				f2 := catField2.Field(j)
+				if !reflect.DeepEqual(f1.Interface(), f2.Interface()) {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -51,10 +51,11 @@ const (
 	URLUpdateState                             // URLUpdateState is 12
 	CategoryManagerState                       // CategoryManagerState is 13
 	QuitConfirmState                           // QuitConfirmState is 14
-	HelpModalState                             // HelpModalState is 15
-	BugReportTargetState                       // BugReportTargetState is 16
-	BugReportSystemDetailsState                // BugReportSystemDetailsState is 17
-	BugReportLogPathState                      // BugReportLogPathState is 18
+	RestartConfirmState                        // RestartConfirmState is 15
+	HelpModalState                             // HelpModalState is 16
+	BugReportTargetState                       // BugReportTargetState is 17
+	BugReportSystemDetailsState                // BugReportSystemDetailsState is 18
+	BugReportLogPathState                      // BugReportLogPathState is 19
 )
 
 type FilePickerOrigin int
@@ -148,6 +149,7 @@ type RootModel struct {
 
 	// Settings
 	Settings             *config.Settings // Application settings
+	SettingsBaseline     *config.Settings // Snapshot of settings when entering the settings view
 	SettingsActiveTab    int              // Active category tab (0-3)
 	SettingsSelectedRow  int              // Selected setting within current tab
 	SettingsIsEditing    bool             // Whether currently editing a value
@@ -203,7 +205,8 @@ type RootModel struct {
 
 	enqueueCtx    context.Context
 	cancelEnqueue context.CancelFunc
-	shuttingDown  bool
+	shuttingDown     bool
+	RestartRequested bool // [NEW] Flag to signal process re-exec after TUI shutdown
 
 	spinner spinner.Model
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -203,8 +203,8 @@ type RootModel struct {
 
 	logoCache string // Cached logo with gradient applied
 
-	enqueueCtx    context.Context
-	cancelEnqueue context.CancelFunc
+	enqueueCtx       context.Context
+	cancelEnqueue    context.CancelFunc
 	shuttingDown     bool
 	RestartRequested bool // [NEW] Flag to signal process re-exec after TUI shutdown
 

--- a/internal/tui/settings_restart_test.go
+++ b/internal/tui/settings_restart_test.go
@@ -1,0 +1,94 @@
+package tui
+
+import (
+	"testing"
+
+	"charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
+	"github.com/SurgeDM/Surge/internal/config"
+)
+
+func TestRestartRequirementDetection(t *testing.T) {
+	m := RootModel{
+		Settings: config.DefaultSettings(),
+	}
+
+	// 1. Initial state: baseline is nil
+	if m.SettingsBaseline != nil {
+		t.Fatal("SettingsBaseline should be nil initially")
+	}
+
+	// 2. Snapshot
+	m.snapshotSettings()
+	if m.SettingsBaseline == nil {
+		t.Fatal("SettingsBaseline should be set after snapshot")
+	}
+
+	// 3. No changes
+	if m.checkRestartRequirement() {
+		t.Error("checkRestartRequirement() should be false when no changes")
+	}
+
+	// 4. Change non-restart setting (e.g. Theme)
+	originalTheme := m.Settings.General.Theme
+	m.Settings.General.Theme = (originalTheme + 1) % 3
+	if m.checkRestartRequirement() {
+		t.Error("checkRestartRequirement() should be false when only non-restart settings changed")
+	}
+
+	// 5. Change restart-required setting (e.g. MaxConcurrentDownloads)
+	m.Settings.Network.MaxConcurrentDownloads += 1
+	if !m.checkRestartRequirement() {
+		t.Error("checkRestartRequirement() should be true when restart-required setting changed")
+	}
+
+	// 6. Reverting should make it false again
+	m.Settings.Network.MaxConcurrentDownloads -= 1
+	if m.checkRestartRequirement() {
+		t.Error("checkRestartRequirement() should be false when settings are reverted to baseline")
+	}
+}
+
+func TestDefensiveSnapshotting(t *testing.T) {
+	m := RootModel{
+		Settings: config.DefaultSettings(),
+		state:    SettingsState,
+	}
+	m.keys = Keys
+
+	// 1. baseline is missing
+	if m.SettingsBaseline != nil {
+		t.Fatal("SettingsBaseline should be nil for this test")
+	}
+
+	// 2. Call updateSettings with a no-op key
+	msg := tea.KeyPressMsg{Text: "j"}
+	newModel, _ := m.updateSettings(msg)
+	res := newModel.(RootModel)
+
+	if res.SettingsBaseline == nil {
+		t.Error("updateSettings should have defensively called snapshotSettings")
+	}
+}
+
+func TestBaselineCleanup(t *testing.T) {
+	m := RootModel{
+		Settings:         config.DefaultSettings(),
+		SettingsBaseline: config.DefaultSettings(),
+		state:            SettingsState,
+	}
+	m.keys = Keys
+
+	// 1. Exit settings using the 'Close' key (e.g. 'esc')
+	msg := tea.KeyPressMsg{Code: tea.KeyEscape}
+	if !key.Matches(msg, m.keys.Settings.Close) {
+		t.Fatal("Key 'esc' should match Settings.Close")
+	}
+
+	newModel, _ := m.updateSettings(msg)
+	res := newModel.(RootModel)
+
+	if res.SettingsBaseline != nil {
+		t.Error("SettingsBaseline should be cleared when exiting settings to DashboardState")
+	}
+}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -208,6 +208,9 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case QuitConfirmState:
 			return m.updateQuitConfirm(msg)
 
+		case RestartConfirmState:
+			return m.updateRestartConfirm(msg)
+
 		case BatchConfirmState:
 			return m.updateBatchConfirm(msg)
 

--- a/internal/tui/update_dashboard.go
+++ b/internal/tui/update_dashboard.go
@@ -217,6 +217,7 @@ func (m RootModel) updateDashboard(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 
 	if key.Matches(msg, m.keys.Dashboard.Settings) {
+		m.snapshotSettings()
 		m.state = SettingsState
 		m.SettingsActiveTab = 0
 		m.SettingsSelectedRow = 0

--- a/internal/tui/update_modals.go
+++ b/internal/tui/update_modals.go
@@ -326,3 +326,34 @@ func (m RootModel) resetBugReportFlow() RootModel {
 	m.state = DashboardState
 	return m
 }
+
+func (m RootModel) updateRestartConfirm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	confirmRestart := func() (tea.Model, tea.Cmd) {
+		if m.cancelEnqueue != nil {
+			m.cancelEnqueue()
+		}
+		m.shuttingDown = true
+		m.RestartRequested = true
+		return m, shutdownCmd(m.Service)
+	}
+	cancelRestart := func() (tea.Model, tea.Cmd) {
+		m.state = DashboardState
+		m.quitConfirmFocused = 0
+		m.SettingsBaseline = nil
+		return m, nil
+	}
+
+	m, decision, handled := m.handleYesNoSelection(msg)
+	if !handled {
+		return m, nil
+	}
+
+	switch decision {
+	case yesNoYes:
+		return confirmRestart()
+	case yesNoNo, yesNoCancel:
+		return cancelRestart()
+	}
+
+	return m, nil
+}

--- a/internal/tui/update_settings.go
+++ b/internal/tui/update_settings.go
@@ -15,6 +15,9 @@ import (
 type extensionTokenFlashFadeMsg struct{}
 
 func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	if m.SettingsBaseline == nil {
+		m.snapshotSettings()
+	}
 	m.normalizeSettingsSelection()
 
 	categories := config.CategoryOrder()
@@ -48,9 +51,16 @@ func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 	// Not editing - handle navigation
 	if key.Matches(msg, m.keys.Settings.Close) {
+		requiresRestart := m.checkRestartRequirement()
 		// Save settings and exit
 		_ = m.persistSettings()
+		if requiresRestart {
+			m.state = RestartConfirmState
+			m.quitConfirmFocused = 0
+			return m, nil
+		}
 		m.state = DashboardState
+		m.SettingsBaseline = nil
 		return m, nil
 	}
 	tabBindings := []key.Binding{

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -288,6 +288,10 @@ func (m RootModel) View() tea.View {
 		return m.wrapView(m.renderModalWithOverlay(m.viewQuitConfirm()))
 	}
 
+	if m.state == RestartConfirmState {
+		return m.wrapView(m.renderModalWithOverlay(m.viewRestartConfirm()))
+	}
+
 	if m.state == UpdateAvailableState && m.UpdateInfo != nil {
 		modal := components.ConfirmationModal{
 			Title:       "\u2b06 Update Available",
@@ -845,6 +849,78 @@ func (m RootModel) viewQuitConfirm() string {
 
 	content := lipgloss.JoinVertical(lipgloss.Left, lines...)
 	return renderBtopBox(PaneTitleStyle.Render(" Quit Surge "), "", content, w, h, colors.Pink())
+}
+
+func (m RootModel) viewRestartConfirm() string {
+	w, h := GetDynamicModalDimensions(m.width, m.height, 40, 8, 60, 10)
+	innerWidth := w - (components.BorderFrameWidth * 2)
+
+	messageStyle := lipgloss.NewStyle().
+		Foreground(colors.White()).
+		Width(innerWidth).
+		Align(lipgloss.Center)
+
+	detailStyle := lipgloss.NewStyle().
+		Foreground(colors.Orange()).
+		Bold(true).
+		Width(innerWidth).
+		Align(lipgloss.Center)
+
+	pad := "   "
+
+	activeFirst := lipgloss.NewStyle().Foreground(colors.White()).Background(colors.Orange()).Bold(true).Underline(true)
+	activeRest := lipgloss.NewStyle().Foreground(colors.White()).Background(colors.Orange()).Bold(true)
+	activePad := lipgloss.NewStyle().Background(colors.Orange())
+
+	inactiveFirst := lipgloss.NewStyle().Foreground(colors.LightGray()).Background(lipgloss.Color("236")).Underline(true)
+	inactiveRest := lipgloss.NewStyle().Foreground(colors.LightGray()).Background(lipgloss.Color("236"))
+	inactivePad := lipgloss.NewStyle().Background(lipgloss.Color("236"))
+
+	renderBtn := func(padStyle, firstStyle, restStyle lipgloss.Style, first, rest string) string {
+		return padStyle.Render(pad) + firstStyle.Render(first) + restStyle.Render(rest) + padStyle.Render(pad)
+	}
+
+	yesFirst, yesRest, yesPad := activeFirst, activeRest, activePad
+	noFirst, noRest, noPad := inactiveFirst, inactiveRest, inactivePad
+	if m.quitConfirmFocused == 1 {
+		yesFirst, yesRest, yesPad = inactiveFirst, inactiveRest, inactivePad
+		noFirst, noRest, noPad = activeFirst, activeRest, activePad
+	}
+
+	yesBtn := renderBtn(yesPad, yesFirst, yesRest, "Y", "es")
+	noBtn := renderBtn(noPad, noFirst, noRest, "N", "o")
+
+	buttons := lipgloss.JoinHorizontal(lipgloss.Center, yesBtn, "     ", noBtn)
+	centeredButtons := lipgloss.NewStyle().Width(innerWidth).Align(lipgloss.Center).Render(buttons)
+
+	helpStyle := lipgloss.NewStyle().Foreground(colors.Gray()).Width(innerWidth).Align(lipgloss.Center)
+	helpText := helpStyle.Render(m.help.View(m.keys.QuitConfirm))
+
+	var lines []string
+	lines = append(lines, messageStyle.Render("Settings saved!"))
+	lines = append(lines, detailStyle.Render("Restart now to take effect?"))
+	lines = append(lines, "")
+	lines = append(lines, "")
+	lines = append(lines, centeredButtons)
+
+	innerHeight := h - components.BorderFrameHeight
+	contentHeight := lipgloss.Height(lipgloss.JoinVertical(lipgloss.Left, lines...))
+	helpHeight := lipgloss.Height(helpText)
+	spacing := innerHeight - contentHeight - helpHeight
+	if spacing < 0 {
+		spacing = 0
+	}
+	for i := 0; i < spacing; i++ {
+		lines = append(lines, "")
+	}
+	if len(lines) > 0 && spacing > 0 {
+		lines[len(lines)-1] = helpText
+	} else {
+		lines = append(lines, helpText)
+	}
+
+	content := lipgloss.JoinVertical(lipgloss.Left, lines...)
+	return renderBtopBox(PaneTitleStyle.Render(" Restart Required "), "", content, w, h, colors.Orange())
 }
 
 // renderBtopBox creates a btop-style box with title embedded in the top border

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -347,7 +347,16 @@ func (m RootModel) renderSettingsDetailBlock(settingsMeta []config.SettingMeta, 
 
 	divider := lipgloss.NewStyle().Foreground(colors.Gray()).Render(strings.Repeat("\u2500", innerWidth))
 
-	wrappedDesc := utils.TruncateTwoLines(meta.Description, innerWidth)
+	desc := meta.Description
+	if meta.RequiresRestart {
+		restartNotice := lipgloss.NewStyle().
+			Foreground(colors.Orange()).
+			Bold(true).
+			Render("(*) Requires Restart")
+		desc = restartNotice + "\n" + desc
+	}
+
+	wrappedDesc := utils.WrapText(desc, innerWidth)
 	descDisplay := lipgloss.NewStyle().
 		Foreground(colors.LightGray()).
 		Width(innerWidth).

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -352,7 +352,7 @@ func (m RootModel) renderSettingsDetailBlock(settingsMeta []config.SettingMeta, 
 		restartNotice := lipgloss.NewStyle().
 			Foreground(colors.Orange()).
 			Bold(true).
-			Render("(*) Requires Restart")
+			Render("\u21ba Requires Restart")
 		desc = restartNotice + "\n" + desc
 	}
 

--- a/internal/utils/open.go
+++ b/internal/utils/open.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 )
 
+// OpenFile opens a file in the system's default file explorer or editor.
 func OpenFile(path string) error {
 	if path == "" {
 		return fmt.Errorf("path is empty")
@@ -26,6 +27,7 @@ func OpenFile(path string) error {
 	return openWithSystem(path)
 }
 
+// OpenContainingFolder opens the containing folder of a file in the system's default file explorer.
 func OpenContainingFolder(path string) error {
 	if path == "" {
 		return fmt.Errorf("path is empty")
@@ -51,6 +53,7 @@ func OpenContainingFolder(path string) error {
 	return openWithSystem(targetPath)
 }
 
+// openWithSystem opens a path using the system's default command.
 func openWithSystem(path string) error {
 	cmd := buildOpenCommand(path)
 	err := cmd.Start()
@@ -62,6 +65,7 @@ func openWithSystem(path string) error {
 	return err
 }
 
+// buildOpenCommand builds the system-specific command for opening a path.
 func buildOpenCommand(path string) *exec.Cmd {
 	switch runtime.GOOS {
 	case "darwin":
@@ -79,4 +83,11 @@ func OpenBrowser(url string) error {
 		return fmt.Errorf("url is empty")
 	}
 	return openWithSystem(url)
+}
+
+// Run executes an executable with the given arguments and environment.
+// On Unix-like systems, it replaces the current process using syscall.Exec.
+// On Windows, it starts a new process and exits the current one.
+func Run(executable string, args []string, env []string) error {
+	return run(executable, args, env)
 }

--- a/internal/utils/run_unix.go
+++ b/internal/utils/run_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package utils
+
+import "syscall"
+
+func run(executable string, args []string, env []string) error {
+	return syscall.Exec(executable, args, env)
+}

--- a/internal/utils/run_windows.go
+++ b/internal/utils/run_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package utils
+
+import (
+	"os"
+	"os/exec"
+)
+
+func run(executable string, args []string, env []string) error {
+	cmd := exec.Command(executable, args[1:]...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	cmd.Env = env
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	// Do NOT call os.Exit(0).
+	// The Go runtime will call os.Exit(0) automatically when the main
+	// goroutine exits.
+	// Calling it here would terminate the parent process (Explorer) prematurely.
+	return nil
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds UI markers for restart-required settings and a confirmation modal that gates a clean process re-exec behind an explicit user choice. The cross-platform restart implementation is solid — `syscall.Exec` on Unix and a detached child-plus-natural-exit on Windows, with the lock explicitly released before spawning — and the reflection-based change detection against a snapshotted baseline is a clean approach. Remaining findings are all P2.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all remaining findings are style/comment P2s with no impact on runtime correctness

No P0 or P1 issues found. The cross-platform restart logic is correct, the ANSI-in-WrapText and other substantive issues were addressed in previous review rounds, and the new test coverage is adequate for the happy path.

internal/utils/run_windows.go (misleading comment), internal/utils/open.go (trivial docstrings)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cmd/root.go | Wires restart signal from TUI model into performRestart(); uses build-constrained utils.Run cleanly |
| internal/utils/run_windows.go | New Windows restart implementation; spawns child and returns nil — correct, but contains a misleading comment about os.Exit and parent processes |
| internal/utils/run_unix.go | New Unix restart via syscall.Exec; straightforward and correct |
| internal/utils/open.go | Adds Run() dispatcher and trivial 'what' docstrings that restate function names |
| internal/config/settings.go | Adds ui_restart struct tag and RequiresRestart field to SettingMeta; reflection-based metadata population looks correct |
| internal/tui/helpers.go | snapshotSettings/checkRestartRequirement use pointer receivers correctly; reflection traversal of ui_restart tags is sound |
| internal/tui/model.go | Adds RestartConfirmState, SettingsBaseline, and RestartRequested; iota comments are now correct; RestartRequested carries a stale [NEW] annotation |
| internal/tui/update_modals.go | updateRestartConfirm correctly sets RestartRequested=true before calling shutdownCmd; cancelRestart clears SettingsBaseline |
| internal/tui/update_settings.go | Adds defensive snapshot on entry and restart-check on close; settings persist before confirmation modal which is intentional |
| internal/tui/view.go | viewRestartConfirm renders the confirmation modal; reuses quitConfirmFocused for button state |
| internal/tui/view_settings.go | Prepends ANSI-styled restartNotice to plain desc before WrapText — known ANSI-width corruption issue for narrow panes (flagged previously) |
| internal/tui/settings_restart_test.go | Tests cover snapshot, detection, revert, defensive snapshot, and baseline cleanup; happy paths only |
| internal/tui/update_dashboard.go | Adds snapshotSettings() call when entering settings from dashboard; straightforward |
| internal/tui/update.go | Routes RestartConfirmState to updateRestartConfirm; no issues |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/utils/run_windows.go
Line: 19-22

Comment:
**Misleading comment about `os.Exit` and the parent process**

`os.Exit(0)` terminates the *current* process, not the parent. The real reason to avoid calling it here is that it would bypass any deferred functions registered in `cmd/root.go` or the Cobra command chain. The current behavior (returning `nil` and letting `main()` exit naturally) is correct, but the comment misdirects anyone who reads it later.

```suggestion
	// Do NOT call os.Exit(0) here.
	// Returning nil lets the normal Cobra/main() teardown path run,
	// executing any deferred cleanup before the process exits.
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/utils/open.go
Line: 9

Comment:
**"What" docstrings that restate function names**

The newly added comments for `OpenFile`, `OpenContainingFolder`, `openWithSystem`, and `buildOpenCommand` each restate exactly what the function name already conveys. Per the project's comment style, comments should explain *why* code exists rather than repeat the name in prose form. For public functions that truly need a doc comment, a single sentence describing a non-obvious constraint (e.g. why it uses `Start` instead of `Run`) is more valuable than a paraphrase of the signature.

This pattern appears on lines 9, 27, 53, and 65.

**Rule Used:** What: Comments must explain *why* code exists, not... ([source](https://app.greptile.com/review/custom-context?memory=4e45ef13-32c2-4753-8060-a44ef767144d))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/tui/model.go
Line: 206

Comment:
**Stale `[NEW]` annotation**

The `[NEW]` marker will be meaningless the moment this PR is merged, and adds noise without explaining *why* the field exists or its invariants (e.g. "set only inside the TUI shutdown path, read by `cmd/root.go` to trigger `performRestart`").

```suggestion
	RestartRequested bool // Set by updateRestartConfirm; signals cmd/root.go to exec a fresh process after TUI shutdown
```

**Rule Used:** What: Comments must explain *why* code exists, not... ([source](https://app.greptile.com/review/custom-context?memory=4e45ef13-32c2-4753-8060-a44ef767144d))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (5): Last reviewed commit: ["feat: implement platform-specific proces..."](https://github.com/surgedm/surge/commit/036775c25b25c4564d0b1f8c1c18af16a44c8253) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29749041)</sub>

**Context used:**

- Rule used - What: Comments must explain *why* code exists, not... ([source](https://app.greptile.com/review/custom-context?memory=4e45ef13-32c2-4753-8060-a44ef767144d))

<!-- /greptile_comment -->