### PR TITLE
feat(tui): pin tab + auto-follow new downloads

### DIFF
--- a/internal/tui/components/tab_bar.go
+++ b/internal/tui/components/tab_bar.go
@@ -27,7 +27,7 @@ func RenderTabBar(tabs []Tab, activeIndex int, activeStyle, inactiveStyle lipglo
 		}
 
 		if t.Pinned {
-			label = "\U0001f4cc " + label
+			label = "\u25c6 " + label
 		}
 
 		var tabStyle lipgloss.Style
@@ -64,7 +64,7 @@ func RenderNumberedTabBar(tabs []Tab, activeIndex int, activeStyle, inactiveStyl
 		}
 
 		if t.Pinned {
-			label = "\U0001f4cc " + label
+			label = "\u25c6 " + label
 		}
 
 		var tabStyle lipgloss.Style

--- a/internal/tui/components/tab_bar.go
+++ b/internal/tui/components/tab_bar.go
@@ -8,8 +8,9 @@ import (
 
 // Tab represents a single tab item
 type Tab struct {
-	Label string
-	Count int // If >= 0, displays as "Label (Count)"; if < 0, displays just "Label"
+	Label  string
+	Count  int  // If >= 0, displays as "Label (Count)"; if < 0, displays just "Label"
+	Pinned bool // If true, displays with a pin icon
 }
 
 // RenderTabBar renders a horizontal tab bar with the given tabs
@@ -23,6 +24,10 @@ func RenderTabBar(tabs []Tab, activeIndex int, activeStyle, inactiveStyle lipglo
 			label = fmt.Sprintf("%s (%d)", t.Label, t.Count)
 		} else {
 			label = t.Label
+		}
+
+		if t.Pinned {
+			label = "\U0001f4cc " + label
 		}
 
 		var tabStyle lipgloss.Style
@@ -56,6 +61,10 @@ func RenderNumberedTabBar(tabs []Tab, activeIndex int, activeStyle, inactiveStyl
 			label = fmt.Sprintf("[%d] %s (%d)", i+1, t.Label, t.Count)
 		} else {
 			label = fmt.Sprintf("[%d] %s", i+1, t.Label)
+		}
+
+		if t.Pinned {
+			label = "\U0001f4cc " + label
 		}
 
 		var tabStyle lipgloss.Style

--- a/internal/tui/follow_test.go
+++ b/internal/tui/follow_test.go
@@ -1,0 +1,117 @@
+package tui
+
+import (
+	"testing"
+
+	"charm.land/bubbles/v2/viewport"
+	"github.com/SurgeDM/Surge/internal/engine/events"
+	"github.com/SurgeDM/Surge/internal/engine/types"
+)
+
+func TestAutoFollow_BrandNewDownload(t *testing.T) {
+	m := RootModel{
+		activeTab:   TabDone,
+		pinnedTab:   -1,
+		list:        NewDownloadList(80, 20),
+		logViewport: viewport.New(viewport.WithWidth(40), viewport.WithHeight(5)),
+	}
+
+	msg := events.DownloadStartedMsg{
+		DownloadID: "new-1",
+		Filename:   "new-file",
+		Total:      100,
+		State:      types.NewProgressState("new-1", 100),
+	}
+
+	updated, _ := m.Update(msg)
+	m2 := updated.(RootModel)
+
+	if m2.activeTab != TabActive {
+		t.Errorf("Expected activeTab to be TabActive (1), got %d", m2.activeTab)
+	}
+	if m2.SelectedDownloadID != "" {
+		t.Errorf("Expected SelectedDownloadID to be cleared, got %q", m2.SelectedDownloadID)
+	}
+}
+
+func TestAutoFollow_ExistingDownloadRestart(t *testing.T) {
+	dm := NewDownloadModel("existing-1", "http://example.com", "file", 100)
+	dm.paused = true
+
+	m := RootModel{
+		activeTab:   TabQueued,
+		pinnedTab:   -1,
+		downloads:   []*DownloadModel{dm},
+		list:        NewDownloadList(80, 20),
+		logViewport: viewport.New(viewport.WithWidth(40), viewport.WithHeight(5)),
+	}
+
+	msg := events.DownloadStartedMsg{
+		DownloadID: "existing-1",
+		Filename:   "file",
+		Total:      100,
+		State:      types.NewProgressState("existing-1", 100),
+	}
+
+	updated, _ := m.Update(msg)
+	m2 := updated.(RootModel)
+
+	if m2.activeTab != TabActive {
+		t.Errorf("Expected activeTab to be TabActive (1), got %d", m2.activeTab)
+	}
+}
+
+func TestAutoFollow_SuppressedByPin(t *testing.T) {
+	m := RootModel{
+		activeTab:   TabDone,
+		pinnedTab:   TabDone,
+		list:        NewDownloadList(80, 20),
+		logViewport: viewport.New(viewport.WithWidth(40), viewport.WithHeight(5)),
+	}
+
+	msg := events.DownloadStartedMsg{
+		DownloadID: "new-1",
+		Filename:   "new-file",
+		Total:      100,
+		State:      types.NewProgressState("new-1", 100),
+	}
+
+	updated, _ := m.Update(msg)
+	m2 := updated.(RootModel)
+
+	if m2.activeTab != TabDone {
+		t.Errorf("Expected activeTab to remain TabDone (2) because it is pinned, got %d", m2.activeTab)
+	}
+}
+
+func TestAutoFollow_QueuedToActiveTransition(t *testing.T) {
+	// Test that transitioning from Queued to Active (via DownloadStartedMsg)
+	// also triggers auto-follow if we are currently on Queued tab.
+	dm := NewDownloadModel("id-1", "http://example.com", "file", 100)
+	// Initially it's queued (done=false, paused=false, speed=0, connections=0)
+
+	m := RootModel{
+		activeTab:   TabQueued,
+		pinnedTab:   -1,
+		downloads:   []*DownloadModel{dm},
+		list:        NewDownloadList(80, 20),
+		logViewport: viewport.New(viewport.WithWidth(40), viewport.WithHeight(5)),
+	}
+
+	// Update list to reflect initial state
+	m.UpdateListItems()
+
+	msg := events.DownloadStartedMsg{
+		DownloadID: "id-1",
+		Filename:   "file",
+		Total:      100,
+		State:      types.NewProgressState("id-1", 100),
+	}
+
+	updated, _ := m.Update(msg)
+	m2 := updated.(RootModel)
+
+	if m2.activeTab != TabActive {
+		t.Errorf("Expected auto-follow to Active tab, got %d", m2.activeTab)
+	}
+}

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -38,6 +38,7 @@ type DashboardKeyMap struct {
 	Quit           key.Binding
 	ForceQuit      key.Binding
 	CategoryFilter key.Binding
+	PinTab         key.Binding
 	// Navigation
 	Up   key.Binding
 	Down key.Binding
@@ -224,6 +225,10 @@ var Keys = KeyMap{
 		CategoryFilter: key.NewBinding(
 			key.WithKeys("c"),
 			key.WithHelp("c", "category"),
+		),
+		PinTab: key.NewBinding(
+			key.WithKeys("ctrl+tab"),
+			key.WithHelp("ctrl+tab", "pin tab"),
 		),
 		Up: key.NewBinding(
 			key.WithKeys("up", "k"),
@@ -487,7 +492,7 @@ func (k DashboardKeyMap) ShortHelp() []key.Binding {
 func (k DashboardKeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.TabQueued, k.TabActive, k.TabDone, k.NextTab},
-		{k.Add, k.BatchImport, k.Search, k.CategoryFilter, k.Pause, k.Refresh, k.Delete, k.Settings},
+		{k.Add, k.BatchImport, k.Search, k.CategoryFilter, k.Pause, k.Refresh, k.Delete, k.Settings, k.PinTab},
 		{k.Log, k.OpenFile, k.ReportBug, k.Quit},
 	}
 }

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -24,6 +24,7 @@ type DashboardKeyMap struct {
 	TabActive      key.Binding
 	TabDone        key.Binding
 	NextTab        key.Binding
+	PrevTab        key.Binding
 	Add            key.Binding
 	BatchImport    key.Binding
 	Search         key.Binding
@@ -167,8 +168,12 @@ var Keys = KeyMap{
 			key.WithHelp("e", "done tab"),
 		),
 		NextTab: key.NewBinding(
-			key.WithKeys("tab"),
-			key.WithHelp("tab", "next tab"),
+			key.WithKeys("tab", "right"),
+			key.WithHelp("tab/→", "next tab"),
+		),
+		PrevTab: key.NewBinding(
+			key.WithKeys("left"),
+			key.WithHelp("←", "prev tab"),
 		),
 		Add: key.NewBinding(
 			key.WithKeys("a"),
@@ -231,20 +236,20 @@ var Keys = KeyMap{
 			key.WithHelp("t", "pin tab"),
 		),
 		Up: key.NewBinding(
-			key.WithKeys("up", "k"),
-			key.WithHelp("\u2191/k", "up"),
+			key.WithKeys("up"),
+			key.WithHelp("\u2191", "up"),
 		),
 		Down: key.NewBinding(
-			key.WithKeys("down", "j"),
-			key.WithHelp("\u2193/j", "down"),
+			key.WithKeys("down"),
+			key.WithHelp("\u2193", "down"),
 		),
 		LogUp: key.NewBinding(
-			key.WithKeys("up", "k"),
-			key.WithHelp("\u2191/k", "scroll up"),
+			key.WithKeys("up"),
+			key.WithHelp("↑", "scroll up"),
 		),
 		LogDown: key.NewBinding(
-			key.WithKeys("down", "j"),
-			key.WithHelp("\u2193/j", "scroll down"),
+			key.WithKeys("down"),
+			key.WithHelp("↓", "scroll down"),
 		),
 		LogTop: key.NewBinding(
 			key.WithKeys("g"),
@@ -385,12 +390,12 @@ var Keys = KeyMap{
 			key.WithHelp("enter", "edit"),
 		),
 		Up: key.NewBinding(
-			key.WithKeys("up", "k"),
-			key.WithHelp("\u2191/k", "up"),
+			key.WithKeys("up"),
+			key.WithHelp("\u2191", "up"),
 		),
 		Down: key.NewBinding(
-			key.WithKeys("down", "j"),
-			key.WithHelp("\u2193/j", "down"),
+			key.WithKeys("down"),
+			key.WithHelp("\u2193", "down"),
 		),
 		Reset: key.NewBinding(
 			key.WithKeys("r", "R"),
@@ -450,8 +455,8 @@ var Keys = KeyMap{
 		),
 	},
 	CategoryMgr: CategoryManagerKeyMap{
-		Up:     key.NewBinding(key.WithKeys("up", "k"), key.WithHelp("\u2191/k", "up")),
-		Down:   key.NewBinding(key.WithKeys("down", "j"), key.WithHelp("\u2193/j", "down")),
+		Up:     key.NewBinding(key.WithKeys("up"), key.WithHelp("↑", "up")),
+		Down:   key.NewBinding(key.WithKeys("down"), key.WithHelp("↓", "down")),
 		Edit:   key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "edit")),
 		Add:    key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "add")),
 		Delete: key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "delete")),
@@ -491,7 +496,7 @@ func (k DashboardKeyMap) ShortHelp() []key.Binding {
 // FullHelp returns keybindings for the expanded help view
 func (k DashboardKeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
-		{k.TabQueued, k.TabActive, k.TabDone, k.NextTab},
+		{k.TabQueued, k.TabActive, k.TabDone, k.NextTab, k.PrevTab},
 		{k.Add, k.BatchImport, k.Search, k.CategoryFilter, k.Pause, k.Refresh, k.Delete, k.Settings, k.PinTab},
 		{k.Log, k.OpenFile, k.ReportBug, k.Quit},
 	}

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -227,8 +227,8 @@ var Keys = KeyMap{
 			key.WithHelp("c", "category"),
 		),
 		PinTab: key.NewBinding(
-			key.WithKeys("ctrl+tab"),
-			key.WithHelp("ctrl+tab", "pin tab"),
+			key.WithKeys("t"),
+			key.WithHelp("t", "pin tab"),
 		),
 		Up: key.NewBinding(
 			key.WithKeys("up", "k"),

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -272,7 +272,7 @@ func (m *RootModel) UpdateListItems() {
 					var newTab int
 					if d.done {
 						newTab = TabDone
-					} else if !d.paused && !d.pausing && (d.Speed > 0 || d.Connections > 0 || d.resuming) {
+					} else if !d.paused && !d.pausing && (d.Speed > 0 || d.Connections > 0 || d.resuming || d.started) {
 						newTab = TabActive
 					} else {
 						newTab = TabQueued

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -278,8 +278,8 @@ func (m *RootModel) UpdateListItems() {
 						newTab = TabQueued
 					}
 
-					// If it belongs to a different tab, switch to it
-					if newTab != -1 && newTab != m.activeTab {
+					// If it belongs to a different tab, switch to it (unless current tab is pinned)
+					if m.pinnedTab == -1 && newTab != -1 && newTab != m.activeTab {
 						m.activeTab = newTab
 
 						// Force selection for the recursive call

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -98,6 +98,7 @@ type DownloadModel struct {
 	state *types.ProgressState // Keep for now if needed for details view, but mostly passive
 
 	done     bool
+	started  bool // Engine has confirmed start
 	err      error
 	paused   bool
 	pausing  bool // UI state: transitioning to pause
@@ -320,11 +321,14 @@ func InitialRootModel(serverPort int, currentVersion string, service core.Downlo
 				switch s.Status {
 				case "completed":
 					dm.done = true
+					dm.started = true
 					dm.progress.SetPercent(1.0)
 				case "error":
 					dm.done = true
+					dm.started = true
 				case "pausing":
 					dm.pausing = true
+					dm.started = true
 				case "paused":
 					if settings.General.AutoResume {
 						dm.resuming = true
@@ -332,10 +336,14 @@ func InitialRootModel(serverPort int, currentVersion string, service core.Downlo
 					} else {
 						dm.paused = true
 					}
+					dm.started = true
 				case "queued":
 					// Always resume queued items
 					dm.resuming = true
 					dm.paused = true // Will update when resume event received
+					dm.started = false
+				case "downloading":
+					dm.started = true
 				}
 
 				if s.TotalSize > 0 {
@@ -528,12 +536,12 @@ func (m RootModel) getFilteredDownloads() []*DownloadModel {
 		switch m.activeTab {
 		case TabQueued:
 			// Queued includes paused downloads and anything not currently active or done
-			if d.done || (!d.paused && !d.pausing && (d.Speed > 0 || d.Connections > 0 || d.resuming)) {
+			if d.done || (!d.paused && !d.pausing && (d.Speed > 0 || d.Connections > 0 || d.resuming || d.started)) {
 				continue
 			}
 		case TabActive:
 			// Active excludes paused downloads and anything without current activity
-			if d.done || d.paused || d.pausing || (d.Speed == 0 && d.Connections == 0 && !d.resuming) {
+			if d.done || d.paused || d.pausing || (d.Speed == 0 && d.Connections == 0 && !d.resuming && !d.started) {
 				continue
 			}
 		case TabDone:

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -110,6 +110,7 @@ type RootModel struct {
 	height       int
 	state        UIState
 	activeTab    int // 0=Queued, 1=Active, 2=Done
+	pinnedTab    int // -1=None, 0=Queued, 1=Active, 2=Done
 	inputs       []textinput.Model
 	focusedInput int
 	// Service Interface
@@ -412,6 +413,7 @@ func InitialRootModel(serverPort int, currentVersion string, service core.Downlo
 
 	m := RootModel{
 		downloads:             downloads,
+		pinnedTab:             -1,
 		inputs:                []textinput.Model{urlInput, mirrorsInput, pathInput, filenameInput},
 		state:                 DashboardState,
 		filepicker:            fp,

--- a/internal/tui/process.go
+++ b/internal/tui/process.go
@@ -135,7 +135,9 @@ func (m RootModel) startDownload(url string, mirrors []string, headers map[strin
 	}
 	m.downloads = append(m.downloads, newDownload)
 	m.SelectedDownloadID = optimisticID
-	m.activeTab = TabQueued
+	if m.pinnedTab == -1 {
+		m.activeTab = TabQueued
+	}
 	m.UpdateListItems()
 
 	// Legacy path for tests or startup wiring where processing is not injected yet.

--- a/internal/tui/update_dashboard.go
+++ b/internal/tui/update_dashboard.go
@@ -270,11 +270,14 @@ func (m RootModel) updateDashboard(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.addLogEntry(LogStyleStarted.Render("📌 Tab Unpinned"))
 		} else {
 			m.pinnedTab = m.activeTab
-			tabName := "Queued"
-			if m.activeTab == TabActive {
+			var tabName string
+			switch m.activeTab {
+			case TabActive:
 				tabName = "Active"
-			} else if m.activeTab == TabDone {
+			case TabDone:
 				tabName = "Done"
+			default:
+				tabName = "Queued"
 			}
 			m.addLogEntry(LogStyleStarted.Render("📌 Tab Pinned: " + tabName))
 		}

--- a/internal/tui/update_dashboard.go
+++ b/internal/tui/update_dashboard.go
@@ -267,7 +267,7 @@ func (m RootModel) updateDashboard(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if key.Matches(msg, m.keys.Dashboard.PinTab) {
 		if m.pinnedTab == m.activeTab {
 			m.pinnedTab = -1
-			m.addLogEntry(LogStyleStarted.Render("📌 Tab Unpinned"))
+			m.addLogEntry(LogStyleStarted.Render("\u25c6 Tab Unpinned"))
 		} else {
 			m.pinnedTab = m.activeTab
 			var tabName string
@@ -279,7 +279,7 @@ func (m RootModel) updateDashboard(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			default:
 				tabName = "Queued"
 			}
-			m.addLogEntry(LogStyleStarted.Render("📌 Tab Pinned: " + tabName))
+			m.addLogEntry(LogStyleStarted.Render("\u25c6 Tab Pinned: " + tabName))
 		}
 		return m, nil
 	}

--- a/internal/tui/update_dashboard.go
+++ b/internal/tui/update_dashboard.go
@@ -103,9 +103,15 @@ func (m RootModel) updateDashboard(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	// Next Tab
+	// Next / Prev Tab
 	if key.Matches(msg, m.keys.Dashboard.NextTab) {
 		m.activeTab = (m.activeTab + 1) % 3
+		m.ManualTabSwitch = true
+		m.UpdateListItems()
+		return m, nil
+	}
+	if key.Matches(msg, m.keys.Dashboard.PrevTab) {
+		m.activeTab = (m.activeTab + 2) % 3 // +2 mod 3 = prev
 		m.ManualTabSwitch = true
 		m.UpdateListItems()
 		return m, nil

--- a/internal/tui/update_dashboard.go
+++ b/internal/tui/update_dashboard.go
@@ -264,6 +264,23 @@ func (m RootModel) updateDashboard(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	if key.Matches(msg, m.keys.Dashboard.PinTab) {
+		if m.pinnedTab == m.activeTab {
+			m.pinnedTab = -1
+			m.addLogEntry(LogStyleStarted.Render("📌 Tab Unpinned"))
+		} else {
+			m.pinnedTab = m.activeTab
+			tabName := "Queued"
+			if m.activeTab == TabActive {
+				tabName = "Active"
+			} else if m.activeTab == TabDone {
+				tabName = "Done"
+			}
+			m.addLogEntry(LogStyleStarted.Render("📌 Tab Pinned: " + tabName))
+		}
+		return m, nil
+	}
+
 	if key.Matches(msg, m.keys.Dashboard.BatchImport) {
 		m.state = BatchFilePickerState
 		m.filepicker = newFilepicker(m.PWD)

--- a/internal/tui/update_dashboard.go
+++ b/internal/tui/update_dashboard.go
@@ -55,6 +55,14 @@ func (m RootModel) updateDashboard(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 
 	// Tab switching
+	pinnedGuard := func() bool {
+		if m.pinnedTab != -1 {
+			m.addLogEntry(LogStyleError.Render("\u25c6 Tab is pinned \u2014 press t to unpin"))
+			return true
+		}
+		return false
+	}
+
 	switchTab := func(tab int) (tea.Model, tea.Cmd) {
 		m.activeTab = tab
 		m.ManualTabSwitch = true
@@ -63,12 +71,21 @@ func (m RootModel) updateDashboard(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 
 	if key.Matches(msg, m.keys.Dashboard.TabQueued) {
+		if pinnedGuard() {
+			return m, nil
+		}
 		return switchTab(TabQueued)
 	}
 	if key.Matches(msg, m.keys.Dashboard.TabActive) {
+		if pinnedGuard() {
+			return m, nil
+		}
 		return switchTab(TabActive)
 	}
 	if key.Matches(msg, m.keys.Dashboard.TabDone) {
+		if pinnedGuard() {
+			return m, nil
+		}
 		return switchTab(TabDone)
 	}
 	// Quit
@@ -105,12 +122,18 @@ func (m RootModel) updateDashboard(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 	// Next / Prev Tab
 	if key.Matches(msg, m.keys.Dashboard.NextTab) {
+		if pinnedGuard() {
+			return m, nil
+		}
 		m.activeTab = (m.activeTab + 1) % 3
 		m.ManualTabSwitch = true
 		m.UpdateListItems()
 		return m, nil
 	}
 	if key.Matches(msg, m.keys.Dashboard.PrevTab) {
+		if pinnedGuard() {
+			return m, nil
+		}
 		m.activeTab = (m.activeTab + 2) % 3 // +2 mod 3 = prev
 		m.ManualTabSwitch = true
 		m.UpdateListItems()

--- a/internal/tui/update_events.go
+++ b/internal/tui/update_events.go
@@ -177,6 +177,7 @@ func (m RootModel) updateEvents(msg tea.Msg) (tea.Model, tea.Cmd) {
 				newDownload.state = msg.State
 			}
 			m.downloads = append(m.downloads, newDownload)
+			m.SelectedDownloadID = msg.DownloadID
 			m.UpdateListItems()
 			m.addLogEntry(LogStyleStarted.Render("\u2b07 Started: " + msg.Filename))
 			return m, m.spinner.Tick
@@ -269,6 +270,7 @@ func (m RootModel) updateEvents(msg tea.Msg) (tea.Model, tea.Cmd) {
 			newDownload := NewDownloadModel(msg.DownloadID, msg.URL, msg.Filename, 0)
 			newDownload.Destination = msg.DestPath
 			m.downloads = append(m.downloads, newDownload)
+			m.SelectedDownloadID = msg.DownloadID
 			m.UpdateListItems()
 			return m, m.spinner.Tick
 		}

--- a/internal/tui/update_events.go
+++ b/internal/tui/update_events.go
@@ -64,12 +64,16 @@ func (m RootModel) updateEvents(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if real.Destination == "" {
 					real.Destination = temp.Destination
 				}
+
+				if m.SelectedDownloadID == msg.tempID || (m.GetSelectedDownload() != nil && m.GetSelectedDownload().ID == msg.tempID) {
+					m.SelectedDownloadID = msg.id
+				}
 				_ = m.removeDownloadByID(msg.tempID)
 			} else if temp != nil {
+				if m.SelectedDownloadID == msg.tempID || (m.GetSelectedDownload() != nil && m.GetSelectedDownload().ID == msg.tempID) {
+					m.SelectedDownloadID = msg.id
+				}
 				temp.ID = msg.id
-			}
-			if m.SelectedDownloadID == msg.tempID {
-				m.SelectedDownloadID = msg.id
 			}
 		}
 		m.UpdateListItems()
@@ -165,6 +169,8 @@ func (m RootModel) updateEvents(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if d.state != nil {
 				d.state.SetTotalSize(msg.Total) // Keep state updated for verification if needed
 			}
+			d.started = true
+			m.SelectedDownloadID = msg.DownloadID
 			m.UpdateListItems()
 			m.addLogEntry(LogStyleStarted.Render("\u2b07 Started: " + msg.Filename))
 			return m, tea.Batch(progressCmd, m.spinner.Tick)
@@ -176,6 +182,7 @@ func (m RootModel) updateEvents(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if msg.State != nil {
 				newDownload.state = msg.State
 			}
+			newDownload.started = true
 			m.downloads = append(m.downloads, newDownload)
 			m.SelectedDownloadID = msg.DownloadID
 			m.UpdateListItems()

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -122,6 +122,7 @@ func TestUpdate_EnqueueSuccessMergesOptimisticEntryAfterStart(t *testing.T) {
 	m := RootModel{
 		downloads:          []*DownloadModel{optimistic},
 		SelectedDownloadID: "pending-1",
+		pinnedTab:          -1,
 		list:               NewDownloadList(80, 20),
 		logViewport:        viewport.New(viewport.WithWidth(40), viewport.WithHeight(5)),
 	}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -765,11 +765,11 @@ func (m RootModel) ComputeViewStats() ViewStats {
 	return stats
 }
 
-func renderTabs(activeTab, activeCount, queuedCount, doneCount int) string {
+func (m RootModel) renderTabs(activeTab, activeCount, queuedCount, doneCount int) string {
 	tabs := []components.Tab{
-		{Label: "Queued", Count: queuedCount},
-		{Label: "Active", Count: activeCount},
-		{Label: "Done", Count: doneCount},
+		{Label: "Queued", Count: queuedCount, Pinned: m.pinnedTab == TabQueued},
+		{Label: "Active", Count: activeCount, Pinned: m.pinnedTab == TabActive},
+		{Label: "Done", Count: doneCount, Pinned: m.pinnedTab == TabDone},
 	}
 	return components.RenderTabBar(tabs, activeTab, ActiveTabStyle, TabStyle)
 }

--- a/internal/tui/view_dashboard_list.go
+++ b/internal/tui/view_dashboard_list.go
@@ -21,7 +21,7 @@ func (m *RootModel) renderDownloadsBox(width, height int, stats ViewStats) strin
 
 	var leftTitle string
 	// Tab Bar
-	tabBar := renderTabs(m.activeTab, stats.ActiveCount, stats.QueuedCount, stats.DownloadedCount)
+	tabBar := m.renderTabs(m.activeTab, stats.ActiveCount, stats.QueuedCount, stats.DownloadedCount)
 
 	// Search bar (shown when search is active or has a query)
 	if m.searchActive || m.searchQuery != "" {


### PR DESCRIPTION
Closes #431

## Summary

Adds a **pin tab** feature to the TUI and implements **auto-follow** for new downloads initiated from the browser extension.

### Pin Tab
- Press **`ctrl+tab`** to pin/unpin the currently active tab
- A 📌 icon appears in the tab bar to indicate the pinned state
- While a tab is pinned, the TUI will **not** automatically switch away — even when downloads complete or new ones arrive
- Pressing `ctrl+tab`again on the same tab unpins it; a log entry confirms the action

### Auto-follow New Downloads (when unpinned)
- When no tab is pinned, the TUI now automatically navigates to a new download when it is started or queued from the browser extension
- This resolves the core UX issue in #431: users no longer need to manually switch tabs to find a newly added download

### UX Design Rationale
Automatic switching alone would be disruptive to users browsing history or other tabs. The pin feature gives users explicit control: **pin a tab to stay there, unpin to let the TUI follow activity**.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a **pin tab** feature (`t` to toggle) and **auto-follow** for downloads started or queued from the browser extension. When unpinned, the TUI automatically navigates to the newly active tab by setting `SelectedDownloadID` before calling `UpdateListItems`; a new `started bool` field on `DownloadModel` ensures downloads appear in TabActive immediately after the engine confirms start, before any progress events arrive.

- `pinnedTab int` (-1 = none) is added to `RootModel`; all tab-switch paths and auto-follow logic check this field before redirecting.
- `renderTabs` is promoted from a package-level function to a `RootModel` method so it can read `pinnedTab` to decorate the label with a `◆` indicator.
- Four new tests in `follow_test.go` cover brand-new download auto-follow, existing-download restart, pin suppression, and Queued→Active transition; the `DownloadQueuedMsg` auto-follow path remains untested.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the pin and auto-follow logic is straightforward and well-contained within the TUI layer.

All tab-switch paths consistently gate on `pinnedTab`, `started` is correctly initialised for every server-status case, and the core auto-follow flow is exercised by the new tests. The one open item — `pinnedGuard` logging a spurious message when the user presses the shortcut for a tab they are already on — is cosmetic and does not affect correctness or data.

No files require special attention beyond the minor guard-log behaviour in `update_dashboard.go`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/tui/components/tab_bar.go | Adds `Pinned bool` to `Tab` and prepends `◆` when set; applied to both `RenderTabBar` and `RenderNumberedTabBar`. Safe change. |
| internal/tui/follow_test.go | New test file covering auto-follow for brand-new downloads, existing restarts, pin suppression, and Queued→Active transitions. The `DownloadQueuedMsg` auto-follow path (update_events.go:280) has no coverage here. |
| internal/tui/keys.go | Adds `PinTab` (`t`) and `PrevTab` (`left`) bindings; removes `j`/`k` vim shortcuts (intentional per thread reply, closes #430). Full-help rows updated. |
| internal/tui/list.go | Auto-follow tab switch now gated on `m.pinnedTab == -1`; adds `d.started` to tab-classification conditions. |
| internal/tui/model.go | Introduces `started bool` on `DownloadModel` and `pinnedTab int` (default -1) on `RootModel`; `started` correctly initialised for all server-status cases. |
| internal/tui/process.go | Wraps the optimistic tab switch to TabQueued in a `pinnedTab == -1` guard so pinned users are not redirected when they add a download. |
| internal/tui/update_dashboard.go | Adds `pinnedGuard` closure and `PinTab` / `PrevTab` handlers. Guard fires a log entry even when the user presses the shortcut for the already-active pinned tab, producing spurious noise. |
| internal/tui/update_events.go | Sets `d.started = true` and `m.SelectedDownloadID` before `UpdateListItems` for `DownloadStartedMsg` (both existing and new). Also adds `SelectedDownloadID` for `DownloadQueuedMsg`. The queued-path auto-follow is untested. |
| internal/tui/update_test.go | Existing test updated to initialise `pinnedTab: -1` so the optimistic-ID merge test continues to pass. |
| internal/tui/view.go | Converts `renderTabs` from a package-level function to a `RootModel` method so it can access `m.pinnedTab` for the tab label; clean refactor. |
| internal/tui/view_dashboard_list.go | Single call-site update from `renderTabs(...)` to `m.renderTabs(...)` following the view.go refactor. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/tui/update_dashboard.go:58-65
**Spurious pin-guard log when already on the pinned tab**

`pinnedGuard` fires unconditionally before each `switchTab` call, including when the user presses the shortcut for the tab they are *already on*. If TabQueued is pinned and the user presses `q`, the guard logs "Tab is pinned — press t to unpin" even though the tab would not have changed anyway. With repeated key presses the log fills up with noise, and the message is misleading since nothing was actually blocked. The guard should only fire when the requested tab differs from `m.activeTab`.

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(tui): address auto-follow edge cases..."](https://github.com/surgedm/surge/commit/7dcae43fd10cf03e24c544d6e9aca4fe0e9357d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31513383)</sub>

<!-- /greptile_comment -->