### PR TITLE
fix: support user-level service and system service fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,17 +115,20 @@ Surge provides an official way to manage it as a system service (daemon). This i
 # Install Surge as a system service
 surge service install
 
-# Manage the service
-surge service start
-surge service stop
-surge service status
+# Install Surge as a user-level service (Linux/macOS)
+surge service install --user
+
+# Manage the service (append --user if installed as a user service)
+surge service start [--user]
+surge service stop [--user]
+surge service status [--user]
 
 # Uninstall the service
-surge service uninstall
+surge service uninstall [--user]
 ```
 
 > [!NOTE]
-> On Linux, these commands may require `sudo`. On Windows, they should be run in an elevated (Administrator) terminal.
+> When installing as a global system service, these commands may require `sudo` on Linux/macOS, or an elevated (Administrator) terminal on Windows. Using `--user` does not require elevated privileges.
 
 ### 4. Remote TUI
 

--- a/cmd/service_kardianos.go
+++ b/cmd/service_kardianos.go
@@ -11,6 +11,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var userLevelService bool
+
 var serviceConfig = &service.Config{
 	Name:        "surge",
 	DisplayName: "Surge Download Manager",
@@ -73,7 +75,11 @@ func (p *program) Stop(s service.Service) error {
 
 func GetService() (service.Service, error) {
 	prg := &program{}
-	return service.New(prg, serviceConfig)
+	cfg := *serviceConfig
+	if userLevelService {
+		cfg.Option = service.KeyValue{"UserService": true}
+	}
+	return service.New(prg, &cfg)
 }
 
 func runAction(action func(service.Service) error, successMsg string) func(*cobra.Command, []string) error {
@@ -160,4 +166,5 @@ func init() {
 	serviceCmd.AddCommand(serviceStopCmd)
 	serviceCmd.AddCommand(serviceStatusCmd)
 	serviceCmd.AddCommand(serviceRunCmd)
+	serviceCmd.PersistentFlags().BoolVar(&userLevelService, "user", false, "Manage the service at the user level (no root/admin required on POSIX)")
 }

--- a/cmd/service_kardianos.go
+++ b/cmd/service_kardianos.go
@@ -77,7 +77,10 @@ func GetService() (service.Service, error) {
 	prg := &program{}
 	cfg := *serviceConfig
 	if userLevelService {
-		cfg.Option = service.KeyValue{"UserService": true}
+		if cfg.Option == nil {
+			cfg.Option = service.KeyValue{}
+		}
+		cfg.Option["UserService"] = true
 	}
 	return service.New(prg, &cfg)
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -22,7 +22,11 @@ func readActivePort() int {
 	portFile := filepath.Join(config.GetRuntimeDir(), "port")
 	data, err := os.ReadFile(portFile)
 	if err != nil {
-		return 0
+		systemPortFile := filepath.Join(config.GetSystemRuntimeDir(), "port")
+		data, err = os.ReadFile(systemPortFile)
+		if err != nil {
+			return 0
+		}
 	}
 	var port int
 	_, _ = fmt.Sscanf(string(data), "%d", &port)
@@ -52,6 +56,21 @@ func resolveLocalToken() string {
 	if token := strings.TrimSpace(os.Getenv("SURGE_TOKEN")); token != "" {
 		return token
 	}
+	
+	stateTokenFile := filepath.Join(config.GetStateDir(), "token")
+	if data, err := os.ReadFile(stateTokenFile); err == nil {
+		if t := strings.TrimSpace(string(data)); t != "" {
+			return t
+		}
+	}
+
+	systemTokenFile := filepath.Join(config.GetSystemStateDir(), "token")
+	if data, err := os.ReadFile(systemTokenFile); err == nil {
+		if t := strings.TrimSpace(string(data)); t != "" {
+			return t
+		}
+	}
+
 	return ensureAuthToken()
 }
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -56,7 +56,7 @@ func resolveLocalToken() string {
 	if token := strings.TrimSpace(os.Getenv("SURGE_TOKEN")); token != "" {
 		return token
 	}
-	
+
 	stateTokenFile := filepath.Join(config.GetStateDir(), "token")
 	if data, err := os.ReadFile(stateTokenFile); err == nil {
 		if t := strings.TrimSpace(string(data)); t != "" {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -17,19 +17,31 @@ import (
 	"github.com/SurgeDM/Surge/internal/utils"
 )
 
-// readActivePort reads the port from the port file
-func readActivePort() int {
+// getActiveConnectionDetails returns the auto-detected port and the corresponding token file to read from.
+// It returns port 0 if no local service is found.
+func getActiveConnectionDetails() (int, string) {
 	portFile := filepath.Join(config.GetRuntimeDir(), "port")
-	data, err := os.ReadFile(portFile)
-	if err != nil {
-		systemPortFile := filepath.Join(config.GetSystemRuntimeDir(), "port")
-		data, err = os.ReadFile(systemPortFile)
-		if err != nil {
-			return 0
+	if data, err := os.ReadFile(portFile); err == nil {
+		var port int
+		if _, err := fmt.Sscanf(string(data), "%d", &port); err == nil && port > 0 {
+			return port, filepath.Join(config.GetStateDir(), "token")
 		}
 	}
-	var port int
-	_, _ = fmt.Sscanf(string(data), "%d", &port)
+
+	systemPortFile := filepath.Join(config.GetSystemRuntimeDir(), "port")
+	if data, err := os.ReadFile(systemPortFile); err == nil {
+		var port int
+		if _, err := fmt.Sscanf(string(data), "%d", &port); err == nil && port > 0 {
+			return port, filepath.Join(config.GetSystemStateDir(), "token")
+		}
+	}
+
+	return 0, filepath.Join(config.GetStateDir(), "token")
+}
+
+// readActivePort reads the port from the port file
+func readActivePort() int {
+	port, _ := getActiveConnectionDetails()
 	return port
 }
 
@@ -57,15 +69,8 @@ func resolveLocalToken() string {
 		return token
 	}
 
-	stateTokenFile := filepath.Join(config.GetStateDir(), "token")
-	if data, err := os.ReadFile(stateTokenFile); err == nil {
-		if t := strings.TrimSpace(string(data)); t != "" {
-			return t
-		}
-	}
-
-	systemTokenFile := filepath.Join(config.GetSystemStateDir(), "token")
-	if data, err := os.ReadFile(systemTokenFile); err == nil {
+	_, tokenFile := getActiveConnectionDetails()
+	if data, err := os.ReadFile(tokenFile); err == nil {
 		if t := strings.TrimSpace(string(data)); t != "" {
 			return t
 		}

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -16,7 +16,7 @@ Surge provides a robust Command Line Interface for automation and scripting. For
 | `surge refresh <id> <url>`  | Updates the source URL of a paused or errored download.                                | None                                                                                                | Reconnects using the new link.                                          |
 | `surge rm <id>`             | Removes a download by ID/prefix.                                                       | `--clean`                                                                                           | Alias: `kill`.                                                          |
 | `surge token`               | Prints current API auth token. (Also visible in TUI > Settings > Extension)            | None                                                                                                | Useful for remote clients.                                              |
-| `surge service <cmd>`       | Manages Surge as a system service (daemon).                                            | `install`, `uninstall`, `start`, `stop`, `status`                                                   | Cross-platform (Linux/Windows/macOS). See [Service Management](#service-management). |
+| `surge service <cmd>`       | Manages Surge as a system or user service (daemon).                                            | `install`, `uninstall`, `start`, `stop`, `status`                                                   | Cross-platform. See [Service Management](#service-management). |
 | `surge bug-report`          | Opens a pre-filled GitHub bug report. Prompts for target (Core/Extension) and optional system/log details. | None                                                                                                | Prints a manual URL fallback if browser open fails.                     |
 
 ## Service Management
@@ -29,7 +29,9 @@ The `service` command allows you to manage Surge as a background daemon that sta
 - `surge service stop`: Stops the background service.
 - `surge service status`: Checks if the service is installed and running.
 
-**Note**: On most systems, these commands require administrative privileges (e.g., `sudo surge service install`).
+You can also pass the `--user` flag to any of these commands to manage Surge as a user-level background service (e.g., `systemd --user` on Linux or LaunchAgents on macOS). This is the recommended approach for most users as it keeps configuration and downloaded files within your user directory.
+
+**Note**: When installing as a global system service, these commands require administrative privileges (e.g., `sudo surge service install`). When using `--user`, elevated privileges are not required.
 
 ## Server Subcommands (Compatibility)
 

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"os/user"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -130,4 +131,26 @@ func EnsureDirs() error {
 	}
 
 	return nil
+}
+
+// GetSystemStateDir returns the state directory for the system service.
+// This is used as a fallback when running client commands as root/admin.
+func GetSystemStateDir() string {
+	if runtime.GOOS == "windows" {
+		systemRoot := os.Getenv("SystemRoot")
+		if systemRoot == "" {
+			systemRoot = "C:\\Windows"
+		}
+		return filepath.Join(systemRoot, "System32", "config", "systemprofile", "AppData", "Roaming", "surge")
+	}
+
+	if u, err := user.Lookup("root"); err == nil && u.HomeDir != "" {
+		return filepath.Join(u.HomeDir, ".local", "state", "surge")
+	}
+	return "/root/.local/state/surge"
+}
+
+// GetSystemRuntimeDir returns the runtime directory for the system service.
+func GetSystemRuntimeDir() string {
+	return filepath.Join(GetSystemStateDir(), "runtime")
 }

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -133,8 +133,11 @@ func EnsureDirs() error {
 	return nil
 }
 
-// GetSystemStateDir returns the state directory for the system service.
-// This is used as a fallback when running client commands as root/admin.
+// GetSystemStateDir returns the state directory for the system service
+// (the service installed and running as LocalSystem/root). Client commands
+// use this as a fallback to auto-detect a system-wide daemon; access to
+// the returned path is restricted by OS filesystem permissions (e.g. 0700
+// on /root), so in practice only a privileged caller can read its contents.
 func GetSystemStateDir() string {
 	if runtime.GOOS == "windows" {
 		systemRoot := os.Getenv("SystemRoot")


### PR DESCRIPTION
Resolves #433

This PR introduces a `--user` flag to `surge service` commands to allow running Surge as a user-level service without elevated privileges. 

Additionally, it implements fallbacks so `surge connect` can auto-detect a system-wide service daemon on Windows (LocalSystem) and Linux (root) as long as it has sufficient permissions.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `--user` flag to `surge service` subcommands so Surge can be installed and managed as a user-level daemon (systemd user instance on Linux, LaunchAgent on macOS) without elevated privileges. It also adds auto-detection fallback logic in the client so that `surge connect` can locate a system-wide service running as root/LocalSystem when no user-level service is found.

- `GetSystemStateDir()` / `GetSystemRuntimeDir()` derive the root/LocalSystem state paths using `user.Lookup(\"root\")` on POSIX and `%SystemRoot%\\System32\\config\\systemprofile` on Windows, matching the paths the daemon actually writes during normal operation.
- `getActiveConnectionDetails()` unifies port and token resolution into a single function with a user-first, system-fallback priority; however, `readActivePort()` and `resolveLocalToken()` each call it independently, so there is a TOCTOU window where the port and token can be sourced from different service instances in a race.
- The `--user` flag is not guarded against Windows, where `kardianos/service` silently ignores the `UserService` option, leaving the service installed as a system service and the user expecting privilege-free installation facing an unexplained access-denied error.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is: the port and token can be sourced from different service instances in the same connection attempt, and the --user flag silently misbehaves on Windows.

The new getActiveConnectionDetails() function correctly pairs port with its corresponding token file, but readActivePort() and resolveLocalToken() each invoke it independently. A service stopping between the two calls can return a port from the user service and a token from the system service (or vice versa), sending the wrong bearer token and producing an opaque auth failure. Separately, --user on Windows passes UserService:true to kardianos/service, which ignores it, so the flag appears to work but installs a system service instead — a user expecting no elevation requirement will hit an unexplained access-denied error.

cmd/utils.go (double invocation of getActiveConnectionDetails) and cmd/service_kardianos.go (missing Windows guard on --user)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/utils.go | Introduces getActiveConnectionDetails() for coupled port+token resolution, but readActivePort() and resolveLocalToken() each call it independently, creating a TOCTOU window where port and token can be sourced from different service instances. |
| cmd/service_kardianos.go | Adds --user PersistentFlag and merges UserService option safely into service config; flag has no Windows guard, so it silently no-ops on Windows and can mislead users expecting privilege-free installation. |
| internal/config/paths.go | Adds GetSystemStateDir() and GetSystemRuntimeDir() that mirror the paths the root/LocalSystem account uses; Windows path matches what GetStateDir() produces for LocalSystem, Linux/macOS path is correctly derived via user.Lookup("root"). |
| README.md | Documents --user flag with accurate scope (Linux/macOS) and updated privilege notes; no issues found. |
| docs/USAGE.md | Updated service management docs to describe --user flag and privilege requirements; accurate and consistent with code. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `cmd/utils.go`, line 52-74 ([link](https://github.com/surgedm/surge/blob/06ec69906de57db971d26420f51ee343750c0087/cmd/utils.go#L52-L74)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Stale user token causes auth failure against system service**

   `root_http_server.go` removes the port file on shutdown but never removes the token file at `GetStateDir()/token`. If a user previously ran a user-level service (writing a token to `~/.local/state/surge/token`) and then switches to a system service, `readActivePort()` correctly falls through to the system port (user port file is gone), but `resolveLocalToken()` still returns the stale user token because the user token file is still present. The client then attempts to connect to the system service with the wrong token, producing a confusing authentication error. The two fallback chains need to be consistent: either check the same file for both port and token, or verify that both came from the same service instance.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: cmd/utils.go
   Line: 52-74

   Comment:
   **Stale user token causes auth failure against system service**

   `root_http_server.go` removes the port file on shutdown but never removes the token file at `GetStateDir()/token`. If a user previously ran a user-level service (writing a token to `~/.local/state/surge/token`) and then switches to a system service, `readActivePort()` correctly falls through to the system port (user port file is gone), but `resolveLocalToken()` still returns the stale user token because the user token file is still present. The client then attempts to connect to the system service with the wrong token, producing a confusing authentication error. The two fallback chains need to be consistent: either check the same file for both port and token, or verify that both came from the same service instance.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `cmd/utils.go`, line 107-130 ([link](https://github.com/surgedm/surge/blob/fe4835f29977e343891754e91f4d7b57cbf318ed/cmd/utils.go#L107-L130)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **TOCTOU mismatch between port and token resolution**

   `resolveAPIConnection` calls `readActivePort()` (which internally calls `getActiveConnectionDetails()`) and then `resolveLocalToken()` (which calls `getActiveConnectionDetails()` a second time). Between the two calls, a service transition — for example the user-level service stopping and its port file being removed — can cause the port to come from the user service while the token comes from the system service, or vice versa. The resulting mismatch sends the wrong bearer token to the server, producing an opaque authentication error with no hint about which service pair was mismatched.

   The straightforward fix is to call `getActiveConnectionDetails()` once in `resolveAPIConnection`, pass the returned `tokenFile` down into token resolution, and eliminate the duplicate file reads.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: cmd/utils.go
   Line: 107-130

   Comment:
   **TOCTOU mismatch between port and token resolution**

   `resolveAPIConnection` calls `readActivePort()` (which internally calls `getActiveConnectionDetails()`) and then `resolveLocalToken()` (which calls `getActiveConnectionDetails()` a second time). Between the two calls, a service transition — for example the user-level service stopping and its port file being removed — can cause the port to come from the user service while the token comes from the system service, or vice versa. The resulting mismatch sends the wrong bearer token to the server, producing an opaque authentication error with no hint about which service pair was mismatched.

   The straightforward fix is to call `getActiveConnectionDetails()` once in `resolveAPIConnection`, pass the returned `tokenFile` down into token resolution, and eliminate the duplicate file reads.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
cmd/utils.go:107-130
**TOCTOU mismatch between port and token resolution**

`resolveAPIConnection` calls `readActivePort()` (which internally calls `getActiveConnectionDetails()`) and then `resolveLocalToken()` (which calls `getActiveConnectionDetails()` a second time). Between the two calls, a service transition — for example the user-level service stopping and its port file being removed — can cause the port to come from the user service while the token comes from the system service, or vice versa. The resulting mismatch sends the wrong bearer token to the server, producing an opaque authentication error with no hint about which service pair was mismatched.

The straightforward fix is to call `getActiveConnectionDetails()` once in `resolveAPIConnection`, pass the returned `tokenFile` down into token resolution, and eliminate the duplicate file reads.

### Issue 2 of 2
cmd/service_kardianos.go:172
The `--user` flag has no platform guard. On Windows, `kardianos/service` does not recognise the `UserService` option — it is silently ignored and the service is installed as a system service, which requires an elevated terminal. A user who runs `surge service install --user` on Windows expecting to avoid elevation will instead get an access-denied error with no indication that `--user` is a POSIX-only feature. Adding a guard that returns a clear error on Windows prevents the silent misbehaviour.

```suggestion
	serviceCmd.PersistentFlags().BoolVar(&userLevelService, "user", false, "Manage the service at the user level (no root/admin required on POSIX)")
	serviceCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
		if userLevelService && runtime.GOOS == "windows" {
			return fmt.Errorf("--user is not supported on Windows; omit the flag to manage the system service")
		}
		return nil
	}
```


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(review): address Greptile review com..."](https://github.com/surgedm/surge/commit/fe4835f29977e343891754e91f4d7b57cbf318ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31479390)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->