### PR TITLE
feat: add Nix support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ build/
 
 # extension
 .wxt/
+
+# Nix binaries
+result
+result-*

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Surge is available on multiple platforms. Choose the method that works best for 
 | **Windows**         | `winget install surge-downloader.surge`<br />or<br />`scoop install surge` | Recommended for Windows users.               |
 | **Dockerfile**               | [See instructions](#4-server-mode-with-docker-compose)                              | Run Surge in server mode with Docker Compose |
 | **Go Install**               | `go install github.com/SurgeDM/Surge@latest`                          | Requires Go 1.25+                           |
+| **Nix / NixOS**              | `nix run github:SurgeDM/Surge`                                        | Via Nix flake. NixOS config: `inputs.surge.packages.${pkgs.system}.default` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ Surge is available on multiple platforms. Choose the method that works best for 
 | **Prebuilt Binary**          | [Download from Releases](https://github.com/SurgeDM/Surge/releases/latest) | Easiest method. Just download and run.       |
 | **Arch Linux (AUR)**         | `yay -S surge`                                                                 | Managed via AUR.                             |
 | **macOS / Linux (Homebrew)** | `brew install SurgeDM/tap/surge`                                      | Recommended for Mac/Linux users.             |
+| **Nix / NixOS**              | `nix run github:SurgeDM/Surge`                                        | Via Nix flake. NixOS config: `inputs.surge.packages.${pkgs.system}.default` |
 | **Windows**         | `winget install surge-downloader.surge`<br />or<br />`scoop install surge` | Recommended for Windows users.               |
 | **Dockerfile**               | [See instructions](#4-server-mode-with-docker-compose)                              | Run Surge in server mode with Docker Compose |
 | **Go Install**               | `go install github.com/SurgeDM/Surge@latest`                          | Requires Go 1.25+                           |
-| **Nix / NixOS**              | `nix run github:SurgeDM/Surge`                                        | Via Nix flake. NixOS config: `inputs.surge.packages.${pkgs.system}.default` |
 
 ---
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -13,12 +13,12 @@
     in
     {
       packages = forEachSystem (pkgs: rec {
-        surge = pkgs.callPackage ./package.nix { inherit (self) src; inherit version; };
+        surge = pkgs.callPackage ./package.nix { src = self; inherit version; };
         default = surge;
       });
 
       overlays.default = final: _prev: {
-        surge = final.callPackage ./package.nix { inherit (self) src; inherit version; };
+        surge = final.callPackage ./package.nix { src = self; inherit version; };
       };
 
       nixosModules.default = { lib, pkgs, config, ... }: {

--- a/flake.nix
+++ b/flake.nix
@@ -5,25 +5,29 @@
 
   outputs = { self, nixpkgs }:
     let
+      version = "0.8.5";
       systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
       forEachSystem = f: nixpkgs.lib.genAttrs systems (system:
         f nixpkgs.legacyPackages.${system}
       );
     in
     {
-      packages = forEachSystem (pkgs: {
-        surge = pkgs.callPackage ./package.nix { };
-        default = self.packages.${pkgs.system}.surge;
+      packages = forEachSystem (pkgs: rec {
+        surge = pkgs.callPackage ./package.nix { inherit (self) src; inherit version; };
+        default = surge;
       });
 
       overlays.default = final: _prev: {
-        surge = final.callPackage ./package.nix { };
+        surge = final.callPackage ./package.nix { inherit (self) src; inherit version; };
       };
 
-      # Applies the overlay so pkgs.surge is available system-wide.
-      nixosModules.default = { pkgs, ... }: {
-        nixpkgs.overlays = [ self.overlays.default ];
-        environment.systemPackages = [ pkgs.surge ];
+      nixosModules.default = { lib, pkgs, config, ... }: {
+        options.programs.surge.enable = lib.mkEnableOption "surge download manager";
+
+        config = lib.mkIf config.programs.surge.enable {
+          nixpkgs.overlays = [ self.overlays.default ];
+          environment.systemPackages = [ pkgs.surge ];
+        };
       };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,29 @@
+{
+  description = "Nix flake for Surge - blazing fast TUI download manager";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forEachSystem = f: nixpkgs.lib.genAttrs systems (system:
+        f nixpkgs.legacyPackages.${system}
+      );
+    in
+    {
+      packages = forEachSystem (pkgs: {
+        surge = pkgs.callPackage ./package.nix { };
+        default = self.packages.${pkgs.system}.surge;
+      });
+
+      overlays.default = final: _prev: {
+        surge = final.callPackage ./package.nix { };
+      };
+
+      # Applies the overlay so pkgs.surge is available system-wide.
+      nixosModules.default = { pkgs, ... }: {
+        nixpkgs.overlays = [ self.overlays.default ];
+        environment.systemPackages = [ pkgs.surge ];
+      };
+    };
+}

--- a/package.nix
+++ b/package.nix
@@ -1,18 +1,12 @@
 { lib
 , buildGoModule
-, fetchFromGitHub
+, src
+, version
 }:
 
-buildGoModule rec {
+buildGoModule {
   pname = "surge";
-  version = "0.8.5";
-
-  src = fetchFromGitHub {
-    owner = "SurgeDM";
-    repo = "Surge";
-    rev = "v${version}";
-    hash = "sha256-ZQeShqNf/vhD5IoZp2grNo0YBzAObIXZIw2kQIaPKWc=";
-  };
+  inherit version src;
 
   vendorHash = "sha256-XHsp2zxLOh9FB93w/g24M7II0yseOUXQGLFkX9BG96A=";
 

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "surge";
+  version = "0.8.5";
+
+  src = fetchFromGitHub {
+    owner = "SurgeDM";
+    repo = "Surge";
+    rev = "v${version}";
+    hash = "sha256-ZQeShqNf/vhD5IoZp2grNo0YBzAObIXZIw2kQIaPKWc=";
+  };
+
+  vendorHash = "sha256-XHsp2zxLOh9FB93w/g24M7II0yseOUXQGLFkX9BG96A=";
+
+  subPackages = [ "." ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${version}"
+  ];
+
+  # Tests write to $HOME/.config; redirect to a writable tmpdir.
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  meta = {
+    description = "Blazing fast TUI download manager built in Go";
+    homepage = "https://github.com/SurgeDM/Surge";
+    license = lib.licenses.mit;
+    mainProgram = "surge";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+}


### PR DESCRIPTION
Adds a minimal Nix flake so Surge can be used on NixOS without manual building.

## What's included
- `flake.nix` - standard flake with packages, overlay, and NixOS module
- `package.nix` - buildGoModule derivation for Surge

## Usage after merge

```sh
nix run github:SurgeDM/Surge
```

Or add to your NixOS configuration:

```nix
# In flake.nix inputs
surge.url = "github:SurgeDM/Surge";

# In your NixOS configuration
environment.systemPackages = [ inputs.surge.packages.${pkgs.system}.default ];
```

Tested on NixOS (x86_64-linux).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Nix flake support so Surge can be installed on NixOS and via `nix run` without manual building. The implementation addresses the issues raised in earlier review rounds and is now structurally sound.

- `flake.nix` defines a multi-system package set using `src = self` (current repo source), a `rec`-based package attrset, an overlay, and a properly opt-in NixOS module gated behind `programs.surge.enable`.
- `package.nix` is a clean `buildGoModule` derivation with correct `vendorHash`, `subPackages`, and a `preCheck` workaround for the config-dir write requirement.
- `.gitignore` gains `result`/`result-*` entries to suppress Nix build symlinks; the README installation table is updated with the new Nix row.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the flake is self-contained, correctly structured, and doesn't touch any existing Go or application code.

All changes are additive Nix packaging files. The build uses src = self so users always get the current repo source; the NixOS module is properly opt-in. The only rough edge is a hardcoded version string that will drift from HEAD over time, but the binary will still build and run correctly.

flake.nix — the hardcoded version constant will need a manual bump on each release unless replaced with a self.shortRev-based pseudo-version.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| flake.nix | Correct flake structure with multi-system support, rec-based package set, enable-gated NixOS module, and src = self; minor issue with hardcoded version string becoming stale at future commits |
| package.nix | Clean buildGoModule derivation; src and version are injected as parameters, vendorHash is set, preCheck redirects HOME correctly |
| flake.lock | Auto-generated lock file pinning nixos-unstable to a specific nixpkgs commit; reproducible and correct |
| README.md | Adds Nix/NixOS row to the installation table with correct nix run command and NixOS config snippet |
| .gitignore | Adds result and result-* patterns to ignore Nix build symlinks |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
flake.nix:8
The `version` string is hardcoded to `"0.8.5"`. Because `src = self` now correctly tracks HEAD, the built binary will always report `0.8.5` via the `-X main.version` ldflag even when built from a newer commit. A common Nix pattern is to derive a pseudo-version from `self.shortRev` (or fall back to `"dirty"` when the tree is unclean), so the reported version at least reflects the commit in use.

```suggestion
      version = self.shortRev or "dirty";
```

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["move nix install method"](https://github.com/surgedm/surge/commit/0ff8bd6b26e8f8ea1b51a2d14d9b3c06f90a29eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31088503)</sub>

<!-- /greptile_comment -->