### PR TITLE
fix: native Termux runit service backend

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,7 +26,6 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/google/uuid"
-	"github.com/kardianos/service"
 	"github.com/spf13/cobra"
 )
 
@@ -494,21 +493,7 @@ func startTUI(port int, exitWhenDone bool, noResume bool) error {
 	m := tui.InitialRootModel(port, Version, GlobalService, currentLifecycle(), noResume, Commit)
 	m = m.WithEnqueueContext(currentEnqueueContext(), currentEnqueueCancel())
 
-	if s, err := GetService(); err == nil {
-		if status, statusErr := s.Status(); statusErr == nil {
-			// If service is installed (running or stopped), consider auto-start as enabled
-			m.Settings.General.AutoStart = (status == service.StatusRunning || status == service.StatusStopped)
-		}
-
-		m.ToggleServiceFunc = func(enable bool) error {
-			if enable {
-				return s.Install()
-			}
-			// Best effort stop before uninstall
-			_ = s.Stop()
-			return s.Uninstall()
-		}
-	}
+	configureServiceUI(&m)
 
 	m.ServerHost = serverBindHost
 	if m.ServerHost == "" {

--- a/cmd/runservice_std.go
+++ b/cmd/runservice_std.go
@@ -1,0 +1,23 @@
+//go:build !android
+
+package cmd
+
+import (
+	"github.com/kardianos/service"
+)
+
+// RunService handles the application execution, checking if it should run as a service.
+// On non-Android platforms, we use kardianos/service's detection to decide whether
+// to run interactively or as a managed service.
+func RunService() error {
+	s, err := GetService()
+	if err != nil {
+		return rootCmd.Execute()
+	}
+
+	if service.Interactive() {
+		return rootCmd.Execute()
+	}
+
+	return s.Run()
+}

--- a/cmd/runservice_termux.go
+++ b/cmd/runservice_termux.go
@@ -1,0 +1,10 @@
+//go:build android
+
+package cmd
+
+// RunService on Android (Termux) always runs interactively since there is no
+// kardianos/service-compatible service manager. Users can still manage Surge
+// as a runit service via 'surge service install/start/stop' which uses sv directly.
+func RunService() error {
+	return rootCmd.Execute()
+}

--- a/cmd/service_android_test.go
+++ b/cmd/service_android_test.go
@@ -1,0 +1,19 @@
+//go:build android
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunServiceDoesNotHangOnAndroid(t *testing.T) {
+	// On Android, RunService always calls rootCmd.Execute() directly.
+	// Use --help which exits immediately to confirm no hang.
+	rootCmd.SetArgs([]string{"--help"})
+	defer rootCmd.SetArgs(nil)
+
+	err := RunService()
+	assert.NoError(t, err)
+}

--- a/cmd/service_kardianos.go
+++ b/cmd/service_kardianos.go
@@ -1,3 +1,5 @@
+//go:build !android
+
 package cmd
 
 import (
@@ -68,20 +70,6 @@ func GetService() (service.Service, error) {
 	return service.New(prg, serviceConfig)
 }
 
-// RunService handles the application execution, checking if it should run as a service.
-func RunService() error {
-	s, err := GetService()
-	if err != nil {
-		return rootCmd.Execute()
-	}
-
-	if service.Interactive() {
-		return rootCmd.Execute()
-	}
-
-	return s.Run()
-}
-
 func runAction(action func(service.Service) error, successMsg string) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		s, err := GetService()
@@ -96,11 +84,6 @@ func runAction(action func(service.Service) error, successMsg string) func(*cobr
 		}
 		return nil
 	}
-}
-
-var serviceCmd = &cobra.Command{
-	Use:   "service",
-	Short: "Manage Surge as a system service",
 }
 
 var serviceInstallCmd = &cobra.Command{
@@ -149,6 +132,11 @@ var serviceStatusCmd = &cobra.Command{
 		}
 		return nil
 	}, ""),
+}
+
+var serviceCmd = &cobra.Command{
+	Use:   "service",
+	Short: "Manage Surge as a system service",
 }
 
 func init() {

--- a/cmd/service_kardianos_test.go
+++ b/cmd/service_kardianos_test.go
@@ -1,0 +1,109 @@
+//go:build !android
+
+package cmd
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kardianos/service"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockService struct {
+	service.Service
+	stopCalled      bool
+	installCalled   bool
+	uninstallCalled bool
+}
+
+func (m *mockService) Stop() error {
+	m.stopCalled = true
+	return nil
+}
+
+func (m *mockService) Install() error {
+	m.installCalled = true
+	return nil
+}
+
+func (m *mockService) Uninstall() error {
+	m.uninstallCalled = true
+	return nil
+}
+
+func (m *mockService) Status() (service.Status, error) {
+	return service.StatusRunning, nil
+}
+
+func waitStop(t *testing.T, p *program, s service.Service) {
+	stopErr := make(chan error, 1)
+	go func() {
+		stopErr <- p.Stop(s)
+	}()
+
+	select {
+	case err := <-stopErr:
+		assert.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("p.Stop timed out")
+	}
+}
+
+func TestProgramLifecycle(t *testing.T) {
+	p := &program{}
+	s := &mockService{}
+
+	// Set args to something safe so rootCmd.ExecuteContext doesn't fail on test flags
+	rootCmd.SetArgs([]string{"--help"})
+	defer rootCmd.SetArgs(nil)
+
+	// Test Start
+	err := p.Start(s)
+	assert.NoError(t, err)
+	assert.NotNil(t, p.cancel)
+	assert.NotNil(t, p.exit)
+
+	// Test Stop with timeout
+	waitStop(t, p, s)
+
+	// Verify p.exit is closed
+	_, ok := <-p.exit
+	assert.False(t, ok, "p.exit should be closed")
+}
+
+func TestToggleServiceFunc(t *testing.T) {
+	s := &mockService{}
+
+	toggleFunc := func(enable bool) error {
+		if enable {
+			return s.Install()
+		}
+		_ = s.Stop()
+		return s.Uninstall()
+	}
+
+	err := toggleFunc(true)
+	assert.NoError(t, err)
+	assert.True(t, s.installCalled)
+
+	err = toggleFunc(false)
+	assert.NoError(t, err)
+	assert.True(t, s.stopCalled)
+	assert.True(t, s.uninstallCalled)
+}
+
+func TestProgramContextCancellation(t *testing.T) {
+	p := &program{}
+	s := &mockService{}
+
+	rootCmd.SetArgs([]string{"--help"})
+	defer rootCmd.SetArgs(nil)
+
+	_ = p.Start(s)
+
+	cancel := p.cancel
+	assert.NotNil(t, cancel)
+
+	waitStop(t, p, s)
+}

--- a/cmd/service_termux.go
+++ b/cmd/service_termux.go
@@ -1,0 +1,210 @@
+//go:build android
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// termuxServiceDir returns the runit service directory for surge.
+// SURGE_SV_DIR overrides the base SVDIR (like SVDIR), not the full path,
+// so that sv commands can resolve the service by name.
+func termuxServiceDir() string {
+	return filepath.Join(svBaseDir(), "surge")
+}
+
+// svServiceName returns the short service name that sv resolves via $SVDIR.
+func svServiceName() string {
+	return "surge"
+}
+
+// defaultPrefix returns the Termux prefix path.
+func defaultPrefix() string {
+	if p := os.Getenv("PREFIX"); p != "" {
+		return p
+	}
+	return "/data/data/com.termux/files/usr"
+}
+
+// svBaseDir returns the base service directory.
+// SURGE_SV_DIR takes precedence over SVDIR for Surge's service management.
+func svBaseDir() string {
+	if dir := os.Getenv("SURGE_SV_DIR"); dir != "" {
+		return dir
+	}
+	if svDir := os.Getenv("SVDIR"); svDir != "" {
+		return svDir
+	}
+	return filepath.Join(defaultPrefix(), "var", "service")
+}
+
+// termuxServiceRunScript returns the content of the run script for the surge service.
+func termuxServiceRunScript() string {
+	exe, _ := os.Executable()
+	if exe == "" {
+		exe = "surge"
+	}
+	return "#!/" + defaultPrefix() + "/bin/sh\nexec " + exe + " server start\n"
+}
+
+// sv runs an sv command and returns its output.
+// If SURGE_SV_DIR is set, it is passed as SVDIR to the sv command
+// so that the service name resolves correctly.
+func sv(args ...string) (string, error) {
+	svcmd := exec.Command("sv", args...)
+	env := os.Environ()
+	if dir := os.Getenv("SURGE_SV_DIR"); dir != "" {
+		filtered := env[:0:len(env)]
+		for _, e := range env {
+			if !strings.HasPrefix(e, "SVDIR=") {
+				filtered = append(filtered, e)
+			}
+		}
+		env = append(filtered, "SVDIR="+dir)
+	}
+	svcmd.Env = env
+	out, err := svcmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+// isTermuxServicesAvailable checks if runit/termux-services is set up.
+func isTermuxServicesAvailable() bool {
+	if _, err := exec.LookPath("sv"); err != nil {
+		return false
+	}
+	info, err := os.Stat(svBaseDir())
+	if err != nil || !info.IsDir() {
+		return false
+	}
+	return true
+}
+
+// writeRunScript writes a service run script with executable permissions.
+func writeRunScript(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0o755)
+}
+
+var serviceInstallCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Install Surge as a system service (Termux/runit)",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if !isTermuxServicesAvailable() {
+			return fmt.Errorf("termux-services is not available. Install it with: pkg install termux-services")
+		}
+
+		svcDir := termuxServiceDir()
+		if info, err := os.Stat(svcDir); err == nil && info.IsDir() {
+			return fmt.Errorf("service already installed at %s. Run 'surge service uninstall' first", svcDir)
+		}
+
+		if err := installTermuxService(); err != nil {
+			return err
+		}
+
+		fmt.Println("Service installed successfully")
+		fmt.Printf("Service directory: %s\n", svcDir)
+		fmt.Println("Use 'surge service start' to start the service")
+		return nil
+	},
+}
+
+var serviceUninstallCmd = &cobra.Command{
+	Use:   "uninstall",
+	Short: "Uninstall the Surge system service",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		svcDir := termuxServiceDir()
+		if _, err := os.Stat(svcDir); os.IsNotExist(err) {
+			return fmt.Errorf("service is not installed")
+		}
+
+		if err := uninstallTermuxService(); err != nil {
+			return err
+		}
+
+		fmt.Println("Service uninstalled successfully")
+		return nil
+	},
+}
+
+var serviceStartCmd = &cobra.Command{
+	Use:   "start",
+	Short: "Start the Surge system service",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if !isTermuxServicesAvailable() {
+			return fmt.Errorf("termux-services is not available. Install with: pkg install termux-services")
+		}
+
+		svcDir := termuxServiceDir()
+		if _, err := os.Stat(svcDir); os.IsNotExist(err) {
+			return fmt.Errorf("service is not installed. Run 'surge service install' first")
+		}
+
+		out, err := sv("up", svServiceName())
+		if err != nil {
+			return fmt.Errorf("failed to start service: %s (%w)", out, err)
+		}
+
+		fmt.Println("Service started successfully")
+		return nil
+	},
+}
+
+var serviceStopCmd = &cobra.Command{
+	Use:   "stop",
+	Short: "Stop the Surge system service",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		svcDir := termuxServiceDir()
+		if _, err := os.Stat(svcDir); os.IsNotExist(err) {
+			return fmt.Errorf("service is not installed")
+		}
+
+		out, err := sv("down", svServiceName())
+		if err != nil {
+			return fmt.Errorf("failed to stop service: %s (%w)", out, err)
+		}
+
+		fmt.Println("Service stopped successfully")
+		return nil
+	},
+}
+
+var serviceStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Check the status of the Surge system service",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if !isTermuxServicesAvailable() {
+			fmt.Println("termux-services is not available. Install with: pkg install termux-services")
+			return nil
+		}
+
+		svcDir := termuxServiceDir()
+		if _, err := os.Stat(svcDir); os.IsNotExist(err) {
+			fmt.Println("Service is not installed")
+			return nil
+		}
+
+		out, _ := sv("status", svServiceName())
+		fmt.Println(out)
+		return nil
+	},
+}
+
+var serviceCmd = &cobra.Command{
+	Use:   "service",
+	Short: "Manage Surge as a system service",
+}
+
+func init() {
+	rootCmd.AddCommand(serviceCmd)
+	serviceCmd.AddCommand(serviceInstallCmd)
+	serviceCmd.AddCommand(serviceUninstallCmd)
+	serviceCmd.AddCommand(serviceStartCmd)
+	serviceCmd.AddCommand(serviceStopCmd)
+	serviceCmd.AddCommand(serviceStatusCmd)
+}

--- a/cmd/service_termux_test.go
+++ b/cmd/service_termux_test.go
@@ -1,0 +1,60 @@
+//go:build android
+
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSvServiceName(t *testing.T) {
+	assert.Equal(t, "surge", svServiceName())
+}
+
+func TestTermuxServiceDirSVDIRFallback(t *testing.T) {
+	origSVDIR := os.Getenv("SVDIR")
+	origSurgeSvDir := os.Getenv("SURGE_SV_DIR")
+	origPrefix := os.Getenv("PREFIX")
+	t.Cleanup(func() {
+		os.Setenv("SVDIR", origSVDIR)
+		os.Setenv("SURGE_SV_DIR", origSurgeSvDir)
+		os.Setenv("PREFIX", origPrefix)
+	})
+
+	os.Unsetenv("SURGE_SV_DIR")
+	os.Setenv("SVDIR", "/custom/sv")
+	os.Setenv("PREFIX", "/data/data/com.termux/files/usr")
+	assert.Equal(t, "/custom/sv/surge", termuxServiceDir())
+}
+
+func TestTermuxServiceDirSurgeSvDirOverride(t *testing.T) {
+	origSVDIR := os.Getenv("SVDIR")
+	origSurgeSvDir := os.Getenv("SURGE_SV_DIR")
+	t.Cleanup(func() {
+		os.Setenv("SVDIR", origSVDIR)
+		os.Setenv("SURGE_SV_DIR", origSurgeSvDir)
+	})
+
+	os.Setenv("SURGE_SV_DIR", "/override/sv")
+	os.Setenv("SVDIR", "/should/be/overridden")
+	assert.Equal(t, "/override/sv/surge", termuxServiceDir())
+}
+
+func TestTermuxServiceDirDefault(t *testing.T) {
+	origSVDIR := os.Getenv("SVDIR")
+	origSurgeSvDir := os.Getenv("SURGE_SV_DIR")
+	origPrefix := os.Getenv("PREFIX")
+	t.Cleanup(func() {
+		os.Setenv("SVDIR", origSVDIR)
+		os.Setenv("SURGE_SV_DIR", origSurgeSvDir)
+		os.Setenv("PREFIX", origPrefix)
+	})
+
+	os.Unsetenv("SURGE_SV_DIR")
+	os.Unsetenv("SVDIR")
+	os.Setenv("PREFIX", "/data/data/com.termux/files/usr")
+	result := termuxServiceDir()
+	assert.Equal(t, "/data/data/com.termux/files/usr/var/service/surge", result)
+}

--- a/cmd/service_test.go
+++ b/cmd/service_test.go
@@ -2,115 +2,9 @@ package cmd
 
 import (
 	"testing"
-	"time"
 
-	"github.com/kardianos/service"
 	"github.com/stretchr/testify/assert"
 )
-
-type mockService struct {
-	service.Service
-	stopCalled      bool
-	installCalled   bool
-	uninstallCalled bool
-}
-
-func (m *mockService) Stop() error {
-	m.stopCalled = true
-	return nil
-}
-
-func (m *mockService) Install() error {
-	m.installCalled = true
-	return nil
-}
-
-func (m *mockService) Uninstall() error {
-	m.uninstallCalled = true
-	return nil
-}
-
-func (m *mockService) Status() (service.Status, error) {
-	return service.StatusRunning, nil
-}
-
-func waitStop(t *testing.T, p *program, s service.Service) {
-	stopErr := make(chan error, 1)
-	go func() {
-		stopErr <- p.Stop(s)
-	}()
-
-	select {
-	case err := <-stopErr:
-		assert.NoError(t, err)
-	case <-time.After(5 * time.Second):
-		t.Fatal("p.Stop timed out")
-	}
-}
-
-func TestProgramLifecycle(t *testing.T) {
-	p := &program{}
-	s := &mockService{}
-
-	// Set args to something safe so rootCmd.ExecuteContext doesn't fail on test flags
-	rootCmd.SetArgs([]string{"--help"})
-	defer rootCmd.SetArgs(nil)
-
-	// Test Start
-	err := p.Start(s)
-	assert.NoError(t, err)
-	assert.NotNil(t, p.cancel)
-	assert.NotNil(t, p.exit)
-
-	// Test Stop with timeout
-	waitStop(t, p, s)
-
-	// Verify p.exit is closed
-	_, ok := <-p.exit
-	assert.False(t, ok, "p.exit should be closed")
-}
-
-func TestToggleServiceFunc(t *testing.T) {
-	// This test verifies the logic we bind to m.ToggleServiceFunc in root.go
-	s := &mockService{}
-
-	toggleFunc := func(enable bool) error {
-		if enable {
-			return s.Install()
-		}
-		// Best effort stop before uninstall
-		_ = s.Stop()
-		return s.Uninstall()
-	}
-
-	err := toggleFunc(true)
-	assert.NoError(t, err)
-	assert.True(t, s.installCalled)
-
-	err = toggleFunc(false)
-	assert.NoError(t, err)
-	assert.True(t, s.stopCalled)
-	assert.True(t, s.uninstallCalled)
-}
-
-func TestProgramContextCancellation(t *testing.T) {
-	p := &program{}
-	s := &mockService{}
-
-	// Set args to something safe so rootCmd.ExecuteContext doesn't fail on test flags
-	rootCmd.SetArgs([]string{"--help"})
-	defer rootCmd.SetArgs(nil)
-
-	// Start the program
-	_ = p.Start(s)
-
-	// Capture the cancel function
-	cancel := p.cancel
-	assert.NotNil(t, cancel)
-
-	// Test Stop with timeout
-	waitStop(t, p, s)
-}
 
 func TestServiceCommandRegistration(t *testing.T) {
 	// Verify service command is registered with correct subcommands
@@ -135,3 +29,4 @@ func TestServiceCommandRegistration(t *testing.T) {
 	}
 	assert.True(t, found, "service command not found in rootCmd")
 }
+

--- a/cmd/service_ui_std.go
+++ b/cmd/service_ui_std.go
@@ -1,0 +1,29 @@
+//go:build !android
+
+package cmd
+
+import (
+	"github.com/SurgeDM/Surge/internal/tui"
+	"github.com/kardianos/service"
+)
+
+// configureServiceUI wires the TUI settings toggle to kardianos/service
+// on platforms with native service manager support.
+func configureServiceUI(m *tui.RootModel) {
+	s, err := GetService()
+	if err != nil {
+		return
+	}
+	status, statusErr := s.Status()
+	if statusErr == nil {
+		m.Settings.General.AutoStart = (status == service.StatusRunning || status == service.StatusStopped)
+	}
+
+	m.ToggleServiceFunc = func(enable bool) error {
+		if enable {
+			return s.Install()
+		}
+		_ = s.Stop()
+		return s.Uninstall()
+	}
+}

--- a/cmd/service_ui_termux.go
+++ b/cmd/service_ui_termux.go
@@ -1,0 +1,82 @@
+//go:build android
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/SurgeDM/Surge/internal/tui"
+)
+
+// configureServiceUI wires the TUI settings toggle to Termux's runit/sv
+// service manager on Android.
+func configureServiceUI(m *tui.RootModel) {
+	if !isTermuxServicesAvailable() {
+		return
+	}
+	svcDir := termuxServiceDir()
+	if info, err := os.Stat(svcDir); err == nil && info.IsDir() {
+		_, downErr := os.Stat(filepath.Join(svcDir, "down"))
+		m.Settings.General.AutoStart = os.IsNotExist(downErr)
+	}
+
+	m.ToggleServiceFunc = func(enable bool) error {
+		if enable {
+			return installTermuxService()
+		}
+		_ = stopTermuxService()
+		return uninstallTermuxService()
+	}
+}
+
+func installTermuxService() error {
+	if !isTermuxServicesAvailable() {
+		return fmt.Errorf("termux-services is not available. Install it with: pkg install termux-services")
+	}
+	svcDir := termuxServiceDir()
+	if _, err := os.Stat(svcDir); err == nil {
+		return fmt.Errorf("service already installed at %s", svcDir)
+	}
+	if err := os.MkdirAll(svcDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create service directory %s: %w", svcDir, err)
+	}
+	// Write run script
+	runPath := filepath.Join(svcDir, "run")
+	if err := writeRunScript(runPath, termuxServiceRunScript()); err != nil {
+		_ = os.RemoveAll(svcDir)
+		return fmt.Errorf("failed to write run script: %w", err)
+	}
+	// Set up log service per termux-services convention:
+	// mkdir <svc>/log, symlink <svc>/log/run -> $PREFIX/share/termux-services/svlogger
+	logDir := filepath.Join(svcDir, "log")
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		_ = os.RemoveAll(svcDir)
+		return fmt.Errorf("failed to create log directory: %w", err)
+	}
+	svloggerPath := filepath.Join(defaultPrefix(), "share", "termux-services", "svlogger")
+	logRunPath := filepath.Join(logDir, "run")
+	if err := os.Symlink(svloggerPath, logRunPath); err != nil {
+		// Fallback: write a script if symlink fails (e.g. across filesystems)
+		logScript := "#!/" + defaultPrefix() + "/bin/sh\nexec svlogd -tt " + filepath.Join(defaultPrefix(), "var", "log", "sv", "surge") + "\n"
+		if err2 := writeRunScript(logRunPath, logScript); err2 != nil {
+			_ = os.RemoveAll(svcDir)
+			return fmt.Errorf("failed to set up log service: %w", err)
+		}
+	}
+	// Create down file so service doesn't auto-start until explicitly started
+	_ = os.WriteFile(filepath.Join(svcDir, "down"), nil, 0o644)
+	return nil
+}
+
+func stopTermuxService() error {
+	_, _ = sv("down", svServiceName())
+	return nil
+}
+
+func uninstallTermuxService() error {
+	svcDir := termuxServiceDir()
+	_ = stopTermuxService()
+	return os.RemoveAll(svcDir)
+}


### PR DESCRIPTION
kardianos/service detects Android as a sysv platform and returns Interactive()==false, causing s.Run() to block indefinitely waiting for service control signals that never come. This made both the TUI and server commands hang on Termux -- even Ctrl+Q couldn't exit the TUI because s.Run() never reached rootCmd.Execute().

So, we platform split using Go build tags.

Fixes regression from 73bca40 (service support PR).

- closes #423

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a Termux hang by platform-splitting the service backend via Go build tags: on Android, `RunService()` always calls `rootCmd.Execute()` directly (bypassing kardianos/service which misdetects Android as sysv and blocks), while non-Android builds retain the existing kardianos/service path. A new native runit/sv backend is added for Termux service management, with correct `$PREFIX` and `SURGE_SV_DIR`/`SVDIR` handling throughout.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is well-scoped and the only findings are minor style/redundancy issues

All findings are P2. The core fix (build-tag platform split, sv() env filtering, defaultPrefix() usage) is correct. No logic errors or security concerns were found.

cmd/service_ui_termux.go — redundant double stop on uninstall; all new files missing EOF newline

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cmd/runservice_std.go | New file: platform-split RunService() for non-Android — correctly delegates to kardianos Interactive() check; missing EOF newline |
| cmd/runservice_termux.go | New file: Android RunService() always calls rootCmd.Execute() directly, fixing the hang described in the PR |
| cmd/service_termux.go | New file: full runit/sv service backend for Termux; sv() correctly strips pre-existing SVDIR= before injecting SURGE_SV_DIR, and all paths use defaultPrefix() instead of hardcoded strings |
| cmd/service_ui_termux.go | New file: TUI service integration for Termux; stopTermuxService() is called redundantly (once in ToggleServiceFunc, once inside uninstallTermuxService) |
| cmd/service_kardianos.go | New file: non-Android kardianos/service backend extracted from old service_test.go; goroutine lifecycle and Windows deadlock guard look correct |
| cmd/service_ui_std.go | New file: non-Android TUI service wiring extracted from root.go into a dedicated configureServiceUI function; no issues |
| cmd/root.go | Inline service wiring replaced with configureServiceUI(&m); clean reduction of concerns |
| cmd/service_test.go | Platform-agnostic tests moved out; remaining TestServiceCommandRegistration is now the only cross-platform test |
| cmd/service_kardianos_test.go | Non-Android lifecycle, toggle, and context-cancellation tests; coverage is adequate for the extracted program struct |
| cmd/service_termux_test.go | Android-only tests for env-var precedence in termuxServiceDir(); covers SURGE_SV_DIR override and SVDIR fallback |
| cmd/service_android_test.go | Android smoke test confirming RunService() does not hang on --help; straightforward and correct |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
cmd/service_ui_termux.go:25-31
**`stopTermuxService` called twice on disable**

When the TUI toggle disables the service, `stopTermuxService()` is called explicitly on line 29, and then `uninstallTermuxService()` (line 30) calls it again internally (line 80). The double `sv down surge` is idempotent but redundant — remove the explicit call here since `uninstallTermuxService` already handles it.

```suggestion
	m.ToggleServiceFunc = func(enable bool) error {
		if enable {
			return installTermuxService()
		}
		return uninstallTermuxService()
	}
```

### Issue 2 of 2
cmd/runservice_std.go:23
**Missing newline at end of file**

All nine new files in this PR (`runservice_std.go`, `runservice_termux.go`, `service_android_test.go`, `service_kardianos.go`, `service_kardianos_test.go`, `service_termux.go`, `service_termux_test.go`, `service_ui_std.go`, `service_ui_termux.go`) are missing a trailing newline. POSIX requires text files to end with a newline and many Go tooling checks (e.g., `gofmt`) flag this as a diff noise issue.

`````

</details>

<sub>Reviews (7): Last reviewed commit: ["fix: native Termux runit service backend"](https://github.com/surgedm/surge/commit/f5c589d41912fe70ecc45d28afc3e183718f6046) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30433561)</sub>

<!-- /greptile_comment -->