### PR TITLE
fix: batch downloads were being overwritten and only last one would be queued. Fixes #469

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -20,6 +20,7 @@ var addCmd = &cobra.Command{
 
 		batchFile, _ := cmd.Flags().GetString("batch")
 		output, _ := cmd.Flags().GetString("output")
+		confirm, _ := cmd.Flags().GetBool("confirm")
 
 		var urls []string
 		urls = append(urls, args...)
@@ -44,6 +45,14 @@ var addCmd = &cobra.Command{
 		}
 		resolvedOutput := resolveClientOutputPath(output)
 
+		if batchFile != "" && confirm {
+			if err := sendBatchToServer(urls, resolvedOutput, baseURL, token, false); err != nil {
+				return err
+			}
+			fmt.Printf("Batch confirmation requested for %d downloads.\n", len(urls))
+			return nil
+		}
+
 		// Send downloads to server
 		count := 0
 		attempted := 0
@@ -53,7 +62,7 @@ var addCmd = &cobra.Command{
 				continue
 			}
 			attempted++
-			if err := sendToServer(url, mirrors, resolvedOutput, baseURL, token); err != nil {
+			if err := sendToServerWithApproval(url, mirrors, resolvedOutput, baseURL, token, !confirm); err != nil {
 				fmt.Printf("Error adding %s: %v\n", url, err)
 				continue
 			}
@@ -77,4 +86,5 @@ func init() {
 	rootCmd.AddCommand(addCmd)
 	addCmd.Flags().StringP("batch", "b", "", "File containing URLs to download (one per line)")
 	addCmd.Flags().StringP("output", "o", "", "Output directory (defaults to current working directory)")
+	addCmd.Flags().Bool("confirm", false, "Show confirmation prompt before starting downloads")
 }

--- a/cmd/http_api.go
+++ b/cmd/http_api.go
@@ -36,6 +36,10 @@ func registerHTTPRoutes(mux *http.ServeMux, port int, defaultOutputDir string, s
 		handleDownload(w, r, defaultOutputDir, service)
 	})
 
+	mux.HandleFunc("/download/batch", func(w http.ResponseWriter, r *http.Request) {
+		handleBatchDownload(w, r, defaultOutputDir, service)
+	})
+
 	mux.HandleFunc("/pause", requireMethod(http.MethodPost, withRequiredID(func(w http.ResponseWriter, _ *http.Request, id string) {
 		if err := service.Pause(id); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/cmd/http_api_test.go
+++ b/cmd/http_api_test.go
@@ -88,6 +88,20 @@ func (s *publishRecordingHTTPService) Publish(msg interface{}) error {
 	return nil
 }
 
+type batchAddRecordingService struct {
+	*httpAPITestService
+	added  []string
+	failOn string
+}
+
+func (s *batchAddRecordingService) Add(url string, _ string, _ string, _ []string, _ map[string]string, _ bool, _ int64, _ bool) (string, error) {
+	if url == s.failOn {
+		return "", errors.New("enqueue failed")
+	}
+	s.added = append(s.added, url)
+	return "id-" + url, nil
+}
+
 func (s *httpAPITestService) GetStatus(id string) (*types.DownloadStatus, error) {
 	if s.getStatusErr != nil {
 		return nil, s.getStatusErr
@@ -258,6 +272,57 @@ func TestHandleBatchDownload_ConfirmPublishesSingleBatchRequest(t *testing.T) {
 	}
 	if msg.Requests[0].URL != "https://example.com/one.zip" || msg.Requests[1].URL != "https://example.com/two.zip" {
 		t.Fatalf("unexpected batch URLs: %#v", msg.Requests)
+	}
+}
+
+func TestHandleBatchDownload_SkipApprovalReportsPartialFailure(t *testing.T) {
+	previousLifecycle := GlobalLifecycle
+	previousCleanup := GlobalLifecycleCleanup
+	t.Cleanup(func() {
+		GlobalLifecycle = previousLifecycle
+		GlobalLifecycleCleanup = previousCleanup
+	})
+	GlobalLifecycle = nil
+	GlobalLifecycleCleanup = nil
+
+	service := &batchAddRecordingService{
+		httpAPITestService: &httpAPITestService{},
+		failOn:             "https://example.com/two.zip",
+	}
+	body := `{
+		"path": "/tmp/downloads",
+		"skip_approval": true,
+		"downloads": [
+			{"url": "https://example.com/one.zip"},
+			{"url": "https://example.com/two.zip"},
+			{"url": "https://example.com/three.zip"}
+		]
+	}`
+	request := httptest.NewRequest(http.MethodPost, "/download/batch", strings.NewReader(body))
+	recorder := httptest.NewRecorder()
+
+	handleBatchDownload(recorder, request, "", service)
+
+	if recorder.Code != http.StatusMultiStatus {
+		t.Fatalf("expected status 207, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+	if len(service.added) != 2 {
+		t.Fatalf("expected 2 queued downloads, got %d: %#v", len(service.added), service.added)
+	}
+
+	var response struct {
+		Status   string              `json:"status"`
+		Count    int                 `json:"count"`
+		Failures []map[string]string `json:"failures"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if response.Status != "partial" || response.Count != 2 || len(response.Failures) != 1 {
+		t.Fatalf("unexpected partial response: %#v", response)
+	}
+	if response.Failures[0]["url"] != "https://example.com/two.zip" {
+		t.Fatalf("unexpected failed URL: %#v", response.Failures)
 	}
 }
 

--- a/cmd/http_api_test.go
+++ b/cmd/http_api_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/core"
 	"github.com/SurgeDM/Surge/internal/engine/events"
@@ -74,6 +75,16 @@ func (s *httpAPITestService) StreamEvents(context.Context) (<-chan interface{}, 
 }
 
 func (s *httpAPITestService) Publish(interface{}) error {
+	return nil
+}
+
+type publishRecordingHTTPService struct {
+	*httpAPITestService
+	published []interface{}
+}
+
+func (s *publishRecordingHTTPService) Publish(msg interface{}) error {
+	s.published = append(s.published, msg)
 	return nil
 }
 
@@ -206,6 +217,47 @@ func TestEventsEndpoint_RequiresAuthAndStreamsSSE(t *testing.T) {
 	}
 	if !strings.Contains(text, `"DownloadID":"queue-1"`) {
 		t.Fatalf("expected queued payload in SSE body, got %q", text)
+	}
+}
+
+func TestHandleBatchDownload_ConfirmPublishesSingleBatchRequest(t *testing.T) {
+	previousProgram := serverProgram
+	serverProgram = &tea.Program{}
+	t.Cleanup(func() {
+		serverProgram = previousProgram
+	})
+
+	service := &publishRecordingHTTPService{
+		httpAPITestService: &httpAPITestService{},
+	}
+	body := `{
+		"path": "/tmp/downloads",
+		"skip_approval": false,
+		"downloads": [
+			{"url": "https://example.com/one.zip"},
+			{"url": "https://example.com/two.zip"}
+		]
+	}`
+	request := httptest.NewRequest(http.MethodPost, "/download/batch", strings.NewReader(body))
+	recorder := httptest.NewRecorder()
+
+	handleBatchDownload(recorder, request, "", service)
+
+	if recorder.Code != http.StatusAccepted {
+		t.Fatalf("expected status 202, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+	if len(service.published) != 1 {
+		t.Fatalf("expected 1 published message, got %d", len(service.published))
+	}
+	msg, ok := service.published[0].(events.BatchDownloadRequestMsg)
+	if !ok {
+		t.Fatalf("expected BatchDownloadRequestMsg, got %T", service.published[0])
+	}
+	if len(msg.Requests) != 2 {
+		t.Fatalf("expected 2 batch requests, got %d", len(msg.Requests))
+	}
+	if msg.Requests[0].URL != "https://example.com/one.zip" || msg.Requests[1].URL != "https://example.com/two.zip" {
+		t.Fatalf("unexpected batch URLs: %#v", msg.Requests)
 	}
 }
 

--- a/cmd/root_downloads.go
+++ b/cmd/root_downloads.go
@@ -30,6 +30,12 @@ type DownloadRequest struct {
 	IsExplicitCategory   bool              `json:"is_explicit_category,omitempty"`
 }
 
+type BatchDownloadRequest struct {
+	Downloads    []DownloadRequest `json:"downloads"`
+	Path         string            `json:"path,omitempty"`
+	SkipApproval bool              `json:"skip_approval,omitempty"`
+}
+
 type resolvedDownloadRequest struct {
 	request       DownloadRequest
 	settings      *config.Settings
@@ -113,6 +119,10 @@ func decodeAndValidateDownloadRequest(r *http.Request) (DownloadRequest, error) 
 	if err := decodeJSONBody(r, &req); err != nil {
 		return req, fmt.Errorf("invalid json: %w", err)
 	}
+	return validateDownloadRequest(req)
+}
+
+func validateDownloadRequest(req DownloadRequest) (DownloadRequest, error) {
 	if req.URL == "" {
 		return req, fmt.Errorf("url is required")
 	}
@@ -138,6 +148,110 @@ func decodeAndValidateDownloadRequest(r *http.Request) (DownloadRequest, error) 
 		req.Path = cleanPath
 	}
 	return req, nil
+}
+
+func handleBatchDownload(w http.ResponseWriter, r *http.Request, defaultOutputDir string, service core.DownloadService) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if service == nil {
+		http.Error(w, "Service unavailable", http.StatusInternalServerError)
+		return
+	}
+
+	var req BatchDownloadRequest
+	if err := decodeJSONBody(r, &req); err != nil {
+		http.Error(w, "invalid json: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if len(req.Downloads) == 0 {
+		http.Error(w, "downloads are required", http.StatusBadRequest)
+		return
+	}
+
+	settings := getSettings()
+	sharedPath := utils.EnsureAbsPath(resolveOutputDir(req.Path, false, defaultOutputDir, settings))
+	requests := make([]events.DownloadRequestMsg, 0, len(req.Downloads))
+
+	for _, item := range req.Downloads {
+		if item.Path == "" {
+			item.Path = sharedPath
+		}
+		item.SkipApproval = req.SkipApproval
+		validated, err := validateDownloadRequest(item)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		urlForAdd, mirrorsForAdd := normalizeDownloadTargets(validated.URL, validated.Mirrors)
+		itemPath := utils.EnsureAbsPath(resolveOutputDir(validated.Path, validated.RelativeToDefaultDir, defaultOutputDir, settings))
+		requests = append(requests, events.DownloadRequestMsg{
+			ID:       uuid.New().String(),
+			URL:      urlForAdd,
+			Filename: validated.Filename,
+			Path:     itemPath,
+			Mirrors:  mirrorsForAdd,
+			Headers:  validated.Headers,
+		})
+	}
+
+	if !req.SkipApproval {
+		if serverProgram == nil {
+			writeJSONResponse(w, http.StatusConflict, map[string]string{
+				"status":  "error",
+				"message": "Batch confirmation requires the TUI",
+			})
+			return
+		}
+		batchID := uuid.New().String()
+		if err := service.Publish(events.BatchDownloadRequestMsg{
+			ID:       batchID,
+			Path:     sharedPath,
+			Requests: requests,
+		}); err != nil {
+			http.Error(w, "Failed to notify TUI: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		writeJSONResponse(w, http.StatusAccepted, map[string]string{
+			"status":  "pending_approval",
+			"message": "Batch download request sent to TUI for confirmation",
+			"id":      batchID,
+		})
+		return
+	}
+
+	queued := 0
+	for _, item := range requests {
+		resolved := &resolvedDownloadRequest{
+			request: DownloadRequest{
+				URL:          item.URL,
+				Filename:     item.Filename,
+				Path:         item.Path,
+				Mirrors:      item.Mirrors,
+				SkipApproval: true,
+				Headers:      item.Headers,
+			},
+			settings:      settings,
+			outPath:       item.Path,
+			urlForAdd:     item.URL,
+			mirrorsForAdd: item.Mirrors,
+		}
+		if _, _, err := enqueueDownloadRequest(r, service, resolved); err != nil {
+			recordPreflightDownloadError(item.URL, item.Path, err)
+			publishSystemLog(fmt.Sprintf("Error adding %s: %v", item.URL, err))
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		atomic.AddInt32(&activeDownloads, 1)
+		queued++
+	}
+
+	writeJSONResponse(w, http.StatusOK, map[string]interface{}{
+		"status":  "queued",
+		"message": "Batch downloads queued successfully",
+		"count":   queued,
+	})
 }
 
 func resolveDownloadRequest(r *http.Request, defaultOutputDir string) (*resolvedDownloadRequest, error) {

--- a/cmd/root_downloads.go
+++ b/cmd/root_downloads.go
@@ -222,6 +222,7 @@ func handleBatchDownload(w http.ResponseWriter, r *http.Request, defaultOutputDi
 	}
 
 	queued := 0
+	var failures []map[string]string
 	for _, item := range requests {
 		resolved := &resolvedDownloadRequest{
 			request: DownloadRequest{
@@ -240,11 +241,32 @@ func handleBatchDownload(w http.ResponseWriter, r *http.Request, defaultOutputDi
 		if _, _, err := enqueueDownloadRequest(r, service, resolved); err != nil {
 			recordPreflightDownloadError(item.URL, item.Path, err)
 			publishSystemLog(fmt.Sprintf("Error adding %s: %v", item.URL, err))
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
+			failures = append(failures, map[string]string{
+				"url":   item.URL,
+				"error": err.Error(),
+			})
+			continue
 		}
 		atomic.AddInt32(&activeDownloads, 1)
 		queued++
+	}
+
+	if len(failures) > 0 {
+		statusCode := http.StatusMultiStatus
+		status := "partial"
+		message := "Batch downloads partially queued"
+		if queued == 0 {
+			statusCode = http.StatusInternalServerError
+			status = "error"
+			message = "Batch downloads failed"
+		}
+		writeJSONResponse(w, statusCode, map[string]interface{}{
+			"status":   status,
+			"message":  message,
+			"count":    queued,
+			"failures": failures,
+		})
+		return
 	}
 
 	writeJSONResponse(w, http.StatusOK, map[string]interface{}{

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -185,10 +185,15 @@ func doAPIRequest(method string, baseURL string, token string, path string, body
 }
 
 func sendToServer(url string, mirrors []string, outPath string, baseURL string, token string) error {
+	return sendToServerWithApproval(url, mirrors, outPath, baseURL, token, true)
+}
+
+func sendToServerWithApproval(url string, mirrors []string, outPath string, baseURL string, token string, skipApproval bool) error {
 	reqBody := DownloadRequest{
-		URL:     url,
-		Mirrors: mirrors,
-		Path:    outPath,
+		URL:          url,
+		Mirrors:      mirrors,
+		Path:         outPath,
+		SkipApproval: skipApproval,
 	}
 	jsonData, err := json.Marshal(reqBody)
 	if err != nil {
@@ -196,6 +201,49 @@ func sendToServer(url string, mirrors []string, outPath string, baseURL string, 
 	}
 
 	resp, err := doAPIRequest(http.MethodPost, baseURL, token, "/download", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to connect to server: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			utils.Debug("Error closing response body: %v", err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("server error: %s - %s", resp.Status, string(body))
+	}
+
+	return nil
+}
+
+func sendBatchToServer(urls []string, outPath string, baseURL string, token string, skipApproval bool) error {
+	reqBody := BatchDownloadRequest{
+		Path:         outPath,
+		SkipApproval: skipApproval,
+	}
+	for _, arg := range urls {
+		url, mirrors := ParseURLArg(arg)
+		if url == "" {
+			continue
+		}
+		reqBody.Downloads = append(reqBody.Downloads, DownloadRequest{
+			URL:     url,
+			Mirrors: mirrors,
+			Path:    outPath,
+		})
+	}
+	if len(reqBody.Downloads) == 0 {
+		return fmt.Errorf("no valid URLs to add")
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	resp, err := doAPIRequest(http.MethodPost, baseURL, token, "/download/batch", bytes.NewBuffer(jsonData))
 	if err != nil {
 		return fmt.Errorf("failed to connect to server: %w", err)
 	}

--- a/internal/engine/events/events.go
+++ b/internal/engine/events/events.go
@@ -152,17 +152,25 @@ type DownloadRequestMsg struct {
 	Headers  map[string]string
 }
 
+// BatchDownloadRequestMsg signals a batch request that should be confirmed once.
+type BatchDownloadRequestMsg struct {
+	ID       string
+	Path     string
+	Requests []DownloadRequestMsg
+}
+
 const (
-	EventTypeProgress = "progress"
-	EventTypeStarted  = "started"
-	EventTypeComplete = "complete"
-	EventTypeError    = "error"
-	EventTypePaused   = "paused"
-	EventTypeResumed  = "resumed"
-	EventTypeQueued   = "queued"
-	EventTypeRemoved  = "removed"
-	EventTypeRequest  = "request"
-	EventTypeSystem   = "system"
+	EventTypeProgress     = "progress"
+	EventTypeStarted      = "started"
+	EventTypeComplete     = "complete"
+	EventTypeError        = "error"
+	EventTypePaused       = "paused"
+	EventTypeResumed      = "resumed"
+	EventTypeQueued       = "queued"
+	EventTypeRemoved      = "removed"
+	EventTypeRequest      = "request"
+	EventTypeBatchRequest = "batch_request"
+	EventTypeSystem       = "system"
 )
 
 // SSEMessage represents one server-sent event frame.
@@ -225,6 +233,8 @@ func EventTypeForMessage(msg interface{}) (string, bool) {
 		return EventTypeRemoved, true
 	case DownloadRequestMsg:
 		return EventTypeRequest, true
+	case BatchDownloadRequestMsg:
+		return EventTypeBatchRequest, true
 	case SystemLogMsg:
 		return EventTypeSystem, true
 	default:
@@ -287,6 +297,12 @@ func DecodeSSEMessage(eventType string, data []byte) (interface{}, bool, error) 
 		msg = m
 	case EventTypeRequest:
 		var m DownloadRequestMsg
+		if err := json.Unmarshal(data, &m); err != nil {
+			return nil, true, err
+		}
+		msg = m
+	case EventTypeBatchRequest:
+		var m BatchDownloadRequestMsg
 		if err := json.Unmarshal(data, &m); err != nil {
 			return nil, true, err
 		}

--- a/internal/tui/download_requests.go
+++ b/internal/tui/download_requests.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (m RootModel) handleDownloadRequestMsg(msg events.DownloadRequestMsg, queueIfBusy bool) (tea.Model, tea.Cmd) {
-	if queueIfBusy && (m.state == ExtensionConfirmationState || m.state == DuplicateWarningState) {
+	if queueIfBusy && (m.state == ExtensionConfirmationState || m.state == DuplicateWarningState || m.state == BatchConfirmState) {
 		m.pendingRequestQueue = append(m.pendingRequestQueue, msg)
 		return m, nil
 	}
@@ -58,9 +58,31 @@ func (m RootModel) handleDownloadRequestMsg(msg events.DownloadRequestMsg, queue
 	return m.startDownload(msg.URL, msg.Mirrors, msg.Headers, path, isDefaultPath, msg.Filename, msg.ID)
 }
 
+func (m RootModel) handleBatchDownloadRequestMsg(msg events.BatchDownloadRequestMsg, queueIfBusy bool) (tea.Model, tea.Cmd) {
+	if queueIfBusy && (m.state == ExtensionConfirmationState || m.state == DuplicateWarningState || m.state == BatchConfirmState) {
+		m.pendingBatchRequestQueue = append(m.pendingBatchRequestQueue, msg)
+		return m, nil
+	}
+
+	m.pendingBatchURLs = nil
+	m.pendingBatchRequests = append([]events.DownloadRequestMsg(nil), msg.Requests...)
+	m.batchFilePath = strings.TrimSpace(msg.Path)
+	if m.batchFilePath == "" {
+		m.batchFilePath = m.defaultDownloadPath()
+	}
+	m.inputs[2].SetValue(m.batchFilePath)
+	m.state = BatchConfirmState
+	return m, nil
+}
+
 func (m RootModel) showNextPendingRequest() (tea.Model, tea.Cmd) {
 	if len(m.pendingRequestQueue) == 0 {
-		return m, nil
+		if len(m.pendingBatchRequestQueue) == 0 {
+			return m, nil
+		}
+		next := m.pendingBatchRequestQueue[0]
+		m.pendingBatchRequestQueue = m.pendingBatchRequestQueue[1:]
+		return m.handleBatchDownloadRequestMsg(next, false)
 	}
 	next := m.pendingRequestQueue[0]
 	m.pendingRequestQueue = m.pendingRequestQueue[1:]

--- a/internal/tui/download_requests.go
+++ b/internal/tui/download_requests.go
@@ -1,0 +1,68 @@
+package tui
+
+import (
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/SurgeDM/Surge/internal/config"
+	"github.com/SurgeDM/Surge/internal/engine/events"
+	"github.com/SurgeDM/Surge/internal/utils"
+)
+
+func (m RootModel) handleDownloadRequestMsg(msg events.DownloadRequestMsg, queueIfBusy bool) (tea.Model, tea.Cmd) {
+	if queueIfBusy && (m.state == ExtensionConfirmationState || m.state == DuplicateWarningState) {
+		m.pendingRequestQueue = append(m.pendingRequestQueue, msg)
+		return m, nil
+	}
+
+	path := strings.TrimSpace(msg.Path)
+	isDefaultPath := m.isDefaultDownloadPath(path)
+	if path == "" {
+		isDefaultPath = true
+		path = m.defaultDownloadPath()
+	}
+
+	duplicate := m.checkForDuplicate(msg.URL)
+
+	if duplicate != nil && config.Resolve[bool](m.Settings.General.WarnOnDuplicate) {
+		utils.Debug("Duplicate download detected in TUI: %s", msg.URL)
+		m.pendingURL = msg.URL
+		m.pendingMirrors = msg.Mirrors
+		m.pendingHeaders = msg.Headers
+		m.pendingPath = path
+		m.pendingIsDefaultPath = isDefaultPath
+		m.pendingFilename = msg.Filename
+		m.duplicateInfo = duplicate.Filename
+		m.state = DuplicateWarningState
+		return m, nil
+	}
+
+	if m.Settings != nil && config.Resolve[bool](m.Settings.Extension.ExtensionPrompt) {
+		m.pendingURL = msg.URL
+		m.pendingMirrors = msg.Mirrors
+		m.pendingHeaders = msg.Headers
+		m.pendingPath = path
+		m.pendingIsDefaultPath = isDefaultPath
+		m.pendingFilename = msg.Filename
+		m.inputs[2].SetValue(path)
+		m.inputs[3].SetValue(msg.Filename)
+		m.focusedInput = 2
+		for i := range m.inputs {
+			m.inputs[i].Blur()
+		}
+		m.inputs[m.focusedInput].Focus()
+		m.state = ExtensionConfirmationState
+		return m, nil
+	}
+
+	return m.startDownload(msg.URL, msg.Mirrors, msg.Headers, path, isDefaultPath, msg.Filename, msg.ID)
+}
+
+func (m RootModel) showNextPendingRequest() (tea.Model, tea.Cmd) {
+	if len(m.pendingRequestQueue) == 0 {
+		return m, nil
+	}
+	next := m.pendingRequestQueue[0]
+	m.pendingRequestQueue = m.pendingRequestQueue[1:]
+	return m.handleDownloadRequestMsg(next, false)
+}

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -418,12 +418,12 @@ var Keys = KeyMap{
 	},
 	BatchConfirm: BatchConfirmKeyMap{
 		Confirm: key.NewBinding(
-			key.WithKeys("y", "Y", "enter"),
-			key.WithHelp("y", "confirm"),
+			key.WithKeys("enter"),
+			key.WithHelp("enter", "confirm"),
 		),
 		Cancel: key.NewBinding(
-			key.WithKeys("n", "N", "esc"),
-			key.WithHelp("n", "cancel"),
+			key.WithKeys("esc"),
+			key.WithHelp("esc", "cancel"),
 		),
 	},
 	Update: UpdateKeyMap{

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/core"
+	"github.com/SurgeDM/Surge/internal/engine/events"
 	"github.com/SurgeDM/Surge/internal/engine/types"
 	"github.com/SurgeDM/Surge/internal/processing"
 	"github.com/SurgeDM/Surge/internal/tui/colors"
@@ -171,8 +172,10 @@ type RootModel struct {
 	searchQuery  string          // Current search query
 
 	// Batch import
-	pendingBatchURLs []string // URLs pending batch import
-	batchFilePath    string   // Path to the batch file
+	pendingBatchURLs     []string // URLs pending batch import
+	pendingBatchRequests []events.DownloadRequestMsg
+	pendingRequestQueue  []events.DownloadRequestMsg
+	batchFilePath        string // Path to the batch file
 
 	// URL Refresh
 	urlUpdateInput textinput.Model // Text input for updating URL

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -172,10 +172,11 @@ type RootModel struct {
 	searchQuery  string          // Current search query
 
 	// Batch import
-	pendingBatchURLs     []string // URLs pending batch import
-	pendingBatchRequests []events.DownloadRequestMsg
-	pendingRequestQueue  []events.DownloadRequestMsg
-	batchFilePath        string // Path to the batch file
+	pendingBatchURLs         []string // URLs pending batch import
+	pendingBatchRequests     []events.DownloadRequestMsg
+	pendingRequestQueue      []events.DownloadRequestMsg
+	pendingBatchRequestQueue []events.BatchDownloadRequestMsg
+	batchFilePath            string // Path to the batch file
 
 	// URL Refresh
 	urlUpdateInput textinput.Model // Text input for updating URL

--- a/internal/tui/update_events.go
+++ b/internal/tui/update_events.go
@@ -106,15 +106,7 @@ func (m RootModel) updateEvents(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleDownloadRequestMsg(msg, true)
 
 	case events.BatchDownloadRequestMsg:
-		m.pendingBatchURLs = nil
-		m.pendingBatchRequests = append([]events.DownloadRequestMsg(nil), msg.Requests...)
-		m.batchFilePath = strings.TrimSpace(msg.Path)
-		if m.batchFilePath == "" {
-			m.batchFilePath = m.defaultDownloadPath()
-		}
-		m.inputs[2].SetValue(m.batchFilePath)
-		m.state = BatchConfirmState
-		return m, nil
+		return m.handleBatchDownloadRequestMsg(msg, true)
 
 	case events.DownloadStartedMsg:
 

--- a/internal/tui/update_events.go
+++ b/internal/tui/update_events.go
@@ -10,7 +10,6 @@ import (
 	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/engine/events"
 	"github.com/SurgeDM/Surge/internal/tui/components"
-	"github.com/SurgeDM/Surge/internal/utils"
 )
 
 func (m RootModel) updateEvents(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -104,47 +103,18 @@ func (m RootModel) updateEvents(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case events.DownloadRequestMsg:
-		path := strings.TrimSpace(msg.Path)
-		isDefaultPath := m.isDefaultDownloadPath(path)
-		if path == "" {
-			isDefaultPath = true
-			path = m.defaultDownloadPath()
+		return m.handleDownloadRequestMsg(msg, true)
+
+	case events.BatchDownloadRequestMsg:
+		m.pendingBatchURLs = nil
+		m.pendingBatchRequests = append([]events.DownloadRequestMsg(nil), msg.Requests...)
+		m.batchFilePath = strings.TrimSpace(msg.Path)
+		if m.batchFilePath == "" {
+			m.batchFilePath = m.defaultDownloadPath()
 		}
-
-		duplicate := m.checkForDuplicate(msg.URL)
-
-		if duplicate != nil && config.Resolve[bool](m.Settings.General.WarnOnDuplicate) {
-			utils.Debug("Duplicate download detected in TUI: %s", msg.URL)
-			m.pendingURL = msg.URL
-			m.pendingMirrors = msg.Mirrors
-			m.pendingHeaders = msg.Headers
-			m.pendingPath = path
-			m.pendingIsDefaultPath = isDefaultPath
-			m.pendingFilename = msg.Filename
-			m.duplicateInfo = duplicate.Filename
-			m.state = DuplicateWarningState
-			return m, nil
-		}
-
-		if m.Settings != nil && config.Resolve[bool](m.Settings.Extension.ExtensionPrompt) {
-			m.pendingURL = msg.URL
-			m.pendingMirrors = msg.Mirrors
-			m.pendingHeaders = msg.Headers
-			m.pendingPath = path
-			m.pendingIsDefaultPath = isDefaultPath
-			m.pendingFilename = msg.Filename
-			m.inputs[2].SetValue(path)
-			m.inputs[3].SetValue(msg.Filename)
-			m.focusedInput = 2
-			for i := range m.inputs {
-				m.inputs[i].Blur()
-			}
-			m.inputs[m.focusedInput].Focus()
-			m.state = ExtensionConfirmationState
-			return m, nil
-		}
-
-		return m.startDownload(msg.URL, msg.Mirrors, msg.Headers, path, isDefaultPath, msg.Filename, msg.ID)
+		m.inputs[2].SetValue(m.batchFilePath)
+		m.state = BatchConfirmState
+		return m, nil
 
 	case events.DownloadStartedMsg:
 

--- a/internal/tui/update_filepicker.go
+++ b/internal/tui/update_filepicker.go
@@ -15,6 +15,7 @@ func (m *RootModel) handleBatchFileSelection(path string) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	m.pendingBatchURLs = urls
+	m.inputs[2].SetValue(m.defaultDownloadPath())
 	m.batchFilePath = path
 	m.resetFilepickerToDirMode()
 	m.state = BatchConfirmState

--- a/internal/tui/update_input.go
+++ b/internal/tui/update_input.go
@@ -172,14 +172,16 @@ func (m RootModel) updateExtensionConfirmation(msg tea.KeyPressMsg) (tea.Model, 
 		}
 
 		m.state = DashboardState
-		return m.startDownload(m.pendingURL, m.pendingMirrors, m.pendingHeaders, m.pendingPath, m.pendingIsDefaultPath, m.pendingFilename, "")
+		updated, cmd := m.startDownload(m.pendingURL, m.pendingMirrors, m.pendingHeaders, m.pendingPath, m.pendingIsDefaultPath, m.pendingFilename, "")
+		nextModel, nextCmd := updated.showNextPendingRequest()
+		return nextModel, tea.Batch(cmd, nextCmd)
 	}
 
 	if key.Matches(msg, m.keys.Extension.Cancel) {
 		m.filepickerOrigin = FilePickerOriginNone
 		m.blurAllInputs()
 		m.state = DashboardState
-		return m, nil
+		return m.showNextPendingRequest()
 	}
 
 	var cmd tea.Cmd

--- a/internal/tui/update_modals.go
+++ b/internal/tui/update_modals.go
@@ -19,12 +19,14 @@ func (m RootModel) updateDuplicateWarning(msg tea.KeyPressMsg) (tea.Model, tea.C
 	if key.Matches(msg, m.keys.Duplicate.Continue) {
 		// Continue anyway - startDownload handles unique filename generation
 		m.state = DashboardState
-		return m.startDownload(m.pendingURL, m.pendingMirrors, m.pendingHeaders, m.pendingPath, m.pendingIsDefaultPath, m.pendingFilename, "")
+		updated, cmd := m.startDownload(m.pendingURL, m.pendingMirrors, m.pendingHeaders, m.pendingPath, m.pendingIsDefaultPath, m.pendingFilename, "")
+		nextModel, nextCmd := updated.showNextPendingRequest()
+		return nextModel, tea.Batch(cmd, nextCmd)
 	}
 	if key.Matches(msg, m.keys.Duplicate.Cancel) {
 		// Cancel - don't add
 		m.state = DashboardState
-		return m, nil
+		return m.showNextPendingRequest()
 	}
 	if key.Matches(msg, m.keys.Duplicate.Focus) {
 		// Focus existing download - find it and select in list
@@ -35,7 +37,7 @@ func (m RootModel) updateDuplicateWarning(msg tea.KeyPressMsg) (tea.Model, tea.C
 			}
 		}
 		m.state = DashboardState
-		return m, nil
+		return m.showNextPendingRequest()
 	}
 	return m, nil
 }
@@ -80,7 +82,10 @@ func (m RootModel) updateBatchConfirm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 
 	if key.Matches(msg, m.keys.BatchConfirm.Confirm) {
 		// Add all URLs as downloads, skipping duplicates
-		path := config.Resolve[string](m.Settings.General.DefaultDownloadDir)
+		path := strings.TrimSpace(m.inputs[2].Value())
+		if path == "" {
+			path = config.Resolve[string](m.Settings.General.DefaultDownloadDir)
+		}
 		if path == "" {
 			path = "."
 		}
@@ -88,6 +93,24 @@ func (m RootModel) updateBatchConfirm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 		added := 0
 		skipped := 0
 		var batchCmds []tea.Cmd
+		for _, request := range m.pendingBatchRequests {
+			requestPath := path
+			isDefaultPath := m.isDefaultDownloadPath(requestPath)
+			if requestPath == "" {
+				isDefaultPath = true
+				requestPath = m.defaultDownloadPath()
+			}
+			if m.checkForDuplicate(request.URL) != nil {
+				skipped++
+				continue
+			}
+			var cmd tea.Cmd
+			m, cmd = m.startDownload(request.URL, request.Mirrors, request.Headers, requestPath, isDefaultPath, request.Filename, request.ID)
+			if cmd != nil {
+				batchCmds = append(batchCmds, cmd)
+			}
+			added++
+		}
 		for _, url := range m.pendingBatchURLs {
 			// Skip duplicate URLs
 			if m.checkForDuplicate(url) != nil {
@@ -108,17 +131,21 @@ func (m RootModel) updateBatchConfirm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 			m.addLogEntry(LogStyleStarted.Render(fmt.Sprintf("\u2b07 Added %d downloads from batch", added)))
 		}
 		m.pendingBatchURLs = nil
+		m.pendingBatchRequests = nil
 		m.batchFilePath = ""
 		m.state = DashboardState
 		return m, tea.Batch(batchCmds...)
 	}
 	if key.Matches(msg, m.keys.BatchConfirm.Cancel) {
 		m.pendingBatchURLs = nil
+		m.pendingBatchRequests = nil
 		m.batchFilePath = ""
 		m.state = DashboardState
 		return m, nil
 	}
-	return m, nil
+	var cmd tea.Cmd
+	m.inputs[2], cmd = m.inputs[2].Update(msg)
+	return m, cmd
 }
 
 func (m RootModel) updateURLUpdate(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {

--- a/internal/tui/update_modals.go
+++ b/internal/tui/update_modals.go
@@ -134,14 +134,15 @@ func (m RootModel) updateBatchConfirm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 		m.pendingBatchRequests = nil
 		m.batchFilePath = ""
 		m.state = DashboardState
-		return m, tea.Batch(batchCmds...)
+		nextModel, nextCmd := m.showNextPendingRequest()
+		return nextModel, tea.Batch(append(batchCmds, nextCmd)...)
 	}
 	if key.Matches(msg, m.keys.BatchConfirm.Cancel) {
 		m.pendingBatchURLs = nil
 		m.pendingBatchRequests = nil
 		m.batchFilePath = ""
 		m.state = DashboardState
-		return m, nil
+		return m.showNextPendingRequest()
 	}
 	var cmd tea.Cmd
 	m.inputs[2], cmd = m.inputs[2].Update(msg)

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -441,6 +441,52 @@ func TestUpdate_DownloadRequestMsg(t *testing.T) {
 	}
 }
 
+func TestUpdate_DownloadRequestMsg_QueuesWhileConfirmationActive(t *testing.T) {
+	m := RootModel{
+		Settings:    config.DefaultSettings(),
+		logViewport: viewport.New(viewport.WithWidth(40), viewport.WithHeight(5)),
+		list:        NewDownloadList(40, 10),
+		inputs:      []textinput.Model{textinput.New(), textinput.New(), textinput.New(), textinput.New()},
+		keys:        Keys,
+	}
+	m.Settings.Extension.ExtensionPrompt.Value = true
+
+	first := events.DownloadRequestMsg{
+		URL:      "https://example.com/first.zip",
+		Filename: "first.zip",
+		Path:     "/tmp/downloads",
+	}
+	second := events.DownloadRequestMsg{
+		URL:      "https://example.com/second.zip",
+		Filename: "second.zip",
+		Path:     "/tmp/downloads",
+	}
+
+	updated, _ := m.Update(first)
+	root := updated.(RootModel)
+	updated, _ = root.Update(second)
+	root = updated.(RootModel)
+
+	if root.state != ExtensionConfirmationState {
+		t.Fatalf("expected ExtensionConfirmationState, got %v", root.state)
+	}
+	if root.pendingURL != first.URL {
+		t.Fatalf("pendingURL was overwritten: got %q, want %q", root.pendingURL, first.URL)
+	}
+	if len(root.pendingRequestQueue) != 1 || root.pendingRequestQueue[0].URL != second.URL {
+		t.Fatalf("expected second request queued, got %#v", root.pendingRequestQueue)
+	}
+
+	updated, _ = root.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	root = updated.(RootModel)
+	if root.state != ExtensionConfirmationState {
+		t.Fatalf("expected queued request to become active, got state %v", root.state)
+	}
+	if root.pendingURL != second.URL {
+		t.Fatalf("expected queued URL %q to become pending, got %q", second.URL, root.pendingURL)
+	}
+}
+
 func TestStartDownload_UsesProvidedIDWhenServiceSupportsIt(t *testing.T) {
 	ch := make(chan any, 16)
 	pool := download.NewWorkerPool(ch, 1)

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -487,6 +487,57 @@ func TestUpdate_DownloadRequestMsg_QueuesWhileConfirmationActive(t *testing.T) {
 	}
 }
 
+func TestUpdate_BatchDownloadRequestMsg_QueuesWhileConfirmationActive(t *testing.T) {
+	m := RootModel{
+		Settings:    config.DefaultSettings(),
+		logViewport: viewport.New(viewport.WithWidth(40), viewport.WithHeight(5)),
+		list:        NewDownloadList(40, 10),
+		inputs:      []textinput.Model{textinput.New(), textinput.New(), textinput.New(), textinput.New()},
+		keys:        Keys,
+	}
+	m.Settings.Extension.ExtensionPrompt.Value = true
+
+	first := events.DownloadRequestMsg{
+		URL:      "https://example.com/first.zip",
+		Filename: "first.zip",
+		Path:     "/tmp/downloads",
+	}
+	batch := events.BatchDownloadRequestMsg{
+		Path: "/tmp/batch",
+		Requests: []events.DownloadRequestMsg{
+			{URL: "https://example.com/one.zip", Path: "/tmp/batch"},
+			{URL: "https://example.com/two.zip", Path: "/tmp/batch"},
+		},
+	}
+
+	updated, _ := m.Update(first)
+	root := updated.(RootModel)
+	updated, _ = root.Update(batch)
+	root = updated.(RootModel)
+
+	if root.state != ExtensionConfirmationState {
+		t.Fatalf("expected active single confirmation to remain, got %v", root.state)
+	}
+	if root.pendingURL != first.URL {
+		t.Fatalf("pendingURL was overwritten: got %q, want %q", root.pendingURL, first.URL)
+	}
+	if len(root.pendingBatchRequestQueue) != 1 {
+		t.Fatalf("expected batch request queued, got %d", len(root.pendingBatchRequestQueue))
+	}
+
+	updated, _ = root.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	root = updated.(RootModel)
+	if root.state != BatchConfirmState {
+		t.Fatalf("expected queued batch to become active, got state %v", root.state)
+	}
+	if len(root.pendingBatchRequests) != 2 {
+		t.Fatalf("expected 2 pending batch requests, got %d", len(root.pendingBatchRequests))
+	}
+	if root.pendingURL != first.URL {
+		t.Fatalf("queued batch should not mutate abandoned single fields, got pendingURL %q", root.pendingURL)
+	}
+}
+
 func TestStartDownload_UsesProvidedIDWhenServiceSupportsIt(t *testing.T) {
 	ch := make(chan any, 16)
 	pool := download.NewWorkerPool(ch, 1)

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -217,10 +217,14 @@ func (m RootModel) View() tea.View {
 		if len(m.pendingBatchRequests) > 0 {
 			urlCount = len(m.pendingBatchRequests)
 		}
+		batchDetail := fmt.Sprintf("Path: %s", m.inputs[2].View())
+		if m.batchFilePath != "" && m.batchFilePath != strings.TrimSpace(m.inputs[2].Value()) {
+			batchDetail = fmt.Sprintf("Source: %s\nPath: %s", m.batchFilePath, m.inputs[2].View())
+		}
 		modal := components.ConfirmationModal{
 			Title:       "Batch Import",
 			Message:     fmt.Sprintf("Add %d downloads?", urlCount),
-			Detail:      fmt.Sprintf("%s\nPath: %s", m.batchFilePath, m.inputs[2].View()),
+			Detail:      batchDetail,
 			Keys:        m.keys.BatchConfirm,
 			Help:        m.help,
 			BorderColor: colors.Cyan(),

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -214,10 +214,13 @@ func (m RootModel) View() tea.View {
 
 	if m.state == BatchConfirmState {
 		urlCount := len(m.pendingBatchURLs)
+		if len(m.pendingBatchRequests) > 0 {
+			urlCount = len(m.pendingBatchRequests)
+		}
 		modal := components.ConfirmationModal{
 			Title:       "Batch Import",
 			Message:     fmt.Sprintf("Add %d downloads?", urlCount),
-			Detail:      m.batchFilePath,
+			Detail:      fmt.Sprintf("%s\nPath: %s", m.batchFilePath, m.inputs[2].View()),
 			Keys:        m.keys.BatchConfirm,
 			Help:        m.help,
 			BorderColor: colors.Cyan(),


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the core bug where concurrent `DownloadRequestMsg` events overwrote each other in the TUI, leaving only the last one in the confirmation queue. It also introduces a `/download/batch` HTTP endpoint and a `--confirm` CLI flag for grouped batch approval.

- **Core fix**: `handleDownloadRequestMsg` and `handleBatchDownloadRequestMsg` now enqueue incoming requests into `pendingRequestQueue` / `pendingBatchRequestQueue` when the TUI is already in a confirmation state; all exit paths (`cancel`, `confirm`, `focus`) call `showNextPendingRequest()` to drain the queue.
- **New batch endpoint**: `POST /download/batch` accepts a `BatchDownloadRequest` with either TUI-confirmation (`skip_approval=false`) or direct enqueue (`skip_approval=true`), with partial-failure reporting via `207 Multi-Status`.
- **New `--confirm` flag**: `surge add --batch file.txt --confirm` routes the batch through the new endpoint for a single grouped TUI confirmation instead of N individual prompts.

<h3>Confidence Score: 5/5</h3>

The fix is well-scoped and the new queuing logic is covered by targeted tests; the findings are non-blocking suggestions that do not affect the main fix.

The core overwrite bug is correctly addressed through a clean queue/drain pattern applied consistently to all confirmation exit paths. The new batch endpoint mirrors the existing single-download handler structure, including partial-failure handling and activeDownloads accounting. Tests cover the queuing state machine for both single and batch requests. The remaining gaps are low-consequence edge cases that do not affect the primary fix.

internal/tui/download_requests.go (queuing guard misses file-picker states) and cmd/utils.go (sendBatchToServer response handling)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/tui/download_requests.go | New file introducing queued dispatch for single and batch download requests; the queuing guard omits FilePickerState and BatchFilePickerState |
| cmd/root_downloads.go | Adds handleBatchDownload with per-item validation, partial-failure reporting, and correct activeDownloads accounting mirroring handleDownload |
| cmd/utils.go | Adds sendBatchToServer and sendToServerWithApproval; sendBatchToServer does not accept 207 Multi-Status as a success response |
| internal/tui/update_modals.go | Batch confirm now processes both pendingBatchRequests and pendingBatchURLs, calls showNextPendingRequest on all exit paths |
| internal/tui/update_filepicker.go | Sets inputs[2] to default download path on file selection; does not clear pendingBatchRequests before entering BatchConfirmState |
| cmd/http_api_test.go | Adds publishRecordingHTTPService, batchAddRecordingService, and two tests covering confirmation and partial-failure batch paths |
| cmd/add.go | Adds --confirm flag; batch+confirm goes through new batch endpoint, individual downloads use sendToServerWithApproval with skipApproval=!confirm |
| internal/engine/events/events.go | Adds BatchDownloadRequestMsg struct, EventTypeBatchRequest constant, and SSE encode/decode support |
| internal/tui/model.go | Adds pendingBatchRequests, pendingRequestQueue, and pendingBatchRequestQueue fields to RootModel |
| internal/tui/update_test.go | Adds queuing tests for both single and batch download request messages; good state-machine coverage |
| internal/tui/view.go | BatchConfirmState view now distinguishes source file from output path; shows shared path when batchFilePath matches inputs[2] |
| internal/tui/keys.go | Batch confirm keys changed from y/n/enter/esc to enter/esc only |
| internal/tui/update_events.go | DownloadRequestMsg and BatchDownloadRequestMsg handling delegated to new handler functions; logic moved cleanly |
| cmd/http_api.go | Registers /download/batch route consistently with existing /download route pattern |
| internal/tui/update_input.go | Extension confirmation now calls showNextPendingRequest on both confirm and cancel paths |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
internal/tui/download_requests.go:61-62
The queuing guard doesn't include `FilePickerState` or `BatchFilePickerState`. If a `BatchDownloadRequestMsg` arrives while the user is actively navigating either file picker, it immediately transitions state to `BatchConfirmState`, abandoning the in-progress selection. For `DownloadRequestMsg` a missed guard during the file picker is relatively benign (the download just starts silently), but a batch message is always modal — it always replaces the visible state — making the interruption visible and disruptive.

```suggestion
func (m RootModel) handleBatchDownloadRequestMsg(msg events.BatchDownloadRequestMsg, queueIfBusy bool) (tea.Model, tea.Cmd) {
	if queueIfBusy && (m.state == ExtensionConfirmationState || m.state == DuplicateWarningState || m.state == BatchConfirmState || m.state == FilePickerState || m.state == BatchFilePickerState) {
```

### Issue 2 of 3
internal/tui/update_filepicker.go:17-19
`handleBatchFileSelection` doesn't clear `m.pendingBatchRequests` before entering `BatchConfirmState`. If a `BatchDownloadRequestMsg` arrived just before the user confirmed a file selection (possible while `FilePickerState` / `BatchFilePickerState` are not yet in the queuing guard), both `pendingBatchURLs` and `pendingBatchRequests` would be non-nil simultaneously, causing `updateBatchConfirm` to process both batches and `view.go` to report the wrong URL count.

```suggestion
	m.pendingBatchURLs = urls
	m.pendingBatchRequests = nil
	m.inputs[2].SetValue(m.defaultDownloadPath())
	m.batchFilePath = path
```

### Issue 3 of 3
cmd/utils.go:256-264
`sendBatchToServer` only accepts `200 OK` or `202 Accepted` as success. When `skipApproval=true` and some items fail, the server returns `207 Multi-Status`, which this code treats as an error — even though downloads were partially queued. The function already accepts a `skipApproval bool` parameter, so any caller that passes `true` would incorrectly surface a failure despite real work being done.

```suggestion
	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusMultiStatus {
		body, _ := io.ReadAll(resp.Body)
		return fmt.Errorf("server error: %s - %s", resp.Status, string(body))
	}

	return nil
}

// GetRemoteDownloads fetches all downloads from the running server
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: addressed greptile concerns"](https://github.com/surgedm/surge/commit/a72e69d03ad0fe2123da0d54460ed9093d8660b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35053936)</sub>

<!-- /greptile_comment -->