### PR TITLE
ci: delete stale test failure comments and run on always

### DIFF
--- a/.github/workflows/core-binary-size-comment.yml
+++ b/.github/workflows/core-binary-size-comment.yml
@@ -58,13 +58,13 @@ jobs:
             `;
 
             // Look for existing comment
-            const comments = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber
             });
             
-            const existingComment = comments.data.find(c => c.body.includes(signature));
+            const existingComment = comments.find(c => c.body.includes(signature));
 
             if (existingComment) {
               // Update the existing comment

--- a/.github/workflows/core-build.yml
+++ b/.github/workflows/core-build.yml
@@ -67,7 +67,7 @@ jobs:
               });
               
               for (const comment of comments) {
-                if (comment.user.type === 'Bot' && comment.body.includes(signature)) {
+                if (comment.user?.type === 'Bot' && comment.body.includes(signature)) {
                   await github.rest.issues.deleteComment({
                     comment_id: comment.id,
                     owner: context.repo.owner,

--- a/.github/workflows/core-build.yml
+++ b/.github/workflows/core-build.yml
@@ -51,11 +51,35 @@ jobs:
           fi
           gotestsum --junitfile test-results.xml --format testdox -- -race $cover_arg ./...
       - name: Comment Test Failures
-        if: failure() && github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
+            const signature = '<!-- core-build-test-failures-${{ matrix.os }} -->';
+            
+            // 1. Delete previous comments
+            try {
+              const comments = await github.rest.issues.listComments({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
+              
+              for (const comment of comments.data) {
+                if (comment.user.type === 'Bot' && comment.body.includes(signature)) {
+                  await github.rest.issues.deleteComment({
+                    comment_id: comment.id,
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                  });
+                }
+              }
+            } catch (err) {
+              core.warning(`Could not delete old comments: ${err.message}`);
+            }
+
+            // 2. Post new comment if there are failures
             if (!fs.existsSync('test-results.xml')) return;
             const content = fs.readFileSync('test-results.xml', 'utf8');
             const regex = /<testcase classname="([^"]+)" name="([^"]+)"[^>]*>\s*<(?:failure|error)/g;
@@ -65,7 +89,7 @@ jobs:
               failures.push(`- **${match[1]}**: \`${match[2]}\``);
             }
             if (failures.length > 0) {
-              const body = `### ❌ Test Failures on \`${{ matrix.os }}\`\n` + failures.join('\n');
+              const body = `${signature}\n### ❌ Test Failures on \`${{ matrix.os }}\`\n` + failures.join('\n');
               try {
                 await github.rest.issues.createComment({
                   issue_number: context.issue.number,

--- a/.github/workflows/core-build.yml
+++ b/.github/workflows/core-build.yml
@@ -60,13 +60,13 @@ jobs:
             
             // 1. Delete previous comments
             try {
-              const comments = await github.rest.issues.listComments({
+              const comments = await github.paginate(github.rest.issues.listComments, {
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
               });
               
-              for (const comment of comments.data) {
+              for (const comment of comments) {
                 if (comment.user.type === 'Bot' && comment.body.includes(signature)) {
                   await github.rest.issues.deleteComment({
                     comment_id: comment.id,


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves PR comment hygiene in two CI workflows by adding paginated comment listing and automatic deletion of stale test-failure comments.

- **`core-build.yml`**: The "Comment Test Failures" step now runs on `always()` instead of `failure()`, so each successful re-run deletes any lingering failure comment from a previous failed run. Deletion is scoped to the specific OS matrix entry via a hidden HTML signature, and the listing uses `github.paginate` to handle PRs with many comments. Optional chaining (`comment.user?.type`) is used to safely handle null-user comments.
- **`core-binary-size-comment.yml`**: Replaces the single-page `listComments` call with `github.paginate` and removes the now-incorrect `.data` accessor, ensuring the existing-comment lookup works on PRs with many comments.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both changes are additive CI improvements with no effect on the main codebase.

The logic is straightforward: paginate all comments, delete matching ones by per-OS signature, then re-post only when failures are present. The `always()` condition correctly handles the cleanup-on-success path, concurrency is already guarded by the workflow's `cancel-in-progress` setting, and optional chaining handles the null-user edge case. No application code is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/core-binary-size-comment.yml | Switches `listComments` to `github.paginate` and removes the now-incorrect `.data` accessor — correctly handles PRs with many comments. |
| .github/workflows/core-build.yml | Changes comment step to run on `always()`, adds paginated stale-comment deletion keyed by per-OS HTML signature before (re)posting failure comments. |

</details>

<sub>Reviews (3): Last reviewed commit: ["ci: use optional chaining for comment.us..."](https://github.com/surgedm/surge/commit/1ba3cad3559d16a2acedfc0845a987bd2ec18b8e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37569027)</sub>

<!-- /greptile_comment -->