### PR TITLE
fix: pair local service discovery with auth token

### DIFF
--- a/.github/workflows/core-lint.yml
+++ b/.github/workflows/core-lint.yml
@@ -27,4 +27,4 @@ jobs:
         with:
           go-version: '1.25.0'
       - name: golangci-lint
-        run: go run github.com/golangci/golangci-lint/cmd/golangci-lint@latest run
+        run: go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,9 @@
+version: "2"
+
+linters:
+  exclusions:
+    rules:
+      - path: _test\.go
+        linters:
+          - staticcheck
+        text: "SA5011"

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -318,6 +318,42 @@ func TestResolveTokenForConnectTarget_IPv6LoopbackUsesLocalToken(t *testing.T) {
 	}
 }
 
+func TestResolveTokenForConnectTarget_UsesActiveTokenForMatchingLocalPort(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("XDG_STATE_HOME", tmpDir)
+	t.Setenv("SURGE_TOKEN", "")
+
+	origToken := globalToken
+	globalToken = ""
+	t.Cleanup(func() {
+		globalToken = origToken
+	})
+
+	if err := config.EnsureDirs(); err != nil {
+		t.Fatalf("Failed to ensure dirs: %v", err)
+	}
+	if err := writeTokenToFile(filepath.Join(config.GetStateDir(), "token"), "connect-token"); err != nil {
+		t.Fatalf("write token failed: %v", err)
+	}
+	saveActivePort(1888)
+	defer removeActivePort()
+
+	target, err := parseConnectTarget("127.0.0.1:1888", false)
+	if err != nil {
+		t.Fatalf("parseConnectTarget returned error: %v", err)
+	}
+
+	token, err := resolveTokenForConnectTarget(target)
+	if err != nil {
+		t.Fatalf("resolveTokenForConnectTarget returned error: %v", err)
+	}
+	if token != "connect-token" {
+		t.Fatalf("token = %q, want %q", token, "connect-token")
+	}
+}
+
 func TestIsPrivateIPHost(t *testing.T) {
 	tests := []struct {
 		host string
@@ -722,6 +758,7 @@ func TestAddCmd_Flags(t *testing.T) {
 	outputFlag := addCmd.Flags().Lookup("output")
 	if outputFlag == nil {
 		t.Fatal("Missing 'output' flag")
+		return
 	}
 	if outputFlag.Shorthand != "o" {
 		t.Errorf("Expected shorthand 'o', got %q", outputFlag.Shorthand)
@@ -730,6 +767,7 @@ func TestAddCmd_Flags(t *testing.T) {
 	batchFlag := addCmd.Flags().Lookup("batch")
 	if batchFlag == nil {
 		t.Fatal("Missing 'batch' flag")
+		return
 	}
 	if batchFlag.Shorthand != "b" {
 		t.Errorf("Expected shorthand 'b', got %q", batchFlag.Shorthand)

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -119,6 +119,10 @@ func resolveTokenForConnectTarget(target connectTarget) (string, error) {
 
 	serverHost, _ := parseRemoteServerAddress(target.BaseURL)
 	if isLocalHost(serverHost) {
+		_, serverPort := parseRemoteServerAddress(target.BaseURL)
+		if details, ok := getActiveConnectionDetails(); ok && details.port == serverPort {
+			return resolveLocalTokenForDetails(details), nil
+		}
 		return ensureAuthToken(), nil
 	}
 	return "", fmt.Errorf("remote target %q requires authentication: use --token or set SURGE_TOKEN", target.BaseURL)

--- a/cmd/connect_test.go
+++ b/cmd/connect_test.go
@@ -112,6 +112,7 @@ func TestNewRemoteRootModel_DownloadRequestUsesServiceAdd(t *testing.T) {
 	selected := root.GetSelectedDownload()
 	if selected == nil {
 		t.Fatal("expected queued remote download to be selected")
+		return
 	}
 	if selected.ID != "remote-add-id" {
 		t.Fatalf("queued download ID = %q, want remote-add-id", selected.ID)

--- a/cmd/startup_test.go
+++ b/cmd/startup_test.go
@@ -70,6 +70,7 @@ func TestServer_Startup_HandlesResume(t *testing.T) {
 		// Check if it's in queued map (GetStatus checks both active and queued internal maps)
 		// Wait, GetStatus implementation in pool.go checks p.downloads and p.queued
 		t.Fatal("Download not found in GlobalPool after resumePausedDownloads()")
+		return
 	}
 
 	if status.Status != "queued" && status.Status != "downloading" {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -17,9 +17,15 @@ import (
 	"github.com/SurgeDM/Surge/internal/utils"
 )
 
-// readActivePort reads the port from the port file
-func readActivePort() int {
-	portFile := filepath.Join(config.GetRuntimeDir(), "port")
+type activeConnectionDetails struct {
+	port       int
+	token      string
+	runtimeDir string
+	stateDir   string
+}
+
+func readPortFile(runtimeDir string) int {
+	portFile := filepath.Join(runtimeDir, "port")
 	data, err := os.ReadFile(portFile)
 	if err != nil {
 		return 0
@@ -27,6 +33,50 @@ func readActivePort() int {
 	var port int
 	_, _ = fmt.Sscanf(string(data), "%d", &port)
 	return port
+}
+
+func readStateToken(stateDir string) string {
+	token, err := readTokenFromFile(filepath.Join(stateDir, "token"))
+	if err != nil {
+		return ""
+	}
+	return token
+}
+
+func activeConnectionCandidates() []activeConnectionDetails {
+	return []activeConnectionDetails{
+		{
+			runtimeDir: config.GetRuntimeDir(),
+			stateDir:   config.GetStateDir(),
+		},
+		{
+			runtimeDir: config.GetSystemRuntimeDir(),
+			stateDir:   config.GetSystemStateDir(),
+		},
+	}
+}
+
+func getActiveConnectionDetails() (activeConnectionDetails, bool) {
+	for _, candidate := range activeConnectionCandidates() {
+		port := readPortFile(candidate.runtimeDir)
+		if port <= 0 {
+			continue
+		}
+		candidate.port = port
+		candidate.token = readStateToken(candidate.stateDir)
+		return candidate, true
+	}
+	return activeConnectionDetails{}, false
+}
+
+// readActivePort reads the active port and keeps legacy callers on the same
+// user-first/system-fallback resolution path as token resolution.
+func readActivePort() int {
+	details, ok := getActiveConnectionDetails()
+	if !ok {
+		return 0
+	}
+	return details.port
 }
 
 // ParseURLArg parses a command line argument that might contain comma-separated mirrors
@@ -46,10 +96,17 @@ func ParseURLArg(arg string) (string, []string) {
 }
 
 func resolveLocalToken() string {
+	return resolveLocalTokenForDetails(activeConnectionDetails{})
+}
+
+func resolveLocalTokenForDetails(details activeConnectionDetails) string {
 	if token := strings.TrimSpace(globalToken); token != "" {
 		return token
 	}
 	if token := strings.TrimSpace(os.Getenv("SURGE_TOKEN")); token != "" {
+		return token
+	}
+	if token := strings.TrimSpace(details.token); token != "" {
 		return token
 	}
 	return ensureAuthToken()
@@ -83,9 +140,9 @@ func resolveClientOutputPath(outputDir string) string {
 func resolveAPIConnection(requireServer bool) (string, string, error) {
 	target := resolveHostTarget()
 	if target == "" {
-		port := readActivePort()
-		if port > 0 {
-			return fmt.Sprintf("http://127.0.0.1:%d", port), resolveLocalToken(), nil
+		details, ok := getActiveConnectionDetails()
+		if ok {
+			return fmt.Sprintf("http://127.0.0.1:%d", details.port), resolveLocalTokenForDetails(details), nil
 		}
 		if !requireServer {
 			return "", "", nil

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/SurgeDM/Surge/internal/config"
 )
 
 func TestResolveClientOutputPath(t *testing.T) {
@@ -135,5 +137,42 @@ func TestResolveAPIConnection_UsesSharedInsecureHTTPSetting(t *testing.T) {
 	}
 	if baseURL != "http://example.com:1700" {
 		t.Fatalf("resolveAPIConnection baseURL = %q, want %q", baseURL, "http://example.com:1700")
+	}
+}
+
+func TestResolveAPIConnection_PairsLocalPortAndTokenFromSameState(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("XDG_STATE_HOME", tmpDir)
+	t.Setenv("SURGE_TOKEN", "")
+
+	originalGlobalHost := globalHost
+	originalGlobalToken := globalToken
+	defer func() {
+		globalHost = originalGlobalHost
+		globalToken = originalGlobalToken
+	}()
+	globalHost = ""
+	globalToken = ""
+
+	if err := config.EnsureDirs(); err != nil {
+		t.Fatalf("config.EnsureDirs() failed: %v", err)
+	}
+	if err := writeTokenToFile(filepath.Join(config.GetStateDir(), "token"), "paired-token"); err != nil {
+		t.Fatalf("write token failed: %v", err)
+	}
+	saveActivePort(1777)
+	defer removeActivePort()
+
+	baseURL, token, err := resolveAPIConnection(true)
+	if err != nil {
+		t.Fatalf("resolveAPIConnection() returned error: %v", err)
+	}
+	if baseURL != "http://127.0.0.1:1777" {
+		t.Fatalf("baseURL = %q, want %q", baseURL, "http://127.0.0.1:1777")
+	}
+	if token != "paired-token" {
+		t.Fatalf("token = %q, want %q", token, "paired-token")
 	}
 }

--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -637,7 +637,12 @@ function handleMessage(message: Record<string, any>): Promise<unknown> | unknown
 
         resolvedBaseUrl = base;
         isConnected = true;
-        const headers = token ? { Authorization: `Bearer ${token}` } : await authHeaders();
+        
+        if (token) {
+          return { ok: true };
+        }
+
+        const headers = await authHeaders();
         try {
           const resp = await fetch(`${base}/list`, {
             headers,

--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -180,8 +180,49 @@ async function discoverBaseUrl(): Promise<string | null> {
     [cachedDiscoveredServerUrl],
   );
 
-  const found = await findReachableCandidate(candidates, healthCheck, PORT_SCAN_BATCH_SIZE);
+  const token = cachedAuthToken;
+  const probe = token
+    ? (candidate: string) => authenticatedHealthCheck(candidate, token)
+    : healthCheck;
+  const found = await findReachableCandidate(candidates, probe, PORT_SCAN_BATCH_SIZE);
   return found;
+}
+
+async function discoverBaseUrlForToken(token: string): Promise<{ base: string | null; sawUnauthorized: boolean; sawReachable: boolean }> {
+  if (cachedServerUrl) {
+    if (!await healthCheck(cachedServerUrl)) return { base: null, sawUnauthorized: false, sawReachable: false };
+    const auth = await checkAuthAtBaseUrl(cachedServerUrl, token);
+    return {
+      base: auth.ok ? cachedServerUrl : null,
+      sawUnauthorized: auth.status === 401,
+      sawReachable: true,
+    };
+  }
+
+  const candidates = buildPortScanCandidates(
+    DEFAULT_PORT,
+    MAX_PORT_SCAN,
+    [cachedDiscoveredServerUrl],
+  );
+
+  let sawUnauthorized = false;
+  let sawReachable = false;
+  for (let index = 0; index < candidates.length; index += PORT_SCAN_BATCH_SIZE) {
+    const batch = candidates.slice(index, index + PORT_SCAN_BATCH_SIZE);
+    const results = await Promise.all(batch.map(async (candidate) => {
+      if (!await healthCheck(candidate)) return { candidate, ok: false, status: 0, reachable: false };
+      const auth = await checkAuthAtBaseUrl(candidate, token);
+      return { candidate, ok: auth.ok, status: auth.status, reachable: true };
+    }));
+
+    for (const result of results) {
+      sawReachable = sawReachable || result.reachable;
+      sawUnauthorized = sawUnauthorized || result.status === 401;
+      if (result.ok) return { base: result.candidate, sawUnauthorized, sawReachable };
+    }
+  }
+
+  return { base: null, sawUnauthorized, sawReachable };
 }
 
 async function getBaseUrl(): Promise<string | null> {
@@ -223,6 +264,23 @@ async function healthCheck(url: string): Promise<boolean> {
   } catch { /* ignore */ }
   if (resolvedBaseUrl === url) resolvedBaseUrl = null;
   return false;
+}
+
+async function checkAuthAtBaseUrl(url: string, token: string): Promise<{ ok: boolean; status: number }> {
+  try {
+    const resp = await fetch(`${url}/list`, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(1000),
+    });
+    return { ok: resp.ok, status: resp.status };
+  } catch {
+    return { ok: false, status: 0 };
+  }
+}
+
+async function authenticatedHealthCheck(url: string, token: string): Promise<boolean> {
+  if (!await healthCheck(url)) return false;
+  return (await checkAuthAtBaseUrl(url, token)).ok;
 }
 
 async function checkHealthSilent(): Promise<boolean> {
@@ -565,10 +623,20 @@ function handleMessage(message: Record<string, any>): Promise<unknown> | unknown
 
     case 'validateAuth':
       return (async () => {
-        const base = await getBaseUrl();
-        if (!base) return { ok: false, error: 'no_server' };
-
         const token = normalizeToken(message.token || '');
+        const discovery = token
+          ? await discoverBaseUrlForToken(token)
+          : { base: await getBaseUrl(), sawUnauthorized: false, sawReachable: isConnected };
+        const base = discovery.base;
+        if (!base) {
+          return {
+            ok: false,
+            error: discovery.sawUnauthorized ? 'invalid_token' : 'no_server',
+          };
+        }
+
+        resolvedBaseUrl = base;
+        isConnected = true;
         const headers = token ? { Authorization: `Bearer ${token}` } : await authHeaders();
         try {
           const resp = await fetch(`${base}/list`, {
@@ -782,6 +850,7 @@ export const __test__ = {
   setCachedAuthToken(token: string | null): void {
     setCachedAuthTokenState(token);
   },
+  discoverBaseUrlForToken,
   resetState(): void {
     cachedServerUrl = null;
     cachedDiscoveredServerUrl = null;

--- a/extension/entrypoints/popup/App.tsx
+++ b/extension/entrypoints/popup/App.tsx
@@ -1,4 +1,4 @@
-import { onMount, onCleanup } from 'solid-js';
+import { createSignal, onMount, onCleanup } from 'solid-js';
 import { readStoredBoolean, readStoredString, STORAGE_KEYS } from '../../lib/storage';
 import {
   serverConnected,
@@ -32,6 +32,7 @@ const SSE_REFRESH_DEBOUNCE_MS = 2_000;
 type RuntimeMessage = Record<string, unknown>;
 
 export default function App() {
+  const [refreshing, setRefreshing] = createSignal(false);
   let pollInterval: ReturnType<typeof setInterval> | null = null;
   let healthInterval: ReturnType<typeof setInterval> | null = null;
   let refreshDebounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -110,6 +111,21 @@ export default function App() {
         setHistoryDownloads(response.history);
       }
     } catch { /* ignore */ }
+  }
+
+  async function refreshNow(): Promise<void> {
+    if (refreshing()) return;
+    setRefreshing(true);
+    try {
+      const healthResp = await sendMessage<{ healthy?: boolean }>({ type: 'checkHealth' }).catch(() => null);
+      if (healthResp && typeof healthResp.healthy === 'boolean') {
+        setServerConnected(healthResp.healthy);
+      }
+      await fetchDownloads();
+      if (currentView() === 'history') await fetchHistory();
+    } finally {
+      setRefreshing(false);
+    }
   }
 
   const handleViewChange = (view: ViewMode) => {
@@ -206,7 +222,12 @@ export default function App() {
       </header>
 
       <section class="downloads-section">
-        <DownloadList activeDownloads={activeDownloads()} onViewChange={handleViewChange} />
+        <DownloadList
+          activeDownloads={activeDownloads()}
+          onViewChange={handleViewChange}
+          onRefresh={() => { void refreshNow(); }}
+          refreshing={refreshing()}
+        />
       </section>
 
       <DuplicateModal />

--- a/extension/entrypoints/popup/components/DownloadItem.tsx
+++ b/extension/entrypoints/popup/components/DownloadItem.tsx
@@ -5,6 +5,7 @@ import type { DownloadStatus } from '../store/types';
 
 interface Props {
   download: Accessor<DownloadStatus>;
+  onActionComplete?: () => void;
 }
 
 const STATUS_LABELS: Record<DownloadStatus['status'], string> = {
@@ -84,6 +85,7 @@ export default function DownloadItem(props: Props) {
     btn.disabled = true;
     try {
       await browser.runtime.sendMessage({ type: action, id: dl().id });
+      props.onActionComplete?.();
     } finally {
       btn.disabled = false;
     }

--- a/extension/entrypoints/popup/components/DownloadList.tsx
+++ b/extension/entrypoints/popup/components/DownloadList.tsx
@@ -9,6 +9,8 @@ import SettingsView from './SettingsView';
 interface Props {
   activeDownloads: DownloadStatus[];
   onViewChange?: (view: ViewMode) => void;
+  onRefresh?: () => void;
+  refreshing?: boolean;
 }
 
 const STATUS_ORDER: Record<DownloadStatus['status'], number> = {
@@ -86,13 +88,28 @@ export default function DownloadList(props: Props) {
     <div class="downloads-list" id="downloadsList">
       <div class="downloads-list-header">
         <ViewSwitch currentView={currentView()} onChange={props.onViewChange || setCurrentView} />
+        <button
+          type="button"
+          class={`refresh-btn${props.refreshing ? ' refreshing' : ''}`}
+          title="Refresh"
+          aria-label="Refresh"
+          disabled={props.refreshing}
+          onClick={() => props.onRefresh?.()}
+        >
+          <svg viewBox="0 0 24 24" class="refresh-icon" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M21 12a9 9 0 0 1-15.5 6.2" />
+            <path d="M3 12A9 9 0 0 1 18.5 5.8" />
+            <path d="M18 2v4h4" />
+            <path d="M6 22v-4H2" />
+          </svg>
+        </button>
       </div>
       <div class="downloads-list-content">
         {currentView() === 'settings'
           ? <SettingsView />
           : currentView() === 'active'
-            ? <For each={sortedActiveDownloadIds()}>{(id) => <DownloadItem download={() => activeDownloadById().get(id)!} />}</For>
-            : <For each={sortedHistoryDownloads()}>{(download) => <DownloadItem download={() => download} />}</For>
+            ? <For each={sortedActiveDownloadIds()}>{(id) => <DownloadItem download={() => activeDownloadById().get(id)!} onActionComplete={props.onRefresh} />}</For>
+            : <For each={sortedHistoryDownloads()}>{(download) => <DownloadItem download={() => download} onActionComplete={props.onRefresh} />}</For>
         }
 
         {currentView() === 'active' && sortedActiveDownloadIds().length === 0 && (

--- a/extension/entrypoints/popup/components/SettingsView.tsx
+++ b/extension/entrypoints/popup/components/SettingsView.tsx
@@ -3,6 +3,7 @@ import { STORAGE_KEYS } from '../../../lib/storage';
 import {
   serverUrl, setServerUrl,
   serverUrlLocked, setServerUrlLocked,
+  serverConnected,
   authToken, setAuthToken,
   authTokenLocked, setAuthTokenLocked,
   authValid, setAuthValid,
@@ -66,10 +67,14 @@ export default function SettingsView() {
       });
       setAuthTokenLocked(token.length > 0);
       showTokenStatus('Saved');
-      const res = await browser.runtime.sendMessage({ type: 'validateAuth', token }).catch(() => null) as { ok?: boolean } | null;
+      const res = await browser.runtime.sendMessage({ type: 'validateAuth', token }).catch(() => null) as { ok?: boolean; error?: string } | null;
       setAuthValid(res?.ok ?? false);
       if (res?.ok) {
         await browser.storage.local.set({ [STORAGE_KEYS.VERIFIED]: 'true' });
+      } else if (res?.error === 'no_server') {
+        showTokenStatus('Server unavailable');
+      } else if (res?.error === 'invalid_token') {
+        showTokenStatus('Invalid Token');
       }
     } catch {
       showTokenStatus('Failed to save');
@@ -142,7 +147,7 @@ export default function SettingsView() {
               disabled={serverUrlLocked()}
               onInput={(e) => { setServerUrl((e.target as HTMLInputElement).value); }}
             />
-            <button onClick={serverUrlLocked() ? handleServerDelete : handleServerSave}>
+            <button onClick={() => { void (serverUrlLocked() ? handleServerDelete() : handleServerSave()); }}>
               {serverUrlLocked() ? 'Delete' : 'Save'}
             </button>
           </div>
@@ -167,7 +172,7 @@ export default function SettingsView() {
               onFocus={() => setTokenFocused(true)}
               onBlur={() => setTokenFocused(false)}
             />
-            <button onClick={authTokenLocked() ? handleDeleteToken : handleSaveToken}>
+            <button onClick={() => { void (authTokenLocked() ? handleDeleteToken() : handleSaveToken()); }}>
               {authTokenLocked() ? 'Delete' : 'Save'}
             </button>
           </div>
@@ -177,8 +182,11 @@ export default function SettingsView() {
           {tokenStatus() && !tokenFocused() && (
             <div class={`auth-status below${tokenStatus() === 'Saved' || tokenStatus() === 'Removed' ? ' ok' : tokenStatus().endsWith('...') ? '' : ' err'}`}>{tokenStatus()}</div>
           )}
-          {authTokenLocked() && !authValid() && !tokenFocused() && !tokenStatus() && (
+          {authTokenLocked() && !authValid() && serverConnected() && !tokenFocused() && !tokenStatus() && (
             <div class="auth-status below err">Invalid Token</div>
+          )}
+          {authTokenLocked() && !authValid() && !serverConnected() && !tokenFocused() && !tokenStatus() && (
+            <div class="auth-status below err">Server unavailable</div>
           )}
           {!authToken() && !tokenFocused() && !tokenStatus() && (
             <div class="auth-status below err">Token is Required</div>

--- a/extension/entrypoints/popup/popup.css
+++ b/extension/entrypoints/popup/popup.css
@@ -258,6 +258,9 @@ body {
 
 .downloads-list-header {
   flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
   padding: 10px 12px 8px;
   border-bottom: 1px solid var(--border-subtle);
   background: var(--bg-surface);
@@ -273,12 +276,51 @@ body {
 }
 
 .view-switch {
+  flex: 1 1 auto;
   display: flex;
   gap: 6px;
   padding: 4px;
   background: var(--bg-base);
   border-radius: 10px;
   border: 1px solid var(--border-subtle);
+}
+
+.refresh-btn {
+  flex: 0 0 38px;
+  width: 38px;
+  height: 38px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-base);
+  color: rgba(228, 228, 235, 0.78);
+  cursor: pointer;
+  transition: all 0.18s ease;
+}
+
+.refresh-btn:hover:not(:disabled) {
+  color: #faf8ff;
+  background: rgba(255, 255, 255, 0.05);
+  border-color: var(--border-default);
+}
+
+.refresh-btn:disabled {
+  cursor: default;
+  opacity: 0.68;
+}
+
+.refresh-icon {
+  width: 17px;
+  height: 17px;
+}
+
+.refresh-btn.refreshing .refresh-icon {
+  animation: refresh-spin 0.8s linear infinite;
+}
+
+@keyframes refresh-spin {
+  to { transform: rotate(360deg); }
 }
 
 .view-tab {

--- a/extension/test/background.test.ts
+++ b/extension/test/background.test.ts
@@ -108,4 +108,56 @@ describe('background auth persistence', () => {
 
     expect(__test__.getCachedState().authToken).toBe('fresh-token');
   });
+
+  it('skips healthy local servers that reject the token during discovery', async () => {
+    storageGet.mockResolvedValue({});
+
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url === 'http://127.0.0.1:1700/health' || url === 'http://127.0.0.1:1701/health') {
+        return new Response('ok', { status: 200 });
+      }
+      if (url === 'http://127.0.0.1:1700/list') {
+        return new Response('Unauthorized', { status: 401 });
+      }
+      if (url === 'http://127.0.0.1:1701/list') {
+        return new Response('[]', { status: 200 });
+      }
+      throw new Error('connection refused');
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+
+    const result = await __test__.discoverBaseUrlForToken('good-token');
+
+    expect(result).toEqual({
+      base: 'http://127.0.0.1:1701',
+      sawUnauthorized: true,
+      sawReachable: true,
+    });
+    expect(fetchImpl).toHaveBeenCalledWith('http://127.0.0.1:1700/list', {
+      headers: { Authorization: 'Bearer good-token' },
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it('reports unauthorized discovery separately from no-server discovery', async () => {
+    storageGet.mockResolvedValue({});
+
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === 'http://127.0.0.1:1700/health') {
+        return new Response('ok', { status: 200 });
+      }
+      if (url === 'http://127.0.0.1:1700/list') {
+        return new Response('Unauthorized', { status: 401 });
+      }
+      throw new Error('connection refused');
+    }));
+
+    const result = await __test__.discoverBaseUrlForToken('bad-token');
+
+    expect(result).toEqual({
+      base: null,
+      sawUnauthorized: true,
+      sawReachable: true,
+    });
+  });
 });

--- a/internal/clipboard/validator_test.go
+++ b/internal/clipboard/validator_test.go
@@ -10,6 +10,7 @@ func TestNewValidator(t *testing.T) {
 	v := NewValidator()
 	if v == nil {
 		t.Fatal("NewValidator() returned nil")
+		return
 	}
 	if v.allowedSchemes == nil {
 		t.Fatal("NewValidator() did not initialize allowedSchemes")

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"os/user"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -40,6 +41,41 @@ func GetStateDir() string {
 		return GetSurgeDir()
 	}
 	return filepath.Join(getXDGBaseDir("XDG_STATE_HOME", xdg.StateHome), "surge")
+}
+
+func GetSystemSurgeDir() string {
+	if runtime.GOOS == "windows" {
+		systemRoot := strings.TrimSpace(os.Getenv("SystemRoot"))
+		if systemRoot == "" {
+			systemRoot = `C:\Windows`
+		}
+		return filepath.Join(systemRoot, "System32", "config", "systemprofile", "AppData", "Roaming", "surge")
+	}
+
+	rootUser, err := user.Lookup("root")
+	if err == nil && strings.TrimSpace(rootUser.HomeDir) != "" {
+		return filepath.Join(rootUser.HomeDir, ".config", "surge")
+	}
+	return filepath.Join(string(filepath.Separator), "root", ".config", "surge")
+}
+
+func GetSystemStateDir() string {
+	if runtime.GOOS == "windows" {
+		return GetSystemSurgeDir()
+	}
+
+	rootUser, err := user.Lookup("root")
+	if err == nil && strings.TrimSpace(rootUser.HomeDir) != "" {
+		return filepath.Join(rootUser.HomeDir, ".local", "state", "surge")
+	}
+	return filepath.Join(string(filepath.Separator), "root", ".local", "state", "surge")
+}
+
+func GetSystemRuntimeDir() string {
+	if runtime.GOOS == "windows" {
+		return filepath.Join(GetSystemStateDir(), "runtime")
+	}
+	return filepath.Join(GetSystemStateDir(), "runtime")
 }
 
 func GetDownloadsDir() string {

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -72,9 +72,6 @@ func GetSystemStateDir() string {
 }
 
 func GetSystemRuntimeDir() string {
-	if runtime.GOOS == "windows" {
-		return filepath.Join(GetSystemStateDir(), "runtime")
-	}
 	return filepath.Join(GetSystemStateDir(), "runtime")
 }
 

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -292,6 +292,7 @@ func TestLoadSettings_CorruptedJSON_FallsBackToDefaults(t *testing.T) {
 	}
 	if settings == nil {
 		t.Fatal("LoadSettings should return defaults, got nil")
+		return
 	}
 
 	defaults := DefaultSettings()
@@ -330,6 +331,7 @@ func TestLoadSettings_TruncatedJSON_FallsBackToDefaults(t *testing.T) {
 	}
 	if settings == nil {
 		t.Fatal("LoadSettings should return defaults, got nil")
+		return
 	}
 	if settings.Network.MaxConnectionsPerHost != DefaultSettings().Network.MaxConnectionsPerHost {
 		t.Error("Expected default settings after truncated JSON")
@@ -392,6 +394,7 @@ func TestToRuntimeConfig(t *testing.T) {
 
 	if runtime == nil {
 		t.Fatal("ToRuntimeConfig returned nil")
+		return
 	}
 
 	// Verify all fields are correctly mapped

--- a/internal/core/local_service_test.go
+++ b/internal/core/local_service_test.go
@@ -348,6 +348,7 @@ func TestLocalDownloadService_Shutdown_PersistsPausedState(t *testing.T) {
 			}
 			if entry == nil {
 				t.Fatal("expected persisted download entry after shutdown")
+				return
 			}
 			if entry.Status != "paused" {
 				t.Fatalf("status = %q, want paused", entry.Status)

--- a/internal/core/pause_resume_integration_test.go
+++ b/internal/core/pause_resume_integration_test.go
@@ -41,6 +41,7 @@ func waitForDownloadStatus(
 	}
 	if last == nil {
 		t.Fatalf("timeout waiting for status for %s; last status: <nil>", id)
+		return nil
 	}
 	t.Fatalf(
 		"timeout waiting for status for %s; last status: status=%s downloaded=%d total=%d speed=%.4f conns=%d progress=%.3f",
@@ -241,6 +242,7 @@ func TestIntegration_PauseResume_HotPath_Aggregates(t *testing.T) {
 	}
 	if entry1 == nil {
 		t.Fatal("missing master-list entry after pause")
+		return
 	}
 	if entry1.Status != "paused" {
 		t.Fatalf("entry status mismatch: got=%q want=paused", entry1.Status)
@@ -422,6 +424,7 @@ func TestIntegration_PauseResume_ColdPath_StateContinuity(t *testing.T) {
 
 	if savedFinal == nil {
 		t.Fatalf("missing final saved state")
+		return
 	}
 
 	if savedFinal.Downloaded != paused2.Downloaded {
@@ -434,6 +437,7 @@ func TestIntegration_PauseResume_ColdPath_StateContinuity(t *testing.T) {
 	}
 	if entry2 == nil {
 		t.Fatal("missing entry after second pause")
+		return
 	}
 	if entry2.Status != "paused" {
 		t.Fatalf("entry status mismatch after cold resume: got=%q", entry2.Status)
@@ -524,6 +528,7 @@ func TestIntegration_PauseResume_ResumeBatchRejectsPausing(t *testing.T) {
 	}
 	if st == nil {
 		t.Fatal("missing status for pausing download")
+		return
 	}
 	if st.Status != "pausing" {
 		t.Fatalf("status changed unexpectedly after rejected resume-batch: got=%q", st.Status)
@@ -689,6 +694,7 @@ func TestIntegration_PauseResume_ConcreteSnapshotDebugString(t *testing.T) {
 	}
 	if entry == nil {
 		t.Fatal("missing DB entry")
+		return
 	}
 
 	snapshot := fmt.Sprintf(

--- a/internal/download/pool_status_test.go
+++ b/internal/download/pool_status_test.go
@@ -39,6 +39,7 @@ func TestWorkerPool_GetStatus_Active(t *testing.T) {
 	status := pool.GetStatus(id)
 	if status == nil {
 		t.Fatal("Expected status to be returned")
+		return
 	}
 
 	if status.ID != id {
@@ -77,6 +78,7 @@ func TestWorkerPool_GetStatus_Paused(t *testing.T) {
 	status := pool.GetStatus(id)
 	if status == nil {
 		t.Fatal("Expected status to be returned")
+		return
 	}
 
 	if status.Status != "paused" {

--- a/internal/engine/concurrent/task_test.go
+++ b/internal/engine/concurrent/task_test.go
@@ -44,6 +44,7 @@ func TestActiveTask_RemainingTask(t *testing.T) {
 	remaining := at.RemainingTask()
 	if remaining == nil {
 		t.Fatal("RemainingTask returned nil")
+		return
 	}
 	if remaining.Offset != 0 || remaining.Length != 1000 {
 		t.Errorf("RemainingTask = %+v, want Offset=0, Length=1000", remaining)

--- a/internal/engine/single/downloader_test.go
+++ b/internal/engine/single/downloader_test.go
@@ -299,6 +299,7 @@ func TestNewSingleDownloader(t *testing.T) {
 
 	if downloader == nil {
 		t.Fatal("NewSingleDownloader returned nil")
+		return
 	}
 	if downloader.ID != "test-id" {
 		t.Errorf("ID mismatch: got %s, want test-id", downloader.ID)

--- a/internal/engine/state/state_test.go
+++ b/internal/engine/state/state_test.go
@@ -230,6 +230,7 @@ func TestSaveStateWithOptions_SkipsHashOnTimeoutButPersistsState(t *testing.T) {
 	}
 	if entry == nil {
 		t.Fatal("expected persisted download entry")
+		return
 	}
 	if entry.Status != "paused" {
 		t.Fatalf("entry status = %q, want paused", entry.Status)
@@ -1056,6 +1057,7 @@ func TestAvgSpeedPersistence(t *testing.T) {
 	}
 	if loaded == nil {
 		t.Fatal("GetDownload returned nil")
+		return
 	}
 	if loaded.AvgSpeed != entry.AvgSpeed {
 		t.Errorf("AvgSpeed = %f, want %f", loaded.AvgSpeed, entry.AvgSpeed)

--- a/internal/engine/types/config_convert_test.go
+++ b/internal/engine/types/config_convert_test.go
@@ -31,6 +31,7 @@ func TestConvertRuntimeConfig_AllFieldsCopied(t *testing.T) {
 
 	if result == nil {
 		t.Fatal("ConvertRuntimeConfig returned nil")
+		return
 	}
 
 	if result.MaxConnectionsPerHost != input.MaxConnectionsPerHost {

--- a/internal/processing/events_internal_test.go
+++ b/internal/processing/events_internal_test.go
@@ -128,6 +128,7 @@ func TestStartEventWorker_MarksCompletionAsErrorWhenFinalizationFails(t *testing
 	}
 	if entry == nil {
 		t.Fatal("expected download entry to remain")
+		return
 	}
 	if entry.Status != "error" {
 		t.Fatalf("status = %q, want error", entry.Status)

--- a/internal/processing/events_test.go
+++ b/internal/processing/events_test.go
@@ -70,6 +70,7 @@ func TestStartEventWorker_FinalizesCompletedFileUsingDestPath(t *testing.T) {
 	}
 	if entry == nil {
 		t.Fatal("expected completed entry to exist")
+		return
 	}
 	if entry.Status != "completed" {
 		t.Fatalf("status = %q, want completed", entry.Status)
@@ -114,6 +115,7 @@ func TestStartEventWorker_PersistsQueuedMirrorsForResume(t *testing.T) {
 	}
 	if queuedState == nil {
 		t.Fatal("expected queued state entry to exist")
+		return
 	}
 	if len(queuedState.Mirrors) != 2 {
 		t.Fatalf("mirrors = %v, want 2 queued mirrors", queuedState.Mirrors)
@@ -159,6 +161,7 @@ func TestStartEventWorker_PreservesQueuedMirrorsAcrossStartedThenError(t *testin
 	}
 	if entry == nil {
 		t.Fatal("expected errored entry to exist")
+		return
 	}
 	if entry.Status != "error" {
 		t.Fatalf("status = %q, want error", entry.Status)

--- a/internal/tui/polling_test.go
+++ b/internal/tui/polling_test.go
@@ -89,6 +89,7 @@ func TestStateSync(t *testing.T) {
 
 	if target == nil {
 		t.Fatal("Download model not found")
+		return
 	}
 
 	// Without fix: TUI creates its own state, so Downloaded stays 0

--- a/internal/tui/startup_test.go
+++ b/internal/tui/startup_test.go
@@ -110,6 +110,7 @@ func TestTUI_Startup_LoadsCompletedTiming(t *testing.T) {
 	}
 	if found == nil {
 		t.Fatal("TUI Model failed to load completed download")
+		return
 	}
 	if !found.done {
 		t.Error("Expected completed download to be marked done")
@@ -158,6 +159,7 @@ func TestTUI_Startup_LoadsErroredDownloadsIntoDoneTab(t *testing.T) {
 	}
 	if found == nil {
 		t.Fatal("TUI Model failed to load errored download")
+		return
 	}
 	if !found.done {
 		t.Fatal("expected errored download to appear in done tab")

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -108,6 +108,7 @@ func TestUpdate_DownloadStartedKeepsResuming(t *testing.T) {
 	}
 	if d == nil {
 		t.Fatal("Expected download id-1 to exist")
+		return
 	}
 	if d.paused || d.pausing || !d.resuming {
 		t.Fatalf("Expected paused/pausing cleared and resuming preserved on DownloadStartedMsg, got paused=%v pausing=%v resuming=%v", d.paused, d.pausing, d.resuming)


### PR DESCRIPTION
## Summary
- Resolve local CLI connection details as a single port/token pair, with user state first and system/root service state as fallback.
- Make extension auto-discovery token-aware so it skips healthy local servers that reject the saved token.
- Separate invalid-token from server-unavailable UI states.
- Fix extension settings save/delete button handlers so they evaluate the current locked state at click time.
- Add a popup refresh button and refresh immediately after download actions to reduce stale/unresponsive UI.
- Add a narrow golangci config exclusion for `SA5011` in tests only; production code still keeps the check enabled.

## Issues
Closes #433
Closes #436
Closes #378
Supersedes #435

## Tests
- `golangci-lint run`
- `GOCACHE=/tmp/go-build go test ./...`
- `npm run check`
- `npm run lint`
- `GOCACHE=/tmp/go-build npm test`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes local service discovery to resolve port and auth token as a matched pair (user state first, system/root fallback), preventing the CLI and extension from mixing tokens from different running instances. It also improves the extension's auth UX by distinguishing "invalid token" from "server unavailable" states and fixing button handlers that previously captured a stale locked-state value at render time.

- **Go backend**: `getActiveConnectionDetails()` reads port+token from the same state directory in a single resolution pass; `resolveTokenForConnectTarget` and `resolveAPIConnection` are updated to use this paired result.
- **Extension discovery**: New `discoverBaseUrlForToken()` skips healthy servers that reject the token and surfaces `sawUnauthorized`/`sawReachable` signals to drive distinct error states in `SettingsView`.
- **Popup UX**: Adds an explicit refresh button and triggers `onActionComplete` after download actions to reduce stale state; fixes `onClick` handlers to evaluate `serverUrlLocked()`/`authTokenLocked()` at click time.

<h3>Confidence Score: 5/5</h3>

Safe to merge; changes are well-scoped, tested, and do not alter any auth enforcement boundaries.

The Go changes are additive and covered by new tests. The extension changes correctly thread token context through discovery without removing any existing guards. The only finding is a minor redundant function call in `resolveTokenForConnectTarget` with no behavioral impact.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/connect.go | Adds port-matching logic to `resolveTokenForConnectTarget` to return the paired token when the active port matches. `parseRemoteServerAddress` is called twice on the same URL to split host and port retrieval. |
| cmd/utils.go | Introduces `activeConnectionDetails` struct and `getActiveConnectionDetails()` for paired port/token resolution. `resolveLocalToken()` now delegates to `resolveLocalTokenForDetails`, preserving original fallback to `ensureAuthToken()`. |
| internal/config/paths.go | Adds `GetSystemSurgeDir()`, `GetSystemStateDir()`, and `GetSystemRuntimeDir()` for root/system-level service discovery on Linux and Windows. |
| extension/entrypoints/background.ts | Adds token-aware `discoverBaseUrlForToken()`, `checkAuthAtBaseUrl()`, and `authenticatedHealthCheck()`. Updates `validateAuth` handler to perform token-aware discovery and distinguish `invalid_token` from `no_server` errors. |
| extension/entrypoints/popup/components/SettingsView.tsx | Fixes button onClick handlers to evaluate locked state at click time, adds distinct "Server unavailable" vs "Invalid Token" status messages, and imports `serverConnected` to gate which error is shown. |
| extension/entrypoints/popup/App.tsx | Adds a `refreshNow()` function and `refreshing` signal, wires them to the `DownloadList` as an explicit refresh button and auto-refresh after download actions. |
| extension/entrypoints/popup/components/DownloadList.tsx | Adds refresh button to the downloads list header and propagates `onRefresh` to each `DownloadItem`. |
| extension/entrypoints/popup/components/DownloadItem.tsx | Adds optional `onActionComplete` callback invoked after each download action message, enabling post-action refresh. |
| .golangci.yml | New config file adding a `SA5011` staticcheck exclusion scoped to `_test.go` files only; production code retains the check. |
| .github/workflows/core-lint.yml | Upgrades golangci-lint import path from v1 to v2 to match the new `.golangci.yml` config format. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `extension/entrypoints/background.ts`, line 638-648 ([link](https://github.com/surgedm/surge/blob/df6efde03ddb7614df97de7957b08a15a24ad671/extension/entrypoints/background.ts#L638-L648)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Redundant `/list` call after token-aware discovery**

   When a token is provided, `discoverBaseUrlForToken` already calls `checkAuthAtBaseUrl` — which hits `${base}/list` — for every candidate before returning `base`. The handler then immediately issues a second `GET /list` on the same URL with the same token. The only new information the second call provides is the response body (which the `validateAuth` handler does use to cache auth state), but the connection and status confirmation are already done. Consider whether returning `{ ok: true, base }` from the discovery path can be used to skip the re-fetch when the token discovery confirms success.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: extension/entrypoints/background.ts
   Line: 638-648

   Comment:
   **Redundant `/list` call after token-aware discovery**

   When a token is provided, `discoverBaseUrlForToken` already calls `checkAuthAtBaseUrl` — which hits `${base}/list` — for every candidate before returning `base`. The handler then immediately issues a second `GET /list` on the same URL with the same token. The only new information the second call provides is the response body (which the `validateAuth` handler does use to cache auth state), but the connection and status confirmation are already done. Consider whether returning `{ ok: true, base }` from the discovery path can be used to skip the re-fetch when the token discovery confirms success.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
cmd/connect.go:120-123
`parseRemoteServerAddress` is already called on the line above to extract `serverHost`; the port return value is discarded there and then retrieved by calling the same function a second time. Combine both into a single call to remove the duplicate parse.

```suggestion
	serverHost, serverPort := parseRemoteServerAddress(target.BaseURL)
	if isLocalHost(serverHost) {
		if details, ok := getActiveConnectionDetails(); ok && details.port == serverPort {
```


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["chore: update golangci-lint to v2"](https://github.com/surgedm/surge/commit/3c6456cdbb39dd88abfccbf89f7bc0b57f8776b7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31511057)</sub>

<!-- /greptile_comment -->