### PR TITLE
ci: add data race detector test for go

### DIFF
--- a/.github/workflows/core-build.yml
+++ b/.github/workflows/core-build.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -52,13 +53,29 @@ jobs:
             cover_arg="-- -coverprofile=coverage.out"
           fi
           gotestsum --junitfile test-results.xml --format testdox $cover_arg ./...
-      - name: Upload Test Results
-        uses: actions/upload-artifact@v4
-        if: always()
+      - name: Comment Test Failures
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
         with:
-          name: test-results-${{ matrix.os }}
-          path: test-results.xml
-          retention-days: 7
+          script: |
+            const fs = require('fs');
+            if (!fs.existsSync('test-results.xml')) return;
+            const content = fs.readFileSync('test-results.xml', 'utf8');
+            const regex = /<testcase classname="([^"]+)" name="([^"]+)"[^>]*>\s*<(?:failure|error)/g;
+            let match;
+            const failures = [];
+            while ((match = regex.exec(content)) !== null) {
+              failures.push(`- **${match[1]}**: \`${match[2]}\``);
+            }
+            if (failures.length > 0) {
+              const body = `### ❌ Test Failures on \`${{ matrix.os }}\`\n` + failures.join('\n');
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: body
+              });
+            }
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         if: matrix.os == 'ubuntu-latest' && success() && hashFiles('coverage.out') != ''

--- a/.github/workflows/core-build.yml
+++ b/.github/workflows/core-build.yml
@@ -66,12 +66,17 @@ jobs:
             }
             if (failures.length > 0) {
               const body = `### ❌ Test Failures on \`${{ matrix.os }}\`\n` + failures.join('\n');
-              await github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: body
-              });
+              try {
+                await github.rest.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: body
+                });
+              } catch (err) {
+                // Fork PRs have a read-only token; log but don't fail the step.
+                core.warning(`Could not post comment (fork PR?): ${err.message}`);
+              }
             }
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/core-build.yml
+++ b/.github/workflows/core-build.yml
@@ -47,9 +47,9 @@ jobs:
         run: |
           cover_arg=""
           if [ "$RUNNER_OS" = "Linux" ]; then
-            cover_arg="-- -coverprofile=coverage.out -race"
+            cover_arg="-coverprofile=coverage.out"
           fi
-          gotestsum --junitfile test-results.xml --format testdox $cover_arg ./...
+          gotestsum --junitfile test-results.xml --format testdox -- -race $cover_arg ./...
       - name: Comment Test Failures
         if: failure() && github.event_name == 'pull_request'
         uses: actions/github-script@v7

--- a/.github/workflows/core-build.yml
+++ b/.github/workflows/core-build.yml
@@ -41,16 +41,13 @@ jobs:
       - name: Build
         shell: bash
         run: go build -v ./...
-      - name: Test with Race Detector
-        if: matrix.os == 'ubuntu-latest'
-        shell: bash
-        run: go test -race -v ./...
+
       - name: Test
         shell: bash
         run: |
           cover_arg=""
           if [ "$RUNNER_OS" = "Linux" ]; then
-            cover_arg="-- -coverprofile=coverage.out"
+            cover_arg="-- -coverprofile=coverage.out -race"
           fi
           gotestsum --junitfile test-results.xml --format testdox $cover_arg ./...
       - name: Comment Test Failures

--- a/.github/workflows/core-build.yml
+++ b/.github/workflows/core-build.yml
@@ -40,6 +40,10 @@ jobs:
       - name: Build
         shell: bash
         run: go build -v ./...
+      - name: Test with Race Detector
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: go test -race -v ./...
       - name: Test
         shell: bash
         run: |

--- a/cmd/autoresume_test.go
+++ b/cmd/autoresume_test.go
@@ -102,6 +102,8 @@ func TestCmd_AutoResume_Execution(t *testing.T) {
 	}
 	defer func() {
 		_ = GlobalService.Shutdown()
+		GlobalService = nil
+		GlobalPool = nil
 		GlobalLifecycle = nil
 	}()
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -209,6 +209,12 @@ func takeLifecycleCleanup() func() {
 	return cleanup
 }
 
+func setLifecycleCleanupForTest(fn func()) {
+	globalLifecycleMu.Lock()
+	GlobalLifecycleCleanup = fn
+	globalLifecycleMu.Unlock()
+}
+
 func currentPoolConfigs() []types.DownloadConfig {
 	if GlobalPool == nil {
 		return nil

--- a/cmd/root_headless.go
+++ b/cmd/root_headless.go
@@ -5,17 +5,18 @@ import (
 	"fmt"
 	"sync/atomic"
 
+	"github.com/SurgeDM/Surge/internal/core"
 	"github.com/SurgeDM/Surge/internal/engine/events"
 	"github.com/SurgeDM/Surge/internal/utils"
 )
 
 // StartHeadlessConsumer starts a goroutine to consume progress messages and log to stdout
-func StartHeadlessConsumer() {
+func StartHeadlessConsumer(service core.DownloadService) {
 	go func() {
-		if GlobalService == nil {
+		if service == nil {
 			return
 		}
-		stream, cleanup, err := GlobalService.StreamEvents(context.Background())
+		stream, cleanup, err := service.StreamEvents(context.Background())
 		if err != nil {
 			utils.Debug("Failed to start event stream: %v", err)
 			return

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -197,7 +197,7 @@ func startServerLogic(cmd *cobra.Command, args []string, portFlag int, batchFile
 	fmt.Printf("Serving on %s:%d\n", host, port)
 	fmt.Println("Press Ctrl+C to exit.")
 
-	StartHeadlessConsumer()
+	StartHeadlessConsumer(GlobalService)
 
 	// Auto-resume paused downloads (unless --no-resume)
 	if !noResume {

--- a/cmd/shutdown_test.go
+++ b/cmd/shutdown_test.go
@@ -62,9 +62,9 @@ func TestDefaultGlobalShutdown_ShutdownBeforeCleanup(t *testing.T) {
 			order = append(order, "shutdown")
 		},
 	}
-	GlobalLifecycleCleanup = func() {
+	setLifecycleCleanupForTest(func() {
 		order = append(order, "cleanup")
-	}
+	})
 	t.Cleanup(func() {
 		GlobalService = nil
 		GlobalLifecycle = nil

--- a/cmd/startup_test.go
+++ b/cmd/startup_test.go
@@ -57,6 +57,11 @@ func TestServer_Startup_HandlesResume(t *testing.T) {
 		})
 	}
 	defer func() {
+		if GlobalService != nil {
+			_ = GlobalService.Shutdown()
+		}
+		GlobalService = nil
+		GlobalPool = nil
 		GlobalLifecycle = nil
 	}()
 

--- a/internal/core/local_service.go
+++ b/internal/core/local_service.go
@@ -67,7 +67,8 @@ type LocalDownloadService struct {
 	settings   *config.Settings
 	settingsMu sync.RWMutex
 
-	lifecycleHooks LifecycleHooks
+	lifecycleHooks   LifecycleHooks
+	lifecycleHooksMu sync.RWMutex
 }
 
 // LifecycleHooks routes service-level management calls through the LifecycleManager.
@@ -523,24 +524,33 @@ func (s *LocalDownloadService) add(url string, path string, filename string, mir
 
 // Pause pauses an active download.
 func (s *LocalDownloadService) Pause(id string) error {
-	if s.lifecycleHooks.Pause != nil {
-		return s.lifecycleHooks.Pause(id)
+	s.lifecycleHooksMu.RLock()
+	fn := s.lifecycleHooks.Pause
+	s.lifecycleHooksMu.RUnlock()
+	if fn != nil {
+		return fn(id)
 	}
 	return fmt.Errorf("PauseFunc not initialized")
 }
 
 // Resume resumes a paused download.
 func (s *LocalDownloadService) Resume(id string) error {
-	if s.lifecycleHooks.Resume != nil {
-		return s.lifecycleHooks.Resume(id)
+	s.lifecycleHooksMu.RLock()
+	fn := s.lifecycleHooks.Resume
+	s.lifecycleHooksMu.RUnlock()
+	if fn != nil {
+		return fn(id)
 	}
 	return fmt.Errorf("ResumeFunc not initialized")
 }
 
 // ResumeBatch resumes multiple paused downloads efficiently.
 func (s *LocalDownloadService) ResumeBatch(ids []string) []error {
-	if s.lifecycleHooks.ResumeBatch != nil {
-		return s.lifecycleHooks.ResumeBatch(ids)
+	s.lifecycleHooksMu.RLock()
+	fn := s.lifecycleHooks.ResumeBatch
+	s.lifecycleHooksMu.RUnlock()
+	if fn != nil {
+		return fn(ids)
 	}
 	errs := make([]error, len(ids))
 	for i := range errs {
@@ -552,13 +562,18 @@ func (s *LocalDownloadService) ResumeBatch(ids []string) []error {
 // SetLifecycleHooks wires the processing layer into the service so
 // pause/resume/cancel/updateURL calls are routed through the lifecycle manager.
 func (s *LocalDownloadService) SetLifecycleHooks(hooks LifecycleHooks) {
+	s.lifecycleHooksMu.Lock()
 	s.lifecycleHooks = hooks
+	s.lifecycleHooksMu.Unlock()
 }
 
 // UpdateURL updates the URL of a paused or errored download
 func (s *LocalDownloadService) UpdateURL(id string, newURL string) error {
-	if s.lifecycleHooks.UpdateURL != nil {
-		return s.lifecycleHooks.UpdateURL(id, newURL)
+	s.lifecycleHooksMu.RLock()
+	fn := s.lifecycleHooks.UpdateURL
+	s.lifecycleHooksMu.RUnlock()
+	if fn != nil {
+		return fn(id, newURL)
 	}
 	// Fallback: update pool in-memory only (no DB persistence)
 	if s.Pool == nil {
@@ -569,8 +584,11 @@ func (s *LocalDownloadService) UpdateURL(id string, newURL string) error {
 
 // Delete cancels and removes a download.
 func (s *LocalDownloadService) Delete(id string) error {
-	if s.lifecycleHooks.Cancel != nil {
-		return s.lifecycleHooks.Cancel(id)
+	s.lifecycleHooksMu.RLock()
+	fn := s.lifecycleHooks.Cancel
+	s.lifecycleHooksMu.RUnlock()
+	if fn != nil {
+		return fn(id)
 	}
 	// Fallback when lifecycle hooks not wired (e.g. tests)
 	if s.Pool == nil {

--- a/internal/download/manager.go
+++ b/internal/download/manager.go
@@ -191,7 +191,6 @@ func TUIDownload(ctx context.Context, cfg *types.DownloadConfig) error {
 		// Pass effectiveTotalSize to avoid unnecessary bootstrap if state already knows the size
 		downloadErr = d.Download(ctx, cfg.URL, mirrors, activeMirrors, finalDestPath, effectiveTotalSize)
 		if d.TotalSize > 0 {
-			cfg.TotalSize = d.TotalSize
 			effectiveTotalSize = d.TotalSize
 		}
 
@@ -221,7 +220,6 @@ func TUIDownload(ctx context.Context, cfg *types.DownloadConfig) error {
 		// Pass effectiveTotalSize here as well
 		downloadErr = d.Download(ctx, cfg.URL, finalDestPath, effectiveTotalSize, finalFilename)
 		if d.TotalSize > 0 {
-			cfg.TotalSize = d.TotalSize
 			effectiveTotalSize = d.TotalSize
 		}
 	}

--- a/internal/download/manager_test.go
+++ b/internal/download/manager_test.go
@@ -235,11 +235,9 @@ func TestTUIDownload_ConcurrentBootstrapWithoutProbeMetadata(t *testing.T) {
 	if err := TUIDownload(context.Background(), &cfg); err != nil {
 		t.Fatalf("TUIDownload failed: %v", err)
 	}
-	if cfg.TotalSize != fileSize {
-		t.Fatalf("cfg.TotalSize = %d, want %d", cfg.TotalSize, fileSize)
-	}
-	if got := cfg.State.TotalSize; got != fileSize {
-		t.Fatalf("state total size = %d, want %d", got, fileSize)
+	_, stateTotal, _, _, _, _ := cfg.State.GetProgress()
+	if stateTotal != fileSize {
+		t.Fatalf("state total size = %d, want %d", stateTotal, fileSize)
 	}
 
 	foundComplete := false
@@ -305,8 +303,9 @@ func TestTUIDownload_OptimisticConcurrentFallsBackToSingle(t *testing.T) {
 	if string(got) != string(content) {
 		t.Fatalf("downloaded content = %q, want %q", string(got), string(content))
 	}
-	if cfg.TotalSize != int64(len(content)) {
-		t.Fatalf("cfg.TotalSize = %d, want %d", cfg.TotalSize, len(content))
+	_, stateTotal, _, _, _, _ := cfg.State.GetProgress()
+	if stateTotal != int64(len(content)) {
+		t.Fatalf("state total size = %d, want %d", stateTotal, len(content))
 	}
 
 	foundComplete := false

--- a/internal/download/pool.go
+++ b/internal/download/pool.go
@@ -81,6 +81,9 @@ func syncConfigFromState(cfg *types.DownloadConfig) {
 		}
 		cfg.Mirrors = urls
 	}
+	if _, totalSize, _, _, _, _ := cfg.State.GetProgress(); totalSize > 0 {
+		cfg.TotalSize = totalSize
+	}
 }
 
 // resolveDestPath resolves the destination path consistently from config, state, and output bounds.
@@ -106,6 +109,7 @@ func (p *WorkerPool) Add(cfg types.DownloadConfig) {
 	}
 	p.mu.Lock()
 	p.queued[cfg.ID] = cfg
+	p.wg.Add(1)
 	p.mu.Unlock()
 
 	p.taskChan <- cfg
@@ -334,10 +338,10 @@ func (p *WorkerPool) worker() {
 		p.mu.RUnlock()
 		if !stillQueued {
 			// Canceled while waiting in queue.
+			p.wg.Done()
 			continue
 		}
 
-		p.wg.Add(1)
 		// Create cancellable context
 		ctx, cancel := context.WithCancel(context.Background())
 
@@ -500,6 +504,7 @@ drainLoop:
 	for {
 		select {
 		case <-p.taskChan:
+			p.wg.Done()
 		default:
 			break drainLoop
 		}

--- a/internal/download/pool.go
+++ b/internal/download/pool.go
@@ -345,6 +345,11 @@ func (p *WorkerPool) worker() {
 		// Create cancellable context
 		ctx, cancel := context.WithCancel(context.Background())
 
+		// Ensure Runtime is initialized before exposing to GetAll
+		if cfg.Runtime == nil {
+			cfg.Runtime = types.DefaultRuntimeConfig()
+		}
+
 		// Register active download
 		ad := &activeDownload{
 			config: cfg,

--- a/internal/download/pool_test.go
+++ b/internal/download/pool_test.go
@@ -970,9 +970,9 @@ func TestWorkerPool_GracefulShutdown_DrainsTaskChan(t *testing.T) {
 		maxDownloads: 0,
 	}
 
-	// Write items directly to taskChan (simulating Add() with no worker to consume).
+	// Use Add() to ensure WaitGroup accounting is correct.
 	for i := 0; i < 5; i++ {
-		pool.taskChan <- types.DownloadConfig{ID: fmt.Sprintf("buffered-%d", i)}
+		pool.Add(types.DownloadConfig{ID: fmt.Sprintf("buffered-%d", i)})
 	}
 	if len(pool.taskChan) != 5 {
 		t.Fatalf("pre-condition: expected 5 items in taskChan, got %d", len(pool.taskChan))
@@ -1008,13 +1008,9 @@ func TestWorkerPool_GracefulShutdown_WorkerSkipsQueuedAfterShutdown(t *testing.T
 	// Single worker, small taskChan.
 	pool := NewWorkerPool(ch, 1)
 
-	// Manually insert into queued + taskChan without a real probe/download,
-	// then immediately shut down before the worker gets to process it.
+	// Add via public API to ensure correct internal state (WaitGroup, queued map).
 	id := "skip-me"
-	pool.mu.Lock()
-	pool.queued[id] = types.DownloadConfig{ID: id}
-	pool.mu.Unlock()
-	pool.taskChan <- types.DownloadConfig{ID: id}
+	pool.Add(types.DownloadConfig{ID: id})
 
 	// Shutdown should drain the queue and close taskChan.
 	done := make(chan struct{})


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR integrates the Go race detector (`-race`) directly into the `gotestsum` test invocation and fixes several underlying data races that the detector exposed across the download pool, lifecycle hooks, and headless consumer.

- **Workflow**: Folds `-race` into the single `gotestsum` call (removing the now-redundant separate step), adds a PR comment on test failure with fork-safe error handling, and restores correct `cover_arg` formatting.
- **Race fixes in Go code**: Moves `p.wg.Add(1)` to `WorkerPool.Add()` with matching `wg.Done()` in the drain loop and canceled-item path; adds `lifecycleHooksMu` to `LocalDownloadService` for safe concurrent hook access; removes the racy `cfg.TotalSize = d.TotalSize` write from `TUIDownload` in favour of reading from `State`; and passes `GlobalService` explicitly to `StartHeadlessConsumer` instead of reading the global inside a goroutine.
- **Test hygiene**: Tests now call `Shutdown()` and nil out shared globals in defers, and use the new `setLifecycleCleanupForTest` helper to set `GlobalLifecycleCleanup` under its mutex.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all Go-level race fixes are correct and well-tested.

The race fixes (WaitGroup accounting, lifecycle hooks mutex, TotalSize write removal, headless consumer parameter) are all logically sound and the tests exercise the corrected code paths. The only trade-off is the removal of the Upload Test Results artifact, which reduces CI observability for push-to-main runs but does not affect correctness.

.github/workflows/core-build.yml — the artifact upload removal is worth a second look if CI observability on direct pushes to main matters to the team.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/core-build.yml | Integrates -race into gotestsum invocation, replaces artifact upload with PR comment on failure, handles fork PRs gracefully — test XML artifact is no longer retained. |
| internal/download/pool.go | Moves wg.Add(1) from worker goroutine to Add(), adds matching wg.Done() in drain loop and canceled-item path, and initializes Runtime before registering active download — WaitGroup accounting is now correct for queued-but-not-started items. |
| internal/core/local_service.go | Adds lifecycleHooksMu RWMutex to protect concurrent reads/writes of lifecycleHooks; all five hook accessors now copy the function pointer under the read lock before calling it. |
| internal/download/manager.go | Removes cfg.TotalSize = d.TotalSize writes from TUIDownload, eliminating data races on the shared DownloadConfig pointer; TotalSize is now sourced exclusively from State via syncConfigFromState. |
| cmd/root_headless.go | StartHeadlessConsumer now takes an explicit core.DownloadService parameter instead of reading GlobalService inside the goroutine, preventing data races in concurrent tests. |
| cmd/root.go | Adds setLifecycleCleanupForTest helper to set GlobalLifecycleCleanup under its mutex, replacing direct global assignment in tests. |
| cmd/startup_test.go | Adds proper GlobalService.Shutdown() and nil-out of GlobalService/GlobalPool in cleanup defer, preventing state leakage between tests. |
| cmd/shutdown_test.go | Uses setLifecycleCleanupForTest() instead of direct GlobalLifecycleCleanup assignment to make the write race-safe. |
| cmd/autoresume_test.go | Adds GlobalService = nil and GlobalPool = nil in cleanup defer alongside GlobalLifecycle = nil to fully reset shared state after each test. |
| cmd/server.go | Passes GlobalService explicitly to StartHeadlessConsumer to match the updated function signature. |
| internal/download/pool_test.go | GracefulShutdown drain tests updated to use pool.Add() with a properly initialized queued map so WaitGroup accounting is exercised correctly by the tests. |
| internal/download/manager_test.go | Updated assertions to check State.GetProgress() rather than cfg.TotalSize, matching the removal of the cfg.TotalSize write in manager.go. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/core-build.yml`, line 43-54 ([link](https://github.com/surgedm/surge/blob/5153e8806a257d0e850178d009b1346e448becb9/.github/workflows/core-build.yml#L43-L54)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Duplicate test execution on Ubuntu**

   The new "Test with Race Detector" step runs `go test -race -v ./...` on `ubuntu-latest`, and immediately after, the existing "Test" step also runs the full test suite via `gotestsum` (with no `-race` flag). On Ubuntu, every test runs twice, doubling CI time for that platform. A cleaner approach is to fold the `-race` flag into the existing `gotestsum` invocation conditionally, e.g. by building a `race_arg` variable alongside `cover_arg` and passing it as part of the `-- [go test flags]` section. This keeps a single test pass per platform, preserves JUnit XML output for race failures, and avoids drift between two parallel invocations.

   **Rule Used:** What: Eliminate duplicate logic, functions, or cod... ([source](https://app.greptile.com/surge-org-3/-/custom-context?memory=f0a796a9-684f-4dfb-a5cf-8c99c16b63a1))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/core-build.yml
   Line: 43-54
   
   Comment:
   **Duplicate test execution on Ubuntu**
   
   The new "Test with Race Detector" step runs `go test -race -v ./...` on `ubuntu-latest`, and immediately after, the existing "Test" step also runs the full test suite via `gotestsum` (with no `-race` flag). On Ubuntu, every test runs twice, doubling CI time for that platform. A cleaner approach is to fold the `-race` flag into the existing `gotestsum` invocation conditionally, e.g. by building a `race_arg` variable alongside `cover_arg` and passing it as part of the `-- [go test flags]` section. This keeps a single test pass per platform, preserves JUnit XML output for race failures, and avoids drift between two parallel invocations.
   
   **Rule Used:** What: Eliminate duplicate logic, functions, or cod... ([source](https://app.greptile.com/surge-org-3/-/custom-context?memory=f0a796a9-684f-4dfb-a5cf-8c99c16b63a1))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (7): Last reviewed commit: ["test: fix remaining data races in pool a..."](https://github.com/surgedm/surge/commit/4b6d8f393592ea9ced3c806b8711a4aa814f6da1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37155547)</sub>

<!-- /greptile_comment -->