### PR TITLE
fix: update Nix vendorHash for sqlite v1.50.0

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -1,16 +1,16 @@
-{ lib
-, buildGoModule
-, src
-, version
+{
+  lib,
+  buildGoModule,
+  src,
+  version,
 }:
-
 buildGoModule {
   pname = "surge";
   inherit version src;
 
-  vendorHash = "sha256-XHsp2zxLOh9FB93w/g24M7II0yseOUXQGLFkX9BG96A=";
+  vendorHash = "sha256-tXJUr/URQZC+tNq+HOIuinaqbeElJMPWQH/MG1rY80I=";
 
-  subPackages = [ "." ];
+  subPackages = ["."];
 
   ldflags = [
     "-s"


### PR DESCRIPTION
Sqlite was updated from 1.49.1 to 1.50.0, which broke the vendorHash in package.nix. 

Fixed it

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the Nix `vendorHash` in `package.nix` to match the new Go vendor tree after sqlite was bumped from v1.49.1 to v1.50.0. The change also reformats the function-argument list to use trailing commas and removes spaces inside the `subPackages` list literal, bringing the file in line with modern Nix style.

- `vendorHash` is replaced with the correct sha256 for the updated dependency tree; without this fix the Nix build fails hash verification.
- Formatting-only cleanup: function args gain trailing commas and the blank line after `}:` is removed — no behavior change.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a mechanical hash update required by the sqlite dependency bump, with no logic changes.

The only substantive change is replacing the vendorHash to match the updated Go vendor tree for sqlite v1.50.0; the accompanying reformatting is purely cosmetic. There is nothing here that could regress runtime behaviour.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| package.nix | Updates vendorHash for sqlite v1.50.0 and applies minor Nix argument-list formatting changes (trailing commas, no spaces inside list brackets) |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: update Nix vendorHash for sqlite v1..."](https://github.com/surgedm/surge/commit/386f879264a34d96304d5e29a7e3ce720092a958) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31355073)</sub>

<!-- /greptile_comment -->