### PR TITLE
feat(tui): add DNS provider presets picker

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -87,6 +87,7 @@ Surge follows OS conventions for storing its files. Below is a breakdown of ever
 | `max_concurrent_probes`    | int    | Maximum number of simultaneous server probes when many downloads are added at once (1-10). Requires restart. | `3`     |
 | `user_agent`               | string | Custom User-Agent string for HTTP requests. Leave empty for default.                                  | `""`    |
 | `proxy_url`                | string | HTTP/HTTPS proxy URL (e.g., `http://127.0.0.1:8080`). Leave empty to use system settings.             | `""`    |
+| `custom_dns`               | string | Custom DNS servers (e.g., `1.1.1.1`). In TUI, press `[Tab]` to cycle through presets (Cloudflare, AdGuard, Google). Leave empty for system. | `""`    |
 | `sequential_download`      | bool   | Download file pieces in strict order (Streaming Mode). Useful for previewing media but may be slower. | `false` |
 | `min_chunk_size`           | int64  | Minimum size of a download chunk in bytes (e.g., `2097152` for 2MB).                                  | `2MB`   |
 | `worker_buffer_size`       | int    | I/O buffer size per worker in bytes (e.g., `524288` for 512KB).                                       | `512KB` |

--- a/internal/config/dns_presets.go
+++ b/internal/config/dns_presets.go
@@ -1,0 +1,75 @@
+package config
+
+import "strings"
+
+// DNSPreset represents a common DNS provider configuration.
+type DNSPreset struct {
+	Name    string
+	Servers []string // One or two IPs, matching the format expected by the engine.
+}
+
+// dnsPresets holds the list of supported DNS presets plus "Custom".
+var dnsPresets = []DNSPreset{
+	{Name: "Cloudflare", Servers: []string{"1.1.1.1", "1.0.0.1"}},
+	{Name: "Cloudflare Family", Servers: []string{"1.1.1.3", "1.0.0.3"}},
+	{Name: "AdGuard", Servers: []string{"94.140.14.14", "94.140.15.15"}},
+	{Name: "Google", Servers: []string{"8.8.8.8", "8.8.4.4"}},
+	{Name: "Custom", Servers: nil}, // Signals manual entry
+}
+
+// IPString returns the comma-separated IP string for the preset.
+func (p DNSPreset) IPString() string {
+	if p.Servers == nil {
+		return ""
+	}
+	return strings.Join(p.Servers, ", ")
+}
+
+// MatchDNSPreset attempts to find a matching DNSPreset for a given comma-separated IP string.
+// If it perfectly matches a known preset's servers, it returns that preset.
+// Otherwise, it returns the Custom preset.
+func MatchDNSPreset(ipStr string) DNSPreset {
+	parts := strings.Split(ipStr, ",")
+	var cleaned []string
+	for _, p := range parts {
+		trimmed := strings.TrimSpace(p)
+		if trimmed != "" {
+			cleaned = append(cleaned, trimmed)
+		}
+	}
+	cleanedStr := strings.Join(cleaned, ",")
+
+	for _, p := range dnsPresets {
+		if p.Name == "Custom" {
+			continue
+		}
+		if cleanedStr == strings.Join(p.Servers, ",") {
+			return p
+		}
+	}
+
+	// Fallback to Custom
+	if len(dnsPresets) > 0 && dnsPresets[len(dnsPresets)-1].Name == "Custom" {
+		return dnsPresets[len(dnsPresets)-1]
+	}
+	return DNSPreset{Name: "Custom", Servers: nil}
+}
+
+// GetNextDNSPreset given a current IP string, returns the next preset in the cycle.
+// Also returns a boolean indicating if the next preset is "Custom".
+func GetNextDNSPreset(currentIPStr string) (string, bool) {
+	currentPreset := MatchDNSPreset(currentIPStr)
+	currentIndex := 0
+	for i, p := range dnsPresets {
+		if p.Name == currentPreset.Name {
+			currentIndex = i
+			break
+		}
+	}
+
+	nextIndex := (currentIndex + 1) % len(dnsPresets)
+	nextPreset := dnsPresets[nextIndex]
+
+	isCustom := nextPreset.Name == "Custom"
+	return nextPreset.IPString(), isCustom
+}

--- a/internal/config/dns_presets_test.go
+++ b/internal/config/dns_presets_test.go
@@ -1,0 +1,115 @@
+package config
+
+import (
+	"net"
+	"testing"
+)
+
+func TestDNSPresets(t *testing.T) {
+	// Test 1: Preset list is complete
+	if len(dnsPresets) < 4 {
+		t.Errorf("Expected at least 4 presets, got %d", len(dnsPresets))
+	}
+
+	// Verify "Custom" is the last element (contract for cycling logic)
+	if len(dnsPresets) == 0 || dnsPresets[len(dnsPresets)-1].Name != "Custom" {
+		t.Fatalf("Expected 'Custom' to be the last preset")
+	}
+
+	requiredNames := map[string]bool{
+		"Cloudflare":        false,
+		"Cloudflare Family": false,
+		"AdGuard":           false,
+		"Google":            false,
+		"Custom":            false,
+	}
+
+	// Test 2: No duplicate names
+	seenNames := make(map[string]bool)
+	var customCount int
+	for _, p := range dnsPresets {
+		if seenNames[p.Name] {
+			t.Errorf("Duplicate preset name found: %s", p.Name)
+		}
+		seenNames[p.Name] = true
+		if _, ok := requiredNames[p.Name]; ok {
+			requiredNames[p.Name] = true
+		}
+
+		if p.Name == "Custom" {
+			customCount++
+			// Test 4: Custom preset has nil Servers
+			if p.Servers != nil {
+				t.Errorf("Custom preset should have nil Servers, got %v", p.Servers)
+			}
+		} else {
+			// Test 3: Server IPs are valid format
+			for _, srv := range p.Servers {
+				if net.ParseIP(srv) == nil {
+					t.Errorf("Invalid IP for preset %s: %s", p.Name, srv)
+				}
+			}
+		}
+	}
+
+	for name, found := range requiredNames {
+		if !found {
+			t.Errorf("Missing required preset: %s", name)
+		}
+	}
+
+	if customCount != 1 {
+		t.Errorf("Expected exactly 1 Custom preset, got %d", customCount)
+	}
+}
+
+func TestMatchDNSPreset(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"1.1.1.1, 1.0.0.1", "Cloudflare"},
+		{"1.1.1.1,1.0.0.1", "Cloudflare"},
+		{"8.8.8.8, 8.8.4.4", "Google"},
+		{"94.140.14.14", "Custom"}, // only one of the two AdGuard IPs
+		{"", "Custom"},
+		{"192.168.1.1", "Custom"},
+	}
+
+	for _, tt := range tests {
+		result := MatchDNSPreset(tt.input)
+		if result.Name != tt.expected {
+			t.Errorf("MatchDNSPreset(%q) = %s; want %s", tt.input, result.Name, tt.expected)
+		}
+	}
+}
+
+func TestGetNextDNSPreset(t *testing.T) {
+	// Use the first non-Custom preset as the starting point.
+	first := dnsPresets[0]
+	if first.Name == "Custom" {
+		t.Fatal("Expected first preset to be a named provider, not Custom")
+	}
+
+	// Test the full cycle
+	currentIP := first.IPString()
+	for i := 0; i < len(dnsPresets); i++ {
+		nextIP, isCustom := GetNextDNSPreset(currentIP)
+		expectedPreset := dnsPresets[(i+1)%len(dnsPresets)]
+		
+		if nextIP != expectedPreset.IPString() {
+			t.Errorf("Step %d: expected IP %q, got %q", i, expectedPreset.IPString(), nextIP)
+		}
+		
+		expectedIsCustom := expectedPreset.Name == "Custom"
+		if isCustom != expectedIsCustom {
+			t.Errorf("Step %d: expected isCustom=%v, got %v", i, expectedIsCustom, isCustom)
+		}
+		
+		if isCustom {
+			currentIP = "1.2.3.4" // Simulate an arbitrary custom value for the next cycle step
+		} else {
+			currentIP = nextIP
+		}
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -157,6 +157,7 @@ type RootModel struct {
 	SettingsInput        textinput.Model  // Input for editing string/int values
 	settingsError        string           // Current validation error in settings
 	ExtensionTokenCopied bool             // Flash message for "Token Copied!"
+	dnsCycleOriginalValue string          // Original value before cycling DNS presets
 
 	// Selection persistence
 	SelectedDownloadID string // ID of the currently selected download

--- a/internal/tui/update_settings.go
+++ b/internal/tui/update_settings.go
@@ -50,6 +50,9 @@ func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			}
 
 			_ = m.setSettingValue(currentCategory, settingKey, val)
+			if settingKey == "custom_dns" {
+				m.dnsCycleOriginalValue = ""
+			}
 			m.SettingsIsEditing = false
 			m.settingsError = ""
 			m.SettingsInput.Blur()
@@ -71,6 +74,7 @@ func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		requiresRestart := m.checkRestartRequirement()
 		// Save settings and exit
 		_ = m.persistSettings()
+		m.dnsCycleOriginalValue = ""
 		if requiresRestart {
 			m.state = RestartConfirmState
 			m.quitConfirmFocused = 0
@@ -140,6 +144,20 @@ func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			cmd := m.openDirectoryPicker(FilePickerOriginTheme, originalPath, browseDir, true, false)
 			m.filepicker.AllowedTypes = []string{".toml"}
 			return m, cmd
+		case "custom_dns":
+			// Cycle DNS presets
+			current := m.Settings.Network.CustomDNS
+			if m.dnsCycleOriginalValue == "" && config.MatchDNSPreset(current).Name == "Custom" {
+				m.dnsCycleOriginalValue = current
+			}
+			nextIP, isCustom := config.GetNextDNSPreset(current)
+			if isCustom {
+				m.Settings.Network.CustomDNS = m.dnsCycleOriginalValue
+				m.dnsCycleOriginalValue = "" // Reset
+			} else {
+				m.Settings.Network.CustomDNS = nextIP
+			}
+			return m, nil
 		}
 		return m, nil
 	}
@@ -251,6 +269,9 @@ func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 		if settingKey == "theme" || settingKey == "theme_path" {
 			m.ApplyTheme(m.Settings.General.Theme, m.Settings.General.ThemePath)
+		}
+		if settingKey == "custom_dns" {
+			m.dnsCycleOriginalValue = ""
 		}
 		return m, nil
 	}

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -354,12 +354,19 @@ func (m RootModel) renderSettingsDetailBlock(settingsMeta []config.SettingMeta, 
 			if meta.Key == "max_global_connections" {
 				valueStr += " (Ignored)"
 			}
+			if meta.Key == "custom_dns" {
+				preset := config.MatchDNSPreset(m.Settings.Network.CustomDNS)
+				valueStr += lipgloss.NewStyle().Foreground(colors.Gray()).Render(fmt.Sprintf(" (%s)", preset.Name))
+			}
 		}
 	}
 
 	valueLabel := "Value: "
 	if (meta.Key == "default_download_dir" || meta.Key == "theme_path") && !m.SettingsIsEditing {
 		valueLabel = "[Tab] Browse: "
+	}
+	if meta.Key == "custom_dns" && !m.SettingsIsEditing {
+		valueLabel = "[Tab] Preset: "
 	}
 	if meta.Type == "link" {
 		valueLabel = "Action: "


### PR DESCRIPTION
## Summary
Adds a preset picker for common DNS providers (Cloudflare, Cloudflare Family, AdGuard, Google) to the TUI settings panel. Users can now select a provider directly instead of typing IP addresses manually. Manual entry is retained for custom setups.

Closes #338.

## What changed
- **`internal/config/dns_presets.go`**: Introduced `DNSPreset` struct and the hardcoded `DNSPresets` slice.
- **`internal/tui/update_settings.go`**: Implemented `[Tab]` key cycling interaction for the DNS field.
- **`internal/tui/model.go`**: Added state memory (`dnsCycleOriginalValue`) to remember manual IP entries when cycling through the list and back to "Custom".
- **`internal/tui/view_settings.go`**: Added UI hints and active preset labels to the `custom_dns` field rendering.
- **`docs/SETTINGS.md`**: Updated documentation to describe the new preset picker behavior.
- **`internal/config/dns_presets_test.go`**: Added unit tests verifying preset validity, data completeness, and cycling logic.

## How to test
**TUI Interaction:**
1. Open Surge and navigate to **Settings** → **Network** → **Custom DNS Server**.
2. Press `[Tab]` to cycle through the presets (Cloudflare, AdGuard, Google, etc.).
3. Confirm the field automatically populates with the correct IPs and the label indicates the selected provider.
4. Cycle to `Custom` and verify the field restores any previously manually typed string.
5. Press `[Enter]` to manually edit the field as usual.

**Tests:**
```bash
go test ./...
```

## Checklist
- [x] Keep PRs focused and readable.
- [x] Add or update tests for behavior changes.
- [x] Run `go test ./...` before opening/updating the PR.
- [x] If behavior or CLI usage changes, update docs (`README.md` or `docs/`).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a Tab-key preset picker for common DNS providers (Cloudflare, Cloudflare Family, AdGuard, Google) to the TUI settings panel, retaining manual entry via a "Custom" sentinel. All three previously reported `dnsCycleOriginalValue` stale-state bugs (manual edit mid-cycle, reset path, settings close path) are addressed in this revision.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all previously flagged P1 state-management bugs are now fixed and the cycling logic is correct.

No new P1 or P0 findings. The three dnsCycleOriginalValue stale-state issues raised in prior review rounds are correctly cleared (on confirm, on reset, and on settings close). Score capped at 4 rather than 5 due to the moderate complexity of the new state machine and the fact that the previous review cycle found real bugs — warranting a cautious but positive assessment.

internal/tui/update_settings.go — contains the dnsCycleOriginalValue state logic; worth one final read-through to confirm all exit paths are covered.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/config/dns_presets.go | New file introducing DNSPreset struct, preset list, and cycling helpers. Logic is sound; MatchDNSPreset correctly normalises whitespace for comparison. GetNextDNSPreset would panic on empty dnsPresets (theoretical only). Previously flagged unreachable-fallback concern already addressed with the defensive check. |
| internal/config/dns_presets_test.go | Comprehensive tests covering preset validity, IP format, no-duplicate check, MatchDNSPreset normalisation, and full cycling round-trip. All meaningful edge cases are covered. |
| internal/tui/update_settings.go | Implements Tab-cycle interaction for custom_dns. All three previously reported dnsCycleOriginalValue stale-state issues (manual edit, reset, session close) are now correctly cleared. Cycling logic is coherent. |
| internal/tui/model.go | Adds dnsCycleOriginalValue string field to RootModel. Minimal, correct change. |
| internal/tui/view_settings.go | Correctly adds [Tab] Preset label and inline preset-name annotation; both additions are gated inside the !SettingsIsEditing branch, so they don't bleed into edit mode. |
| docs/SETTINGS.md | Adds custom_dns row to the settings reference table, accurately describing the Tab preset-picker behaviour. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `internal/tui/update_settings.go`, line 70-82 ([link](https://github.com/surgedm/surge/blob/778a96cc42f5130e9491cc1990af1e90b2ecbe53/internal/tui/update_settings.go#L70-L82)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Stale `dnsCycleOriginalValue` persists across settings sessions**

   `dnsCycleOriginalValue` is never cleared when the settings panel is closed or saved. If a user starts cycling from a Custom value (say `"192.168.1.1"`), lands on Cloudflare, and **saves** (closes settings), the field now holds `"1.1.1.1, 1.0.0.1"` but `dnsCycleOriginalValue` is still `"192.168.1.1"`. The next time they open settings and cycle all the way through to "Custom", their old IP is silently restored — overriding what they explicitly saved. The fix is to reset `dnsCycleOriginalValue = ""` in the `Settings.Close` handler alongside `m.SettingsBaseline = nil`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/tui/update_settings.go
   Line: 70-82

   Comment:
   **Stale `dnsCycleOriginalValue` persists across settings sessions**

   `dnsCycleOriginalValue` is never cleared when the settings panel is closed or saved. If a user starts cycling from a Custom value (say `"192.168.1.1"`), lands on Cloudflare, and **saves** (closes settings), the field now holds `"1.1.1.1, 1.0.0.1"` but `dnsCycleOriginalValue` is still `"192.168.1.1"`. The next time they open settings and cycle all the way through to "Custom", their old IP is silently restored — overriding what they explicitly saved. The fix is to reset `dnsCycleOriginalValue = ""` in the `Settings.Close` handler alongside `m.SettingsBaseline = nil`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `internal/tui/update_settings.go`, line 247-270 ([link](https://github.com/surgedm/surge/blob/778a96cc42f5130e9491cc1990af1e90b2ecbe53/internal/tui/update_settings.go#L247-L270)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`dnsCycleOriginalValue` not cleared on `custom_dns` reset**

   When the user resets `custom_dns` to its default value via the Reset key, `dnsCycleOriginalValue` is not cleared. A subsequent Tab press will skip over the save condition (`dnsCycleOriginalValue == ""` is false), and when cycling eventually lands on "Custom" it restores the pre-reset value instead of the reset default. Add `m.dnsCycleOriginalValue = ""` to the reset path when `settingKey == "custom_dns"`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/tui/update_settings.go
   Line: 247-270

   Comment:
   **`dnsCycleOriginalValue` not cleared on `custom_dns` reset**

   When the user resets `custom_dns` to its default value via the Reset key, `dnsCycleOriginalValue` is not cleared. A subsequent Tab press will skip over the save condition (`dnsCycleOriginalValue == ""` is false), and when cycling eventually lands on "Custom" it restores the pre-reset value instead of the reset default. Add `m.dnsCycleOriginalValue = ""` to the reset path when `settingKey == "custom_dns"`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

3. `internal/tui/update_settings.go`, line 52-56 ([link](https://github.com/surgedm/surge/blob/b3ecf0cbc47445751fca1f7db1e034826a1855ad/internal/tui/update_settings.go#L52-L56)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Stale `dnsCycleOriginalValue` after manual edit mid-cycle**

   If a user starts Tab-cycling (saving `dnsCycleOriginalValue`), stops on a named preset, then manually edits the field via Enter to a new custom value, `dnsCycleOriginalValue` is never updated in this confirm path. The next Tab-cycle ultimately restores the stale pre-cycle value when it reaches "Custom" instead of the value the user just typed. Add `if settingKey == "custom_dns" { m.dnsCycleOriginalValue = "" }` after `m.setSettingValue` here.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/tui/update_settings.go
   Line: 52-56

   Comment:
   **Stale `dnsCycleOriginalValue` after manual edit mid-cycle**

   If a user starts Tab-cycling (saving `dnsCycleOriginalValue`), stops on a named preset, then manually edits the field via Enter to a new custom value, `dnsCycleOriginalValue` is never updated in this confirm path. The next Tab-cycle ultimately restores the stale pre-cycle value when it reaches "Custom" instead of the value the user just typed. Add `if settingKey == "custom_dns" { m.dnsCycleOriginalValue = "" }` after `m.setSettingValue` here.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (6): Last reviewed commit: ["feat(tui): add DNS provider presets pick..."](https://github.com/surgedm/surge/commit/a398ff4adedaad01e512e62022cfee780a5f91bb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30761748)</sub>

<!-- /greptile_comment -->