### PR TITLE
Enhance Category Manager UX and Implement Robust Settings Validation

### DIFF
--- a/cmd/bugreport.go
+++ b/cmd/bugreport.go
@@ -78,7 +78,7 @@ func runBugReportCommand(cmd *cobra.Command) error {
 		return nil
 	}
 
-	fmt.Fprintln(out, "Opening browser to file bug report...")
+	_, _ = fmt.Fprintln(out, "Opening browser to file bug report...")
 	if err := openBrowser(reportURL); err != nil {
 		printManualURL(out, "Could not open browser. Please open this URL manually:", reportURL)
 		return nil
@@ -88,15 +88,15 @@ func runBugReportCommand(cmd *cobra.Command) error {
 }
 
 func printManualURL(out io.Writer, message, reportURL string) {
-	fmt.Fprintf(out, "%s\n\n%s\n", message, reportURL)
+	_, _ = fmt.Fprintf(out, "%s\n\n%s\n", message, reportURL)
 }
 
 func promptBugReportTarget(reader *bufio.Reader, out io.Writer) (bugReportTarget, error) {
 	for {
-		fmt.Fprintln(out, "What would you like to report?")
-		fmt.Fprintln(out, "  1) Surge Core (CLI/TUI/server)")
-		fmt.Fprintln(out, "  2) Browser Extension")
-		fmt.Fprint(out, "Choose [1/2] (default 1): ")
+		_, _ = fmt.Fprintln(out, "What would you like to report?")
+		_, _ = fmt.Fprintln(out, "  1) Surge Core (CLI/TUI/server)")
+		_, _ = fmt.Fprintln(out, "  2) Browser Extension")
+		_, _ = fmt.Fprint(out, "Choose [1/2] (default 1): ")
 
 		choice, eof, err := readPromptLine(reader)
 		if err != nil {
@@ -109,7 +109,7 @@ func promptBugReportTarget(reader *bufio.Reader, out io.Writer) (bugReportTarget
 		case "2", "extension", "ext", "e":
 			return bugReportExtension, nil
 		default:
-			fmt.Fprintln(out, "Invalid selection. Enter 1 for Core or 2 for Extension.")
+			_, _ = fmt.Fprintln(out, "Invalid selection. Enter 1 for Core or 2 for Extension.")
 			if eof {
 				return 0, fmt.Errorf("invalid bug report target: %q", choice)
 			}
@@ -119,7 +119,7 @@ func promptBugReportTarget(reader *bufio.Reader, out io.Writer) (bugReportTarget
 
 func promptYesNo(reader *bufio.Reader, out io.Writer, prompt string, defaultYes bool) (bool, error) {
 	for {
-		fmt.Fprint(out, prompt)
+		_, _ = fmt.Fprint(out, prompt)
 
 		choice, eof, err := readPromptLine(reader)
 		if err != nil {
@@ -134,7 +134,7 @@ func promptYesNo(reader *bufio.Reader, out io.Writer, prompt string, defaultYes 
 		case "n", "no":
 			return false, nil
 		default:
-			fmt.Fprintln(out, "Invalid selection. Enter y or n.")
+			_, _ = fmt.Fprintln(out, "Invalid selection. Enter y or n.")
 			if eof {
 				return false, fmt.Errorf("invalid yes/no selection: %q", choice)
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -384,7 +384,21 @@ func initializeRootLocalRuntime() error {
 	if err := ensureGlobalLocalServiceAndLifecycle(); err != nil {
 		return fmt.Errorf("error creating lifecycle event stream: %w", err)
 	}
+
+	publishStartupWarnings()
+
 	return nil
+}
+
+func publishStartupWarnings() {
+	if globalSettings == nil || len(globalSettings.StartupWarnings) == 0 {
+		return
+	}
+	for _, warning := range globalSettings.StartupWarnings {
+		GlobalService.Publish(events.SystemLogMsg{
+			Message: warning,
+		})
+	}
 }
 
 func startRootHTTPServer(opts rootRunOptions) (int, func(), error) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -395,7 +395,7 @@ func publishStartupWarnings() {
 		return
 	}
 	for _, warning := range globalSettings.StartupWarnings {
-		GlobalService.Publish(events.SystemLogMsg{
+		_ = GlobalService.Publish(events.SystemLogMsg{
 			Message: warning,
 		})
 	}

--- a/cmd/root_lifecycle_test.go
+++ b/cmd/root_lifecycle_test.go
@@ -235,6 +235,9 @@ func TestProcessDownloads_RoutesBinFilesToCustomCategory(t *testing.T) {
 
 	defaultDir := t.TempDir()
 	customDir := filepath.Join(t.TempDir(), "bin-artifacts")
+	if err := os.MkdirAll(customDir, 0755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
 	settings := config.DefaultSettings()
 	settings.General.DefaultDownloadDir = defaultDir
 	settings.Categories.CategoryEnabled = true
@@ -336,6 +339,9 @@ func TestProcessDownloads_UsesLatestSavedCategorySettings(t *testing.T) {
 	}
 
 	customDir := filepath.Join(t.TempDir(), "bin-updated")
+	if err := os.MkdirAll(customDir, 0755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
 	updated := config.DefaultSettings()
 	updated.General.DefaultDownloadDir = defaultDir
 	updated.Categories.CategoryEnabled = true

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -33,6 +33,16 @@ The `settings.json` file expects a nested structure divided into `general`, `net
 
 *Note: You do not need to specify all keys. Surge will automatically infer missing keys and use their internal default values.*
 
+## Configuration Validation
+
+Surge implements a self-healing configuration system to ensure the application remains stable even if the `settings.json` file is manually edited with invalid values.
+
+- **Range Enforcement**: Numeric values (like connection limits and concurrent downloads) are strictly enforced. If a value is set outside its safe operating range in the JSON file, Surge will automatically reset that specific field to its default value on startup while preserving your other valid settings.
+- **Path Verification**: Paths like `default_download_dir` and individual category paths are verified for existence and accessibility. Broken or inaccessible paths are rolled back to the system's default Downloads directory.
+- **Syntactic Validation**: Proxy URLs and DNS server lists are validated for correct syntax.
+- **Category Integrity**: If a custom category has an invalid regular expression pattern, it is automatically pruned from the active list to prevent engine crashes.
+- **Corrupt JSON Fallback**: If the `settings.json` file is completely unparseable (e.g., missing brackets or commas), Surge will log a warning and start with all factory default settings for that session.
+
 ## Directory Structure
 
 Surge follows OS conventions for storing its files. Below is a breakdown of every directory it uses and where to find it on each platform.

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -2,9 +2,12 @@ package config
 
 import (
 	"encoding/json"
+	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/SurgeDM/Surge/internal/utils"
@@ -270,7 +273,143 @@ func LoadSettings() (*Settings, error) {
 		return DefaultSettings(), nil
 	}
 
+	// Validate settings and roll back individual invalid fields to defaults
+	settings.Validate()
+
 	return settings, nil
+}
+
+// Validate ensures all settings are within reasonable bounds, resetting
+// individual invalid fields to their default values.
+func (s *Settings) Validate() {
+	s.General.Validate()
+	s.Network.Validate()
+	s.Performance.Validate()
+	s.Categories.Validate()
+}
+
+// Validate checks GeneralSettings for invalid paths or out-of-bounds values.
+func (gs *GeneralSettings) Validate() {
+	defaults := DefaultSettings().General
+
+	if gs.Theme < 0 || gs.Theme > 2 {
+		gs.Theme = defaults.Theme
+	}
+	if gs.LogRetentionCount < 1 || gs.LogRetentionCount > 100 {
+		gs.LogRetentionCount = defaults.LogRetentionCount
+	}
+
+	// Validate DefaultDownloadDir
+	trimmed := strings.TrimSpace(gs.DefaultDownloadDir)
+	if trimmed != "" {
+		if info, err := os.Stat(trimmed); err != nil {
+			// If path is invalid or inaccessible, fallback to default system downloads dir
+			gs.DefaultDownloadDir = defaults.DefaultDownloadDir
+		} else if !info.IsDir() {
+			gs.DefaultDownloadDir = defaults.DefaultDownloadDir
+		}
+	}
+}
+
+// Validate checks NetworkSettings for valid IPs, URLs, and numeric bounds.
+func (ns *NetworkSettings) Validate() {
+	defaults := DefaultSettings().Network
+
+	if ns.MaxConnectionsPerHost < 1 || ns.MaxConnectionsPerHost > 64 {
+		ns.MaxConnectionsPerHost = defaults.MaxConnectionsPerHost
+	}
+	if ns.MaxConcurrentDownloads < 1 || ns.MaxConcurrentDownloads > 10 {
+		ns.MaxConcurrentDownloads = defaults.MaxConcurrentDownloads
+	}
+	if ns.MaxConcurrentProbes < 1 || ns.MaxConcurrentProbes > 10 {
+		ns.MaxConcurrentProbes = defaults.MaxConcurrentProbes
+	}
+	if ns.MinChunkSize < 100*KB {
+		ns.MinChunkSize = defaults.MinChunkSize
+	}
+	if ns.WorkerBufferSize < 1*KB {
+		ns.WorkerBufferSize = defaults.WorkerBufferSize
+	}
+	if ns.DialHedgeCount < 0 || ns.DialHedgeCount > 16 {
+		ns.DialHedgeCount = defaults.DialHedgeCount
+	}
+
+	// Validate ProxyURL if set
+	if ns.ProxyURL != "" {
+		if _, err := url.Parse(ns.ProxyURL); err != nil {
+			ns.ProxyURL = defaults.ProxyURL
+		}
+	}
+
+	// Validate CustomDNS if set
+	if ns.CustomDNS != "" {
+		parts := strings.Split(ns.CustomDNS, ",")
+		allValid := true
+		for _, part := range parts {
+			p := strings.TrimSpace(part)
+			if p == "" {
+				continue
+			}
+			host, _, err := net.SplitHostPort(p)
+			if err != nil {
+				if net.ParseIP(p) == nil {
+					allValid = false
+					break
+				}
+			} else {
+				if net.ParseIP(host) == nil {
+					allValid = false
+					break
+				}
+			}
+		}
+		if !allValid {
+			ns.CustomDNS = defaults.CustomDNS
+		}
+	}
+}
+
+// Validate checks PerformanceSettings for valid floating point ranges and durations.
+func (ps *PerformanceSettings) Validate() {
+	defaults := DefaultSettings().Performance
+
+	if ps.MaxTaskRetries < 0 || ps.MaxTaskRetries > 10 {
+		ps.MaxTaskRetries = defaults.MaxTaskRetries
+	}
+	if ps.SlowWorkerThreshold < 0.0 || ps.SlowWorkerThreshold > 1.0 {
+		ps.SlowWorkerThreshold = defaults.SlowWorkerThreshold
+	}
+	if ps.SpeedEmaAlpha < 0.0 || ps.SpeedEmaAlpha > 1.0 {
+		ps.SpeedEmaAlpha = defaults.SpeedEmaAlpha
+	}
+	if ps.SlowWorkerGracePeriod < 0 {
+		ps.SlowWorkerGracePeriod = defaults.SlowWorkerGracePeriod
+	}
+	if ps.StallTimeout < 0 {
+		ps.StallTimeout = defaults.StallTimeout
+	}
+}
+
+// Validate checks CategorySettings and ensures all defined categories are valid.
+func (cs *CategorySettings) Validate() {
+	validCats := make([]Category, 0, len(cs.Categories))
+	for _, cat := range cs.Categories {
+		if err := cat.Validate(); err == nil {
+			// Extra path check for each category
+			catPath := strings.TrimSpace(cat.Path)
+			if catPath != "" {
+				if info, err := os.Stat(catPath); err != nil || !info.IsDir() {
+					// Fallback to default download dir for this category if path is broken
+					cat.Path = DefaultSettings().General.DefaultDownloadDir
+				}
+			}
+			validCats = append(validCats, cat)
+		} else {
+			utils.Debug("Config: Removing invalid category %q: %v", cat.Name, err)
+		}
+	}
+
+	cs.Categories = validCats
 }
 
 // SaveSettings saves settings to disk atomically.

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -284,14 +284,13 @@ func LoadSettings() (*Settings, error) {
 	return settings, nil
 }
 
-// Validate ensures all settings are within reasonable bounds, resetting
-// individual invalid fields to their default values.
 func (s *Settings) Validate() {
 	s.StartupWarnings = nil
 	s.StartupWarnings = append(s.StartupWarnings, s.General.Validate()...)
 	s.StartupWarnings = append(s.StartupWarnings, s.Network.Validate()...)
 	s.StartupWarnings = append(s.StartupWarnings, s.Performance.Validate()...)
 	s.StartupWarnings = append(s.StartupWarnings, s.Categories.Validate(s.General.DefaultDownloadDir)...)
+	s.StartupWarnings = append(s.StartupWarnings, s.Extension.Validate()...)
 }
 
 // Validate checks GeneralSettings for invalid paths or out-of-bounds values.
@@ -449,6 +448,15 @@ func (cs *CategorySettings) Validate(fallbackDir string) []string {
 	}
 
 	cs.Categories = validCats
+	return warnings
+}
+
+// Validate checks ExtensionSettings for any necessary field sanitization.
+func (es *ExtensionSettings) Validate() []string {
+	var warnings []string
+	// Extension settings are currently mostly URLs or booleans that don't
+	// require strict range enforcement, but we maintain the Validate method
+	// for future consistency and testing.
 	return warnings
 }
 

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"net/url"
 	"os"
@@ -20,6 +21,10 @@ type Settings struct {
 	Performance PerformanceSettings `json:"performance" ui_label:"Performance"`
 	Categories  CategorySettings    `json:"categories" ui_label:"Categories"`
 	Extension   ExtensionSettings   `json:"extension" ui_label:"Extension"`
+
+	// StartupWarnings holds validation messages from the most recent LoadSettings call.
+	// It is ignored during JSON serialization.
+	StartupWarnings []string `json:"-"`
 }
 
 // GeneralSettings contains application behavior settings.
@@ -282,21 +287,25 @@ func LoadSettings() (*Settings, error) {
 // Validate ensures all settings are within reasonable bounds, resetting
 // individual invalid fields to their default values.
 func (s *Settings) Validate() {
-	s.General.Validate()
-	s.Network.Validate()
-	s.Performance.Validate()
-	s.Categories.Validate()
+	s.StartupWarnings = nil
+	s.StartupWarnings = append(s.StartupWarnings, s.General.Validate()...)
+	s.StartupWarnings = append(s.StartupWarnings, s.Network.Validate()...)
+	s.StartupWarnings = append(s.StartupWarnings, s.Performance.Validate()...)
+	s.StartupWarnings = append(s.StartupWarnings, s.Categories.Validate()...)
 }
 
 // Validate checks GeneralSettings for invalid paths or out-of-bounds values.
-func (gs *GeneralSettings) Validate() {
+func (gs *GeneralSettings) Validate() []string {
+	var warnings []string
 	defaults := DefaultSettings().General
 
 	if gs.Theme < 0 || gs.Theme > 2 {
 		gs.Theme = defaults.Theme
+		warnings = append(warnings, "Invalid theme reset to default")
 	}
 	if gs.LogRetentionCount < 1 || gs.LogRetentionCount > 100 {
 		gs.LogRetentionCount = defaults.LogRetentionCount
+		warnings = append(warnings, fmt.Sprintf("Log retention count reset to default (%d)", defaults.LogRetentionCount))
 	}
 
 	// Validate DefaultDownloadDir
@@ -305,39 +314,50 @@ func (gs *GeneralSettings) Validate() {
 		if info, err := os.Stat(trimmed); err != nil {
 			// If path is invalid or inaccessible, fallback to default system downloads dir
 			gs.DefaultDownloadDir = defaults.DefaultDownloadDir
+			warnings = append(warnings, fmt.Sprintf("Download directory %q is inaccessible; reset to default", trimmed))
 		} else if !info.IsDir() {
 			gs.DefaultDownloadDir = defaults.DefaultDownloadDir
+			warnings = append(warnings, fmt.Sprintf("Download directory %q is not a folder; reset to default", trimmed))
 		}
 	}
+	return warnings
 }
 
 // Validate checks NetworkSettings for valid IPs, URLs, and numeric bounds.
-func (ns *NetworkSettings) Validate() {
+func (ns *NetworkSettings) Validate() []string {
+	var warnings []string
 	defaults := DefaultSettings().Network
 
 	if ns.MaxConnectionsPerHost < 1 || ns.MaxConnectionsPerHost > 64 {
 		ns.MaxConnectionsPerHost = defaults.MaxConnectionsPerHost
+		warnings = append(warnings, fmt.Sprintf("Max connections/host reset to default (%d)", defaults.MaxConnectionsPerHost))
 	}
 	if ns.MaxConcurrentDownloads < 1 || ns.MaxConcurrentDownloads > 10 {
 		ns.MaxConcurrentDownloads = defaults.MaxConcurrentDownloads
+		warnings = append(warnings, fmt.Sprintf("Max concurrent downloads reset to default (%d)", defaults.MaxConcurrentDownloads))
 	}
 	if ns.MaxConcurrentProbes < 1 || ns.MaxConcurrentProbes > 10 {
 		ns.MaxConcurrentProbes = defaults.MaxConcurrentProbes
+		warnings = append(warnings, fmt.Sprintf("Max concurrent probes reset to default (%d)", defaults.MaxConcurrentProbes))
 	}
 	if ns.MinChunkSize < 100*KB {
 		ns.MinChunkSize = defaults.MinChunkSize
+		warnings = append(warnings, "Min chunk size reset to default")
 	}
 	if ns.WorkerBufferSize < 1*KB {
 		ns.WorkerBufferSize = defaults.WorkerBufferSize
+		warnings = append(warnings, "Worker buffer size reset to default")
 	}
 	if ns.DialHedgeCount < 0 || ns.DialHedgeCount > 16 {
 		ns.DialHedgeCount = defaults.DialHedgeCount
+		warnings = append(warnings, "Dial hedge count reset to default")
 	}
 
 	// Validate ProxyURL if set
 	if ns.ProxyURL != "" {
 		if _, err := url.Parse(ns.ProxyURL); err != nil {
 			ns.ProxyURL = defaults.ProxyURL
+			warnings = append(warnings, "Invalid proxy URL reset to empty")
 		}
 	}
 
@@ -365,33 +385,43 @@ func (ns *NetworkSettings) Validate() {
 		}
 		if !allValid {
 			ns.CustomDNS = defaults.CustomDNS
+			warnings = append(warnings, "Invalid DNS configuration reset to empty")
 		}
 	}
+	return warnings
 }
 
 // Validate checks PerformanceSettings for valid floating point ranges and durations.
-func (ps *PerformanceSettings) Validate() {
+func (ps *PerformanceSettings) Validate() []string {
+	var warnings []string
 	defaults := DefaultSettings().Performance
 
 	if ps.MaxTaskRetries < 0 || ps.MaxTaskRetries > 10 {
 		ps.MaxTaskRetries = defaults.MaxTaskRetries
+		warnings = append(warnings, fmt.Sprintf("Max task retries reset to default (%d)", defaults.MaxTaskRetries))
 	}
 	if ps.SlowWorkerThreshold < 0.0 || ps.SlowWorkerThreshold > 1.0 {
 		ps.SlowWorkerThreshold = defaults.SlowWorkerThreshold
+		warnings = append(warnings, "Slow worker threshold reset to default")
 	}
 	if ps.SpeedEmaAlpha < 0.0 || ps.SpeedEmaAlpha > 1.0 {
 		ps.SpeedEmaAlpha = defaults.SpeedEmaAlpha
+		warnings = append(warnings, "Speed smoothing factor reset to default")
 	}
 	if ps.SlowWorkerGracePeriod < 0 {
 		ps.SlowWorkerGracePeriod = defaults.SlowWorkerGracePeriod
+		warnings = append(warnings, "Slow worker grace period reset to default")
 	}
 	if ps.StallTimeout < 0 {
 		ps.StallTimeout = defaults.StallTimeout
+		warnings = append(warnings, "Stall timeout reset to default")
 	}
+	return warnings
 }
 
 // Validate checks CategorySettings and ensures all defined categories are valid.
-func (cs *CategorySettings) Validate() {
+func (cs *CategorySettings) Validate() []string {
+	var warnings []string
 	validCats := make([]Category, 0, len(cs.Categories))
 	for _, cat := range cs.Categories {
 		if err := cat.Validate(); err == nil {
@@ -401,15 +431,18 @@ func (cs *CategorySettings) Validate() {
 				if info, err := os.Stat(catPath); err != nil || !info.IsDir() {
 					// Fallback to default download dir for this category if path is broken
 					cat.Path = DefaultSettings().General.DefaultDownloadDir
+					warnings = append(warnings, fmt.Sprintf("Category %q path is broken; reset to default", cat.Name))
 				}
 			}
 			validCats = append(validCats, cat)
 		} else {
+			warnings = append(warnings, fmt.Sprintf("Removed invalid category %q: %v", cat.Name, err))
 			utils.Debug("Config: Removing invalid category %q: %v", cat.Name, err)
 		}
 	}
 
 	cs.Categories = validCats
+	return warnings
 }
 
 // SaveSettings saves settings to disk atomically.

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -291,7 +291,7 @@ func (s *Settings) Validate() {
 	s.StartupWarnings = append(s.StartupWarnings, s.General.Validate()...)
 	s.StartupWarnings = append(s.StartupWarnings, s.Network.Validate()...)
 	s.StartupWarnings = append(s.StartupWarnings, s.Performance.Validate()...)
-	s.StartupWarnings = append(s.StartupWarnings, s.Categories.Validate()...)
+	s.StartupWarnings = append(s.StartupWarnings, s.Categories.Validate(s.General.DefaultDownloadDir)...)
 }
 
 // Validate checks GeneralSettings for invalid paths or out-of-bounds values.
@@ -427,7 +427,7 @@ func (ps *PerformanceSettings) Validate() []string {
 }
 
 // Validate checks CategorySettings and ensures all defined categories are valid.
-func (cs *CategorySettings) Validate() []string {
+func (cs *CategorySettings) Validate(fallbackDir string) []string {
 	var warnings []string
 	validCats := make([]Category, 0, len(cs.Categories))
 	for _, cat := range cs.Categories {
@@ -436,8 +436,8 @@ func (cs *CategorySettings) Validate() []string {
 			catPath := strings.TrimSpace(cat.Path)
 			if catPath != "" {
 				if info, err := os.Stat(catPath); err != nil || !info.IsDir() {
-					// Fallback to default download dir for this category if path is broken
-					cat.Path = DefaultSettings().General.DefaultDownloadDir
+					// Fallback to validated default download dir for this category if path is broken
+					cat.Path = fallbackDir
 					warnings = append(warnings, fmt.Sprintf("Category %q path is broken; reset to default", cat.Name))
 				}
 			}

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -355,40 +355,47 @@ func (ns *NetworkSettings) Validate() []string {
 
 	// Validate ProxyURL if set
 	if ns.ProxyURL != "" {
-		if _, err := url.Parse(ns.ProxyURL); err != nil {
+		u, err := url.Parse(ns.ProxyURL)
+		if err != nil || u.Scheme == "" || u.Host == "" {
 			ns.ProxyURL = defaults.ProxyURL
-			warnings = append(warnings, "Invalid proxy URL reset to empty")
+			warnings = append(warnings, "Invalid proxy URL reset to default")
 		}
 	}
 
 	// Validate CustomDNS if set
 	if ns.CustomDNS != "" {
-		parts := strings.Split(ns.CustomDNS, ",")
-		allValid := true
-		for _, part := range parts {
-			p := strings.TrimSpace(part)
-			if p == "" {
-				continue
-			}
-			host, _, err := net.SplitHostPort(p)
-			if err != nil {
-				if net.ParseIP(p) == nil {
-					allValid = false
-					break
-				}
-			} else {
-				if net.ParseIP(host) == nil {
-					allValid = false
-					break
-				}
-			}
-		}
-		if !allValid {
+		if err := ValidateDNSList(ns.CustomDNS); err != nil {
 			ns.CustomDNS = defaults.CustomDNS
-			warnings = append(warnings, "Invalid DNS configuration reset to empty")
+			warnings = append(warnings, "Invalid DNS configuration reset to default")
 		}
 	}
 	return warnings
+}
+
+// ValidateDNSList checks if a comma-separated list of DNS servers (IP or IP:port) is valid.
+func ValidateDNSList(s string) error {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" {
+		return nil
+	}
+	parts := strings.Split(trimmed, ",")
+	for _, part := range parts {
+		p := strings.TrimSpace(part)
+		if p == "" {
+			continue
+		}
+		host, _, err := net.SplitHostPort(p)
+		if err != nil {
+			if net.ParseIP(p) == nil {
+				return fmt.Errorf("invalid DNS: %s", p)
+			}
+		} else {
+			if net.ParseIP(host) == nil {
+				return fmt.Errorf("invalid DNS IP: %s", host)
+			}
+		}
+	}
+	return nil
 }
 
 // Validate checks PerformanceSettings for valid floating point ranges and durations.

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -911,7 +911,7 @@ func TestSettings_FutureProofValidation(t *testing.T) {
 		_, ok := field.Type.MethodByName("Validate")
 		if !ok {
 			// If the type itself doesn't have it, check if a pointer to it does
-			_, ok = reflect.PtrTo(field.Type).MethodByName("Validate")
+			_, ok = reflect.PointerTo(field.Type).MethodByName("Validate")
 		}
 
 		if !ok {

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -621,7 +621,7 @@ func TestLoadSettings_RealFunction(t *testing.T) {
 	// Test LoadSettings actually reads from disk
 	// First save something
 	original := DefaultSettings()
-	original.Performance.MaxTaskRetries = 99
+	original.Performance.MaxTaskRetries = 9
 	err := SaveSettings(original)
 	if err != nil {
 		t.Fatalf("SaveSettings failed: %v", err)
@@ -633,8 +633,8 @@ func TestLoadSettings_RealFunction(t *testing.T) {
 		t.Fatalf("LoadSettings failed: %v", err)
 	}
 
-	if loaded.Performance.MaxTaskRetries != 99 {
-		t.Errorf("MaxTaskRetries mismatch: got %d, want 99", loaded.Performance.MaxTaskRetries)
+	if loaded.Performance.MaxTaskRetries != 9 {
+		t.Errorf("MaxTaskRetries mismatch: got %d, want 9", loaded.Performance.MaxTaskRetries)
 	}
 
 	// Cleanup
@@ -744,5 +744,151 @@ func TestDefaultSettings_Fallback(t *testing.T) {
 		if info, err := os.Stat(dir); err != nil || !info.IsDir() {
 			t.Errorf("DefaultDownloadDir fallback returned invalid path: %s", dir)
 		}
+	}
+}
+
+func TestSettings_Validate(t *testing.T) {
+	defaults := DefaultSettings()
+
+	tests := []struct {
+		name     string
+		modify   func(*Settings)
+		validate func(*testing.T, *Settings)
+	}{
+		{
+			name: "Valid Settings Unchanged",
+			modify: func(s *Settings) {
+				s.Network.MaxConnectionsPerHost = 48
+				s.General.LogRetentionCount = 10
+				s.Performance.SlowWorkerThreshold = 0.5
+			},
+			validate: func(t *testing.T, s *Settings) {
+				if s.Network.MaxConnectionsPerHost != 48 {
+					t.Errorf("Expected 48, got %d", s.Network.MaxConnectionsPerHost)
+				}
+				if s.General.LogRetentionCount != 10 {
+					t.Errorf("Expected 10, got %d", s.General.LogRetentionCount)
+				}
+				if s.Performance.SlowWorkerThreshold != 0.5 {
+					t.Errorf("Expected 0.5, got %f", s.Performance.SlowWorkerThreshold)
+				}
+			},
+		},
+		{
+			name: "Invalid Connections High Reset",
+			modify: func(s *Settings) {
+				s.Network.MaxConnectionsPerHost = 999
+			},
+			validate: func(t *testing.T, s *Settings) {
+				if s.Network.MaxConnectionsPerHost != defaults.Network.MaxConnectionsPerHost {
+					t.Errorf("Expected default %d, got %d", defaults.Network.MaxConnectionsPerHost, s.Network.MaxConnectionsPerHost)
+				}
+			},
+		},
+		{
+			name: "Invalid Connections Low Reset",
+			modify: func(s *Settings) {
+				s.Network.MaxConnectionsPerHost = 0
+			},
+			validate: func(t *testing.T, s *Settings) {
+				if s.Network.MaxConnectionsPerHost != defaults.Network.MaxConnectionsPerHost {
+					t.Errorf("Expected default %d, got %d", defaults.Network.MaxConnectionsPerHost, s.Network.MaxConnectionsPerHost)
+				}
+			},
+		},
+		{
+			name: "Invalid Concurrent Downloads Reset",
+			modify: func(s *Settings) {
+				s.Network.MaxConcurrentDownloads = 15
+			},
+			validate: func(t *testing.T, s *Settings) {
+				if s.Network.MaxConcurrentDownloads != defaults.Network.MaxConcurrentDownloads {
+					t.Errorf("Expected default %d, got %d", defaults.Network.MaxConcurrentDownloads, s.Network.MaxConcurrentDownloads)
+				}
+			},
+		},
+		{
+			name: "Invalid Retention Count Reset",
+			modify: func(s *Settings) {
+				s.General.LogRetentionCount = 0
+			},
+			validate: func(t *testing.T, s *Settings) {
+				if s.General.LogRetentionCount != defaults.General.LogRetentionCount {
+					t.Errorf("Expected default %d, got %d", defaults.General.LogRetentionCount, s.General.LogRetentionCount)
+				}
+			},
+		},
+		{
+			name: "Invalid Threshold Reset",
+			modify: func(s *Settings) {
+				s.Performance.SlowWorkerThreshold = 1.5
+			},
+			validate: func(t *testing.T, s *Settings) {
+				if s.Performance.SlowWorkerThreshold != defaults.Performance.SlowWorkerThreshold {
+					t.Errorf("Expected default %f, got %f", defaults.Performance.SlowWorkerThreshold, s.Performance.SlowWorkerThreshold)
+				}
+			},
+		},
+		{
+			name: "Invalid Duration Reset",
+			modify: func(s *Settings) {
+				s.Performance.SlowWorkerGracePeriod = -1 * time.Second
+			},
+			validate: func(t *testing.T, s *Settings) {
+				if s.Performance.SlowWorkerGracePeriod != defaults.Performance.SlowWorkerGracePeriod {
+					t.Errorf("Expected default, got %v", s.Performance.SlowWorkerGracePeriod)
+				}
+			},
+		},
+		{
+			name: "Broken Path Reset",
+			modify: func(s *Settings) {
+				s.General.DefaultDownloadDir = "/non/existent/path/that/should/fail"
+			},
+			validate: func(t *testing.T, s *Settings) {
+				if s.General.DefaultDownloadDir != defaults.General.DefaultDownloadDir {
+					t.Errorf("Expected fallback to %q, got %q", defaults.General.DefaultDownloadDir, s.General.DefaultDownloadDir)
+				}
+			},
+		},
+		{
+			name: "Broken Category Regex Removal",
+			modify: func(s *Settings) {
+				s.Categories.Categories = []Category{
+					{Name: "Broken", Pattern: "[", Path: "/tmp"},
+					{Name: "Valid", Pattern: ".*", Path: "/tmp"},
+				}
+			},
+			validate: func(t *testing.T, s *Settings) {
+				if len(s.Categories.Categories) != 1 {
+					t.Errorf("Expected 1 valid category, got %d", len(s.Categories.Categories))
+				}
+				if s.Categories.Categories[0].Name != "Valid" {
+					t.Errorf("Expected 'Valid' category, got %q", s.Categories.Categories[0].Name)
+				}
+			},
+		},
+		{
+			name: "All Broken Categories Removal",
+			modify: func(s *Settings) {
+				s.Categories.Categories = []Category{
+					{Name: "Broken", Pattern: "[", Path: "/tmp"},
+				}
+			},
+			validate: func(t *testing.T, s *Settings) {
+				if len(s.Categories.Categories) != 0 {
+					t.Errorf("Expected 0 categories, got %d", len(s.Categories.Categories))
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := DefaultSettings()
+			tt.modify(s)
+			s.Validate()
+			tt.validate(t, s)
+		})
 	}
 }

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -892,3 +892,30 @@ func TestSettings_Validate(t *testing.T) {
 		})
 	}
 }
+
+func TestSettings_FutureProofValidation(t *testing.T) {
+	s := Settings{}
+	v := reflect.ValueOf(s)
+	tpe := v.Type()
+
+	for i := 0; i < tpe.NumField(); i++ {
+		field := tpe.Field(i)
+		// Skip unexported fields or non-struct fields
+		if field.PkgPath != "" || field.Type.Kind() != reflect.Struct {
+			continue
+		}
+
+		// Ensure the field type has a Validate method
+		// Some might take parameters (like Categories), some don't.
+		// We just check if a method named "Validate" exists.
+		_, ok := field.Type.MethodByName("Validate")
+		if !ok {
+			// If the type itself doesn't have it, check if a pointer to it does
+			_, ok = reflect.PtrTo(field.Type).MethodByName("Validate")
+		}
+
+		if !ok {
+			t.Errorf("Field %s (type %s) does not have a Validate method. Every settings group MUST implement validation to ensure application stability.", field.Name, field.Type.Name())
+		}
+	}
+}

--- a/internal/tui/delete_resilience_test.go
+++ b/internal/tui/delete_resilience_test.go
@@ -19,7 +19,7 @@ func (m *mockService) Delete(id string) error {
 	return m.deleteErr
 }
 
-func (m *mockService) List() ([]types.DownloadStatus, error) { return nil, nil }
+func (m *mockService) List() ([]types.DownloadStatus, error)   { return nil, nil }
 func (m *mockService) History() ([]types.DownloadEntry, error) { return nil, nil }
 func (m *mockService) Add(url string, path string, filename string, mirrors []string, headers map[string]string, isExplicitCategory bool, totalSize int64, supportsRange bool) (string, error) {
 	return "", nil
@@ -31,12 +31,12 @@ func (m *mockService) ResumeBatch(ids []string) []error { return nil }
 func (m *mockService) StreamEvents(ctx context.Context) (<-chan interface{}, func(), error) {
 	return nil, nil, nil
 }
-func (m *mockService) Publish(msg interface{}) error { return nil }
-func (m *mockService) Pause(id string) error { return nil }
-func (m *mockService) Resume(id string) error { return nil }
-func (m *mockService) UpdateURL(id string, newURL string) error { return nil }
+func (m *mockService) Publish(msg interface{}) error                      { return nil }
+func (m *mockService) Pause(id string) error                              { return nil }
+func (m *mockService) Resume(id string) error                             { return nil }
+func (m *mockService) UpdateURL(id string, newURL string) error           { return nil }
 func (m *mockService) GetStatus(id string) (*types.DownloadStatus, error) { return nil, nil }
-func (m *mockService) Shutdown() error { return nil }
+func (m *mockService) Shutdown() error                                    { return nil }
 
 func TestUpdateDashboard_DeleteResilience(t *testing.T) {
 	// This test validates the TUI's defensive layer independently of the service
@@ -44,7 +44,7 @@ func TestUpdateDashboard_DeleteResilience(t *testing.T) {
 	// IDs, the TUI should still gracefully handle ErrNotFound if it occurs.
 	dm := &DownloadModel{ID: "ghost-id", Filename: "ghost.zip"}
 	svc := &mockService{deleteErr: types.ErrNotFound}
-	
+
 	m := RootModel{
 		state:     DashboardState,
 		downloads: []*DownloadModel{dm},
@@ -71,7 +71,7 @@ func TestUpdateDashboard_DeleteResilience(t *testing.T) {
 func TestUpdateDashboard_DeleteSuccess(t *testing.T) {
 	dm := &DownloadModel{ID: "real-id", Filename: "real.zip"}
 	svc := &mockService{deleteErr: nil}
-	
+
 	m := RootModel{
 		state:     DashboardState,
 		downloads: []*DownloadModel{dm},
@@ -94,7 +94,7 @@ func TestUpdateDashboard_DeleteSuccess(t *testing.T) {
 func TestUpdateDashboard_DeleteOtherError(t *testing.T) {
 	dm := &DownloadModel{ID: "error-id", Filename: "error.zip"}
 	svc := &mockService{deleteErr: errors.New("some other error")}
-	
+
 	m := RootModel{
 		state:     DashboardState,
 		downloads: []*DownloadModel{dm},

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -179,6 +179,7 @@ type RootModel struct {
 	catMgrEditField int                // 0=Name, 1=Description, 2=Pattern, 3=Path
 	catMgrInputs    [4]textinput.Model // Inputs for Name, Description, Pattern, Path
 	catMgrIsNew     bool               // Whether adding a new category
+	catMgrError     string             // Error message for display in category manager
 	// Quit confirm button focus (0 = Yep!, 1 = Nope)
 	quitConfirmFocused int
 
@@ -206,7 +207,7 @@ type RootModel struct {
 	enqueueCtx       context.Context
 	cancelEnqueue    context.CancelFunc
 	shuttingDown     bool
-	RestartRequested bool // [NEW] Flag to signal process re-exec after TUI shutdown
+	RestartRequested bool // Flag to signal process re-exec after TUI shutdown
 
 	spinner spinner.Model
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -155,6 +155,7 @@ type RootModel struct {
 	SettingsSelectedRow  int              // Selected setting within current tab
 	SettingsIsEditing    bool             // Whether currently editing a value
 	SettingsInput        textinput.Model  // Input for editing string/int values
+	settingsError        string           // Current validation error in settings
 	ExtensionTokenCopied bool             // Flash message for "Token Copied!"
 
 	// Selection persistence

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -56,6 +56,7 @@ const (
 	BugReportTargetState                       // BugReportTargetState is 17
 	BugReportSystemDetailsState                // BugReportSystemDetailsState is 18
 	BugReportLogPathState                      // BugReportLogPathState is 19
+	CategoryResetConfirmState                  // CategoryResetConfirmState is 20
 )
 
 type FilePickerOrigin int

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -242,6 +242,9 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case BugReportLogPathState:
 			return m.updateBugReportLogPath(msg)
 
+		case CategoryResetConfirmState:
+			return m.updateCategoryResetConfirm(msg)
+
 		default:
 			return m, nil
 		}

--- a/internal/tui/update_category.go
+++ b/internal/tui/update_category.go
@@ -137,6 +137,23 @@ func (m RootModel) updateCategoryManager(msg tea.KeyPressMsg) (tea.Model, tea.Cm
 			m.catMgrInputs[m.catMgrEditField].Focus()
 			return m, nil
 		}
+		if key.Matches(msg, m.keys.CategoryMgr.Up) {
+			m.catMgrError = ""
+			m.catMgrInputs[m.catMgrEditField].Blur()
+			m.catMgrEditField--
+			if m.catMgrEditField < 0 {
+				m.catMgrEditField = 3
+			}
+			m.catMgrInputs[m.catMgrEditField].Focus()
+			return m, nil
+		}
+		if key.Matches(msg, m.keys.CategoryMgr.Down) {
+			m.catMgrError = ""
+			m.catMgrInputs[m.catMgrEditField].Blur()
+			m.catMgrEditField = (m.catMgrEditField + 1) % 4
+			m.catMgrInputs[m.catMgrEditField].Focus()
+			return m, nil
+		}
 		if key.Matches(msg, m.keys.CategoryMgr.Edit) {
 			// Save edits
 			if m.catMgrCursor < 0 || m.catMgrCursor >= len(m.Settings.Categories.Categories) {

--- a/internal/tui/update_category.go
+++ b/internal/tui/update_category.go
@@ -142,7 +142,6 @@ func (m RootModel) updateCategoryManager(msg tea.KeyPressMsg) (tea.Model, tea.Cm
 			if m.catMgrCursor < 0 || m.catMgrCursor >= len(m.Settings.Categories.Categories) {
 				m.catMgrError = "Invalid category selection"
 				utils.Debug("Category Manager Error: %s", m.catMgrError)
-				m.addLogEntry(LogStyleError.Render("\u2716 " + m.catMgrError))
 				return m, nil
 			}
 
@@ -154,25 +153,21 @@ func (m RootModel) updateCategoryManager(msg tea.KeyPressMsg) (tea.Model, tea.Cm
 			if name == "" {
 				m.catMgrError = "Category name cannot be empty"
 				utils.Debug("Category Manager Error: %s", m.catMgrError)
-				m.addLogEntry(LogStyleError.Render("\u2716 " + m.catMgrError))
 				return m, nil
 			}
 			if pattern == "" {
 				m.catMgrError = "Category pattern cannot be empty"
 				utils.Debug("Category Manager Error: %s", m.catMgrError)
-				m.addLogEntry(LogStyleError.Render("\u2716 " + m.catMgrError))
 				return m, nil
 			}
 			if _, err := regexp.Compile(pattern); err != nil {
 				m.catMgrError = fmt.Sprintf("Invalid regex pattern: %v", err)
 				utils.Debug("Category Manager Error: %s", m.catMgrError)
-				m.addLogEntry(LogStyleError.Render("\u2716 " + m.catMgrError))
 				return m, nil
 			}
 			if path == "" {
 				m.catMgrError = "Category path cannot be empty"
 				utils.Debug("Category Manager Error: %s", m.catMgrError)
-				m.addLogEntry(LogStyleError.Render("\u2716 " + m.catMgrError))
 				return m, nil
 			}
 

--- a/internal/tui/update_category.go
+++ b/internal/tui/update_category.go
@@ -9,6 +9,7 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 	"github.com/SurgeDM/Surge/internal/config"
+	"github.com/SurgeDM/Surge/internal/utils"
 )
 
 func (m *RootModel) catMgrBeginAdd() {
@@ -17,6 +18,7 @@ func (m *RootModel) catMgrBeginAdd() {
 	m.catMgrCursor = len(m.Settings.Categories.Categories) - 1
 	m.catMgrIsNew = true
 	m.catMgrEditing = true
+	m.catMgrError = ""
 	m.catMgrEditField = 0
 	m.catMgrInputs[0].SetValue(newCat.Name)
 	m.catMgrInputs[1].SetValue(newCat.Description)
@@ -112,9 +114,11 @@ func (m RootModel) updateCategoryManager(msg tea.KeyPressMsg) (tea.Model, tea.Cm
 				}
 			}
 			m.catMgrIsNew = false
+			m.catMgrError = ""
 			return m, nil
 		}
 		if key.Matches(msg, m.keys.CategoryMgr.Tab) {
+			m.catMgrError = ""
 			// On Path field, open file picker for directory browsing
 			if m.catMgrEditField == 3 {
 				originalPath := m.catMgrInputs[3].Value()
@@ -136,7 +140,9 @@ func (m RootModel) updateCategoryManager(msg tea.KeyPressMsg) (tea.Model, tea.Cm
 		if key.Matches(msg, m.keys.CategoryMgr.Edit) {
 			// Save edits
 			if m.catMgrCursor < 0 || m.catMgrCursor >= len(m.Settings.Categories.Categories) {
-				m.addLogEntry(LogStyleError.Render("\u2716 Invalid category selection"))
+				m.catMgrError = "Invalid category selection"
+				utils.Debug("Category Manager Error: %s", m.catMgrError)
+				m.addLogEntry(LogStyleError.Render("\u2716 " + m.catMgrError))
 				return m, nil
 			}
 
@@ -146,19 +152,27 @@ func (m RootModel) updateCategoryManager(msg tea.KeyPressMsg) (tea.Model, tea.Cm
 			path := strings.TrimSpace(m.catMgrInputs[3].Value())
 
 			if name == "" {
-				m.addLogEntry(LogStyleError.Render("\u2716 Category name cannot be empty"))
+				m.catMgrError = "Category name cannot be empty"
+				utils.Debug("Category Manager Error: %s", m.catMgrError)
+				m.addLogEntry(LogStyleError.Render("\u2716 " + m.catMgrError))
 				return m, nil
 			}
 			if pattern == "" {
-				m.addLogEntry(LogStyleError.Render("\u2716 Category pattern cannot be empty"))
+				m.catMgrError = "Category pattern cannot be empty"
+				utils.Debug("Category Manager Error: %s", m.catMgrError)
+				m.addLogEntry(LogStyleError.Render("\u2716 " + m.catMgrError))
 				return m, nil
 			}
 			if _, err := regexp.Compile(pattern); err != nil {
-				m.addLogEntry(LogStyleError.Render(fmt.Sprintf("\u2716 Invalid category pattern: %v", err)))
+				m.catMgrError = fmt.Sprintf("Invalid regex pattern: %v", err)
+				utils.Debug("Category Manager Error: %s", m.catMgrError)
+				m.addLogEntry(LogStyleError.Render("\u2716 " + m.catMgrError))
 				return m, nil
 			}
 			if path == "" {
-				m.addLogEntry(LogStyleError.Render("\u2716 Category path cannot be empty"))
+				m.catMgrError = "Category path cannot be empty"
+				utils.Debug("Category Manager Error: %s", m.catMgrError)
+				m.addLogEntry(LogStyleError.Render("\u2716 " + m.catMgrError))
 				return m, nil
 			}
 
@@ -168,8 +182,15 @@ func (m RootModel) updateCategoryManager(msg tea.KeyPressMsg) (tea.Model, tea.Cm
 			target.Pattern = pattern
 			target.Path = filepath.Clean(path)
 
+			if m.catMgrIsNew {
+				utils.Debug("Category Added: %s (Path: %s)", name, path)
+			} else {
+				utils.Debug("Category Updated: %s (Path: %s)", name, path)
+			}
+
 			m.catMgrEditing = false
 			m.catMgrIsNew = false
+			m.catMgrError = ""
 
 			m.blurAllCatInputs()
 
@@ -190,12 +211,14 @@ func (m RootModel) updateCategoryManager(msg tea.KeyPressMsg) (tea.Model, tea.Cm
 	}
 
 	if key.Matches(msg, m.keys.CategoryMgr.Up) {
+		m.catMgrError = ""
 		if m.catMgrCursor > 0 {
 			m.catMgrCursor--
 		}
 		return m, nil
 	}
 	if key.Matches(msg, m.keys.CategoryMgr.Down) {
+		m.catMgrError = ""
 		if m.catMgrCursor < len(cats) { // len(cats) = "+Add" row
 			m.catMgrCursor++
 		}
@@ -208,11 +231,14 @@ func (m RootModel) updateCategoryManager(msg tea.KeyPressMsg) (tea.Model, tea.Cm
 	}
 
 	if key.Matches(msg, m.keys.CategoryMgr.Delete) {
+		m.catMgrError = ""
 		if m.catMgrCursor < len(cats) {
+			deletedName := cats[m.catMgrCursor].Name
 			m.Settings.Categories.Categories = append(
 				m.Settings.Categories.Categories[:m.catMgrCursor],
 				m.Settings.Categories.Categories[m.catMgrCursor+1:]...,
 			)
+			utils.Debug("Category Removed: %s", deletedName)
 			if m.catMgrCursor >= len(m.Settings.Categories.Categories) && m.catMgrCursor > 0 {
 				m.catMgrCursor--
 			}

--- a/internal/tui/update_modals.go
+++ b/internal/tui/update_modals.go
@@ -361,8 +361,8 @@ func (m RootModel) updateRestartConfirm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd
 
 func (m RootModel) updateCategoryResetConfirm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	confirmReset := func() (tea.Model, tea.Cmd) {
-		m.Settings.Categories.Categories = config.DefaultCategories()
-		m.Settings.Categories.CategoryEnabled = false
+		defaults := config.DefaultSettings()
+		m.Settings.Categories = defaults.Categories
 		m.addLogEntry(LogStyleStarted.Render("\u2714 Categories reset to defaults"))
 		utils.Debug("Categories Reset to Defaults")
 		m.state = SettingsState

--- a/internal/tui/update_modals.go
+++ b/internal/tui/update_modals.go
@@ -8,6 +8,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/SurgeDM/Surge/internal/bugreport"
 	"github.com/SurgeDM/Surge/internal/clipboard"
+	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/utils"
 )
 
@@ -353,6 +354,37 @@ func (m RootModel) updateRestartConfirm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd
 		return confirmRestart()
 	case yesNoNo, yesNoCancel:
 		return cancelRestart()
+	}
+
+	return m, nil
+}
+
+func (m RootModel) updateCategoryResetConfirm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	confirmReset := func() (tea.Model, tea.Cmd) {
+		m.Settings.Categories.Categories = config.DefaultCategories()
+		m.Settings.Categories.CategoryEnabled = false
+		m.addLogEntry(LogStyleStarted.Render("\u2714 Categories reset to defaults"))
+		utils.Debug("Categories Reset to Defaults")
+		m.state = SettingsState
+		m.quitConfirmFocused = 0
+		return m, nil
+	}
+	cancelReset := func() (tea.Model, tea.Cmd) {
+		m.state = SettingsState
+		m.quitConfirmFocused = 0
+		return m, nil
+	}
+
+	m, decision, handled := m.handleYesNoSelection(msg)
+	if !handled {
+		return m, nil
+	}
+
+	switch decision {
+	case yesNoYes:
+		return confirmReset()
+	case yesNoNo, yesNoCancel:
+		return cancelReset()
 	}
 
 	return m, nil

--- a/internal/tui/update_settings.go
+++ b/internal/tui/update_settings.go
@@ -211,6 +211,14 @@ func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		if settingKey == "max_global_connections" {
 			return m, nil
 		}
+
+		// Categories tab → 'Manage Categories' selected → confirm full reset
+		if m.SettingsActiveTab < len(categories) && categories[m.SettingsActiveTab] == "Categories" && settingKey == "category_enabled" {
+			m.state = CategoryResetConfirmState
+			m.quitConfirmFocused = 0
+			return m, nil
+		}
+
 		defaults := config.DefaultSettings()
 		currentCategory := categories[m.SettingsActiveTab]
 		m.resetSettingToDefault(currentCategory, settingKey, defaults)

--- a/internal/tui/update_settings.go
+++ b/internal/tui/update_settings.go
@@ -292,11 +292,16 @@ func (m *RootModel) validateSetting(key, value string) error {
 			return fmt.Errorf("must be between 0.0 and 1.0")
 		}
 	case "slow_worker_grace_period", "stall_timeout":
-		if _, err := strconv.ParseFloat(trimmed, 64); err == nil {
+		if v, err := strconv.ParseFloat(trimmed, 64); err == nil {
+			if v < 0 {
+				return fmt.Errorf("must be non-negative")
+			}
 			return nil
 		}
-		if _, err := time.ParseDuration(trimmed); err != nil {
+		if d, err := time.ParseDuration(trimmed); err != nil {
 			return fmt.Errorf("invalid duration (e.g. 5s or 5)")
+		} else if d < 0 {
+			return fmt.Errorf("must be non-negative")
 		}
 	case "log_retention_count":
 		v, err := strconv.Atoi(trimmed)

--- a/internal/tui/update_settings.go
+++ b/internal/tui/update_settings.go
@@ -1,8 +1,11 @@
 package tui
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 
 	"charm.land/bubbles/v2/key"
@@ -37,8 +40,17 @@ func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		if key.Matches(msg, m.keys.SettingsEditor.Confirm) {
 			currentCategory := categories[m.SettingsActiveTab]
 			settingKey := m.getCurrentSettingKey()
-			_ = m.setSettingValue(currentCategory, settingKey, m.SettingsInput.Value())
+			val := m.SettingsInput.Value()
+
+			if err := m.validateSetting(settingKey, val); err != nil {
+				m.settingsError = err.Error()
+				utils.Debug("Settings Validation Error: %s = %s (%v)", settingKey, val, err)
+				return m, nil
+			}
+
+			_ = m.setSettingValue(currentCategory, settingKey, val)
 			m.SettingsIsEditing = false
+			m.settingsError = ""
 			m.SettingsInput.Blur()
 			return m, nil
 		}
@@ -46,6 +58,10 @@ func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		// Pass to text input
 		var cmd tea.Cmd
 		m.SettingsInput, cmd = m.SettingsInput.Update(msg)
+		// Clear error when typing
+		if m.SettingsInput.Value() != "" && m.settingsError != "" {
+			m.settingsError = ""
+		}
 		return m, cmd
 	}
 
@@ -74,6 +90,7 @@ func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		if key.Matches(msg, binding) {
 			if categoryCount > i {
 				m.SettingsActiveTab = i
+				m.settingsError = ""
 			}
 			m.SettingsSelectedRow = 0
 			return m, nil
@@ -84,11 +101,13 @@ func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if key.Matches(msg, m.keys.Settings.NextTab) {
 		m.SettingsActiveTab = (m.SettingsActiveTab + 1) % categoryCount
 		m.SettingsSelectedRow = 0
+		m.settingsError = ""
 		return m, nil
 	}
 	if key.Matches(msg, m.keys.Settings.PrevTab) {
 		m.SettingsActiveTab = (m.SettingsActiveTab - 1 + categoryCount) % categoryCount
 		m.SettingsSelectedRow = 0
+		m.settingsError = ""
 		return m, nil
 	}
 
@@ -131,6 +150,7 @@ func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if key.Matches(msg, m.keys.Settings.Up) {
 		if m.SettingsSelectedRow > 0 {
 			m.SettingsSelectedRow--
+			m.settingsError = ""
 		}
 		return m, nil
 	}
@@ -138,6 +158,7 @@ func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		maxRow := m.getSettingsCount() - 1
 		if m.SettingsSelectedRow < maxRow {
 			m.SettingsSelectedRow++
+			m.settingsError = ""
 		}
 		return m, nil
 	}
@@ -229,4 +250,58 @@ func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 
 	return m, nil
+}
+
+func (m *RootModel) validateSetting(key, value string) error {
+	trimmed := strings.TrimSpace(value)
+	switch key {
+	case "max_connections_per_host":
+		v, err := strconv.Atoi(trimmed)
+		if err != nil || v < 1 || v > 64 {
+			return fmt.Errorf("must be between 1 and 64")
+		}
+	case "max_concurrent_downloads", "max_concurrent_probes":
+		v, err := strconv.Atoi(trimmed)
+		if err != nil || v < 1 || v > 10 {
+			return fmt.Errorf("must be between 1 and 10")
+		}
+	case "min_chunk_size":
+		v, err := strconv.ParseFloat(trimmed, 64)
+		if err != nil || v < 0.1 {
+			return fmt.Errorf("must be at least 0.1 MB")
+		}
+	case "worker_buffer_size":
+		v, err := strconv.Atoi(trimmed)
+		if err != nil || v < 1 {
+			return fmt.Errorf("must be at least 1 KB")
+		}
+	case "dial_hedge_count":
+		v, err := strconv.Atoi(trimmed)
+		if err != nil || v < 0 || v > 16 {
+			return fmt.Errorf("must be between 0 and 16")
+		}
+	case "max_task_retries":
+		v, err := strconv.Atoi(trimmed)
+		if err != nil || v < 0 || v > 10 {
+			return fmt.Errorf("must be between 0 and 10")
+		}
+	case "slow_worker_threshold", "speed_ema_alpha":
+		v, err := strconv.ParseFloat(trimmed, 64)
+		if err != nil || v < 0.0 || v > 1.0 {
+			return fmt.Errorf("must be between 0.0 and 1.0")
+		}
+	case "slow_worker_grace_period", "stall_timeout":
+		if _, err := strconv.ParseFloat(trimmed, 64); err == nil {
+			return nil
+		}
+		if _, err := time.ParseDuration(trimmed); err != nil {
+			return fmt.Errorf("invalid duration (e.g. 5s or 5)")
+		}
+	case "log_retention_count":
+		v, err := strconv.Atoi(trimmed)
+		if err != nil || v < 1 || v > 100 {
+			return fmt.Errorf("must be between 1 and 100")
+		}
+	}
+	return nil
 }

--- a/internal/tui/update_settings.go
+++ b/internal/tui/update_settings.go
@@ -2,7 +2,6 @@ package tui
 
 import (
 	"fmt"
-	"net"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -61,7 +60,7 @@ func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		var cmd tea.Cmd
 		m.SettingsInput, cmd = m.SettingsInput.Update(msg)
 		// Clear error when typing
-		if m.SettingsInput.Value() != "" && m.settingsError != "" {
+		if m.settingsError != "" {
 			m.settingsError = ""
 		}
 		return m, cmd
@@ -313,26 +312,7 @@ func (m *RootModel) validateSetting(key, value string) error {
 			return fmt.Errorf("invalid URL (e.g. http://127.0.0.1:1080)")
 		}
 	case "custom_dns":
-		if trimmed == "" {
-			return nil
-		}
-		parts := strings.Split(trimmed, ",")
-		for _, part := range parts {
-			p := strings.TrimSpace(part)
-			if p == "" {
-				continue
-			}
-			host, _, err := net.SplitHostPort(p)
-			if err != nil {
-				if net.ParseIP(p) == nil {
-					return fmt.Errorf("invalid DNS: %s", p)
-				}
-			} else {
-				if net.ParseIP(host) == nil {
-					return fmt.Errorf("invalid DNS IP: %s", host)
-				}
-			}
-		}
+		return config.ValidateDNSList(trimmed)
 	}
 	return nil
 }

--- a/internal/tui/update_settings.go
+++ b/internal/tui/update_settings.go
@@ -2,6 +2,8 @@ package tui
 
 import (
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -301,6 +303,35 @@ func (m *RootModel) validateSetting(key, value string) error {
 		v, err := strconv.Atoi(trimmed)
 		if err != nil || v < 1 || v > 100 {
 			return fmt.Errorf("must be between 1 and 100")
+		}
+	case "proxy_url":
+		if trimmed == "" {
+			return nil
+		}
+		u, err := url.Parse(trimmed)
+		if err != nil || u.Scheme == "" || u.Host == "" {
+			return fmt.Errorf("invalid URL (e.g. http://127.0.0.1:1080)")
+		}
+	case "custom_dns":
+		if trimmed == "" {
+			return nil
+		}
+		parts := strings.Split(trimmed, ",")
+		for _, part := range parts {
+			p := strings.TrimSpace(part)
+			if p == "" {
+				continue
+			}
+			host, _, err := net.SplitHostPort(p)
+			if err != nil {
+				if net.ParseIP(p) == nil {
+					return fmt.Errorf("invalid DNS: %s", p)
+				}
+			} else {
+				if net.ParseIP(host) == nil {
+					return fmt.Errorf("invalid DNS IP: %s", host)
+				}
+			}
 		}
 	}
 	return nil

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -292,6 +292,10 @@ func (m RootModel) View() tea.View {
 		return m.wrapView(m.renderModalWithOverlay(m.viewRestartConfirm()))
 	}
 
+	if m.state == CategoryResetConfirmState {
+		return m.wrapView(m.renderModalWithOverlay(m.viewCategoryResetConfirm()))
+	}
+
 	if m.state == UpdateAvailableState && m.UpdateInfo != nil {
 		modal := components.ConfirmationModal{
 			Title:       "\u2b06 Update Available",
@@ -921,6 +925,78 @@ func (m RootModel) viewRestartConfirm() string {
 
 	content := lipgloss.JoinVertical(lipgloss.Left, lines...)
 	return renderBtopBox(PaneTitleStyle.Render(" Restart Required "), "", content, w, h, colors.Orange())
+}
+
+func (m RootModel) viewCategoryResetConfirm() string {
+	w, h := GetDynamicModalDimensions(m.width, m.height, 40, 8, 60, 10)
+	innerWidth := w - (components.BorderFrameWidth * 2)
+
+	messageStyle := lipgloss.NewStyle().
+		Foreground(colors.White()).
+		Width(innerWidth).
+		Align(lipgloss.Center)
+
+	detailStyle := lipgloss.NewStyle().
+		Foreground(colors.Orange()).
+		Bold(true).
+		Width(innerWidth).
+		Align(lipgloss.Center)
+
+	pad := "   "
+
+	activeFirst := lipgloss.NewStyle().Foreground(colors.White()).Background(colors.Orange()).Bold(true).Underline(true)
+	activeRest := lipgloss.NewStyle().Foreground(colors.White()).Background(colors.Orange()).Bold(true)
+	activePad := lipgloss.NewStyle().Background(colors.Orange())
+
+	inactiveFirst := lipgloss.NewStyle().Foreground(colors.LightGray()).Background(lipgloss.Color("236")).Underline(true)
+	inactiveRest := lipgloss.NewStyle().Foreground(colors.LightGray()).Background(lipgloss.Color("236"))
+	inactivePad := lipgloss.NewStyle().Background(lipgloss.Color("236"))
+
+	renderBtn := func(padStyle, firstStyle, restStyle lipgloss.Style, first, rest string) string {
+		return padStyle.Render(pad) + firstStyle.Render(first) + restStyle.Render(rest) + padStyle.Render(pad)
+	}
+
+	yesFirst, yesRest, yesPad := activeFirst, activeRest, activePad
+	noFirst, noRest, noPad := inactiveFirst, inactiveRest, inactivePad
+	if m.quitConfirmFocused == 1 {
+		yesFirst, yesRest, yesPad = inactiveFirst, inactiveRest, inactivePad
+		noFirst, noRest, noPad = activeFirst, activeRest, activePad
+	}
+
+	yesBtn := renderBtn(yesPad, yesFirst, yesRest, "Y", "es")
+	noBtn := renderBtn(noPad, noFirst, noRest, "N", "o")
+
+	buttons := lipgloss.JoinHorizontal(lipgloss.Center, yesBtn, "     ", noBtn)
+	centeredButtons := lipgloss.NewStyle().Width(innerWidth).Align(lipgloss.Center).Render(buttons)
+
+	helpStyle := lipgloss.NewStyle().Foreground(colors.Gray()).Width(innerWidth).Align(lipgloss.Center)
+	helpText := helpStyle.Render(m.help.View(m.keys.QuitConfirm))
+
+	var lines []string
+	lines = append(lines, messageStyle.Render("Reset all categories to defaults?"))
+	lines = append(lines, detailStyle.Render("This will overwrite your custom rules."))
+	lines = append(lines, "")
+	lines = append(lines, "")
+	lines = append(lines, centeredButtons)
+
+	innerHeight := h - components.BorderFrameHeight
+	contentHeight := lipgloss.Height(lipgloss.JoinVertical(lipgloss.Left, lines...))
+	helpHeight := lipgloss.Height(helpText)
+	spacing := innerHeight - contentHeight - helpHeight
+	if spacing < 0 {
+		spacing = 0
+	}
+	for i := 0; i < spacing; i++ {
+		lines = append(lines, "")
+	}
+	if len(lines) > 0 && spacing > 0 {
+		lines[len(lines)-1] = helpText
+	} else {
+		lines = append(lines, helpText)
+	}
+
+	content := lipgloss.JoinVertical(lipgloss.Left, lines...)
+	return renderBtopBox(PaneTitleStyle.Render(" Category Reset "), "", content, w, h, colors.Orange())
 }
 
 // renderBtopBox creates a btop-style box with title embedded in the top border

--- a/internal/tui/view_category.go
+++ b/internal/tui/view_category.go
@@ -78,6 +78,14 @@ func (m RootModel) viewCategoryManager() string {
 		bodyHeight = 3
 	}
 
+	var errorLine string
+	if m.catMgrError != "" {
+		errorLine = lipgloss.NewStyle().
+			Foreground(colors.StateError()).
+			Bold(true).
+			Render("  \u2716 " + m.catMgrError)
+	}
+
 	var content string
 	if width >= 76 && bodyHeight >= 9 {
 		content = m.renderCategoryTwoColumn(cats, cursor, width, bodyHeight)
@@ -86,7 +94,8 @@ func (m RootModel) viewCategoryManager() string {
 	}
 
 	contentHeight := lipgloss.Height(content)
-	usedHeight := toggleBarHeight + infoHeight + LayoutGapStyle.GetVerticalFrameSize() + contentHeight + helpHeight
+	errorHeight := lipgloss.Height(errorLine)
+	usedHeight := toggleBarHeight + infoHeight + errorHeight + LayoutGapStyle.GetVerticalFrameSize() + contentHeight + helpHeight
 	paddingLines := innerHeight - usedHeight
 	if paddingLines < 0 {
 		paddingLines = 0
@@ -96,6 +105,7 @@ func (m RootModel) viewCategoryManager() string {
 	fullContent := lipgloss.JoinVertical(lipgloss.Left,
 		toggleLine,
 		infoLine,
+		errorLine,
 		"",
 		content,
 		padding+helpText,

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -76,7 +76,22 @@ func (m RootModel) viewSettings() string {
 	innerHeight := height - BoxStyle.GetVerticalFrameSize()
 	tabBarHeight := lipgloss.Height(tabBar)
 	helpHeight := lipgloss.Height(helpText)
-	bodyHeight := innerHeight - tabBarHeight - helpHeight - (LayoutGapStyle.GetVerticalFrameSize() * 2) // one line gap above body and help
+
+	errorLine := ""
+	if m.settingsError != "" {
+		errorLine = lipgloss.NewStyle().
+			Foreground(colors.StateError()).
+			Bold(true).
+			Padding(0, 2).
+			Render("\u2716 " + m.settingsError)
+	}
+
+	errorHeight := lipgloss.Height(errorLine)
+	if errorHeight > 0 {
+		errorHeight += 1 // Gap after error
+	}
+
+	bodyHeight := innerHeight - tabBarHeight - helpHeight - errorHeight - (LayoutGapStyle.GetVerticalFrameSize() * 2)
 	if bodyHeight < 3 {
 		bodyHeight = 3
 	}
@@ -89,20 +104,20 @@ func (m RootModel) viewSettings() string {
 	}
 
 	contentHeight := lipgloss.Height(content)
-	usedHeight := tabBarHeight + LayoutGapStyle.GetVerticalFrameSize() + contentHeight + LayoutGapStyle.GetVerticalFrameSize() + helpHeight
+	usedHeight := tabBarHeight + LayoutGapStyle.GetVerticalFrameSize() + errorHeight + contentHeight + LayoutGapStyle.GetVerticalFrameSize() + helpHeight
 	paddingLines := innerHeight - usedHeight
 	if paddingLines < 0 {
 		paddingLines = 0
 	}
 	padding := strings.Repeat("\n", paddingLines)
 
-	fullContent := lipgloss.JoinVertical(lipgloss.Left,
-		tabBar,
-		"",
-		content,
-		padding,
-		helpText,
-	)
+	parts := []string{tabBar, ""}
+	if errorLine != "" {
+		parts = append(parts, errorLine, "")
+	}
+	parts = append(parts, content, padding, helpText)
+
+	fullContent := lipgloss.JoinVertical(lipgloss.Left, parts...)
 
 	box := renderBtopBox(PaneTitleStyle.Render(" Settings "), "", fullContent, width, height, colors.Magenta())
 	return m.renderModalWithOverlay(box)


### PR DESCRIPTION
This PR improves the Category Manager UX and introduces a comprehensive validation system for all application settings.

### Key Changes:

#### Category Manager
- Added real-time validation feedback in the UI for category names, patterns, and paths.
- Enabled Up/Down arrow key navigation between input fields while editing.
- Implemented a reset confirmation modal to prevent accidental loss of custom categories.
- Standardized debug logging for category lifecycle events.

#### Settings & Validation
- Implemented a structured, hierarchical validation system (OOP-style) where each settings group manages its own integrity.
- Added real-time TUI feedback for invalid numeric ranges, durations, URLs, and DNS configurations.
- Introduced "partial rollback" logic: if the settings.json file on disk contains invalid values, Surge now corrects only the broken fields while preserving all other valid customizations.
- Added rigorous path verification for default download directories and category folders.

#### Documentation & Tests
- Updated docs/SETTINGS.md to include a section on the new self-healing configuration logic.
- Added comprehensive unit tests in internal/config/settings_test.go covering range enforcement, path rollback, and category pruning.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a hierarchical settings validation system with per-group `Validate()` methods, partial rollback of invalid fields on startup, real-time TUI error feedback for settings and the category manager, Up/Down field navigation, and a reset confirmation modal for categories. The implementation is solid — the shared `ValidateDNSList` helper eliminates the previously duplicated DNS parsing, proxy URL validation now correctly checks for empty `Scheme`/`Host`, and the `updateCategoryResetConfirm` handler correctly derives defaults from `config.DefaultSettings()`. Only P2 findings remain: the new `viewCategoryResetConfirm` introduces a third verbatim copy of the button-rendering boilerplate, and the new test suite is missing coverage for the category path-rollback branch.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no P0 or P1 findings; all remaining feedback is non-blocking style and test coverage.

Only P2 findings present: a style concern around duplicated button-rendering boilerplate and a missing test case for category path rollback. No runtime errors, data loss risk, or security issues were identified.

internal/tui/view.go (button rendering duplication) and internal/config/settings_test.go (missing category path rollback test).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/config/settings.go | Adds hierarchical Validate() methods for all settings groups with range enforcement, path checks, proxy URL guards, and a shared ValidateDNSList helper; StartupWarnings field accumulates messages for post-startup display. |
| internal/config/settings_test.go | Comprehensive new Validate test suite covering range resets, path rollback, and regex pruning; missing coverage for the category path-rollback code path. |
| internal/tui/update_settings.go | Adds validateSetting() for real-time TUI feedback with correct non-negative guards on durations; settingsError cleared on navigation/tab switches. |
| internal/tui/view.go | New viewCategoryResetConfirm() modal works correctly but triples the button-rendering boilerplate that already appears in viewQuitConfirm and viewRestartConfirm. |
| internal/tui/update_modals.go | updateCategoryResetConfirm() now correctly derives defaults from config.DefaultSettings() instead of hardcoding false. |
| internal/tui/update_category.go | Adds Up/Down field navigation, migrates errors to catMgrError for inline display, and standardises debug logging for category lifecycle events. |
| internal/tui/view_settings.go | Error line injected into layout correctly; bodyHeight and usedHeight accounting updated to include errorHeight and the trailing gap. |
| internal/tui/view_category.go | Inline catMgrError line rendered below infoLine with correct height accounting. |
| cmd/root.go | publishStartupWarnings() correctly guards on globalSettings nil and is only reachable after ensureGlobalLocalServiceAndLifecycle() succeeds (guaranteeing GlobalService is non-nil). |
| cmd/bugreport.go | Silences fmt.Fprint* return values with blank identifiers; cosmetic cleanup with no functional change. |
| internal/tui/model.go | Adds CategoryResetConfirmState, settingsError, and catMgrError fields; removes [NEW] comment tag from RestartRequested. |
| docs/SETTINGS.md | Adds a Configuration Validation section accurately documenting range enforcement, path verification, proxy/DNS syntax checks, category pruning, and corrupt-JSON fallback. |
| cmd/root_lifecycle_test.go | Pre-creates custom directories with os.MkdirAll so tests pass under the new path-verification logic in settings.Validate(). |
| internal/tui/delete_resilience_test.go | Whitespace-only formatting cleanup; no functional change. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (4)</h3></summary>

1. `internal/config/settings.go`, line 104-109 ([link](https://github.com/surgedm/surge/blob/05738df7ab7363d0a51fd4fc529bbe46c5675cb2/internal/config/settings.go#L104-L109)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`url.Parse` won't catch invalid proxy URLs**

   `url.Parse` in Go is extremely permissive and almost never returns an error. Strings like `"badproxy"`, `"://noscheme"`, or `"ftp://missing-host"` all parse without error, resulting in a `url.URL` with empty `Scheme` or `Host`. The self-healing behavior documented in `SETTINGS.md` — "Proxy URLs are validated for correct syntax" — will silently skip any invalid proxy URL read from disk, leaving the broken value in place.

   The TUI's `validateSetting` (in `update_settings.go`) correctly guards against this by checking `u.Scheme == "" || u.Host == ""`. The same guard should be applied here:

   ```go
   if ns.ProxyURL != "" {
       u, err := url.Parse(ns.ProxyURL)
       if err != nil || u.Scheme == "" || u.Host == "" {
           ns.ProxyURL = defaults.ProxyURL
       }
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/config/settings.go
   Line: 104-109

   Comment:
   **`url.Parse` won't catch invalid proxy URLs**

   `url.Parse` in Go is extremely permissive and almost never returns an error. Strings like `"badproxy"`, `"://noscheme"`, or `"ftp://missing-host"` all parse without error, resulting in a `url.URL` with empty `Scheme` or `Host`. The self-healing behavior documented in `SETTINGS.md` — "Proxy URLs are validated for correct syntax" — will silently skip any invalid proxy URL read from disk, leaving the broken value in place.

   The TUI's `validateSetting` (in `update_settings.go`) correctly guards against this by checking `u.Scheme == "" || u.Host == ""`. The same guard should be applied here:

   ```go
   if ns.ProxyURL != "" {
       u, err := url.Parse(ns.ProxyURL)
       if err != nil || u.Scheme == "" || u.Host == "" {
           ns.ProxyURL = defaults.ProxyURL
       }
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `internal/tui/update_modals.go`, line 621-630 ([link](https://github.com/surgedm/surge/blob/05738df7ab7363d0a51fd4fc529bbe46c5675cb2/internal/tui/update_modals.go#L621-L630)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Hardcoded `false` should be derived from defaults**

   `CategoryEnabled` is reset to a hardcoded `false` rather than the value returned by `config.DefaultSettings()`. This means if the default ever changes (e.g., to `true`), this reset path diverges silently. Using the defaults struct is consistent with how every other field is rolled back in `resetSettingToDefault` and `Validate()`:

   ```go
   defaults := config.DefaultSettings()
   m.Settings.Categories = defaults.Categories
   m.addLogEntry(LogStyleStarted.Render("\u2714 Categories reset to defaults"))
   utils.Debug("Categories Reset to Defaults")
   m.state = SettingsState
   m.quitConfirmFocused = 0
   return m, nil
   ```

   This also avoids having to remember to update two places if a new `CategorySettings` field is added.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/tui/update_modals.go
   Line: 621-630

   Comment:
   **Hardcoded `false` should be derived from defaults**

   `CategoryEnabled` is reset to a hardcoded `false` rather than the value returned by `config.DefaultSettings()`. This means if the default ever changes (e.g., to `true`), this reset path diverges silently. Using the defaults struct is consistent with how every other field is rolled back in `resetSettingToDefault` and `Validate()`:

   ```go
   defaults := config.DefaultSettings()
   m.Settings.Categories = defaults.Categories
   m.addLogEntry(LogStyleStarted.Render("\u2714 Categories reset to defaults"))
   utils.Debug("Categories Reset to Defaults")
   m.state = SettingsState
   m.quitConfirmFocused = 0
   return m, nil
   ```

   This also avoids having to remember to update two places if a new `CategorySettings` field is added.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

3. `internal/tui/update_settings.go`, line 692-695 ([link](https://github.com/surgedm/surge/blob/05738df7ab7363d0a51fd4fc529bbe46c5675cb2/internal/tui/update_settings.go#L692-L695)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Stale error persists when input is cleared**

   The error is cleared only when `m.SettingsInput.Value() != ""`. If a user types an invalid value (error appears), then deletes all characters, the error remains shown even though the input field is now empty. The condition should just check whether `m.settingsError != ""` to clear it on any keystroke:

   ```go
   if m.settingsError != "" {
       m.settingsError = ""
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/tui/update_settings.go
   Line: 692-695

   Comment:
   **Stale error persists when input is cleared**

   The error is cleared only when `m.SettingsInput.Value() != ""`. If a user types an invalid value (error appears), then deletes all characters, the error remains shown even though the input field is now empty. The condition should just check whether `m.settingsError != ""` to clear it on any keystroke:

   ```go
   if m.settingsError != "" {
       m.settingsError = ""
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

4. `internal/config/settings.go`, line 112-136 ([link](https://github.com/surgedm/surge/blob/05738df7ab7363d0a51fd4fc529bbe46c5675cb2/internal/config/settings.go#L112-L136)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Duplicated DNS validation logic**

   The DNS-parsing loop (split on `,`, `net.SplitHostPort`, `net.ParseIP`) is essentially identical to the one in `validateSetting` in `update_settings.go`. Per the project's no-duplicate-logic rule, consider extracting a shared helper (e.g., `config.ValidateDNSList(s string) error`) that both call, so any future changes (hostname support, IPv6 tweaks) only need to be made in one place.

   **Rule Used:** What: Eliminate duplicate logic, functions, or cod... ([source](https://app.greptile.com/review/custom-context?memory=f0a796a9-684f-4dfb-a5cf-8c99c16b63a1))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: internal/config/settings.go
   Line: 112-136
   
   Comment:
   **Duplicated DNS validation logic**
   
   The DNS-parsing loop (split on `,`, `net.SplitHostPort`, `net.ParseIP`) is essentially identical to the one in `validateSetting` in `update_settings.go`. Per the project's no-duplicate-logic rule, consider extracting a shared helper (e.g., `config.ValidateDNSList(s string) error`) that both call, so any future changes (hostname support, IPv6 tweaks) only need to be made in one place.
   
   **Rule Used:** What: Eliminate duplicate logic, functions, or cod... ([source](https://app.greptile.com/review/custom-context?memory=f0a796a9-684f-4dfb-a5cf-8c99c16b63a1))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/tui/view.go
Line: 947-969

Comment:
**Triplicated button-rendering boilerplate**

The `activeFirst / inactiveFirst / renderBtn / quitConfirmFocused` swap pattern is now copy-pasted verbatim across three functions — `viewQuitConfirm` (line 794), `viewRestartConfirm` (line 875), and the new `viewCategoryResetConfirm` (line 947). The only differences are the accent colour and the button label suffix. Per the project's no-duplicate-logic rule, extracting a shared helper (e.g., `renderYesNoButtons(focused int, accentColor lipgloss.Color, yesLabel, noLabel string) string`) would remove ~20 duplicated lines from each modal and ensure future colour/layout tweaks only need to happen in one place.

**Rule Used:** What: Eliminate duplicate logic, functions, or cod... ([source](https://app.greptile.com/review/custom-context?memory=f0a796a9-684f-4dfb-a5cf-8c99c16b63a1))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/config/settings_test.go
Line: 487-515

Comment:
**Category path-rollback code path is untested**

`CategorySettings.Validate` has an explicit `os.Stat` check that resets a category's path to `fallbackDir` when it is broken or inaccessible, but none of the new test cases exercise this branch. The existing tests only cover regex-invalid categories (which are pruned entirely), not the case of a valid-regex / broken-path category that should be kept but have its path replaced. A test case like the following would cover it:

```go
{
    name: "Broken Category Path Rollback",
    modify: func(s *Settings) {
        s.Categories.Categories = []Category{
            {Name: "Movies", Pattern: `\.mkv$`, Path: "/non/existent/path"},
        }
    },
    validate: func(t *testing.T, s *Settings) {
        if len(s.Categories.Categories) != 1 {
            t.Fatalf("expected category to be kept, got %d", len(s.Categories.Categories))
        }
        if s.Categories.Categories[0].Path == "/non/existent/path" {
            t.Errorf("expected broken path to be rolled back, but it was not")
        }
    },
},
```

**Rule Used:** What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (5): Last reviewed commit: ["refactor: replace deprecated reflect.Ptr..."](https://github.com/surgedm/surge/commit/8ffde102b1b46421e8428d36388b3e83a44abcf2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30235433)</sub>

**Context used:**

- Rule used - What: Eliminate duplicate logic, functions, or cod... ([source](https://app.greptile.com/review/custom-context?memory=f0a796a9-684f-4dfb-a5cf-8c99c16b63a1))
- Rule used - What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))

<!-- /greptile_comment -->