### PR TITLE
fix(extension): prevent download items from shrinking in popup list

### DIFF
--- a/extension/entrypoints/popup/popup.css
+++ b/extension/entrypoints/popup/popup.css
@@ -464,6 +464,7 @@ body {
 
 /* === Download Item === */
 .download-item {
+  flex-shrink: 0;
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0)),
     var(--bg-surface);


### PR DESCRIPTION
Related issue: https://github.com/SurgeDM/Surge/issues/445

**Edge/Chrome:**
<img width="360" height="539" alt="image" src="https://github.com/user-attachments/assets/4d0451bc-dcf3-4f5d-beaf-49820c5d5352" />

**Firefox:**
<img width="361" height="538" alt="image" src="https://github.com/user-attachments/assets/23287efe-eaa0-497c-9b53-4c68ea209c6c" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `flex-shrink: 0` to `.download-item` to prevent individual download items from being compressed when the popup list contains many items. The fix is minimal, targeted, and correct.

- `.downloads-list-content` is a `display: flex; flex-direction: column` container, so its children participate in flex layout. Without `flex-shrink: 0`, items shrink to fill the available space rather than maintaining their natural height. The added property resolves this across all supported browsers (Edge, Chrome, Firefox).

<h3>Confidence Score: 5/5</h3>

Safe to merge — single one-line CSS addition with no side effects on other layout rules.

The change adds exactly one property to one selector. The parent container is a flex column with overflow-y: auto, so flex-shrink: 0 on the child is the standard, correct fix for item compression. No other rules are affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| extension/entrypoints/popup/popup.css | Adds `flex-shrink: 0` to `.download-item` — correct, targeted one-line fix that prevents items from collapsing inside the flex column scroll container. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(extension): prevent download items f..."](https://github.com/surgedm/surge/commit/b6915de3785884f0ab1a3600dddfb11b7446fc5f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32008315)</sub>

<!-- /greptile_comment -->