### PR TITLE
fix: gate service mode behind internal subcommand

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -591,7 +591,7 @@ func performRestart() error {
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 func Execute() error {
-	return RunService()
+	return rootCmd.Execute()
 }
 
 func init() {

--- a/cmd/runservice_std.go
+++ b/cmd/runservice_std.go
@@ -5,7 +5,7 @@ package cmd
 func RunService() error {
 	s, err := GetService()
 	if err != nil {
-		return rootCmd.Execute()
+		return err
 	}
 	return s.Run()
 }

--- a/cmd/runservice_std.go
+++ b/cmd/runservice_std.go
@@ -2,22 +2,10 @@
 
 package cmd
 
-import (
-	"github.com/kardianos/service"
-)
-
-// RunService handles the application execution, checking if it should run as a service.
-// On non-Android platforms, we use kardianos/service's detection to decide whether
-// to run interactively or as a managed service.
 func RunService() error {
 	s, err := GetService()
 	if err != nil {
 		return rootCmd.Execute()
 	}
-
-	if service.Interactive() {
-		return rootCmd.Execute()
-	}
-
 	return s.Run()
 }

--- a/cmd/service_kardianos.go
+++ b/cmd/service_kardianos.go
@@ -36,7 +36,10 @@ func (p *program) Start(s service.Service) error {
 	go func() {
 		defer close(p.exit)
 		// Re-enter cobra as `server start` instead of replaying os.Args
-		// (which would re-match __run and recurse into RunService).
+		// (which would re-match __run and recurse into RunService). This
+		// permanently overrides rootCmd's args for the rest of the process
+		// lifetime, which is fine: the process is owned by the service
+		// manager from here until shutdown.
 		rootCmd.SetArgs([]string{"server", "start"})
 		if err := rootCmd.ExecuteContext(ctx); err != nil {
 			fmt.Fprintf(os.Stderr, "Service error: %v\n", err)

--- a/cmd/service_kardianos.go
+++ b/cmd/service_kardianos.go
@@ -15,7 +15,7 @@ var serviceConfig = &service.Config{
 	Name:        "surge",
 	DisplayName: "Surge Download Manager",
 	Description: "Blazing fast TUI download manager built in Go.",
-	Arguments:   []string{"server", "start"},
+	Arguments:   []string{"service", "__run"},
 }
 
 type program struct {
@@ -35,6 +35,9 @@ func (p *program) Start(s service.Service) error {
 
 	go func() {
 		defer close(p.exit)
+		// Re-enter cobra as `server start` instead of replaying os.Args
+		// (which would re-match __run and recurse into RunService).
+		rootCmd.SetArgs([]string{"server", "start"})
 		if err := rootCmd.ExecuteContext(ctx); err != nil {
 			fmt.Fprintf(os.Stderr, "Service error: %v\n", err)
 			p.errCh <- err
@@ -139,6 +142,13 @@ var serviceCmd = &cobra.Command{
 	Short: "Manage Surge as a system service",
 }
 
+// __run is the entry point the installer writes into ExecStart
+var serviceRunCmd = &cobra.Command{
+	Use:    "__run",
+	Hidden: true,
+	RunE:   func(cmd *cobra.Command, args []string) error { return RunService() },
+}
+
 func init() {
 	rootCmd.AddCommand(serviceCmd)
 	serviceCmd.AddCommand(serviceInstallCmd)
@@ -146,4 +156,5 @@ func init() {
 	serviceCmd.AddCommand(serviceStartCmd)
 	serviceCmd.AddCommand(serviceStopCmd)
 	serviceCmd.AddCommand(serviceStatusCmd)
+	serviceCmd.AddCommand(serviceRunCmd)
 }


### PR DESCRIPTION
`Execute()` routes every invocation through `kardianos/service`. Its `Getppid() != 1` check misfires in nested PID namespaces (nix sandboxes, `unshare --pid`, CI), hanging `surge completion zsh`, `--version`, etc. forever. #424 patched this for Android. This removes the underlying check for every platform.

The installer now points the unit's `ExecStart` at a hidden `service __run` subcommand whose only job is to call `RunService()`. Every other invocation runs cobra directly and exits when done.

### Reproduction

```sh
unshare -r --pid --fork --mount-proc sh -c "surge --version >/dev/null"
# main: hangs indefinitely
# fix: exits cleanly
```

### Notes

* Linux/macOS/BSD pre-existing service installs keep working because `surge server start` handles its own SIGTERM/context.
* Windows SCM users should re-run `surge service install` to pick up the new entry point (a `svc.IsWindowsService()` fallback could fix this in a follow-up).
* Termux unchanged.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a hang in `kardianos/service`'s `Getppid() != 1` detection misfiring inside nested PID namespaces by moving all normal invocations onto a direct `rootCmd.Execute()` path. A new hidden `service __run` subcommand becomes the sole entry point for the service manager, and `p.Start()` explicitly overrides args to `server start` before re-entering cobra to avoid re-dispatch recursion.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the fix is targeted and the two previously-identified issues (recursion on error path and SetArgs mutation) are both correctly addressed and documented.

All three files have focused, correct changes. The infinite-recursion bug in the error path is fixed by returning the error directly. The permanent SetArgs mutation is intentional and explained with a clear comment. No new P0/P1 issues found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cmd/root.go | Single-line change: `Execute()` now calls `rootCmd.Execute()` directly instead of routing through `RunService()`, breaking the service-detection code path for all normal invocations. |
| cmd/runservice_std.go | Simplified to remove the `Interactive()` fallback and the recursive `rootCmd.Execute()` error fallback; now returns `GetService()` errors directly and always calls `s.Run()` on success. |
| cmd/service_kardianos.go | Adds hidden `service __run` subcommand as the new service entry point; updates `serviceConfig.Arguments` from `["server","start"]` to `["service","__run"]`; adds `rootCmd.SetArgs([]string{"server","start"})` before executing to prevent re-dispatch loop, with an explanatory comment. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: prevent recursion when GetService f..."](https://github.com/surgedm/surge/commit/eea92543c1adb94e690372cf6203c2bffd143c01) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30580442)</sub>

<!-- /greptile_comment -->