### PR TITLE
fix(cli): don't split a single URL into mirrors on query-string commas (#316)

### DIFF
--- a/cmd/mirrors_integration_test.go
+++ b/cmd/mirrors_integration_test.go
@@ -122,6 +122,12 @@ func TestParseURLArg_Unit(t *testing.T) {
 			expectedMirrors: []string{"https://archive.org/compress/item/formats=PNG,LOG", "http://mirror.example.com/item.zip"},
 		},
 		{
+			name:            "Bare scheme in query is not a mirror boundary",
+			input:           "https://primary.com/file?a=1,http:,http://mirror.example.com/file",
+			expectedURL:     "https://primary.com/file?a=1,http:",
+			expectedMirrors: []string{"https://primary.com/file?a=1,http:", "http://mirror.example.com/file"},
+		},
+		{
 			name:            "Empty URL",
 			input:           "",
 			expectedURL:     "",

--- a/cmd/mirrors_integration_test.go
+++ b/cmd/mirrors_integration_test.go
@@ -110,6 +110,18 @@ func TestParseURLArg_Unit(t *testing.T) {
 			expectedMirrors: []string{"http://a.com", "http://b.com"},
 		},
 		{
+			name:            "Single URL with commas in query string (archive.org formats)",
+			input:           "https://archive.org/compress/item/formats=PNG,ITEM TILE,LOG,ISO IMAGE",
+			expectedURL:     "https://archive.org/compress/item/formats=PNG,ITEM TILE,LOG,ISO IMAGE",
+			expectedMirrors: []string{"https://archive.org/compress/item/formats=PNG,ITEM TILE,LOG,ISO IMAGE"},
+		},
+		{
+			name:            "Query-comma URL followed by a real mirror",
+			input:           "https://archive.org/compress/item/formats=PNG,LOG,http://mirror.example.com/item.zip",
+			expectedURL:     "https://archive.org/compress/item/formats=PNG,LOG",
+			expectedMirrors: []string{"https://archive.org/compress/item/formats=PNG,LOG", "http://mirror.example.com/item.zip"},
+		},
+		{
 			name:            "Empty URL",
 			input:           "",
 			expectedURL:     "",

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -86,14 +86,33 @@ func ParseURLArg(arg string) (string, []string) {
 	parts := strings.Split(arg, ",")
 	var urls []string
 	for _, p := range parts {
-		if trimmed := strings.TrimSpace(p); trimmed != "" {
-			urls = append(urls, trimmed)
+		trimmed := strings.TrimSpace(p)
+		if trimmed == "" {
+			continue
 		}
+		// Only an http(s) URL starts a new mirror. A segment without a
+		// scheme means the comma lived inside the previous URL (e.g. the
+		// "formats=PNG,ITEM TILE,LOG" query in an archive.org compress link),
+		// so glue it back instead of treating it as a separate mirror.
+		if len(urls) > 0 && !startsNewMirror(trimmed) {
+			urls[len(urls)-1] += "," + trimmed
+			continue
+		}
+		urls = append(urls, trimmed)
 	}
 	if len(urls) == 0 {
 		return "", nil
 	}
 	return urls[0], urls
+}
+
+// startsNewMirror reports whether a comma-separated segment begins a new
+// mirror rather than continuing the previous URL. Only http(s) URLs are
+// downloadable, so a segment is a mirror boundary only when it parses as an
+// absolute http or https URL.
+func startsNewMirror(segment string) bool {
+	u, err := url.Parse(segment)
+	return err == nil && (u.Scheme == "http" || u.Scheme == "https")
 }
 
 func resolveLocalToken() string {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -108,11 +108,13 @@ func ParseURLArg(arg string) (string, []string) {
 
 // startsNewMirror reports whether a comma-separated segment begins a new
 // mirror rather than continuing the previous URL. Only http(s) URLs are
-// downloadable, so a segment is a mirror boundary only when it parses as an
-// absolute http or https URL.
+// downloadable, so a segment is a mirror boundary only when it starts with the
+// http:// or https:// prefix. Matching the literal prefix (rather than a
+// non-empty url.Parse scheme) keeps bare-scheme query values like "http:" glued
+// to the previous URL, and matches how the rest of the CLI recognizes URLs
+// (internal/clipboard/validator.go).
 func startsNewMirror(segment string) bool {
-	u, err := url.Parse(segment)
-	return err == nil && (u.Scheme == "http" || u.Scheme == "https")
+	return strings.HasPrefix(segment, "http://") || strings.HasPrefix(segment, "https://")
 }
 
 func resolveLocalToken() string {


### PR DESCRIPTION
Fixes #316.

`surge` mangles any URL that has commas in its query string. archive.org "compress" links are the case in the issue:

```
surge "https://archive.org/compress/<item>/formats=PNG,ITEM TILE,LOG,ISO IMAGE"
```

`ParseURLArg` splits the argument on every comma to support comma-separated mirrors, so that one URL gets cut into `.../formats=PNG` plus three junk "mirrors" (`ITEM TILE`, `LOG`, `ISO IMAGE`). only the first fragment downloads - a tiny stub instead of the archive. aria2c handles the same link fine.

## the fix

a comma only starts a new mirror when the next segment parses as an absolute http(s) URL. otherwise the comma lived inside the previous URL, so it gets glued back. surge only downloads http/https (`internal/clipboard/validator.go`, `cmd/connect.go`), so a schemeless segment is never a standalone mirror.

genuine mirror lists are unaffected, since every real mirror is a full URL:

```
surge "http://a.com/file,http://b.com/file,http://c.com/file"   # still 3 mirrors
```

## tests

extended `TestParseURLArg_Unit` in `cmd/mirrors_integration_test.go`:

- the archive.org link stays one URL
- a query-comma URL followed by a real mirror splits into exactly those two

red before the change (the archive case shredded into 4 mirrors), green after. the existing cases and `TestMirrors_CLI_Integration` are unchanged. `go test ./...`, `go build ./...`, `go vet`, and golangci-lint v2 are all clean.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes query-string commas being misinterpreted as mirror separators in `ParseURLArg`. It replaces the naive split-on-every-comma approach with a `startsNewMirror` helper that only opens a new mirror slot when a segment starts with the literal `http://` or `https://` prefix.

- `cmd/utils.go`: Introduces `startsNewMirror` and updates `ParseURLArg` to glue non-http segments back to the preceding URL rather than treating them as standalone mirrors.
- `cmd/mirrors_integration_test.go`: Adds three new table-driven test cases — the archive.org formats link, a mixed query-comma-plus-real-mirror input, and the bare-scheme (`http:`) edge case — all of which were red before this fix.

<h3>Confidence Score: 5/5</h3>

This is a small, self-contained fix to a parsing function with no side effects on download logic; genuine multi-mirror inputs are unaffected, and the new tests confirm both the happy path and the tricky edge cases.

The change is minimal and surgical: a two-line helper and a guard in one loop. The fix uses a `strings.HasPrefix` check rather than `url.Parse`, correctly handling the bare-scheme edge case raised in the previous review. All pre-existing test cases remain green, and the three new cases directly cover the bug scenario from the issue report as well as the boundary cases.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cmd/utils.go | Adds `startsNewMirror` helper and reworks the comma-split loop in `ParseURLArg` so that only segments starting with `http://` or `https://` open a new mirror slot; all other segments are glued back to the preceding URL. |
| cmd/mirrors_integration_test.go | Extends `TestParseURLArg_Unit` with three new table cases: query-string-only URL, query-comma URL mixed with a real mirror, and bare-scheme segment gluing — all covering the edge cases raised in the original issue and the previous review thread. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(cli): match the http(s):// prefix in..."](https://github.com/surgedm/surge/commit/d1bb68aa311bff0ce683837d765dec947dc7b061) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36750195)</sub>

<!-- /greptile_comment -->