### PR TITLE
feat: implement live actual speed calculation and update TUI to display raw speed instead of smoothed EMA

### DIFF
--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -68,19 +68,19 @@ type ExtensionSettings struct {
 
 // NetworkSettings contains network connection parameters.
 type NetworkSettings struct {
-	MaxConnectionsPerDownload int    `json:"max_connections_per_host" ui_label:"Max Connections/Download" ui_desc:"Maximum concurrent connections per download (1-64)."`
+	MaxConnectionsPerDownload int `json:"max_connections_per_host" ui_label:"Max Connections/Download" ui_desc:"Maximum concurrent connections per download (1-64)."`
 	// Deprecated: use MaxConnectionsPerDownload.
 	// Kept as a non-serialized compatibility alias for older code paths and tests.
-	MaxConnectionsPerHost     int    `json:"-" ui_ignored:"true"`
-	MaxConcurrentDownloads    int    `json:"max_concurrent_downloads" ui_label:"Max Concurrent Downloads" ui_desc:"Maximum number of downloads running at once (1-10)." ui_restart:"true"`
-	MaxConcurrentProbes       int    `json:"max_concurrent_probes" ui_label:"Max Concurrent Probes" ui_desc:"Maximum number of simultaneous server probes when adding many downloads at once (1-10)." ui_restart:"true"`
-	UserAgent                 string `json:"user_agent" ui_label:"User Agent" ui_desc:"Custom User-Agent string for HTTP requests. Leave empty for default."`
-	ProxyURL                  string `json:"proxy_url" ui_label:"Proxy URL" ui_desc:"HTTP/HTTPS proxy URL (e.g. http://127.0.0.1:1700). Leave empty to use system default."`
-	CustomDNS                 string `json:"custom_dns" ui_label:"Custom DNS Server" ui_desc:"Set custom DNS (e.g., 1.1.1.1:53, 94.140.14.14:53). Leave empty for system."`
-	SequentialDownload        bool   `json:"sequential_download" ui_label:"Sequential Download" ui_desc:"Download pieces in order (Streaming Mode). May be slower."`
-	MinChunkSize              int64  `json:"min_chunk_size" ui_label:"Min Chunk Size" ui_desc:"Minimum download chunk size in MB (e.g., 2)."`
-	WorkerBufferSize          int    `json:"worker_buffer_size" ui_label:"Worker Buffer Size" ui_desc:"I/O buffer size per worker in KB (e.g., 512)."`
-	DialHedgeCount            int    `json:"dial_hedge_count" ui_label:"Dial Hedge Count" ui_desc:"Number of extra connections to dial pre-emptively to avoid slow connects (0-16)."`
+	MaxConnectionsPerHost  int    `json:"-" ui_ignored:"true"`
+	MaxConcurrentDownloads int    `json:"max_concurrent_downloads" ui_label:"Max Concurrent Downloads" ui_desc:"Maximum number of downloads running at once (1-10)." ui_restart:"true"`
+	MaxConcurrentProbes    int    `json:"max_concurrent_probes" ui_label:"Max Concurrent Probes" ui_desc:"Maximum number of simultaneous server probes when adding many downloads at once (1-10)." ui_restart:"true"`
+	UserAgent              string `json:"user_agent" ui_label:"User Agent" ui_desc:"Custom User-Agent string for HTTP requests. Leave empty for default."`
+	ProxyURL               string `json:"proxy_url" ui_label:"Proxy URL" ui_desc:"HTTP/HTTPS proxy URL (e.g. http://127.0.0.1:1700). Leave empty to use system default."`
+	CustomDNS              string `json:"custom_dns" ui_label:"Custom DNS Server" ui_desc:"Set custom DNS (e.g., 1.1.1.1:53, 94.140.14.14:53). Leave empty for system."`
+	SequentialDownload     bool   `json:"sequential_download" ui_label:"Sequential Download" ui_desc:"Download pieces in order (Streaming Mode). May be slower."`
+	MinChunkSize           int64  `json:"min_chunk_size" ui_label:"Min Chunk Size" ui_desc:"Minimum download chunk size in MB (e.g., 2)."`
+	WorkerBufferSize       int    `json:"worker_buffer_size" ui_label:"Worker Buffer Size" ui_desc:"I/O buffer size per worker in KB (e.g., 512)."`
+	DialHedgeCount         int    `json:"dial_hedge_count" ui_label:"Dial Hedge Count" ui_desc:"Number of extra connections to dial pre-emptively to avoid slow connects (0-16)."`
 }
 
 // PerformanceSettings contains performance tuning parameters.

--- a/internal/core/local_service.go
+++ b/internal/core/local_service.go
@@ -177,6 +177,8 @@ func (s *LocalDownloadService) broadcastLoop() {
 
 func (s *LocalDownloadService) reportProgressLoop() {
 	lastSpeeds := make(map[string]float64)
+	lastDownloaded := make(map[string]int64)
+	lastTick := make(map[string]time.Time)
 	lastChunkSnapshot := make(map[string]time.Time)
 
 	if s.reportTicker == nil {
@@ -198,30 +200,42 @@ func (s *LocalDownloadService) reportProgressLoop() {
 		var batch events.BatchProgressMsg
 
 		activeConfigs := s.Pool.GetAll()
+		now := time.Now()
 		for _, cfg := range activeConfigs {
 			if cfg.State == nil || cfg.State.IsPaused() || cfg.State.Done.Load() {
-				// Clean up speed history for inactive
+				// Clean up history for inactive
 				delete(lastSpeeds, cfg.ID)
+				delete(lastDownloaded, cfg.ID)
+				delete(lastTick, cfg.ID)
 				delete(lastChunkSnapshot, cfg.ID)
 				continue
 			}
 
 			// Calculate Progress
-			downloaded, total, totalElapsed, sessionElapsed, connections, sessionStart := cfg.State.GetProgress()
+			downloaded, total, totalElapsed, _, connections, _ := cfg.State.GetProgress()
 
-			// Calculate Speed with EMA
-			sessionDownloaded := downloaded - sessionStart
-			var instantSpeed float64
-			if sessionElapsed.Seconds() > 0 && sessionDownloaded > 0 {
-				instantSpeed = float64(sessionDownloaded) / sessionElapsed.Seconds()
+			// Calculate Live Actual Speed (raw delta)
+			var liveSpeed float64
+			prevDownloaded := lastDownloaded[cfg.ID]
+			prevTick := lastTick[cfg.ID]
+
+			if !prevTick.IsZero() && downloaded > prevDownloaded {
+				deltaBytes := downloaded - prevDownloaded
+				deltaTime := now.Sub(prevTick).Seconds()
+				if deltaTime > 0 {
+					liveSpeed = float64(deltaBytes) / deltaTime
+				}
 			}
+			lastDownloaded[cfg.ID] = downloaded
+			lastTick[cfg.ID] = now
 
+			// Calculate Smoothed Speed with EMA for graphs
 			lastSpeed := lastSpeeds[cfg.ID]
 			var currentSpeed float64
 			if lastSpeed == 0 {
-				currentSpeed = instantSpeed
+				currentSpeed = liveSpeed
 			} else {
-				currentSpeed = alpha*instantSpeed + (1-alpha)*lastSpeed
+				currentSpeed = alpha*liveSpeed + (1-alpha)*lastSpeed
 			}
 			lastSpeeds[cfg.ID] = currentSpeed
 
@@ -231,6 +245,7 @@ func (s *LocalDownloadService) reportProgressLoop() {
 				Downloaded:        downloaded,
 				Total:             total,
 				Speed:             currentSpeed,
+				ActualSpeed:       liveSpeed,
 				Elapsed:           totalElapsed,
 				ActiveConnections: int(connections),
 			}

--- a/internal/engine/events/events.go
+++ b/internal/engine/events/events.go
@@ -13,7 +13,8 @@ type ProgressMsg struct {
 	DownloadID        string
 	Downloaded        int64
 	Total             int64
-	Speed             float64 // bytes per second
+	Speed             float64 // smoothed speed (EMA)
+	ActualSpeed       float64 // instant speed (raw)
 	Elapsed           time.Duration
 	ActiveConnections int
 	ChunkBitmap       []byte

--- a/internal/engine/types/accuracy_test.go
+++ b/internal/engine/types/accuracy_test.go
@@ -94,7 +94,7 @@ func TestRestoreBitmap_ShortBitmapRecoversWithoutPanic(t *testing.T) {
 
 	state := types.NewProgressState("test-short-restore", totalSize)
 	malformed := []byte{0x02} // Too short: only enough storage for 4 chunks.
-	expectedBytes := 25      // 100 chunks * 2 bits = 25 bytes.
+	expectedBytes := 25       // 100 chunks * 2 bits = 25 bytes.
 
 	defer func() {
 		if r := recover(); r != nil {

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/tui/colors"
 	"github.com/SurgeDM/Surge/internal/tui/components"
 	"github.com/SurgeDM/Surge/internal/utils"
@@ -54,8 +55,8 @@ func (i DownloadItem) Description() string {
 		utils.ConvertBytesToHumanReadable(d.Total))
 
 	speedInfo := ""
-	if d.Speed > 0 {
-		speedInfo = fmt.Sprintf(" \u2022 %.2f MB/s", d.Speed/float64(MB))
+	if d.ActualSpeed > 0 {
+		speedInfo = fmt.Sprintf(" \u2022 %.2f MB/s", d.ActualSpeed/float64(config.MB))
 	}
 
 	return fmt.Sprintf("%s \u2022 %.0f%%%s \u2022 %s", styledStatus, pct, speedInfo, sizeInfo)

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -39,7 +39,7 @@ func (i DownloadItem) Description() string {
 	} else if d.resuming {
 		styledStatus = lipgloss.NewStyle().Foreground(colors.StateDownloading()).Render(i.spinnerView + " Resuming...")
 	} else {
-		status := components.DetermineStatus(d.done, d.paused, d.err != nil, d.Speed, d.Downloaded)
+		status := components.DetermineStatus(d.done, d.paused, d.err != nil, d.ActualSpeed, d.Downloaded)
 		styledStatus = status.RenderWithSpinner(i.spinnerView)
 	}
 
@@ -273,7 +273,7 @@ func (m *RootModel) UpdateListItems() {
 					var newTab int
 					if d.done {
 						newTab = TabDone
-					} else if !d.paused && !d.pausing && (d.Speed > 0 || d.Connections > 0 || d.resuming || d.started) {
+					} else if !d.paused && !d.pausing && (d.ActualSpeed > 0 || d.Speed > 0 || d.Connections > 0 || d.resuming || d.started) {
 						newTab = TabActive
 					} else {
 						newTab = TabQueued

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -84,7 +84,8 @@ type DownloadModel struct {
 	Destination   string // Full path to the destination file
 	Total         int64
 	Downloaded    int64
-	Speed         float64
+	Speed         float64 // EMA smoothed speed for graphs
+	ActualSpeed   float64 // Live actual speed for TUI display
 	Connections   int
 
 	StartTime time.Time

--- a/internal/tui/process.go
+++ b/internal/tui/process.go
@@ -28,7 +28,7 @@ func (m *RootModel) processProgressMsg(msg events.ProgressMsg) tea.Cmd {
 	d.Connections = msg.ActiveConnections
 
 	// Keep "Resuming..." visible until we observe actual transfer.
-	if d.resuming && (d.Speed > 0 || d.Downloaded > prevDownloaded) {
+	if d.resuming && (d.ActualSpeed > 0 || d.Speed > 0 || d.Downloaded > prevDownloaded) {
 		d.resuming = false
 	}
 

--- a/internal/tui/process.go
+++ b/internal/tui/process.go
@@ -23,6 +23,7 @@ func (m *RootModel) processProgressMsg(msg events.ProgressMsg) tea.Cmd {
 	d.Downloaded = msg.Downloaded
 	d.Total = msg.Total
 	d.Speed = msg.Speed
+	d.ActualSpeed = msg.ActualSpeed
 	d.Elapsed = msg.Elapsed
 	d.Connections = msg.ActiveConnections
 

--- a/internal/tui/update_events.go
+++ b/internal/tui/update_events.go
@@ -23,7 +23,7 @@ func (m RootModel) updateEvents(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		needsSpinner := false
 		for _, d := range m.downloads {
-			if d.pausing || d.resuming || components.DetermineStatus(d.done, d.paused, d.err != nil, d.Speed, d.Downloaded) == components.StatusQueued {
+			if d.pausing || d.resuming || components.DetermineStatus(d.done, d.paused, d.err != nil, d.ActualSpeed, d.Downloaded) == components.StatusQueued {
 				needsSpinner = true
 				break
 			}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -615,14 +615,14 @@ func renderFocusedDetails(d *DownloadModel, w int, spinnerView string) string {
 	} else if d.resuming {
 		speedStr = "Resuming..."
 		etaStr = "..."
-	} else if d.paused || d.Speed == 0 {
+	} else if d.paused || d.ActualSpeed == 0 {
 		speedStr = "Paused"
 		etaStr = "\u221e"
 	} else {
-		speedStr = fmt.Sprintf("%.2f MB/s", d.Speed/float64(config.MB))
+		speedStr = fmt.Sprintf("%.2f MB/s", d.ActualSpeed/float64(config.MB))
 		if d.Total > 0 {
 			remaining := d.Total - d.Downloaded
-			etaSeconds := float64(remaining) / d.Speed
+			etaSeconds := float64(remaining) / d.ActualSpeed
 			// Clamp ETA to 24 hours max to prevent bonkers values
 			const maxETASeconds = 24 * 60 * 60
 			if etaSeconds > maxETASeconds || etaSeconds < 0 {
@@ -745,7 +745,7 @@ func (m RootModel) calcTotalSpeed() float64 {
 		if d.done {
 			continue
 		}
-		total += d.Speed
+		total += d.ActualSpeed
 	}
 	return total / float64(config.MB)
 }

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -622,7 +622,11 @@ func renderFocusedDetails(d *DownloadModel, w int, spinnerView string) string {
 		speedStr = fmt.Sprintf("%.2f MB/s", d.ActualSpeed/float64(config.MB))
 		if d.Total > 0 {
 			remaining := d.Total - d.Downloaded
-			etaSeconds := float64(remaining) / d.ActualSpeed
+			etaSpeed := d.ActualSpeed
+			if etaSpeed == 0 {
+				etaSpeed = d.Speed // EMA fallback so ETA stays stable during brief stall ticks
+			}
+			etaSeconds := float64(remaining) / etaSpeed
 			// Clamp ETA to 24 hours max to prevent bonkers values
 			const maxETASeconds = 24 * 60 * 60
 			if etaSeconds > maxETASeconds || etaSeconds < 0 {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -615,7 +615,7 @@ func renderFocusedDetails(d *DownloadModel, w int, spinnerView string) string {
 	} else if d.resuming {
 		speedStr = "Resuming..."
 		etaStr = "..."
-	} else if d.paused || d.ActualSpeed == 0 {
+	} else if d.paused || (d.ActualSpeed == 0 && d.Speed == 0) {
 		speedStr = "Paused"
 		etaStr = "\u221e"
 	} else {
@@ -650,7 +650,7 @@ func renderFocusedDetails(d *DownloadModel, w int, spinnerView string) string {
 		lipgloss.JoinHorizontal(lipgloss.Left, StatsLabelStyle.Width(7).Render("Size:"), StatsValueStyle.Render(sizeStr)),
 		lipgloss.JoinHorizontal(lipgloss.Left, StatsLabelStyle.Width(7).Render("Speed:"), StatsValueStyle.Render(speedStr)),
 	}
-	isActive := !d.done && !d.paused && !d.pausing && d.Speed > 0
+	isActive := !d.done && !d.paused && !d.pausing && (d.ActualSpeed > 0 || d.Speed > 0)
 	if isActive {
 		conns := d.Connections
 		if conns == 0 {
@@ -734,7 +734,7 @@ func getDownloadStatus(d *DownloadModel, spinnerView string) string {
 	if d.resuming {
 		return lipgloss.NewStyle().Foreground(colors.StateDownloading()).Render(spinnerView + " Resuming...")
 	}
-	status := components.DetermineStatus(d.done, d.paused, d.err != nil, d.Speed, d.Downloaded)
+	status := components.DetermineStatus(d.done, d.paused, d.err != nil, d.ActualSpeed, d.Downloaded)
 	return status.RenderWithSpinner(spinnerView)
 }
 
@@ -755,7 +755,7 @@ func (m RootModel) ComputeViewStats() ViewStats {
 	for _, d := range m.downloads {
 		if d.done {
 			stats.DownloadedCount++
-		} else if !d.paused && !d.pausing && (d.Speed > 0 || d.Connections > 0 || d.resuming) {
+		} else if !d.paused && !d.pausing && (d.ActualSpeed > 0 || d.Speed > 0 || d.Connections > 0 || d.resuming || d.started) {
 			stats.ActiveCount++
 		} else {
 			stats.QueuedCount++


### PR DESCRIPTION
Closes #428

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the cumulative session-average speed with a per-tick byte-delta (`liveSpeed`) as the primary TUI speed signal, while keeping the EMA-smoothed value as a fallback for ETA and graphs. The focused-detail panel, list descriptions, status helpers, and speed graph all switch to `ActualSpeed`, and an EMA fallback is added for ETA calculation when `ActualSpeed` is zero during a stall tick.

- `internal/core/local_service.go`: introduces per-download `lastDownloaded`/`lastTick` maps; computes `liveSpeed = deltaBytes / deltaTime` each ticker interval and feeds it as both `ActualSpeed` and the EMA input; previous cumulative `sessionDownloaded / sessionElapsed` input is dropped.
- `internal/engine/events/events.go` + `internal/tui/model.go`: add `ActualSpeed` field end-to-end from the service through the event message to the TUI model.
- `internal/tui/view.go` + `internal/tui/list.go`: display `ActualSpeed` everywhere speed is shown; guard for \"Paused\" now requires both speeds to be zero; ETA falls back to EMA when raw speed is zero.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the core speed-display logic is additive and well-guarded, with no breaking changes to existing fields.

The change is additive — `ActualSpeed` is a new field alongside the existing `Speed` EMA, and all TUI paths that previously used `Speed` alone now use `ActualSpeed` with `Speed` as a fallback. The "Paused" guard and ETA calculation both have explicit fallbacks for the zero-speed case. The main concern is that the EMA is now fed per-tick deltas (which decay to zero during stalls) instead of the more stable cumulative session average, making the ETA fallback less reliable after extended pauses — but this is a quality-of-display issue rather than incorrect data or a crash path.

internal/core/local_service.go — the new live speed algorithm has no unit tests and the EMA input is now more volatile than before.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/core/local_service.go | Replaces cumulative session-average speed with per-tick delta for `liveSpeed`; feeds EMA with raw deltas; no test coverage for the new algorithm |
| internal/engine/events/events.go | Adds `ActualSpeed float64` field to `ProgressMsg`; straightforward additive change with clear documentation comments |
| internal/tui/model.go | Adds `ActualSpeed float64` field to `DownloadModel` with inline comments distinguishing EMA from live speed |
| internal/tui/view.go | Switches focused-detail panel to display raw `ActualSpeed`; adds EMA fallback for ETA when `ActualSpeed == 0`; updates `isActive`, `calcTotalSpeed`, and status helpers consistently |
| internal/tui/list.go | Updates list item description and tab classification to use `ActualSpeed`; fixes `MB` constant reference to use the config package |
| internal/tui/process.go | Copies `ActualSpeed` from the event message into the download model and uses it alongside EMA for the `resuming` guard |
| internal/tui/update_events.go | Passes `ActualSpeed` instead of `Speed` to `DetermineStatus` for spinner/queued detection; consistent with other TUI changes |
| internal/config/settings.go | Formatting-only change: re-aligns struct field tags in `NetworkSettings`; no behavioral change |
| internal/engine/types/accuracy_test.go | Whitespace-only fix: aligns a comment to match surrounding code style; no logic change |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `internal/tui/view.go`, line 653 ([link](https://github.com/surgedm/surge/blob/25c9ac3ae350ac1436ec76c7649deabcb1511cc3/internal/tui/view.go#L653)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Inconsistent speed signals between `isActive` flag and speed display**

   `isActive` uses `d.Speed` (EMA) while the Paused branch above uses `d.ActualSpeed`. This means that whenever `d.ActualSpeed == 0` (any stall tick) but `d.Speed > 0`, the speed label reads "Paused" while `isActive == true` and the Conns row is still rendered — the two rows directly contradict each other. Align the signal to whichever field you choose for the guard on line 618.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/tui/view.go
   Line: 653

   Comment:
   **Inconsistent speed signals between `isActive` flag and speed display**

   `isActive` uses `d.Speed` (EMA) while the Paused branch above uses `d.ActualSpeed`. This means that whenever `d.ActualSpeed == 0` (any stall tick) but `d.Speed > 0`, the speed label reads "Paused" while `isActive == true` and the Conns row is still rendered — the two rows directly contradict each other. Align the signal to whichever field you choose for the guard on line 618.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `internal/tui/list.go`, line 42-43 ([link](https://github.com/surgedm/surge/blob/25c9ac3ae350ac1436ec76c7649deabcb1511cc3/internal/tui/list.go#L42-L43)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Status icon and speed display use different speed signals**

   `DetermineStatus` is still passed `d.Speed` (EMA), while the description line immediately below now shows `d.ActualSpeed`. When a tick has no progress (`ActualSpeed == 0`), the status icon could render "⬇ Downloading" while the description shows no speed or "Paused", producing a contradictory item row. Consider passing `d.ActualSpeed` here as well so the two pieces of the list item agree.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/tui/list.go
   Line: 42-43

   Comment:
   **Status icon and speed display use different speed signals**

   `DetermineStatus` is still passed `d.Speed` (EMA), while the description line immediately below now shows `d.ActualSpeed`. When a tick has no progress (`ActualSpeed == 0`), the status icon could render "⬇ Downloading" while the description shows no speed or "Paused", producing a contradictory item row. Consider passing `d.ActualSpeed` here as well so the two pieces of the list item agree.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/core/local_service.go:232-240
**EMA fed zero every stall tick — ETA fallback degrades quickly**

The old `instantSpeed` was a cumulative session average (`sessionDownloaded / sessionElapsed`), so it stayed roughly stable during brief stalls. The new input is a per-tick delta, meaning every stall tick feeds `liveSpeed = 0` directly into the EMA: `currentSpeed = (1-alpha)*lastSpeed`. With a typical alpha of 0.3 and a 500 ms ticker, the EMA reaches ~3% of its original value after a 5-second stall. The ETA fallback in `view.go` (`etaSpeed = d.Speed`) then produces an increasingly inflated ETA that can tip into the "∞" cap even though the download is merely paused momentarily at the OS or disk layer.

### Issue 2 of 2
internal/core/local_service.go:218-230
**Live speed calculation has no test coverage**

The new per-tick delta logic (`liveSpeed = deltaBytes / deltaTime`) introduces several edge cases — first tick (`prevTick.IsZero()` → `liveSpeed = 0`), stall tick (`downloaded == prevDownloaded`), backward jump (`downloaded < prevDownloaded`), and the interaction with EMA reinitialization when `lastSpeed == 0`. None of these are exercised in `local_service_test.go` or anywhere else in the test suite. Given that this algorithm now drives the primary speed display and the ETA calculation fallback, unit tests covering at least the zero-progress and first-tick cases would prevent regressions here.


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: improve ETA stability by falling ba..."](https://github.com/surgedm/surge/commit/aae9eda427a03d5b1ad47af8ff3f0deb21454235) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32284555)</sub>

**Context used:**

- Rule used - What: All code changes must include tests for edge... ([source](https://app.greptile.com/review/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))

<!-- /greptile_comment -->