### PR TITLE
fix(cli): send download id as ?id= query param to match HTTP API

### DIFF
--- a/cmd/http_api_test.go
+++ b/cmd/http_api_test.go
@@ -385,3 +385,42 @@ func TestEnsureOpenActionRequestAllowed_ForwardedLoopbackDenied(t *testing.T) {
 		t.Fatalf("expected forwarded loopback request to be allowed when enabled, got: %v", err)
 	}
 }
+
+// recordingPauseService records the id passed to Pause so tests can assert how
+// the CLI delivered it to the HTTP API.
+type recordingPauseService struct {
+	*httpAPITestService
+	pausedID string
+}
+
+func (s *recordingPauseService) Pause(id string) error {
+	s.pausedID = id
+	return nil
+}
+
+// Regression for #456: ExecuteAPIAction sent the download id as a path segment
+// (POST /pause/<id>), but the HTTP API registers exact routes and reads the id
+// from the "id" query parameter (withRequiredID), so pause/resume/delete/open
+// 404'd against a remote daemon. The id must be sent as ?id=.
+func TestExecuteAPIAction_SendsIDAsQueryParam(t *testing.T) {
+	rec := &recordingPauseService{httpAPITestService: &httpAPITestService{}}
+	mux := http.NewServeMux()
+	registerHTTPRoutes(mux, 0, "", rec)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	prevHost, prevToken := globalHost, globalToken
+	globalHost, globalToken = "", ""
+	defer func() { globalHost, globalToken = prevHost, prevToken }()
+	t.Setenv("SURGE_HOST", server.URL)
+	t.Setenv("SURGE_TOKEN", "test-token")
+
+	// 32 chars so resolveDownloadID treats it as a full id (no server lookup).
+	const fullID = "abcdef0123456789abcdef0123456789"
+	if err := ExecuteAPIAction(fullID, "/pause", http.MethodPost, "Paused download"); err != nil {
+		t.Fatalf("ExecuteAPIAction returned error (id should reach /pause via ?id=): %v", err)
+	}
+	if rec.pausedID != fullID {
+		t.Fatalf("server received id %q via query param, want %q", rec.pausedID, fullID)
+	}
+}

--- a/cmd/http_api_test.go
+++ b/cmd/http_api_test.go
@@ -386,24 +386,25 @@ func TestEnsureOpenActionRequestAllowed_ForwardedLoopbackDenied(t *testing.T) {
 	}
 }
 
-// recordingPauseService records the id passed to Pause so tests can assert how
-// the CLI delivered it to the HTTP API.
-type recordingPauseService struct {
+// recordingActionService records the id passed to each lifecycle action so
+// tests can assert how the CLI delivered it to the HTTP API.
+type recordingActionService struct {
 	*httpAPITestService
-	pausedID string
+	ids map[string]string // action -> received id
 }
 
-func (s *recordingPauseService) Pause(id string) error {
-	s.pausedID = id
-	return nil
-}
+func (s *recordingActionService) Pause(id string) error  { s.ids["pause"] = id; return nil }
+func (s *recordingActionService) Resume(id string) error { s.ids["resume"] = id; return nil }
+func (s *recordingActionService) Delete(id string) error { s.ids["delete"] = id; return nil }
 
 // Regression for #456: ExecuteAPIAction sent the download id as a path segment
-// (POST /pause/<id>), but the HTTP API registers exact routes and reads the id
-// from the "id" query parameter (withRequiredID), so pause/resume/delete/open
-// 404'd against a remote daemon. The id must be sent as ?id=.
+// (e.g. POST /pause/<id>), but the HTTP API registers exact routes and reads the
+// id from the "id" query parameter (withRequiredID), so pause/resume/delete/open
+// 404'd against a remote daemon. The id must be sent as ?id=. Exercise every
+// ExecuteAPIAction caller (pause/resume/delete), not just one, so a future
+// action-specific regression is caught.
 func TestExecuteAPIAction_SendsIDAsQueryParam(t *testing.T) {
-	rec := &recordingPauseService{httpAPITestService: &httpAPITestService{}}
+	rec := &recordingActionService{httpAPITestService: &httpAPITestService{}, ids: map[string]string{}}
 	mux := http.NewServeMux()
 	registerHTTPRoutes(mux, 0, "", rec)
 	server := httptest.NewServer(mux)
@@ -417,10 +418,16 @@ func TestExecuteAPIAction_SendsIDAsQueryParam(t *testing.T) {
 
 	// 32 chars so resolveDownloadID treats it as a full id (no server lookup).
 	const fullID = "abcdef0123456789abcdef0123456789"
-	if err := ExecuteAPIAction(fullID, "/pause", http.MethodPost, "Paused download"); err != nil {
-		t.Fatalf("ExecuteAPIAction returned error (id should reach /pause via ?id=): %v", err)
-	}
-	if rec.pausedID != fullID {
-		t.Fatalf("server received id %q via query param, want %q", rec.pausedID, fullID)
+	for _, action := range []struct{ name, endpoint string }{
+		{"pause", "/pause"},
+		{"resume", "/resume"},
+		{"delete", "/delete"},
+	} {
+		if err := ExecuteAPIAction(fullID, action.endpoint, http.MethodPost, action.name); err != nil {
+			t.Fatalf("ExecuteAPIAction(%s): id should reach %s via ?id=, got error: %v", action.name, action.endpoint, err)
+		}
+		if rec.ids[action.name] != fullID {
+			t.Fatalf("%s: server received id %q via query param, want %q", action.name, rec.ids[action.name], fullID)
+		}
 	}
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -248,7 +249,11 @@ func ExecuteAPIAction(rawID, endpoint, method, successMsg string) error {
 		return fmt.Errorf("failed to resolve download ID: %w", err)
 	}
 
-	resp, err := doAPIRequest(method, baseURL, token, fmt.Sprintf("%s/%s", endpoint, id), nil)
+	// The HTTP API expects the download id as the "id" query parameter (see
+	// withRequiredID in cmd/http_api.go); a path segment (e.g. /pause/<id>)
+	// doesn't match the registered routes and 404s. Matches the extension and
+	// internal/core/remote_service.go, which already use ?id=.
+	resp, err := doAPIRequest(method, baseURL, token, fmt.Sprintf("%s?id=%s", endpoint, url.QueryEscape(id)), nil)
 	if err != nil {
 		return fmt.Errorf("failed to send request to server: %w", err)
 	}


### PR DESCRIPTION
## What

The CLI's `ExecuteAPIAction` (`cmd/utils.go`) built the request path as `<endpoint>/<id>` (e.g. `POST /pause/<id>`), but the HTTP API registers exact routes (`/pause`, `/resume`, `/delete`, `/open-file`, `/open-folder`, …) and reads the download id from the `id` query parameter via `withRequiredID` (`cmd/http_api.go`). A path segment doesn't match the registered routes, so `pause`, `resume`, `rm`, and `open` returned **404 Not Found** against a remote Surge daemon.

## Fix

Send the id as `?id=<url-escaped>`, matching the server's contract — and what the browser extension (`/pause?id=...`) and `internal/core/remote_service.go` (`/pause?id=" + url.QueryEscape(id)`) already use. One-line change in `ExecuteAPIAction`; the CLI was the only client using the path form.

## Testing

- Added `TestExecuteAPIAction_SendsIDAsQueryParam` (`cmd/http_api_test.go`): it registers the real routes via `registerHTTPRoutes` + `httptest.NewServer`, points the CLI at it via `SURGE_HOST`, and asserts the server receives the id.
- Reproduced + fixed: with the old `<endpoint>/<id>` path the test fails with `server error: 404 Not Found`; with `?id=` it passes.
- `go test ./...`, `gofmt`, `go vet ./...`, and `golangci-lint run` (v2) all clean.

Fixes #456

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a 404 regression in the CLI's `ExecuteAPIAction` function: it was building request paths as `<endpoint>/<id>` (path segment form), but the HTTP server only registers exact routes and reads the download ID from the `?id=` query parameter via `withRequiredID`. The fix aligns the CLI with the browser extension and `internal/core/remote_service.go`, which already used the correct query-parameter form.

- `cmd/utils.go`: One-line change replacing `fmt.Sprintf(\"%s/%s\", endpoint, id)` with `fmt.Sprintf(\"%s?id=%s\", endpoint, url.QueryEscape(id))`, with an explanatory comment.
- `cmd/http_api_test.go`: Adds `TestExecuteAPIAction_SendsIDAsQueryParam`, a regression test that registers real HTTP routes via `registerHTTPRoutes`, starts a test server, and asserts all three `ExecuteAPIAction` callers (pause, resume, delete) correctly deliver the ID as a query parameter.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted one-line fix to a well-understood API contract mismatch, backed by a regression test against real routes.

The fix is minimal and precisely targeted: it corrects the query-parameter format in a single function that all affected CLI commands share, and the new test exercises all three callers against a real HTTP mux to prevent future regressions.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cmd/utils.go | One-line fix: sends download ID as `?id=` query parameter instead of a path segment; correctly uses `url.QueryEscape` and adds an explanatory comment. |
| cmd/http_api_test.go | Adds a regression test covering all three `ExecuteAPIAction` callers (pause/resume/delete) against a real registered HTTP mux; test structure and assertions are correct. |

</details>

<sub>Reviews (3): Last reviewed commit: ["test(cli): cover resume and delete in Ex..."](https://github.com/surgedm/surge/commit/9ce9dc66d499c7855fd3e5ff2d14d6e6b776ca38) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34810010)</sub>

<!-- /greptile_comment -->