### PR TITLE
fix config fails

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -78,7 +78,8 @@ var (
 	GlobalService           core.DownloadService
 	GlobalLifecycleCleanup  func()
 	serverProgram           *tea.Program
-	startupIntegrityMessage string
+	startupIntegrityMessage  string
+	startupConfigWarnings   []string
 	globalSettings          *config.Settings
 	GlobalLifecycle         *processing.LifecycleManager
 	globalLifecycleMu       sync.Mutex
@@ -381,24 +382,17 @@ func initializeRootLocalRuntime() error {
 
 	startupIntegrityMessage = runStartupIntegrityCheck()
 
+	// Capture config warnings now; publish them after TUI starts so they
+	// arrive in the live event stream rather than being dropped.
+	if globalSettings != nil {
+		startupConfigWarnings = globalSettings.StartupWarnings
+	}
+
 	if err := ensureGlobalLocalServiceAndLifecycle(); err != nil {
 		return fmt.Errorf("error creating lifecycle event stream: %w", err)
 	}
 
-	publishStartupWarnings()
-
 	return nil
-}
-
-func publishStartupWarnings() {
-	if globalSettings == nil || len(globalSettings.StartupWarnings) == 0 {
-		return
-	}
-	for _, warning := range globalSettings.StartupWarnings {
-		_ = GlobalService.Publish(events.SystemLogMsg{
-			Message: warning,
-		})
-	}
 }
 
 func startRootHTTPServer(opts rootRunOptions) (int, func(), error) {
@@ -524,6 +518,12 @@ func startTUI(port int, exitWhenDone bool, noResume bool) error {
 			Message: startupIntegrityMessage,
 		})
 		startupIntegrityMessage = ""
+	}
+	if len(startupConfigWarnings) > 0 && GlobalService != nil {
+		for _, w := range startupConfigWarnings {
+			_ = GlobalService.Publish(events.SystemLogMsg{Message: w})
+		}
+		startupConfigWarnings = nil
 	}
 
 	// Exit-when-done checker for TUI

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -78,7 +78,7 @@ var (
 	GlobalService           core.DownloadService
 	GlobalLifecycleCleanup  func()
 	serverProgram           *tea.Program
-	startupIntegrityMessage  string
+	startupIntegrityMessage string
 	startupConfigWarnings   []string
 	globalSettings          *config.Settings
 	GlobalLifecycle         *processing.LifecycleManager

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -79,7 +79,6 @@ var (
 	GlobalLifecycleCleanup  func()
 	serverProgram           *tea.Program
 	startupIntegrityMessage string
-	startupConfigWarnings   []string
 	globalSettings          *config.Settings
 	GlobalLifecycle         *processing.LifecycleManager
 	globalLifecycleMu       sync.Mutex
@@ -382,12 +381,6 @@ func initializeRootLocalRuntime() error {
 
 	startupIntegrityMessage = runStartupIntegrityCheck()
 
-	// Capture config warnings now; publish them after TUI starts so they
-	// arrive in the live event stream rather than being dropped.
-	if globalSettings != nil {
-		startupConfigWarnings = globalSettings.StartupWarnings
-	}
-
 	if err := ensureGlobalLocalServiceAndLifecycle(); err != nil {
 		return fmt.Errorf("error creating lifecycle event stream: %w", err)
 	}
@@ -518,12 +511,6 @@ func startTUI(port int, exitWhenDone bool, noResume bool) error {
 			Message: startupIntegrityMessage,
 		})
 		startupIntegrityMessage = ""
-	}
-	if len(startupConfigWarnings) > 0 && GlobalService != nil {
-		for _, w := range startupConfigWarnings {
-			_ = GlobalService.Publish(events.SystemLogMsg{Message: w})
-		}
-		startupConfigWarnings = nil
 	}
 
 	// Exit-when-done checker for TUI

--- a/internal/config/config_warning_regression_test.go
+++ b/internal/config/config_warning_regression_test.go
@@ -1,0 +1,238 @@
+package config
+
+// Regression tests for: config problems must be surfaced in StartupWarnings,
+// never silently swallowed.
+//
+// Root causes fixed (branch fix-config-fails):
+//  1. Corrupt settings.json returned DefaultSettings() with no warning at all.
+//  2. publishStartupWarnings() fired before the TUI event stream was connected,
+//     so valid warnings were silently dropped.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestLoadSettings_CorruptJSON_PopulatesStartupWarning is the primary regression
+// test for bug 2: corrupt settings must set StartupWarnings, not return silent defaults.
+func TestLoadSettings_CorruptJSON_PopulatesStartupWarning(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	surgeDir := GetSurgeDir()
+	if err := os.MkdirAll(surgeDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(surgeDir, "settings.json"), []byte("{not valid json!!!"), 0o644); err != nil {
+		t.Fatalf("write corrupt settings: %v", err)
+	}
+
+	settings, err := LoadSettings()
+
+	if err != nil {
+		t.Fatalf("LoadSettings must not return an error for corrupt JSON, got: %v", err)
+	}
+	if settings == nil {
+		t.Fatal("LoadSettings returned nil settings for corrupt JSON")
+	}
+
+	// THE REGRESSION: StartupWarnings must NOT be empty for a corrupt file.
+	if len(settings.StartupWarnings) == 0 {
+		t.Fatal("corrupt settings.json produced no StartupWarnings — config problems would be silently hidden")
+	}
+
+	// The warning should mention both the corruption and the reset action.
+	warn := strings.Join(settings.StartupWarnings, " ")
+	if !strings.Contains(strings.ToLower(warn), "corrupt") {
+		t.Errorf("warning should mention 'corrupt', got: %q", warn)
+	}
+	if !strings.Contains(strings.ToLower(warn), "reset") && !strings.Contains(strings.ToLower(warn), "default") {
+		t.Errorf("warning should mention 'reset' or 'default', got: %q", warn)
+	}
+}
+
+// TestLoadSettings_TruncatedJSON_PopulatesStartupWarning covers the crash-during-write
+// scenario (atomically incomplete file).
+func TestLoadSettings_TruncatedJSON_PopulatesStartupWarning(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	surgeDir := GetSurgeDir()
+	if err := os.MkdirAll(surgeDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	truncated := `{"general": {"default_download_dir": "/home/user/Downloads", "warn_on_duplicate": tr`
+	if err := os.WriteFile(filepath.Join(surgeDir, "settings.json"), []byte(truncated), 0o644); err != nil {
+		t.Fatalf("write truncated settings: %v", err)
+	}
+
+	settings, err := LoadSettings()
+
+	if err != nil {
+		t.Fatalf("LoadSettings must not return an error for truncated JSON, got: %v", err)
+	}
+	if settings == nil {
+		t.Fatal("LoadSettings returned nil for truncated JSON")
+	}
+	if len(settings.StartupWarnings) == 0 {
+		t.Fatal("truncated settings.json produced no StartupWarnings — config problems would be silently hidden")
+	}
+}
+
+// TestLoadSettings_ValidSettings_NoStartupWarnings ensures clean configs stay quiet.
+func TestLoadSettings_ValidSettings_NoStartupWarnings(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	defaults := DefaultSettings()
+	if err := SaveSettings(defaults); err != nil {
+		t.Fatalf("SaveSettings: %v", err)
+	}
+
+	settings, err := LoadSettings()
+	if err != nil {
+		t.Fatalf("LoadSettings: %v", err)
+	}
+	if settings == nil {
+		t.Fatal("LoadSettings returned nil for valid settings")
+	}
+	if len(settings.StartupWarnings) != 0 {
+		t.Errorf("valid settings should produce zero StartupWarnings, got: %v", settings.StartupWarnings)
+	}
+}
+
+// TestLoadSettings_MissingFile_NoStartupWarnings covers the first-run case where
+// no settings file exists — this is expected and must not produce warnings.
+func TestLoadSettings_MissingFile_NoStartupWarnings(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	// No file created — GetSurgeDir() path doesn't exist, settings.json absent.
+
+	settings, err := LoadSettings()
+	if err != nil {
+		t.Fatalf("LoadSettings: %v", err)
+	}
+	if settings == nil {
+		t.Fatal("LoadSettings returned nil for missing file")
+	}
+	if len(settings.StartupWarnings) != 0 {
+		t.Errorf("missing settings file should not produce warnings (first run), got: %v", settings.StartupWarnings)
+	}
+}
+
+// TestValidate_InvalidField_PopulatesStartupWarnings ensures that field-level
+// validation warnings (out-of-range values, invalid paths) also surface.
+func TestValidate_InvalidField_PopulatesStartupWarnings(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*Settings)
+	}{
+		{
+			name:   "MaxConnectionsPerHost out of range",
+			mutate: func(s *Settings) { s.Network.MaxConnectionsPerHost = 999 },
+		},
+		{
+			name:   "MaxConcurrentDownloads out of range",
+			mutate: func(s *Settings) { s.Network.MaxConcurrentDownloads = 99 },
+		},
+		{
+			name:   "MaxTaskRetries out of range",
+			mutate: func(s *Settings) { s.Performance.MaxTaskRetries = 999 },
+		},
+		{
+			name:   "SlowWorkerThreshold out of range",
+			mutate: func(s *Settings) { s.Performance.SlowWorkerThreshold = 5.0 },
+		},
+		{
+			name:   "LogRetentionCount out of range",
+			mutate: func(s *Settings) { s.General.LogRetentionCount = 0 },
+		},
+		{
+			name:   "Invalid proxy URL",
+			mutate: func(s *Settings) { s.Network.ProxyURL = "not-a-url" },
+		},
+		{
+			name:   "Invalid DNS server",
+			mutate: func(s *Settings) { s.Network.CustomDNS = "not.a.valid.ip.server.!!!" },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := DefaultSettings()
+			tc.mutate(s)
+			s.Validate()
+
+			if len(s.StartupWarnings) == 0 {
+				t.Errorf("expected at least one StartupWarning for invalid field, got none")
+			}
+		})
+	}
+}
+
+// TestValidate_MultipleInvalidFields_AllWarningsPresent ensures each invalid
+// field independently contributes a warning (no short-circuiting).
+func TestValidate_MultipleInvalidFields_AllWarningsPresent(t *testing.T) {
+	s := DefaultSettings()
+	s.Network.MaxConnectionsPerHost = 999  // invalid
+	s.Network.MaxConcurrentDownloads = 99  // invalid
+	s.Performance.SlowWorkerThreshold = -1 // invalid
+	s.Validate()
+
+	if len(s.StartupWarnings) < 3 {
+		t.Errorf("expected at least 3 warnings for 3 invalid fields, got %d: %v",
+			len(s.StartupWarnings), s.StartupWarnings)
+	}
+}
+
+// TestValidate_ClearsOldWarningsOnRevalidation ensures Validate() is idempotent:
+// it starts fresh each call (sets StartupWarnings = nil first), so a second call
+// on already-reset settings produces zero warnings rather than accumulating.
+func TestValidate_ClearsOldWarningsOnRevalidation(t *testing.T) {
+	s := DefaultSettings()
+	s.Network.MaxConnectionsPerHost = 999 // invalid — will be reset to default
+	s.Validate()
+
+	firstCount := len(s.StartupWarnings)
+	if firstCount == 0 {
+		t.Fatal("expected at least one warning on first Validate()")
+	}
+
+	// After Validate(), MaxConnectionsPerHost has been reset to the default (valid).
+	// A second Validate() should find nothing wrong and produce zero warnings.
+	// This confirms that warnings are cleared and not accumulated across calls.
+	s.Validate()
+	secondCount := len(s.StartupWarnings)
+
+	if secondCount != 0 {
+		t.Errorf("second Validate() on already-reset settings should produce 0 warnings, got %d: %v",
+			secondCount, s.StartupWarnings)
+	}
+}
+
+// TestLoadSettings_CorruptJSON_ReturnsDefaultValues verifies that the returned
+// settings are actually defaults, not a partially-parsed struct.
+func TestLoadSettings_CorruptJSON_ReturnsDefaultValues(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	surgeDir := GetSurgeDir()
+	if err := os.MkdirAll(surgeDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(surgeDir, "settings.json"), []byte("GARBAGE"), 0o644); err != nil {
+		t.Fatalf("write corrupt settings: %v", err)
+	}
+
+	settings, _ := LoadSettings()
+	defaults := DefaultSettings()
+
+	if settings == nil {
+		t.Fatal("LoadSettings returned nil")
+	}
+	if settings.Network.MaxConnectionsPerHost != defaults.Network.MaxConnectionsPerHost {
+		t.Errorf("MaxConnectionsPerHost = %d, want default %d",
+			settings.Network.MaxConnectionsPerHost, defaults.Network.MaxConnectionsPerHost)
+	}
+	if settings.Performance.MaxTaskRetries != defaults.Performance.MaxTaskRetries {
+		t.Errorf("MaxTaskRetries = %d, want default %d",
+			settings.Performance.MaxTaskRetries, defaults.Performance.MaxTaskRetries)
+	}
+}

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -276,7 +276,10 @@ func LoadSettings() (*Settings, error) {
 	settings := DefaultSettings() // Start with defaults to fill any missing fields
 	if err := json.Unmarshal(data, settings); err != nil {
 		utils.Debug("Warning: corrupt settings file %s: %v \u2014 using defaults", path, err)
-		return DefaultSettings(), nil
+		defaults := DefaultSettings()
+		defaults.StartupWarnings = append(defaults.StartupWarnings,
+			fmt.Sprintf("Config: settings file is corrupt (%v) — all settings reset to defaults", err))
+		return defaults, nil
 	}
 
 	// Validate settings and roll back individual invalid fields to defaults

--- a/internal/tui/config_warning_regression_test.go
+++ b/internal/tui/config_warning_regression_test.go
@@ -43,11 +43,16 @@ func TestConfigWarning_StartupConfigWarningMsg_AppearsInActivityLog(t *testing.T
 	}
 
 	entry := strings.Join(m2.logEntries, " ")
-	if !strings.Contains(entry, "Config:") {
-		t.Errorf("log entry should contain 'Config:' prefix, got: %q", entry)
-	}
 	if !strings.Contains(entry, "⚠") {
 		t.Errorf("log entry should contain warning glyph ⚠, got: %q", entry)
+	}
+	// The corrupt-JSON warning text itself contains "Config:" — confirm it is present.
+	if !strings.Contains(entry, "Config:") {
+		t.Errorf("log entry should contain 'Config:' from the warning text, got: %q", entry)
+	}
+	// Make sure the prefix is NOT doubled (handler must not add its own "Config:" prefix).
+	if strings.Contains(entry, "Config: Config:") {
+		t.Errorf("log entry has doubled 'Config:' prefix — handler is prepending it again: %q", entry)
 	}
 	if !strings.Contains(entry, "corrupt") {
 		t.Errorf("log entry should contain the original warning text, got: %q", entry)

--- a/internal/tui/config_warning_regression_test.go
+++ b/internal/tui/config_warning_regression_test.go
@@ -1,0 +1,211 @@
+package tui
+
+// Regression tests for: config warnings must appear in the TUI activity log.
+//
+// Root causes fixed (branch fix-config-fails):
+//  1. publishStartupWarnings() fired before the TUI event stream connected → silently dropped.
+//  2. Corrupt settings.json produced no StartupWarnings at all.
+//
+// These tests cover the TUI side: startupConfigWarningMsg dispatch and rendering.
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/bubbles/v2/viewport"
+	"github.com/SurgeDM/Surge/internal/config"
+)
+
+// newModelWithWarnings builds a minimal RootModel with pre-populated
+// StartupConfigWarnings to exercise the Init() → startupConfigWarningMsg path.
+func newModelWithWarnings(warnings []string) RootModel {
+	return RootModel{
+		StartupConfigWarnings: warnings,
+		logViewport:           viewport.New(viewport.WithWidth(80), viewport.WithHeight(10)),
+		list:                  NewDownloadList(80, 20),
+		Settings:              config.DefaultSettings(),
+	}
+}
+
+// TestConfigWarning_StartupConfigWarningMsg_AppearsInActivityLog is the primary
+// regression test: the TUI must show config warnings in the activity log.
+func TestConfigWarning_StartupConfigWarningMsg_AppearsInActivityLog(t *testing.T) {
+	m := newModelWithWarnings([]string{
+		"Config: settings file is corrupt (invalid character 'n') — all settings reset to defaults",
+	})
+
+	// Dispatch the message directly — same code path as Init() → cmd() → Update()
+	updated, _ := m.Update(startupConfigWarningMsg(m.StartupConfigWarnings))
+	m2 := updated.(RootModel)
+
+	if len(m2.logEntries) == 0 {
+		t.Fatal("no log entries after startupConfigWarningMsg — config warning was silently dropped")
+	}
+
+	entry := strings.Join(m2.logEntries, " ")
+	if !strings.Contains(entry, "Config:") {
+		t.Errorf("log entry should contain 'Config:' prefix, got: %q", entry)
+	}
+	if !strings.Contains(entry, "⚠") {
+		t.Errorf("log entry should contain warning glyph ⚠, got: %q", entry)
+	}
+	if !strings.Contains(entry, "corrupt") {
+		t.Errorf("log entry should contain the original warning text, got: %q", entry)
+	}
+}
+
+// TestConfigWarning_MultipleWarnings_AllAppearInLog ensures each warning gets
+// its own log entry — no truncation or merging.
+func TestConfigWarning_MultipleWarnings_AllAppearInLog(t *testing.T) {
+	warnings := []string{
+		"Max connections/host reset to default (32)",
+		"Max concurrent downloads reset to default (3)",
+		"Speed smoothing factor reset to default",
+	}
+	m := newModelWithWarnings(warnings)
+
+	updated, _ := m.Update(startupConfigWarningMsg(warnings))
+	m2 := updated.(RootModel)
+
+	if len(m2.logEntries) < len(warnings) {
+		t.Errorf("expected at least %d log entries for %d warnings, got %d: %v",
+			len(warnings), len(warnings), len(m2.logEntries), m2.logEntries)
+	}
+
+	// Each warning text must appear somewhere in the log.
+	combined := strings.Join(m2.logEntries, "\n")
+	for _, w := range warnings {
+		if !strings.Contains(combined, w) {
+			t.Errorf("warning %q not found in activity log", w)
+		}
+	}
+}
+
+// TestConfigWarning_EmptyWarnings_NoLogEntry ensures a startupConfigWarningMsg
+// with all empty strings doesn't produce phantom log entries.
+func TestConfigWarning_EmptyWarnings_NoLogEntry(t *testing.T) {
+	m := newModelWithWarnings(nil)
+	m.logEntries = nil
+
+	updated, _ := m.Update(startupConfigWarningMsg([]string{"", ""}))
+	m2 := updated.(RootModel)
+
+	if len(m2.logEntries) != 0 {
+		t.Errorf("empty warning strings should produce no log entries, got: %v", m2.logEntries)
+	}
+}
+
+// TestConfigWarning_StartupConfigWarnings_CapturedFromSettings verifies that
+// InitialRootModel correctly copies StartupWarnings from the settings object
+// into the model's StartupConfigWarnings field.
+func TestConfigWarning_StartupConfigWarnings_CapturedFromSettings(t *testing.T) {
+	// Build a settings object that already has warnings (as LoadSettings would
+	// produce for a corrupt or invalid config).
+	settings := config.DefaultSettings()
+	settings.StartupWarnings = []string{
+		"Config: settings file is corrupt — all settings reset to defaults",
+	}
+
+	// Build the model manually with these pre-warmed settings to simulate the
+	// InitialRootModel path without needing a real disk write.
+	var captured []string
+	if len(settings.StartupWarnings) > 0 {
+		captured = append([]string(nil), settings.StartupWarnings...)
+	}
+
+	m := RootModel{
+		Settings:              settings,
+		StartupConfigWarnings: captured,
+		logViewport:           viewport.New(viewport.WithWidth(80), viewport.WithHeight(10)),
+		list:                  NewDownloadList(80, 20),
+	}
+
+	if len(m.StartupConfigWarnings) == 0 {
+		t.Fatal("StartupConfigWarnings was not populated from settings.StartupWarnings")
+	}
+	if m.StartupConfigWarnings[0] != settings.StartupWarnings[0] {
+		t.Errorf("StartupConfigWarnings[0] = %q, want %q",
+			m.StartupConfigWarnings[0], settings.StartupWarnings[0])
+	}
+}
+
+// TestConfigWarning_ValidSettings_NoStartupConfigWarnings is the happy-path
+// regression: clean settings must not produce any startup log noise.
+func TestConfigWarning_ValidSettings_NoStartupConfigWarnings(t *testing.T) {
+	settings := config.DefaultSettings()
+	// DefaultSettings() should have zero warnings.
+	if len(settings.StartupWarnings) != 0 {
+		t.Errorf("DefaultSettings() produced unexpected StartupWarnings: %v", settings.StartupWarnings)
+	}
+
+	// Simulate InitialRootModel's capture logic.
+	var captured []string
+	if len(settings.StartupWarnings) > 0 {
+		captured = append([]string(nil), settings.StartupWarnings...)
+	}
+
+	if len(captured) != 0 {
+		t.Errorf("clean settings should produce no StartupConfigWarnings, got: %v", captured)
+	}
+}
+
+// TestConfigWarning_SystemLogMsg_UsesInfoStyle verifies that normal system log
+// messages (not config warnings) still render with the info (ℹ) prefix and NOT
+// with the warning (⚠) prefix. This is a style-regression guard.
+func TestConfigWarning_SystemLogMsg_UsesInfoStyle(t *testing.T) {
+	m := RootModel{
+		logViewport: viewport.New(viewport.WithWidth(80), viewport.WithHeight(10)),
+		list:        NewDownloadList(80, 20),
+	}
+
+	from := "github.com/SurgeDM/Surge/internal/engine/events"
+	_ = from // suppress unused import — events imported via update_events.go
+
+	// Use the events.SystemLogMsg path directly
+	m.addLogEntry(LogStyleStarted.Render("ℹ Startup integrity check: no issues found"))
+
+	if len(m.logEntries) == 0 {
+		t.Fatal("expected a log entry")
+	}
+	entry := m.logEntries[len(m.logEntries)-1]
+	if strings.Contains(entry, "⚠") {
+		t.Errorf("normal system log should not use warning glyph ⚠, got: %q", entry)
+	}
+}
+
+// TestConfigWarning_WarningSurvivesLogTruncation verifies that config warnings
+// are not lost when the log rolls over the 100-entry cap. This tests ordering:
+// warnings added at startup should still be visible if they're recent.
+func TestConfigWarning_WarningSurvivesLogTruncation(t *testing.T) {
+	m := RootModel{
+		logViewport: viewport.New(viewport.WithWidth(80), viewport.WithHeight(10)),
+		list:        NewDownloadList(80, 20),
+	}
+
+	// Fill log to just under the cap.
+	for i := 0; i < 99; i++ {
+		m.addLogEntry("filler entry")
+	}
+
+	// Now add a config warning as the 100th entry.
+	const configWarn = "⚠ Config: settings file is corrupt — all settings reset to defaults"
+	m.addLogEntry(LogStyleError.Render(configWarn))
+
+	if len(m.logEntries) != 100 {
+		t.Fatalf("expected 100 entries at cap, got %d", len(m.logEntries))
+	}
+	last := m.logEntries[len(m.logEntries)-1]
+	if !strings.Contains(last, "corrupt") {
+		t.Errorf("config warning should be the newest entry (last), got: %q", last)
+	}
+
+	// Add one more to trigger truncation — warning should be evicted (it's oldest now
+	// only if it was first, but here it's the newest so it should survive).
+	// Add 2 more to push over the cap: the warning is now entry 100 of 101, so truncation
+	// keeps entries [1..100] — warning survives.
+	m.addLogEntry("post-warning filler")
+	combined := strings.Join(m.logEntries, "\n")
+	if !strings.Contains(combined, "corrupt") {
+		t.Error("config warning was evicted from the log before older filler entries — ordering is wrong")
+	}
+}

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -33,3 +33,7 @@ type resumeResultMsg struct {
 	id  string
 	err error
 }
+
+// startupConfigWarningMsg carries config validation warnings to display in the
+// activity log during Init, after the viewport is sized and ready.
+type startupConfigWarningMsg []string

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -151,15 +151,15 @@ type RootModel struct {
 	logFocused  bool           // Whether the log viewport is focused
 
 	// Settings
-	Settings             *config.Settings // Application settings
-	SettingsBaseline     *config.Settings // Snapshot of settings when entering the settings view
+	Settings              *config.Settings // Application settings
+	SettingsBaseline      *config.Settings // Snapshot of settings when entering the settings view
 	StartupConfigWarnings []string         // Config validation warnings to emit on first render
-	SettingsActiveTab    int              // Active category tab (0-3)
-	SettingsSelectedRow  int              // Selected setting within current tab
-	SettingsIsEditing    bool             // Whether currently editing a value
-	SettingsInput        textinput.Model  // Input for editing string/int values
-	settingsError        string           // Current validation error in settings
-	ExtensionTokenCopied bool             // Flash message for "Token Copied!"
+	SettingsActiveTab     int              // Active category tab (0-3)
+	SettingsSelectedRow   int              // Selected setting within current tab
+	SettingsIsEditing     bool             // Whether currently editing a value
+	SettingsInput         textinput.Model  // Input for editing string/int values
+	settingsError         string           // Current validation error in settings
+	ExtensionTokenCopied  bool             // Flash message for "Token Copied!"
 
 	// Selection persistence
 	SelectedDownloadID string // ID of the currently selected download

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -153,6 +153,7 @@ type RootModel struct {
 	// Settings
 	Settings             *config.Settings // Application settings
 	SettingsBaseline     *config.Settings // Snapshot of settings when entering the settings view
+	StartupConfigWarnings []string         // Config validation warnings to emit on first render
 	SettingsActiveTab    int              // Active category tab (0-3)
 	SettingsSelectedRow  int              // Selected setting within current tab
 	SettingsIsEditing    bool             // Whether currently editing a value
@@ -289,6 +290,13 @@ func InitialRootModel(serverPort int, currentVersion string, service core.Downlo
 	settings, _ := config.LoadSettings()
 	if settings == nil {
 		settings = config.DefaultSettings()
+	}
+
+	// Capture any config warnings produced during load so Init() can surface
+	// them in the activity log once the viewport is ready.
+	var startupConfigWarnings []string
+	if len(settings.StartupWarnings) > 0 {
+		startupConfigWarnings = append([]string(nil), settings.StartupWarnings...)
 	}
 
 	// Override AutoResume if CLI flag provided
@@ -431,6 +439,7 @@ func InitialRootModel(serverPort int, currentVersion string, service core.Downlo
 		Orchestrator:          orchestrator,
 		PWD:                   pwd,
 		Settings:              settings,
+		StartupConfigWarnings: startupConfigWarnings,
 		SpeedHistory:          make([]float64, GraphHistoryPoints),                          // 60 points of history (30s at 0.5s interval)
 		logViewport:           viewport.New(viewport.WithWidth(40), viewport.WithHeight(5)), // Default size, will be resized
 		logEntries:            make([]string, 0),
@@ -510,6 +519,14 @@ func (m RootModel) Init() tea.Cmd {
 				})
 			}
 			return tea.Batch(batch...)()
+		})
+	}
+
+	// Emit any config warnings from startup into the activity log
+	if len(m.StartupConfigWarnings) > 0 {
+		warnings := m.StartupConfigWarnings
+		cmds = append(cmds, func() tea.Msg {
+			return startupConfigWarningMsg(warnings)
 		})
 	}
 

--- a/internal/tui/update_events.go
+++ b/internal/tui/update_events.go
@@ -297,6 +297,14 @@ func (m RootModel) updateEvents(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.addLogEntry(LogStyleStarted.Render("\u2139 " + msg.Message))
 		}
 		return m, nil
+
+	case startupConfigWarningMsg:
+		for _, w := range msg {
+			if w != "" {
+				m.addLogEntry(LogStyleError.Render("\u26a0 Config: " + w))
+			}
+		}
+		return m, nil
 	}
 
 	return m, nil

--- a/internal/tui/update_events.go
+++ b/internal/tui/update_events.go
@@ -301,7 +301,7 @@ func (m RootModel) updateEvents(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case startupConfigWarningMsg:
 		for _, w := range msg {
 			if w != "" {
-				m.addLogEntry(LogStyleError.Render("\u26a0 Config: " + w))
+				m.addLogEntry(LogStyleError.Render("\u26a0 " + w))
 			}
 		}
 		return m, nil


### PR DESCRIPTION
- **fix: capture and surface config validation warnings in TUI activity log and add regression tests**
- **chore: go fmt**

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two root causes for config warnings being silently dropped: corrupt `settings.json` now populates `StartupWarnings` before returning defaults, and the old `publishStartupWarnings()` (which fired before the TUI event stream was connected) is replaced by a `startupConfigWarningMsg` dispatched from `Init()` after the viewport is ready.

- **`internal/config/settings.go`**: corrupt-JSON path now appends a descriptive `StartupWarnings` entry instead of silently returning defaults.
- **`cmd/root.go`**: removes `publishStartupWarnings()` and its call, eliminating the dropped-before-stream-connected path.
- **`internal/tui/`**: adds `StartupConfigWarnings` field to `RootModel`, captures it in `InitialRootModel`, emits it via `startupConfigWarningMsg` in `Init()`, and handles it in `updateEvents` with `LogStyleError` rendering.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is well-scoped, both delivery paths are exercised by the new regression tests, and no existing behavior is broken.

The core change (capture warnings in InitialRootModel, emit via Init, handle in updateEvents) is straightforward and tested end-to-end. The only gap is that OS-level read errors on the settings file still produce no startup warning, but this is a pre-existing omission unrelated to the changes on the hot path.

internal/tui/model.go — the LoadSettings() error is silently discarded; OS-level read failures won't surface a warning.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cmd/root.go | Removes `publishStartupWarnings()` and its call from `initializeRootLocalRuntime()`, eliminating the pre-TUI-connection delivery path that silently dropped warnings. |
| internal/config/settings.go | Corrupt-JSON path now populates `StartupWarnings` with a descriptive message before returning defaults, fixing the silent swallow. |
| internal/tui/model.go | Adds `StartupConfigWarnings` field, captures it from `LoadSettings()` in `InitialRootModel`, and emits `startupConfigWarningMsg` from `Init()`; OS-level read errors on the settings file are still silently discarded without a warning entry. |
| internal/tui/update_events.go | Adds `startupConfigWarningMsg` handler that renders each non-empty warning with the error style (⚠ prefix) into the activity log. |
| internal/tui/messages.go | Adds `startupConfigWarningMsg` type (`[]string`) with a clear doc comment explaining its purpose. |
| internal/config/config_warning_regression_test.go | Comprehensive regression tests for `LoadSettings` and `Validate` covering corrupt/truncated/missing/valid JSON, multi-field validation, and idempotent re-validation. |
| internal/tui/config_warning_regression_test.go | TUI-side regression tests for the warning dispatch and rendering pipeline; has a dead-code string variable and a misleading comment about "Add 2 more" entries when only one is added. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
internal/tui/config_warning_regression_test.go:207-211
The comment says "Add 2 more" but only one `addLogEntry` call follows. The comment is misleading about how truncation works here — after adding the 101st entry the warning is still the 100th-newest entry and does survive, but the "2 more" language contradicts the single call and will confuse future maintainers editing this test.

```suggestion
	// Add one more to push over the 100-entry cap (101 total). The warning is entry 100
	// (second-newest), so truncation keeps entries [2..101] — warning survives.
	m.addLogEntry("post-warning filler")
```

### Issue 2 of 3
internal/tui/config_warning_regression_test.go:166-169
The `from` variable holds a plain string literal, not an import path. The comment "suppress unused import" is misleading — assigning a string to a variable and blanking it doesn't import anything. The two lines are dead code and should be removed entirely.

```suggestion
	// Use the events.SystemLogMsg path directly
```

### Issue 3 of 3
internal/tui/model.go:290-293
**Permission-denied errors silently produce no startup warning**

`LoadSettings()` returns `(nil, err)` for OS-level failures (e.g. permission denied on the settings file) — distinct from the corrupt-JSON path that now correctly populates `StartupWarnings`. Here the error is discarded and `DefaultSettings()` is used silently, so a user whose settings file is unreadable due to wrong ownership gets no indication in the activity log. Consider adding the read error to `StartupWarnings` (or constructing a `Settings` with a prefilled warning) before the `nil` check returns `DefaultSettings()`.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor: remove redundant Config prefix..."](https://github.com/surgedm/surge/commit/e8d066747ccbaba1ef1e06a50caf802cb0e400de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31551030)</sub>

<!-- /greptile_comment -->