### PR TITLE
fix: make keymap parsing case-insensitive and add open folder binding

### DIFF
--- a/internal/config/keymaps.go
+++ b/internal/config/keymaps.go
@@ -51,6 +51,7 @@ type DashboardKeyMap struct {
 	ToggleHelp     key.Binding
 	ReportBug      key.Binding
 	OpenFile       key.Binding
+	OpenFolder     key.Binding
 	Quit           key.Binding
 	ForceQuit      key.Binding
 	CategoryFilter key.Binding
@@ -199,10 +200,13 @@ func GetKeyMapConfigPath() string {
 func LoadKeyMap() (*KeyMap, error) {
 	defaults := DefaultKeyMap()
 	path := GetKeyMapConfigPath()
+	utils.Debug("Loading keymap from %s", path)
 	data, err := os.ReadFile(path)
 	if err != nil {
+		utils.Debug("Failed to read keymap file: %v", err)
 		if os.IsNotExist(err) {
 			utils.Debug("Warning: Created New %s file \u2014 using defaults", path)
+			defaults.StartupWarnings = append(defaults.StartupWarnings, "Config: created new keymap file "+path)
 			_ = SaveKeyMap(defaults)
 			return defaults, nil
 		}
@@ -225,6 +229,7 @@ func LoadKeyMap() (*KeyMap, error) {
 	// ONLY if it differs from what was on disk to avoid constant disk thrashing.
 	mergedData, _ := json.MarshalIndent(defaults.ToConfig(), "", "  ")
 	if string(data) != string(mergedData) {
+		defaults.StartupWarnings = append(defaults.StartupWarnings, "Config: keymap file was updated to include missing keys or fix formatting")
 		_ = SaveKeyMap(defaults)
 	}
 
@@ -243,13 +248,19 @@ func (k *KeyMap) ApplyConfig(cfg *KeyMapConfig) {
 	}
 
 	applyToStruct := func(s any, m map[string]KeyBindingConfig) {
+		ciMap := make(map[string]KeyBindingConfig)
+		for k, vCfg := range m {
+			ciMap[strings.ToLower(k)] = vCfg
+		}
+
 		v := reflect.ValueOf(s).Elem()
 		t := v.Type()
 		for i := 0; i < v.NumField(); i++ {
 			field := v.Field(i)
 			if field.Type() == reflect.TypeFor[key.Binding]() {
-				fieldName := t.Field(i).Name
-				if bCfg, ok := m[fieldName]; ok {
+				fieldName := strings.ToLower(t.Field(i).Name)
+				if bCfg, ok := ciMap[fieldName]; ok {
+					utils.Debug("Applying custom keybinding for %s.%s", t.Name(), t.Field(i).Name)
 					if len(bCfg.Keys) > 0 {
 						helpDesc := bCfg.Help
 						if helpDesc == "" {
@@ -433,6 +444,10 @@ func DefaultKeyMap() *KeyMap {
 			OpenFile: key.NewBinding(
 				key.WithKeys("o"),
 				key.WithHelp("o", "open file"),
+			),
+			OpenFolder: key.NewBinding(
+				key.WithKeys("O"),
+				key.WithHelp("O", "open folder"),
 			),
 			Quit: key.NewBinding(
 				key.WithKeys("ctrl+c", "ctrl+q"),
@@ -719,7 +734,7 @@ func (k DashboardKeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.TabQueued, k.TabActive, k.TabDone, k.NextTab, k.PrevTab},
 		{k.Add, k.BatchImport, k.Search, k.CategoryFilter, k.Pause, k.Refresh, k.Delete, k.PurgeFile, k.Settings, k.PinTab},
-		{k.Log, k.OpenFile, k.ReportBug, k.Quit},
+		{k.Log, k.OpenFile, k.OpenFolder, k.ReportBug, k.Quit},
 	}
 }
 

--- a/internal/config/keymaps_test.go
+++ b/internal/config/keymaps_test.go
@@ -16,6 +16,25 @@ func TestDefaultKeyMap(t *testing.T) {
 	if len(km.Dashboard.Quit.Keys()) == 0 {
 		t.Error("Default Dashboard.Quit keys should not be empty")
 	}
+
+	// Verify OpenFolder default binding
+	if len(km.Dashboard.OpenFolder.Keys()) == 0 || km.Dashboard.OpenFolder.Keys()[0] != "O" {
+		t.Errorf("Default Dashboard.OpenFolder should have key 'O', got %v", km.Dashboard.OpenFolder.Keys())
+	}
+
+	// Verify OpenFolder is in FullHelp
+	foundOpenFolder := false
+	for _, row := range km.Dashboard.FullHelp() {
+		for _, b := range row {
+			if b.Help().Desc == "open folder" {
+				foundOpenFolder = true
+				break
+			}
+		}
+	}
+	if !foundOpenFolder {
+		t.Error("Dashboard.OpenFolder missing from FullHelp")
+	}
 }
 
 func TestKeyMapConversion(t *testing.T) {
@@ -33,18 +52,26 @@ func TestKeyMapConversion(t *testing.T) {
 
 	// Verify reflection-based conversion
 	km2 := DefaultKeyMap()
-	// Change a key in config
-	cfg.Dashboard["Quit"] = KeyBindingConfig{
+	
+	// Remove original exact-case key to test case-insensitive matching
+	delete(cfg.Dashboard, "Quit")
+	
+	// Change a key in config using mixed case
+	cfg.Dashboard["qUiT"] = KeyBindingConfig{
 		Keys: []string{"ctrl+x"},
 		Help: "exit",
 	}
+	// Case-collision testing
+	cfg.Dashboard["quit"] = KeyBindingConfig{
+		Keys: []string{"ctrl+z"},
+		Help: "exit alt",
+	}
+	
 	km2.ApplyConfig(cfg)
 
-	if km2.Dashboard.Quit.Keys()[0] != "ctrl+x" {
-		t.Errorf("Expected Quit key to be ctrl+x, got %v", km2.Dashboard.Quit.Keys())
-	}
-	if km2.Dashboard.Quit.Help().Desc != "exit" {
-		t.Errorf("Expected Quit help desc to be exit, got %s", km2.Dashboard.Quit.Help().Desc)
+	appliedKey := km2.Dashboard.Quit.Keys()[0]
+	if appliedKey != "ctrl+x" && appliedKey != "ctrl+z" {
+		t.Errorf("Expected Quit key to be ctrl+x or ctrl+z (from mixed-case configs), got %v", km2.Dashboard.Quit.Keys())
 	}
 }
 

--- a/internal/tui/update_dashboard.go
+++ b/internal/tui/update_dashboard.go
@@ -9,6 +9,7 @@ import (
 	"github.com/SurgeDM/Surge/internal/clipboard"
 	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/engine/types"
+	"github.com/SurgeDM/Surge/internal/utils"
 )
 
 func (m RootModel) updateDashboard(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
@@ -230,6 +231,20 @@ func (m RootModel) updateDashboard(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 					filePath = d.Destination + types.IncompleteSuffix
 				}
 				_ = openWithSystem(filePath)
+			}
+		}
+		return m, nil
+	}
+
+	// Open folder
+	if key.Matches(msg, m.keys.Dashboard.OpenFolder) {
+		if d := m.GetSelectedDownload(); d != nil {
+			if d.Destination != "" {
+				filePath := d.Destination
+				if !d.done {
+					filePath = d.Destination + types.IncompleteSuffix
+				}
+				_ = utils.OpenContainingFolder(filePath)
 			}
 		}
 		return m, nil


### PR DESCRIPTION
Closes #486. Makes the keymap JSON unmarshaling case-insensitive to correctly apply custom user keybindings, and adds the missing OpenFolder keybinding.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes custom user keybindings being silently ignored due to case-sensitive map lookups, and adds the missing `OpenFolder` binding to the dashboard. The fix is focused and correct — a `ciMap` pre-processes user-supplied keys to lowercase before matching against struct field names.

- **Case-insensitive keymap parsing** (`keymaps.go`): `ApplyConfig` now builds a lowercased copy of the incoming config map before reflecting over the struct fields, so user configs with any capitalisation (e.g. `"quit"`, `"QUIT"`) correctly apply.
- **OpenFolder binding** (`keymaps.go`, `update_dashboard.go`): Adds `DashboardKeyMap.OpenFolder` with default key `O`, registers it in `DefaultKeyMap` and `FullHelp`, and wires the key handler to open the containing folder of the selected download.
- **Tests** (`keymaps_test.go`): Covers the new default binding, its presence in `FullHelp`, and the case-insensitive matching path including a case-collision scenario.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is narrow and well-tested, and the only identified issue is a loop-variable naming nit that carries no runtime risk.

All three changed files make self-contained, well-reasoned edits. The case-insensitive lookup uses a straightforward lowercase copy rather than a fragile regex or custom parser. The OpenFolder handler mirrors the existing OpenFile pattern correctly. The only finding is a loop variable `k` that shadows the method receiver, which doesn't cause incorrect behaviour today but is worth cleaning up.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/config/keymaps.go | Adds OpenFolder binding, makes ApplyConfig case-insensitive via ciMap, adds debug logging and startup warnings. Loop variable `k` shadows the method receiver in the new ciMap construction loop. |
| internal/config/keymaps_test.go | Adds tests for OpenFolder default binding and FullHelp presence, and exercises case-insensitive + case-collision paths. The collision test accepts non-deterministic outcomes (either ctrl+x or ctrl+z). |
| internal/tui/update_dashboard.go | Adds OpenFolder key handler that opens the containing folder of the selected download's destination path; mirrors OpenFile structure without the done-guard, which is intentional for folder navigation. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(config): add coverage for case-inse..."](https://github.com/surgedm/surge/commit/d24f7ea72f43d38e70288677257c23b828d63946) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37556372)</sub>

<!-- /greptile_comment -->