### PR TITLE
symlink 'Surge' binary as 'surge' for nix run compatibility

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -18,6 +18,16 @@ buildGoModule {
     "-X main.version=${version}"
   ];
 
+  postInstall = ''
+    ln -s Surge $out/bin/surge
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/Surge --version
+    $out/bin/surge --version
+  '';
+
   # Tests write to $HOME/.config; redirect to a writable tmpdir.
   preCheck = ''
     export HOME=$TMPDIR


### PR DESCRIPTION
## Problem

   Running `nix run github:SurgeDM/Surge` fails with:

 ```
 error: unable to execute '/nix/store/.../bin/surge': No such file or directory
 ```

---

The Go module produces a `Surge` binary (uppercase), but `meta.mainProgram` references `surge` (lowercase).

This PR adds a symlink from `Surge` to `surge` in `postInstall`, so both names work. This fixes `nix run` without breaking existing users who invoke `Surge` directly.

The `installCheckPhase` runs `--version` on both binaries to catch regressions.

Running  `nix run github:andersonjoseph/Surge/fix-nix-run` shows the fix.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `nix run github:SurgeDM/Surge` by adding a relative symlink from `surge` to `Surge` in `$out/bin` via `postInstall`, aligning the installed binary name with the `meta.mainProgram = "surge"` declaration already present in `package.nix`.

- Adds `postInstall` to create `ln -s Surge $out/bin/surge`, letting `nix run` resolve `meta.mainProgram` correctly while leaving the `Surge` binary intact for existing users.
- Adds `doInstallCheck = true` with an `installCheckPhase` that invokes `--version` on both `$out/bin/Surge` and `$out/bin/surge` to catch regressions from either name.

<h3>Confidence Score: 5/5</h3>

The change is a minimal, targeted Nix packaging fix with no logic changes to the Go binary itself.

The symlink direction is correct (`surge` → `Surge` as a relative path within `$out/bin`), the `installCheckPhase` exercises both names, and the change is fully isolated to the Nix package definition. No business logic or source code is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| package.nix | Adds a relative symlink `surge` → `Surge` in `postInstall` and an `installCheckPhase` that validates both names; fixes `nix run` breakage with no logic changes to the build itself. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
package.nix:26-29
**Missing `runHook` calls in `installCheckPhase`**

The Nix `stdenv` convention for overriding a phase is to include `runHook preInstallCheck` at the start and `runHook postInstallCheck` at the end. Without these, any downstream derivations or overlays that extend this package by appending to `preInstallCheck`/`postInstallCheck` will have their hooks silently skipped. The same applies to `postInstall` — adding `runHook postInstall` at the end is idiomatic. Not a blocker for the immediate fix, but worth aligning with upstream Nix conventions.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into fix-nix-run"](https://github.com/surgedm/surge/commit/1f9e7f6bc2a2f1272135d5ea1181a3ff12e08f0c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32070271)</sub>

<!-- /greptile_comment -->