### PR TITLE
Fix runtime directory for Termux on Android

### DIFF
--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -76,10 +76,10 @@ func GetRuntimeDir() string {
 		}
 	}
 
-	// In headless Linux sessions, XDG_RUNTIME_DIR is often unset and xdg.RuntimeDir
-	// may point to /run/user/<uid>, which can be absent/unwritable. Use a writable
-	// state-dir fallback in that case.
-	if runtime.GOOS == "linux" && runtimeEnv == "" {
+	// In headless Linux sessions and Android/Termux, XDG_RUNTIME_DIR is often unset
+	// and xdg.RuntimeDir may point to /run/user/<uid>, which can be absent/unwritable.
+	// Use a writable state-dir fallback in that case.
+	if (runtime.GOOS == "linux" || runtime.GOOS == "android") && runtimeEnv == "" {
 		runtimeBase = ""
 	}
 
@@ -124,8 +124,8 @@ func EnsureDirs() error {
 			return err
 		}
 	}
-	// On Linux runtime dir, we might want stricter permissions (0700) if it's in /run/user
-	if runtime.GOOS == "linux" && os.Getenv("XDG_RUNTIME_DIR") != "" {
+	// On Linux/Android runtime dir, we might want stricter permissions (0700) if it's in /run/user
+	if (runtime.GOOS == "linux" || runtime.GOOS == "android") && os.Getenv("XDG_RUNTIME_DIR") != "" {
 		_ = os.Chmod(GetRuntimeDir(), 0o700)
 	}
 


### PR DESCRIPTION
The xdg library returns /run/user/<uid> which doesn't exist on Android.

Added android alongside linux in the GOOS checks so runtime directory falls back to ~/.local/state/surge/runtime instead of failing with 'mkdir /run: read-only file system'.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extends two `runtime.GOOS` checks in `GetRuntimeDir` and `EnsureDirs` to include `"android"`, so that Termux builds fall back to `~/.local/state/surge/runtime` instead of trying (and failing) to use `/run/user/<uid>` from `xdg.RuntimeDir`. The fix is minimal and correctly scoped — the XDG path is still honoured on Android when `XDG_RUNTIME_DIR` is explicitly set by the user.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is a two-line, low-risk platform guard with no behavioural impact on non-Android targets.

Only P2 findings (missing tests for the new Android branch). Logic is correct, change is minimal, and existing Linux/Windows/macOS behaviour is unaffected.

No files require special attention beyond the missing test coverage for the Android case in `internal/config/paths.go`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/config/paths.go | Adds `runtime.GOOS == "android"` alongside `"linux"` in two conditions to force the state-dir fallback for the runtime directory on Termux, fixing the read-only `/run` filesystem error; logic is correct and minimal. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/config/paths.go
Line: 82-84

Comment:
**No tests for Android path resolution**

The new `runtime.GOOS == "android"` branch in both `GetRuntimeDir` and `EnsureDirs` is untested. A table-driven test overriding the env vars and mocking `runtime.GOOS` (via build tags or a helper variable) would confirm that the fallback to `GetStateDir()/runtime` is taken on Android when `XDG_RUNTIME_DIR` is unset, and that the XDG path is still respected when it is set.

**Rule Used:** What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: support Termux(Android)"](https://github.com/surgedm/surge/commit/5180e8ca81b9483e9b6b414a932d34794c561e9d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30072930)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->