### PR TITLE
refactor: modularize concurrent downloader logic by extracting helper methods and state management into dedicated routines

### DIFF
--- a/internal/engine/concurrent/downloader.go
+++ b/internal/engine/concurrent/downloader.go
@@ -265,14 +265,14 @@ func (d *ConcurrentDownloader) Download(ctx context.Context, rawurl string, cand
 		}
 	}()
 
+	// Initialize chunk visualization (must happen BEFORE setupTasks so RestoreBitmap can overwrite it)
+	if d.State != nil {
+		d.State.InitBitmap(fileSize, chunkSize)
+	}
+
 	tasks, err := d.setupTasks(destPath, fileSize, chunkSize, outFile)
 	if err != nil {
 		return err
-	}
-
-	// Initialize chunk visualization
-	if d.State != nil {
-		d.State.InitBitmap(fileSize, chunkSize)
 	}
 
 	queue := NewTaskQueue()
@@ -287,9 +287,11 @@ func (d *ConcurrentDownloader) Download(ctx context.Context, rawurl string, cand
 	// Handle pause request: must return types.ErrPaused to prevent finalization
 	if d.State != nil && d.State.IsPaused() {
 		pauseErr := d.handlePause(destPath, fileSize, queue, candidateMirrors)
-		if pauseErr != nil {
-			return pauseErr
+		if pauseErr == nil {
+			// Pause was requested at completion boundary, so handlePause finalized it.
+			return d.syncFile(outFile)
 		}
+		return pauseErr
 	}
 
 	// Handle cancel: context was cancelled but not via Pause()
@@ -600,13 +602,14 @@ func (d *ConcurrentDownloader) bootstrapMetadata(ctx context.Context, client *ht
 		return 0, fmt.Errorf("failed to create concurrent bootstrap request: %w", err)
 	}
 
-	// Forward custom headers (essential for authenticated mirrors)
+	// Preserve auth/session cookies from the browser across the bootstrap request;
+	// the server may reject unauthenticated probes with 401/403.
 	for key, val := range d.Headers {
 		if key != "Range" {
 			req.Header.Set(key, val)
 		}
 	}
-	// Ensure User-Agent and Range are set
+	// Range must come after custom headers so a caller-supplied Range can't override the probe byte
 	req.Header.Set("User-Agent", d.Runtime.GetUserAgent())
 	req.Header.Set("Range", "bytes=0-0")
 

--- a/internal/engine/concurrent/downloader.go
+++ b/internal/engine/concurrent/downloader.go
@@ -2,6 +2,7 @@ package concurrent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -213,107 +214,43 @@ func (d *ConcurrentDownloader) applyClientSettings(client *http.Client) {
 func (d *ConcurrentDownloader) Download(ctx context.Context, rawurl string, candidateMirrors []string, activeMirrors []string, destPath string, fileSize int64) error {
 	utils.Debug("ConcurrentDownloader.Download: %s -> %s (size: %d, mirrors: %d)", rawurl, destPath, fileSize, len(activeMirrors))
 
-	// Store URL and path for pause/resume (final path without .surge)
-	d.URL = rawurl
-	d.DestPath = destPath
+	d.initMirrorStatus(rawurl, candidateMirrors, activeMirrors, destPath)
 
-	// Initialize mirror status in state
-	if d.State != nil {
-		d.State.SetURL(rawurl)
-		d.State.SetDestPath(destPath)
-
-		var statuses []types.MirrorStatus
-		// Add primary
-		statuses = append(statuses, types.MirrorStatus{URL: rawurl, Active: true})
-
-		// Add active mirrors (marked active)
-		activeMap := make(map[string]bool)
-		for _, m := range activeMirrors {
-			activeMap[m] = true
-			if m != rawurl {
-				statuses = append(statuses, types.MirrorStatus{URL: m, Active: true})
-			}
-		}
-
-		// Add inactive/failed mirrors (from candidate list that aren't active)
-		for _, m := range candidateMirrors {
-			if !activeMap[m] && m != rawurl {
-				// Mark as Error since they failed probing (passed as candidates but not active)
-				statuses = append(statuses, types.MirrorStatus{URL: m, Active: false, Error: true})
-			}
-		}
-
-		d.State.SetMirrors(statuses)
-	}
-
-	// Working file has .surge suffix until download completes
 	workingPath := destPath + types.IncompleteSuffix
-
-	// Create cancellable context for pause support
 	downloadCtx, cancel := context.WithCancel(ctx)
-
-	// Helper synchronization
-	var wgHelpers sync.WaitGroup
-	// Ensure we wait for helpers to finish; run wait AFTER cancel (LIFO: cancel runs first)
-	defer wgHelpers.Wait()
-	defer cancel()
 
 	if d.State != nil {
 		d.State.SetCancelFunc(cancel)
 	}
 
-	// Acquire a single stable transport for the entire download session.
-	var proxyURL, customDNS string
-	if d.Runtime != nil {
-		proxyURL = d.Runtime.ProxyURL
-		customDNS = d.Runtime.CustomDNS
-	}
-
-	// Standardize on PoolMaxConnsPerHost for probes to match the eventual download path
-	transport := engine.DefaultNetworkPool.AcquireTransport(proxyURL, customDNS, types.PoolMaxConnsPerHost)
+	client, transport := d.setupNetwork()
+	// Release transport back to the pool ONLY after all helpers and workers are joined (LIFO: runs last)
 	defer engine.DefaultNetworkPool.ReleaseTransport(transport)
 
-	bootstrapClient := &http.Client{Transport: transport}
-	d.applyClientSettings(bootstrapClient)
+	// Helper synchronization for monitors and balancer
+	var wgHelpers sync.WaitGroup
+	// Ensure we wait for helpers to finish; run wait AFTER cancel (LIFO: Wait runs second, cancel runs first)
+	defer wgHelpers.Wait()
+	defer cancel()
 
-	// Determine connections and chunk size
+	// Ensure we have the total file size
 	if fileSize <= 0 {
-		discoveredSize, err := d.bootstrapMetadata(downloadCtx, bootstrapClient, rawurl)
+		var err error
+		fileSize, err = d.bootstrapMetadata(downloadCtx, client, rawurl)
 		if err != nil {
 			return err
 		}
-		fileSize = discoveredSize
 	}
 	d.TotalSize = fileSize
 
 	numConns := d.getInitialConnections(fileSize)
 	chunkSize := d.determineChunkSize(fileSize, numConns)
 
-	// Create tuned HTTP client for concurrent downloads reusing the same transport
-	client := &http.Client{Transport: transport}
-	d.applyClientSettings(client)
+	workerMirrors := d.getWorkerMirrors(activeMirrors)
 
-	// Initialize chunk visualization
-	if d.State != nil {
-		d.State.InitBitmap(fileSize, chunkSize)
-	}
-
-	// Prepare list of targets for workers AND pre-warming
-	var workerMirrors []string
-	workerMirrors = append(workerMirrors, rawurl)
-	for _, v := range activeMirrors {
-		if v != rawurl {
-			workerMirrors = append(workerMirrors, v)
-		}
-	}
-	if len(workerMirrors) == 0 {
-		workerMirrors = []string{rawurl}
-	}
-
-	// HEDGED DIALING: Pre-warm connections to bypass slow dials
+	// Pre-warm connections if configured
 	hedgeCount := d.Runtime.GetDialHedgeCount()
 	if hedgeCount > 0 {
-		utils.Debug("Pre-warming %d connections (hedge=%d)", numConns, hedgeCount)
 		d.prewarmConnections(downloadCtx, client, numConns, hedgeCount, workerMirrors)
 	}
 
@@ -323,162 +260,240 @@ func (d *ConcurrentDownloader) Download(ctx context.Context, rawurl string, cand
 		return fmt.Errorf("failed to open working file: %w", err)
 	}
 	defer func() {
-		if err := outFile.Close(); err != nil {
-			utils.Debug("Error closing file: %v", err)
+		if outFile != nil {
+			_ = outFile.Close()
 		}
 	}()
-	finalizeCompletedDownload := func() error {
-		// Final sync
-		if err := outFile.Sync(); err != nil {
-			return fmt.Errorf("failed to sync file: %w", err)
-		}
 
-		// Close file before renaming
-		_ = outFile.Close()
-
-		return nil
+	tasks, err := d.setupTasks(destPath, fileSize, chunkSize, outFile)
+	if err != nil {
+		return err
 	}
 
-	tasks := createTasks(fileSize, chunkSize)
-
-	// Check for saved state BEFORE truncating (resume case)
-	savedState, err := state.LoadState(rawurl, destPath)
-	isResume := err == nil && savedState != nil && len(savedState.Tasks) > 0
-
-	if isResume {
-		// Resume: use saved tasks and restore downloaded counter
-		tasks = savedState.Tasks
-		if d.State != nil {
-			d.State.Downloaded.Store(savedState.Downloaded)
-			d.State.VerifiedProgress.Store(savedState.Downloaded)
-			// Restore elapsed time from previous sessions
-			d.State.SetSavedElapsed(time.Duration(savedState.Elapsed))
-			// Fix speed spike: sync session start so we don't count previous bytes as new speed
-			d.State.SyncSessionStart()
-
-			// RESTORE CHUNK BITMAP if available
-			if len(savedState.ChunkBitmap) > 0 && savedState.ActualChunkSize > 0 {
-				d.State.RestoreBitmap(savedState.ChunkBitmap, savedState.ActualChunkSize)
-
-				// Reconstruct internal progress from remaining tasks to ensure partial chunks are handled correctly
-				d.State.RecalculateProgress(savedState.Tasks)
-				// Keep counters aligned after reconstruction to avoid session speed spikes.
-				d.State.Downloaded.Store(d.State.VerifiedProgress.Load())
-				d.State.SyncSessionStart()
-
-				utils.Debug("Restored chunk map: size %d", savedState.ActualChunkSize)
-			}
-		}
-		utils.Debug("Resuming from saved state: %d tasks, %d bytes downloaded", len(tasks), savedState.Downloaded)
-	} else {
-		// Fresh download: preallocate file and create new tasks
-		if err := outFile.Truncate(fileSize); err != nil {
-			return fmt.Errorf("failed to preallocate file: %w", err)
-		}
-		// Robustness: ensure state counter starts at 0 for fresh download
-		if d.State != nil {
-			d.State.Downloaded.Store(0)
-			d.State.SyncSessionStart()
-		}
+	// Initialize chunk visualization
+	if d.State != nil {
+		d.State.InitBitmap(fileSize, chunkSize)
 	}
+
 	queue := NewTaskQueue()
 	queue.PushMultiple(tasks)
 
-	// Start balancer goroutine for dynamic chunk splitting
-	balancerCtx, cancelBalancer := context.WithCancel(downloadCtx)
-	defer cancelBalancer()
+	// Start monitoring and balancing helpers
+	d.startHelpers(downloadCtx, &wgHelpers, queue, fileSize, numConns)
 
-	wgHelpers.Add(1)
+	// Execute download workers
+	downloadErr := d.executeWorkers(downloadCtx, client, outFile, queue, fileSize, workerMirrors, numConns)
+
+	// Handle pause request: must return types.ErrPaused to prevent finalization
+	if d.State != nil && d.State.IsPaused() {
+		pauseErr := d.handlePause(destPath, fileSize, queue, candidateMirrors)
+		if pauseErr != nil {
+			return pauseErr
+		}
+	}
+
+	// Handle cancel: context was cancelled but not via Pause()
+	// Propagate cancellation so callers don't treat this as a successful completion.
+	if downloadCtx.Err() == context.Canceled {
+		return context.Canceled
+	}
+	if downloadErr != nil {
+		return downloadErr
+	}
+
+	// Note: Download completion notifications are handled by the TUI via DownloadCompleteMsg
+	return d.syncFile(outFile)
+}
+
+func (d *ConcurrentDownloader) initMirrorStatus(rawurl string, candidateMirrors []string, activeMirrors []string, destPath string) {
+	d.URL = rawurl
+	d.DestPath = destPath
+
+	if d.State == nil {
+		return
+	}
+
+	d.State.SetURL(rawurl)
+	d.State.SetDestPath(destPath)
+
+	var statuses []types.MirrorStatus
+	statuses = append(statuses, types.MirrorStatus{URL: rawurl, Active: true})
+
+	activeMap := make(map[string]bool)
+	for _, m := range activeMirrors {
+		activeMap[m] = true
+		if m != rawurl {
+			statuses = append(statuses, types.MirrorStatus{URL: m, Active: true})
+		}
+	}
+
+	for _, m := range candidateMirrors {
+		if !activeMap[m] && m != rawurl {
+			statuses = append(statuses, types.MirrorStatus{URL: m, Active: false, Error: true})
+		}
+	}
+
+	d.State.SetMirrors(statuses)
+}
+
+func (d *ConcurrentDownloader) setupNetwork() (*http.Client, *http.Transport) {
+	var proxyURL, customDNS string
+	if d.Runtime != nil {
+		proxyURL = d.Runtime.ProxyURL
+		customDNS = d.Runtime.CustomDNS
+	}
+
+	transport := engine.DefaultNetworkPool.AcquireTransport(proxyURL, customDNS, types.PoolMaxConnsPerHost)
+	client := &http.Client{Transport: transport}
+	d.applyClientSettings(client)
+	return client, transport
+}
+
+func (d *ConcurrentDownloader) getWorkerMirrors(activeMirrors []string) []string {
+	mirrors := make([]string, 0, len(activeMirrors)+1)
+	mirrors = append(mirrors, d.URL)
+	for _, v := range activeMirrors {
+		if v != d.URL {
+			mirrors = append(mirrors, v)
+		}
+	}
+	return mirrors
+}
+
+func (d *ConcurrentDownloader) setupTasks(destPath string, fileSize, chunkSize int64, outFile *os.File) ([]types.Task, error) {
+	savedState, err := state.LoadState(d.URL, destPath)
+	isResume := err == nil && savedState != nil && len(savedState.Tasks) > 0
+
+	if isResume {
+		if d.State != nil {
+			d.State.Downloaded.Store(savedState.Downloaded)
+			d.State.VerifiedProgress.Store(savedState.Downloaded)
+			d.State.SetSavedElapsed(time.Duration(savedState.Elapsed))
+			d.State.SyncSessionStart()
+
+			if len(savedState.ChunkBitmap) > 0 && savedState.ActualChunkSize > 0 {
+				d.State.RestoreBitmap(savedState.ChunkBitmap, savedState.ActualChunkSize)
+				d.State.RecalculateProgress(savedState.Tasks)
+				d.State.Downloaded.Store(d.State.VerifiedProgress.Load())
+				d.State.SyncSessionStart()
+				utils.Debug("Restored chunk map: size %d", savedState.ActualChunkSize)
+			}
+		}
+		utils.Debug("Resuming from saved state: %d tasks, %d bytes downloaded", len(savedState.Tasks), savedState.Downloaded)
+		return savedState.Tasks, nil
+	}
+
+	if err := outFile.Truncate(fileSize); err != nil {
+		return nil, fmt.Errorf("failed to preallocate file: %w", err)
+	}
+	if d.State != nil {
+		d.State.Downloaded.Store(0)
+		d.State.SyncSessionStart()
+	}
+	return createTasks(fileSize, chunkSize), nil
+}
+
+func (d *ConcurrentDownloader) startHelpers(ctx context.Context, wg *sync.WaitGroup, queue *TaskQueue, fileSize int64, numConns int) {
+	// Balancer for dynamic chunk splitting and work stealing
+	wg.Add(1)
 	go func() {
-		defer wgHelpers.Done()
-		ticker := time.NewTicker(200 * time.Millisecond)
-		defer ticker.Stop()
+		defer wg.Done()
+		d.runBalancer(ctx, queue)
+	}()
 
-		for {
-			select {
-			case <-balancerCtx.Done():
-				return
-			case <-ticker.C:
-				// Aggressively fill idle workers
-				// Continue splitting/stealing as long as we have idle workers and are making progress
-				for queue.IdleWorkers() > 0 {
-					didWork := false
-					if queue.Len() == 0 {
-						// Try to steal from an active worker
-						if d.StealWork(queue) {
-							didWork = true
-						}
-					}
+	// Monitor for download completion
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		d.runCompletionMonitor(ctx, queue, fileSize, numConns)
+	}()
 
-					// If stealing failed (chunks too small), try hedged request:
-					// Duplicate a task so an idle worker races on a fresh connection
-					if !didWork && queue.Len() == 0 {
-						if d.HedgeWork(queue) {
-							didWork = true
-						}
-					}
+	// Health monitor for detecting slow workers
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		d.runHealthMonitor(ctx)
+	}()
+}
 
-					// If we couldn't split, steal, or hedge anything, stop trying for this tick
-					if !didWork {
-						break
+func (d *ConcurrentDownloader) runBalancer(ctx context.Context, queue *TaskQueue) {
+	ticker := time.NewTicker(200 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			for queue.IdleWorkers() > 0 {
+				didWork := false
+				if queue.Len() == 0 {
+					if d.StealWork(queue) {
+						didWork = true
 					}
+				}
+				if !didWork && queue.Len() == 0 {
+					if d.HedgeWork(queue) {
+						didWork = true
+					}
+				}
+				if !didWork {
+					break
 				}
 			}
 		}
-	}()
+	}
+}
 
-	// Monitor for completion
-	wgHelpers.Add(1)
-	go func() {
-		defer wgHelpers.Done()
-		ticker := time.NewTicker(50 * time.Millisecond)
-		defer ticker.Stop()
+func (d *ConcurrentDownloader) runCompletionMonitor(ctx context.Context, queue *TaskQueue, fileSize int64, numConns int) {
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
 
-		for {
-			select {
-			case <-ctx.Done():
+	for {
+		select {
+		case <-ctx.Done():
+			queue.Close()
+			return
+		case <-ticker.C:
+			// Completion condition:
+			// 1. Queue is empty (no pending retries)
+			// AND
+			// 2. All workers are idle OR we've accounted for all bytes
+			// Ensure queue is empty (no pending retries) before considering byte count.
+			// This protects against cutting off active retries even if byte count seems high (due to overlaps etc).
+			isDone := queue.Len() == 0 && (int(queue.IdleWorkers()) == numConns || (d.State != nil && d.State.Downloaded.Load() >= fileSize))
+			if isDone {
 				queue.Close()
 				return
-			case <-balancerCtx.Done():
-				queue.Close()
-				return
-			case <-ticker.C:
-				// Ensure queue is empty (no pending retries) before considering byte count.
-				// This protects against cutting off active retries even if byte count seems high (due to overlaps etc).
-				if queue.Len() == 0 && (int(queue.IdleWorkers()) == numConns || d.State.Downloaded.Load() >= fileSize) {
-					queue.Close()
-					return
-				}
 			}
 		}
-	}()
+	}
+}
 
-	// Health monitor: detect slow workers
-	wgHelpers.Add(1)
-	go func() {
-		defer wgHelpers.Done()
-		ticker := time.NewTicker(types.HealthCheckInterval) // Fixed: using types constant
-		defer ticker.Stop()
+func (d *ConcurrentDownloader) runHealthMonitor(ctx context.Context) {
+	ticker := time.NewTicker(types.HealthCheckInterval)
+	defer ticker.Stop()
 
-		for {
-			select {
-			case <-balancerCtx.Done():
-				return
-			case <-ticker.C:
-				d.checkWorkerHealth()
-			}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			d.checkWorkerHealth()
 		}
-	}()
+	}
+}
 
-	// Start workers
+func (d *ConcurrentDownloader) executeWorkers(ctx context.Context, client *http.Client, outFile *os.File, queue *TaskQueue, fileSize int64, workerMirrors []string, numConns int) error {
 	var wg sync.WaitGroup
 	workerErrors := make(chan error, numConns)
 
+	// Start workers
 	for i := 0; i < numConns; i++ {
 		wg.Add(1)
 		go func(workerID int) {
 			defer wg.Done()
-			err := d.worker(downloadCtx, workerID, workerMirrors, outFile, queue, fileSize, client)
+			err := d.worker(ctx, workerID, workerMirrors, outFile, queue, fileSize, client)
 			if err != nil && err != context.Canceled {
 				workerErrors <- err
 			}
@@ -494,91 +509,89 @@ func (d *ConcurrentDownloader) Download(ctx context.Context, rawurl string, cand
 
 	// Check for errors or pause
 	var downloadErr error
+	seenErrors := make(map[string]bool)
 	for err := range workerErrors {
 		if err != nil {
-			downloadErr = err
-		}
-	}
-
-	// Handle pause: state saved
-	if d.State != nil && d.State.IsPaused() {
-		// 1. Collect active tasks as remaining work FIRST
-		var activeRemaining []types.Task
-		d.activeMu.Lock()
-		for _, active := range d.activeTasks {
-			if remaining := active.RemainingTask(); remaining != nil {
-				activeRemaining = append(activeRemaining, *remaining)
+			errStr := err.Error()
+			if !seenErrors[errStr] {
+				downloadErr = errors.Join(downloadErr, err)
+				seenErrors[errStr] = true
 			}
 		}
-		d.activeMu.Unlock()
+	}
+	return downloadErr
+}
 
-		// 2. Collect remaining tasks from queue
-		remainingTasks := queue.DrainRemaining()
-		remainingTasks = append(remainingTasks, activeRemaining...)
-
-		// Calculate Downloaded from remaining tasks (ensures consistency)
-		var remainingBytes int64
-		for _, task := range remainingTasks {
-			remainingBytes += task.Length
+func (d *ConcurrentDownloader) handlePause(destPath string, fileSize int64, queue *TaskQueue, candidateMirrors []string) error {
+	// 1. Collect active tasks as remaining work FIRST
+	var activeRemaining []types.Task
+	d.activeMu.Lock()
+	for _, active := range d.activeTasks {
+		if remaining := active.RemainingTask(); remaining != nil {
+			activeRemaining = append(activeRemaining, *remaining)
 		}
-		if remainingBytes == 0 {
-			utils.Debug("Download pause requested at completion boundary; finalizing as completed")
-			d.State.Resume()
-			_, _ = d.State.FinalizeSession(fileSize)
-			return finalizeCompletedDownload()
+	}
+	d.activeMu.Unlock()
+
+	// 2. Collect remaining tasks from queue
+	remainingTasks := queue.DrainRemaining()
+	remainingTasks = append(remainingTasks, activeRemaining...)
+
+	// Calculate Downloaded from remaining tasks (ensures consistency)
+	var remainingBytes int64
+	for _, task := range remainingTasks {
+		remainingBytes += task.Length
+	}
+	if remainingBytes == 0 {
+		utils.Debug("Download pause requested at completion boundary; finalizing as completed")
+		d.State.Resume()
+		_, _ = d.State.FinalizeSession(fileSize)
+		return nil
+	}
+	computedDownloaded := fileSize - remainingBytes
+
+	// Calculate total elapsed time
+	totalElapsed := d.State.FinalizePauseSession(computedDownloaded)
+
+	// Get persisted bitmap data
+	bitmap, _, _, chunkSize, _ := d.State.GetBitmapSnapshot(false)
+
+	// Save state for resume (use computed value for consistency)
+	s := &types.DownloadState{
+		URL:             d.URL,
+		ID:              d.ID,
+		DestPath:        destPath,
+		TotalSize:       fileSize,
+		Downloaded:      computedDownloaded,
+		Tasks:           remainingTasks,
+		Filename:        filepath.Base(destPath),
+		Elapsed:         totalElapsed.Nanoseconds(),
+		Mirrors:         candidateMirrors,
+		ChunkBitmap:     bitmap,
+		ActualChunkSize: chunkSize,
+	}
+	if d.ProgressChan != nil {
+		d.ProgressChan <- events.DownloadPausedMsg{
+			DownloadID: d.ID,
+			Filename:   filepath.Base(destPath),
+			Downloaded: computedDownloaded,
+			State:      s,
 		}
-		computedDownloaded := fileSize - remainingBytes
-
-		// Calculate total elapsed time
-		totalElapsed := d.State.FinalizePauseSession(computedDownloaded)
-		var chunkBitmap []byte
-		var actualChunkSize int64
-
-		// Get persisted bitmap data
-		bitmap, _, _, chunkSize, _ := d.State.GetBitmapSnapshot(false)
-		chunkBitmap = bitmap
-		actualChunkSize = chunkSize
-
-		// Save state for resume (use computed value for consistency)
-		s := &types.DownloadState{
-			URL:             d.URL,
-			ID:              d.ID,
-			DestPath:        destPath,
-			TotalSize:       fileSize,
-			Downloaded:      computedDownloaded,
-			Tasks:           remainingTasks,
-			Filename:        filepath.Base(destPath),
-			Elapsed:         totalElapsed.Nanoseconds(),
-			Mirrors:         candidateMirrors,
-			ChunkBitmap:     chunkBitmap,
-			ActualChunkSize: actualChunkSize,
-		}
-		if d.ProgressChan != nil {
-			d.ProgressChan <- events.DownloadPausedMsg{
-				DownloadID: d.ID,
-				Filename:   filepath.Base(destPath),
-				Downloaded: computedDownloaded,
-				State:      s,
-			}
-		}
-
-		utils.Debug("Download paused, state saved (Downloaded=%d, RemainingTasks=%d, RemainingBytes=%d)",
-			computedDownloaded, len(remainingTasks), remainingBytes)
-		return types.ErrPaused // Signal valid pause to caller
 	}
 
-	// Handle cancel: context was cancelled but not via Pause()
-	// Propagate cancellation so callers don't treat this as a successful completion.
-	if downloadCtx.Err() == context.Canceled {
-		return context.Canceled
-	}
+	utils.Debug("Download paused, state saved (Downloaded=%d, RemainingTasks=%d, RemainingBytes=%d)",
+		computedDownloaded, len(remainingTasks), remainingBytes)
+	return types.ErrPaused
+}
 
-	if downloadErr != nil {
-		return downloadErr
+func (d *ConcurrentDownloader) syncFile(outFile *os.File) error {
+	if outFile == nil {
+		return nil
 	}
-
-	// Note: Download completion notifications are handled by the TUI via DownloadCompleteMsg
-	return finalizeCompletedDownload()
+	if err := outFile.Sync(); err != nil {
+		return fmt.Errorf("failed to sync file: %w", err)
+	}
+	return nil
 }
 
 func (d *ConcurrentDownloader) bootstrapMetadata(ctx context.Context, client *http.Client, rawurl string) (int64, error) {
@@ -587,11 +600,13 @@ func (d *ConcurrentDownloader) bootstrapMetadata(ctx context.Context, client *ht
 		return 0, fmt.Errorf("failed to create concurrent bootstrap request: %w", err)
 	}
 
+	// Forward custom headers (essential for authenticated mirrors)
 	for key, val := range d.Headers {
 		if key != "Range" {
 			req.Header.Set(key, val)
 		}
 	}
+	// Ensure User-Agent and Range are set
 	req.Header.Set("User-Agent", d.Runtime.GetUserAgent())
 	req.Header.Set("Range", "bytes=0-0")
 

--- a/internal/engine/concurrent/downloader_helpers_test.go
+++ b/internal/engine/concurrent/downloader_helpers_test.go
@@ -68,7 +68,7 @@ func TestSetupTasks_NewDownload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	state := types.NewProgressState("test-id", fileSize)
 	downloader := &ConcurrentDownloader{
@@ -159,7 +159,7 @@ func TestSetupTasks_BitmapRestoration(t *testing.T) {
 	}
 
 	f, _ := os.Create(destPath + types.IncompleteSuffix)
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	progState := types.NewProgressState("test-id", fileSize)
 	downloader := &ConcurrentDownloader{

--- a/internal/engine/concurrent/downloader_helpers_test.go
+++ b/internal/engine/concurrent/downloader_helpers_test.go
@@ -1,0 +1,213 @@
+package concurrent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/SurgeDM/Surge/internal/engine/state"
+	"github.com/SurgeDM/Surge/internal/engine/types"
+)
+
+func TestHandlePause_CompletionBoundary(t *testing.T) {
+	tmpDir, cleanup := initTestState(t)
+	defer cleanup()
+
+	fileSize := int64(1000)
+	destPath := filepath.Join(tmpDir, "test.bin")
+	state := types.NewProgressState("test-id", fileSize)
+	downloader := &ConcurrentDownloader{
+		ID:    "test-id",
+		State: state,
+	}
+
+	queue := NewTaskQueue()
+	// No tasks in queue means remainingBytes == 0
+
+	err := downloader.handlePause(destPath, fileSize, queue, nil)
+	if err != nil {
+		t.Fatalf("handlePause returned error on completion boundary: %v", err)
+	}
+
+	if state.IsPaused() {
+		t.Errorf("State should not be paused on completion boundary")
+	}
+}
+
+func TestHandlePause_Normal(t *testing.T) {
+	tmpDir, cleanup := initTestState(t)
+	defer cleanup()
+
+	fileSize := int64(1000)
+	destPath := filepath.Join(tmpDir, "test.bin")
+	state := types.NewProgressState("test-id", fileSize)
+	downloader := &ConcurrentDownloader{
+		ID:    "test-id",
+		State: state,
+	}
+
+	queue := NewTaskQueue()
+	queue.Push(types.Task{Offset: 500, Length: 500})
+
+	err := downloader.handlePause(destPath, fileSize, queue, nil)
+	if err != types.ErrPaused {
+		t.Fatalf("Expected ErrPaused, got %v", err)
+	}
+}
+
+func TestSetupTasks_NewDownload(t *testing.T) {
+	tmpDir, cleanup := initTestState(t)
+	defer cleanup()
+
+	fileSize := int64(1000)
+	chunkSize := int64(500)
+	destPath := filepath.Join(tmpDir, "new.bin")
+	workingPath := destPath + types.IncompleteSuffix
+
+	f, err := os.Create(workingPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	state := types.NewProgressState("test-id", fileSize)
+	downloader := &ConcurrentDownloader{
+		ID:      "test-id",
+		State:   state,
+		Runtime: &types.RuntimeConfig{},
+	}
+
+	tasks, err := downloader.setupTasks(destPath, fileSize, chunkSize, f)
+	if err != nil {
+		t.Fatalf("setupTasks failed: %v", err)
+	}
+
+	if len(tasks) != 2 {
+		t.Errorf("Expected 2 tasks, got %d", len(tasks))
+	}
+}
+
+func TestGetWorkerMirrors(t *testing.T) {
+	d := &ConcurrentDownloader{URL: "http://primary.com"}
+	active := []string{"http://primary.com", "http://mirror1.com", "http://mirror2.com"}
+
+	mirrors := d.getWorkerMirrors(active)
+
+	if len(mirrors) != 3 {
+		t.Errorf("Expected 3 mirrors, got %d", len(mirrors))
+	}
+	if mirrors[0] != "http://primary.com" {
+		t.Errorf("Primary URL should be first, got %s", mirrors[0])
+	}
+}
+
+func TestInitMirrorStatus(t *testing.T) {
+	state := types.NewProgressState("test-id", 1000)
+	d := &ConcurrentDownloader{ID: "test-id", State: state}
+
+	primary := "http://primary.com"
+	candidates := []string{"http://mirror1.com", "http://mirror2.com"}
+	active := []string{"http://primary.com", "http://mirror1.com"}
+
+	d.initMirrorStatus(primary, candidates, active, "/path/to/dest")
+
+	statuses := state.GetMirrors()
+	if len(statuses) != 3 {
+		t.Errorf("Expected 3 statuses, got %d", len(statuses))
+	}
+
+	foundMirror2 := false
+	for _, s := range statuses {
+		if s.URL == "http://mirror2.com" {
+			foundMirror2 = true
+			if s.Active {
+				t.Error("Mirror2 should be inactive")
+			}
+			if !s.Error {
+				t.Error("Mirror2 should have error (as it is not active)")
+			}
+		}
+	}
+	if !foundMirror2 {
+		t.Error("Mirror2 status not found")
+	}
+}
+
+func TestSetupTasks_BitmapRestoration(t *testing.T) {
+	tmpDir, cleanup := initTestState(t)
+	defer cleanup()
+
+	fileSize := int64(1000)
+	chunkSize := int64(100)
+	destPath := filepath.Join(tmpDir, "resume.bin")
+
+	// Create a saved state
+	savedBitmap := []byte{0xFF, 0x00, 0x00} // 10 chunks need 3 bytes
+	savedState := &types.DownloadState{
+		ID:              "test-id",
+		URL:             "http://example.com",
+		DestPath:        destPath,
+		TotalSize:       fileSize,
+		Downloaded:      500,
+		ActualChunkSize: chunkSize,
+		ChunkBitmap:     savedBitmap,
+		Tasks:           []types.Task{{Offset: 500, Length: 500}},
+	}
+	// Note: state.SaveState and state.LoadState are already used in the codebase.
+	if err := state.SaveState("http://example.com", destPath, savedState); err != nil {
+		t.Fatal(err)
+	}
+
+	f, _ := os.Create(destPath + types.IncompleteSuffix)
+	defer f.Close()
+
+	progState := types.NewProgressState("test-id", fileSize)
+	downloader := &ConcurrentDownloader{
+		ID:    "test-id",
+		URL:   "http://example.com",
+		State: progState,
+	}
+
+	// This simulates the fixed order in Download():
+	// 1. InitBitmap
+	progState.InitBitmap(fileSize, chunkSize)
+	// 2. setupTasks (which calls RestoreBitmap)
+	_, err := downloader.setupTasks(destPath, fileSize, chunkSize, f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify bitmap is NOT empty (it should have the restored data)
+	bitmap, _, _, _, _ := progState.GetBitmapSnapshot(false)
+	if len(bitmap) == 0 {
+		t.Error("Bitmap should have been restored, but it is empty")
+	}
+	if bitmap[0] != 0xAA {
+		t.Errorf("Bitmap[0] should be 0xAA (all chunks completed), got 0x%02X", bitmap[0])
+	}
+}
+
+func TestHandlePause_CompletionFinalization(t *testing.T) {
+	tmpDir, cleanup := initTestState(t)
+	defer cleanup()
+
+	fileSize := int64(1000)
+	destPath := filepath.Join(tmpDir, "test.bin")
+	progState := types.NewProgressState("test-id", fileSize)
+	downloader := &ConcurrentDownloader{
+		ID:    "test-id",
+		State: progState,
+	}
+
+	queue := NewTaskQueue()
+	// No tasks left
+
+	err := downloader.handlePause(destPath, fileSize, queue, nil)
+	if err != nil {
+		t.Errorf("Expected nil error for completion boundary, got %v", err)
+	}
+
+	if progState.IsPaused() {
+		t.Error("Should have resumed state for completion")
+	}
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the monolithic `Download` method in the concurrent downloader by extracting its internal phases into dedicated methods (`initMirrorStatus`, `setupNetwork`, `getWorkerMirrors`, `setupTasks`, `startHelpers`, `runBalancer`, `runCompletionMonitor`, `runHealthMonitor`, `executeWorkers`, `handlePause`, `syncFile`). A companion test file covers the extracted helpers.

- The refactoring fixes a nil-pointer risk in `runCompletionMonitor` by guarding `d.State.Downloaded.Load()` behind a `d.State != nil` check that the original inline goroutine lacked.
- `executeWorkers` now deduplicates and joins multiple worker errors with `errors.Join` instead of silently overwriting with the last error, surfacing all unique failure causes to callers.
- The bitmap initialization order (`InitBitmap` \u2192 `setupTasks`/`RestoreBitmap`) is preserved correctly, and the pause-at-completion-boundary path now explicitly returns `d.syncFile(outFile)` rather than falling through to the cancel check.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the extracted helpers preserve the original control flow and the only finding is a redundant test.

The decomposition is mechanically faithful to the original logic, the defer ordering is correct, the nil-guard improvement is sound, and the new tests cover the key extracted paths. No functional regressions were identified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/engine/concurrent/downloader.go | Download logic decomposed into focused helpers; nil-guard for d.State in runCompletionMonitor added; error deduplication via errors.Join introduced; defer ordering and file-close logic are correct. |
| internal/engine/concurrent/downloader_helpers_test.go | New test file covering extracted helpers; TestHandlePause_CompletionBoundary and TestHandlePause_CompletionFinalization duplicate the same scenario and one should be removed. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/engine/concurrent/downloader_helpers_test.go:12-35
**Duplicate test scenario**

`TestHandlePause_CompletionBoundary` (lines 12–35) and `TestHandlePause_CompletionFinalization` (lines 183–213) are structurally identical: both construct a fresh `ConcurrentDownloader` with an empty queue and assert that `handlePause` returns `nil` and leaves the state unpaused. Running the same setup twice adds noise and maintenance overhead without covering any additional behavior — if the logic under test changes, both tests will break (or pass) in lockstep. One of them should be removed.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into speed-limit-hnd..."](https://github.com/surgedm/surge/commit/ed3aed398d459283dc07e9cfb93868e9c1019907) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31969493)</sub>

<!-- /greptile_comment -->