### PR TITLE
fix delete failed

### DIFF
--- a/internal/core/local_service.go
+++ b/internal/core/local_service.go
@@ -467,7 +467,7 @@ func (s *LocalDownloadService) AddWithID(url string, path string, filename strin
 
 func (s *LocalDownloadService) add(url string, path string, filename string, mirrors []string, headers map[string]string, requestedID string, isExplicitCategory bool, totalSize int64, supportsRange bool) (string, error) {
 	if s.Pool == nil {
-		return "", fmt.Errorf("worker pool not initialized")
+		return "", types.ErrPoolNotInit
 	}
 
 	s.settingsMu.RLock()
@@ -489,12 +489,12 @@ func (s *LocalDownloadService) add(url string, path string, filename string, mir
 		id = uuid.New().String()
 	}
 	if st := s.Pool.GetStatus(id); st != nil {
-		return "", fmt.Errorf("download id already exists")
+		return "", types.ErrIDExists
 	}
 	if entry, err := state.GetDownload(id); err != nil {
 		return "", fmt.Errorf("failed to query download state: %w", err)
 	} else if entry != nil {
-		return "", fmt.Errorf("download id already exists")
+		return "", types.ErrIDExists
 	}
 
 	state := types.NewProgressState(id, 0)
@@ -561,7 +561,7 @@ func (s *LocalDownloadService) UpdateURL(id string, newURL string) error {
 	}
 	// Fallback: update pool in-memory only (no DB persistence)
 	if s.Pool == nil {
-		return fmt.Errorf("worker pool not initialized")
+		return types.ErrPoolNotInit
 	}
 	return s.Pool.UpdateURL(id, newURL)
 }
@@ -573,7 +573,7 @@ func (s *LocalDownloadService) Delete(id string) error {
 	}
 	// Fallback when lifecycle hooks not wired (e.g. tests)
 	if s.Pool == nil {
-		return fmt.Errorf("worker pool not initialized")
+		return types.ErrPoolNotInit
 	}
 	s.Pool.Cancel(id)
 	if entry, err := state.GetDownload(id); err == nil && entry != nil {
@@ -628,7 +628,7 @@ func (s *LocalDownloadService) GetStatus(id string) (*types.DownloadStatus, erro
 		return &status, nil
 	}
 
-	return nil, fmt.Errorf("download not found")
+	return nil, types.ErrNotFound
 }
 
 // History returns completed downloads

--- a/internal/download/pool.go
+++ b/internal/download/pool.go
@@ -2,7 +2,6 @@ package download
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
 	"sync"
 	"sync/atomic"
@@ -308,14 +307,14 @@ func (p *WorkerPool) UpdateURL(downloadID string, newURL string) error {
 
 	if qExists {
 		p.mu.Unlock()
-		return fmt.Errorf("cannot update URL for a queued download, please cancel or wait for it to start")
+		return types.ErrQueuedUpdate
 	}
 
 	if exists && ad != nil {
 		if ad.config.State != nil && !ad.config.State.IsPaused() {
 			if ad.running.Load() {
 				p.mu.Unlock()
-				return fmt.Errorf("download is currently active, please pause it before updating the URL")
+				return types.ErrActiveUpdate
 			}
 		}
 		ad.config.URL = newURL

--- a/internal/engine/concurrent/downloader.go
+++ b/internal/engine/concurrent/downloader.go
@@ -192,7 +192,7 @@ func (d *ConcurrentDownloader) applyClientSettings(client *http.Client) {
 	// Since these headers were explicitly provided by the browser for this download, we forward them.
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		if len(via) >= 10 {
-			return fmt.Errorf("stopped after 10 redirects")
+			return types.ErrMaxRedirects
 		}
 		// Copy headers from original request to redirect request
 		if len(via) > 0 {

--- a/internal/engine/single/downloader.go
+++ b/internal/engine/single/downloader.go
@@ -50,7 +50,7 @@ func NewSingleDownloader(id string, progressCh chan<- any, state *types.Progress
 func (d *SingleDownloader) applyClientSettings(client *http.Client) {
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		if len(via) >= 10 {
-			return fmt.Errorf("stopped after 10 redirects")
+			return types.ErrMaxRedirects
 		}
 		if len(via) > 0 {
 			utils.CopyRedirectHeaders(req, via[0])

--- a/internal/engine/types/errors.go
+++ b/internal/engine/types/errors.go
@@ -4,5 +4,6 @@ import "errors"
 
 // Common errors
 var (
-	ErrPaused = errors.New("download paused")
+	ErrPaused   = errors.New("download paused")
+	ErrNotFound = errors.New("download not found")
 )

--- a/internal/engine/types/errors.go
+++ b/internal/engine/types/errors.go
@@ -4,6 +4,17 @@ import "errors"
 
 // Common errors
 var (
-	ErrPaused   = errors.New("download paused")
-	ErrNotFound = errors.New("download not found")
+	ErrPaused             = errors.New("download paused")
+	ErrNotFound           = errors.New("download not found")
+	ErrCompleted          = errors.New("download already completed")
+	ErrPausing            = errors.New("download is still pausing, try again in a moment")
+	ErrEngineNotInit      = errors.New("engine not initialized")
+	ErrPoolNotInit        = errors.New("worker pool not initialized")
+	ErrIDExists           = errors.New("download id already exists")
+	ErrURLRequired        = errors.New("URL is required")
+	ErrDestRequired       = errors.New("destination path is required")
+	ErrServiceUnavailable = errors.New("service unavailable")
+	ErrQueuedUpdate       = errors.New("cannot update URL for a queued download, please cancel or wait for it to start")
+	ErrActiveUpdate       = errors.New("download is currently active, please pause it before updating the URL")
+	ErrMaxRedirects       = errors.New("stopped after 10 redirects")
 )

--- a/internal/processing/manager.go
+++ b/internal/processing/manager.go
@@ -195,7 +195,7 @@ type DownloadRequest struct {
 // Enqueue probes and reserves a stable destination before dispatching to the queue layer.
 func (mgr *LifecycleManager) Enqueue(ctx context.Context, req *DownloadRequest) (string, string, error) {
 	if mgr.addFunc == nil {
-		return "", "", fmt.Errorf("add function unavailable")
+		return "", "", types.ErrServiceUnavailable
 	}
 
 	utils.Debug("Lifecycle: Enqueue %s (Filename: %s)", req.URL, req.Filename)
@@ -216,7 +216,7 @@ func (mgr *LifecycleManager) Enqueue(ctx context.Context, req *DownloadRequest) 
 // EnqueueWithID does the same lifecycle work as Enqueue while preserving a caller-owned id.
 func (mgr *LifecycleManager) EnqueueWithID(ctx context.Context, req *DownloadRequest, requestID string) (string, string, error) {
 	if mgr.addWithIDFunc == nil {
-		return "", "", fmt.Errorf("addWithID function unavailable")
+		return "", "", types.ErrServiceUnavailable
 	}
 
 	utils.Debug("Lifecycle: EnqueueWithID %s (%s)", req.URL, requestID)
@@ -238,10 +238,10 @@ func (mgr *LifecycleManager) EnqueueWithID(ctx context.Context, req *DownloadReq
 // download to the engine, so workers and lifecycle events agree on one stable destination.
 func (mgr *LifecycleManager) enqueueResolved(ctx context.Context, req *DownloadRequest, dispatch func(string, string, *ProbeResult) (string, error)) (string, string, error) {
 	if req.URL == "" {
-		return "", "", fmt.Errorf("URL is required")
+		return "", "", types.ErrURLRequired
 	}
 	if req.Path == "" {
-		return "", "", fmt.Errorf("destination path is required")
+		return "", "", types.ErrDestRequired
 	}
 
 	settings := mgr.GetSettings()

--- a/internal/processing/manager_test.go
+++ b/internal/processing/manager_test.go
@@ -961,8 +961,8 @@ func TestLifecycleManager_Cancel_NotFound(t *testing.T) {
 	})
 
 	err := mgr.Cancel("ghost-id")
-	if err == nil {
-		t.Fatal("expected error for non-existent download")
+	if err != nil {
+		t.Fatalf("expected nil error for non-existent download (idempotent), got %v", err)
 	}
 }
 

--- a/internal/processing/pause_resume.go
+++ b/internal/processing/pause_resume.go
@@ -8,6 +8,7 @@ import (
 	"github.com/SurgeDM/Surge/internal/engine/events"
 	"github.com/SurgeDM/Surge/internal/engine/state"
 	"github.com/SurgeDM/Surge/internal/engine/types"
+	"github.com/SurgeDM/Surge/internal/utils"
 )
 
 // EngineHooks defines the minimal callbacks Processing needs to orchestrate the worker pool.
@@ -268,7 +269,8 @@ func (mgr *LifecycleManager) Cancel(id string) error {
 	}
 
 	if !found {
-		return fmt.Errorf("download not found")
+		utils.Debug("Cancel: download %s not found in pool or DB, treating as success", id)
+		return nil
 	}
 
 	// Emit removal event — event worker handles DB deletion and file cleanup.

--- a/internal/processing/pause_resume.go
+++ b/internal/processing/pause_resume.go
@@ -58,7 +58,7 @@ func (mgr *LifecycleManager) Pause(id string) error {
 		return nil // Already stopped
 	}
 
-	return fmt.Errorf("download not found")
+	return types.ErrNotFound
 }
 
 // hydrateConfigFromDisk loads the latest persisted pause snapshot from disk
@@ -116,7 +116,7 @@ func (mgr *LifecycleManager) Resume(id string) error {
 	// Cold path: download from a prior session (only in DB).
 	entry, err := state.GetDownload(id)
 	if err != nil || entry == nil {
-		return fmt.Errorf("download not found")
+		return types.ErrNotFound
 	}
 
 	if entry.Status == "completed" {
@@ -269,6 +269,9 @@ func (mgr *LifecycleManager) Cancel(id string) error {
 	}
 
 	if !found {
+		// It's safe to treat a missing download as success during cancellation
+		// because it may have been deleted in a prior session or removed
+		// during a race condition (e.g. TUI refresh vs engine deletion).
 		utils.Debug("Cancel: download %s not found in pool or DB, treating as success", id)
 		return nil
 	}

--- a/internal/processing/pause_resume.go
+++ b/internal/processing/pause_resume.go
@@ -37,7 +37,7 @@ type EngineHooks struct {
 func (mgr *LifecycleManager) Pause(id string) error {
 	hooks := mgr.getEngineHooks()
 	if hooks.Pause == nil {
-		return fmt.Errorf("engine not initialized")
+		return types.ErrEngineNotInit
 	}
 
 	if hooks.Pause(id) {
@@ -91,7 +91,7 @@ func (mgr *LifecycleManager) Resume(id string) error {
 	// Guard: still transitioning to paused
 	if hooks.GetStatus != nil {
 		if st := hooks.GetStatus(id); st != nil && st.Status == "pausing" {
-			return fmt.Errorf("download is still pausing, try again in a moment")
+			return types.ErrPausing
 		}
 	}
 
@@ -120,7 +120,7 @@ func (mgr *LifecycleManager) Resume(id string) error {
 	}
 
 	if entry.Status == "completed" {
-		return fmt.Errorf("download already completed")
+		return types.ErrCompleted
 	}
 
 	settings := mgr.GetSettings()
@@ -168,7 +168,7 @@ func (mgr *LifecycleManager) ResumeBatch(ids []string) []error {
 	for i, id := range ids {
 		if hooks.GetStatus != nil {
 			if st := hooks.GetStatus(id); st != nil && st.Status == "pausing" {
-				errs[i] = fmt.Errorf("download is still pausing, try again in a moment")
+				errs[i] = types.ErrPausing
 				continue
 			}
 		}

--- a/internal/tui/delete_resilience_test.go
+++ b/internal/tui/delete_resilience_test.go
@@ -39,8 +39,11 @@ func (m *mockService) GetStatus(id string) (*types.DownloadStatus, error) { retu
 func (m *mockService) Shutdown() error { return nil }
 
 func TestUpdateDashboard_DeleteResilience(t *testing.T) {
+	// This test validates the TUI's defensive layer independently of the service
+	// implementation. Even though Service.Delete currently returns nil for missing
+	// IDs, the TUI should still gracefully handle ErrNotFound if it occurs.
 	dm := &DownloadModel{ID: "ghost-id", Filename: "ghost.zip"}
-	svc := &mockService{deleteErr: errors.New("download not found")}
+	svc := &mockService{deleteErr: types.ErrNotFound}
 	
 	m := RootModel{
 		state:     DashboardState,

--- a/internal/tui/delete_resilience_test.go
+++ b/internal/tui/delete_resilience_test.go
@@ -1,0 +1,112 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/SurgeDM/Surge/internal/engine/types"
+)
+
+type mockService struct {
+	deleteErr error
+	deletedID string
+}
+
+func (m *mockService) Delete(id string) error {
+	m.deletedID = id
+	return m.deleteErr
+}
+
+func (m *mockService) List() ([]types.DownloadStatus, error) { return nil, nil }
+func (m *mockService) History() ([]types.DownloadEntry, error) { return nil, nil }
+func (m *mockService) Add(url string, path string, filename string, mirrors []string, headers map[string]string, isExplicitCategory bool, totalSize int64, supportsRange bool) (string, error) {
+	return "", nil
+}
+func (m *mockService) AddWithID(url string, path string, filename string, mirrors []string, headers map[string]string, id string, totalSize int64, supportsRange bool) (string, error) {
+	return "", nil
+}
+func (m *mockService) ResumeBatch(ids []string) []error { return nil }
+func (m *mockService) StreamEvents(ctx context.Context) (<-chan interface{}, func(), error) {
+	return nil, nil, nil
+}
+func (m *mockService) Publish(msg interface{}) error { return nil }
+func (m *mockService) Pause(id string) error { return nil }
+func (m *mockService) Resume(id string) error { return nil }
+func (m *mockService) UpdateURL(id string, newURL string) error { return nil }
+func (m *mockService) GetStatus(id string) (*types.DownloadStatus, error) { return nil, nil }
+func (m *mockService) Shutdown() error { return nil }
+
+func TestUpdateDashboard_DeleteResilience(t *testing.T) {
+	dm := &DownloadModel{ID: "ghost-id", Filename: "ghost.zip"}
+	svc := &mockService{deleteErr: errors.New("download not found")}
+	
+	m := RootModel{
+		state:     DashboardState,
+		downloads: []*DownloadModel{dm},
+		Service:   svc,
+		keys:      Keys,
+		list:      NewDownloadList(80, 20),
+	}
+	m.UpdateListItems()
+	m.list.Select(0) // Select the ghost download
+
+	// Simulate pressing 'x' (Delete)
+	msg := tea.KeyPressMsg{Code: 'x', Text: "x"}
+	updated, _ := m.updateDashboard(msg)
+	m2 := updated.(RootModel)
+
+	if len(m2.downloads) != 0 {
+		t.Errorf("Expected download to be removed even on 'not found' error, but %d entries remain", len(m2.downloads))
+	}
+	if svc.deletedID != "ghost-id" {
+		t.Errorf("Expected Service.Delete to be called with 'ghost-id', got %q", svc.deletedID)
+	}
+}
+
+func TestUpdateDashboard_DeleteSuccess(t *testing.T) {
+	dm := &DownloadModel{ID: "real-id", Filename: "real.zip"}
+	svc := &mockService{deleteErr: nil}
+	
+	m := RootModel{
+		state:     DashboardState,
+		downloads: []*DownloadModel{dm},
+		Service:   svc,
+		keys:      Keys,
+		list:      NewDownloadList(80, 20),
+	}
+	m.UpdateListItems()
+	m.list.Select(0)
+
+	msg := tea.KeyPressMsg{Code: 'x', Text: "x"}
+	updated, _ := m.updateDashboard(msg)
+	m2 := updated.(RootModel)
+
+	if len(m2.downloads) != 0 {
+		t.Errorf("Expected download to be removed on success, but %d entries remain", len(m2.downloads))
+	}
+}
+
+func TestUpdateDashboard_DeleteOtherError(t *testing.T) {
+	dm := &DownloadModel{ID: "error-id", Filename: "error.zip"}
+	svc := &mockService{deleteErr: errors.New("some other error")}
+	
+	m := RootModel{
+		state:     DashboardState,
+		downloads: []*DownloadModel{dm},
+		Service:   svc,
+		keys:      Keys,
+		list:      NewDownloadList(80, 20),
+	}
+	m.UpdateListItems()
+	m.list.Select(0)
+
+	msg := tea.KeyPressMsg{Code: 'x', Text: "x"}
+	updated, _ := m.updateDashboard(msg)
+	m2 := updated.(RootModel)
+
+	if len(m2.downloads) != 1 {
+		t.Errorf("Expected download to REMAIN on non-not-found error, but %d entries remain", len(m2.downloads))
+	}
+}

--- a/internal/tui/update_dashboard.go
+++ b/internal/tui/update_dashboard.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"strings"
+
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/list"
 	tea "charm.land/bubbletea/v2"
@@ -122,7 +124,13 @@ func (m RootModel) updateDashboard(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 			// Call Service Delete
 			if err := m.Service.Delete(targetID); err != nil {
-				m.addLogEntry(LogStyleError.Render("✖ Delete failed: " + err.Error()))
+				// If the download is not found, it's already gone from the engine/DB.
+				// We still remove it from our local list to avoid it being "stuck".
+				if strings.Contains(strings.ToLower(err.Error()), "not found") {
+					m.removeDownloadByID(targetID)
+				} else {
+					m.addLogEntry(LogStyleError.Render("✖ Delete failed: " + err.Error()))
+				}
 			} else {
 				m.removeDownloadByID(targetID)
 			}

--- a/internal/tui/update_dashboard.go
+++ b/internal/tui/update_dashboard.go
@@ -1,7 +1,7 @@
 package tui
 
 import (
-	"strings"
+	"errors"
 
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/list"
@@ -126,7 +126,7 @@ func (m RootModel) updateDashboard(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			if err := m.Service.Delete(targetID); err != nil {
 				// If the download is not found, it's already gone from the engine/DB.
 				// We still remove it from our local list to avoid it being "stuck".
-				if strings.Contains(strings.ToLower(err.Error()), "not found") {
+				if errors.Is(err, types.ErrNotFound) {
 					m.removeDownloadByID(targetID)
 				} else {
 					m.addLogEntry(LogStyleError.Render("✖ Delete failed: " + err.Error()))


### PR DESCRIPTION
- **fix: handle missing downloads gracefully by ignoring not-found errors during deletion**
- **fix: make cancellation idempotent and add resilience for download deletion in TUI**
Closes #373

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a delete-failure bug by making `Cancel` idempotent (returning `nil` for missing downloads) and replacing brittle string-matching in the TUI with a proper `errors.Is(err, types.ErrNotFound)` guard. It also consolidates scattered `fmt.Errorf` literals into a shared sentinel errors package in `internal/engine/types/errors.go`.

<h3>Confidence Score: 5/5</h3>

Safe to merge; only a P2 style inconsistency found.

All findings are P2. The core fix (idempotent Cancel + sentinel error guard in TUI) is correct and well-tested. The only gap is one missed fmt.Errorf in ResumeBatch that was not converted alongside the rest of the refactoring.

internal/processing/pause_resume.go — ResumeBatch cold path at line 217 still uses fmt.Errorf instead of types.ErrNotFound.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/engine/types/errors.go | Introduces sentinel errors to replace scattered fmt.Errorf calls; clean and well-structured. |
| internal/processing/pause_resume.go | Cancel made idempotent with clear comment explaining the rationale; one fmt.Errorf was missed in ResumeBatch cold path. |
| internal/tui/update_dashboard.go | Delete handler now uses errors.Is(err, types.ErrNotFound) instead of brittle string matching — the primary TUI fix. |
| internal/tui/delete_resilience_test.go | New test file covering ErrNotFound, success, and other-error paths for the TUI delete handler; good coverage of the defensive layer. |
| internal/core/local_service.go | Inline fmt.Errorf calls replaced with sentinel errors; GetStatus now returns types.ErrNotFound for missing downloads. |
| internal/download/pool.go | UpdateURL error strings replaced with ErrQueuedUpdate and ErrActiveUpdate sentinels. |
| internal/engine/concurrent/downloader.go | 10-redirect guard replaced with ErrMaxRedirects sentinel; no behavioral change. |
| internal/engine/single/downloader.go | Same ErrMaxRedirects sentinel change as concurrent downloader; consistent. |
| internal/processing/manager.go | Enqueue/EnqueueWithID nil-func guards replaced with ErrServiceUnavailable sentinel; straightforward. |
| internal/processing/manager_test.go | Cancel_NotFound test correctly inverted to expect nil error after idempotent Cancel change. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/processing/pause_resume.go
Line: 217

Comment:
**Missed sentinel error in `ResumeBatch` cold path**

This `fmt.Errorf("download not found or completed")` was not converted as part of the sentinel-error refactoring in this PR. Any caller (including the TUI) that tries `errors.Is(err, types.ErrNotFound)` on a `ResumeBatch` result will silently miss this case.

```suggestion
errs[idx] = types.ErrNotFound
```

**Rule Used:** What: Eliminate duplicate logic, functions, or cod... ([source](https://app.greptile.com/review/custom-context?memory=f0a796a9-684f-4dfb-a5cf-8c99c16b63a1))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor: centralize error handling by d..."](https://github.com/surgedm/surge/commit/f1bf8489497384a4fc635d328d35f480d2799633) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29820453)</sub>

**Context used:**

- Rule used - What: Eliminate duplicate logic, functions, or cod... ([source](https://app.greptile.com/review/custom-context?memory=f0a796a9-684f-4dfb-a5cf-8c99c16b63a1))

<!-- /greptile_comment -->