### PR TITLE
fix(utils): trim trailing periods and spaces after stripping control chars

### DIFF
--- a/internal/utils/filename.go
+++ b/internal/utils/filename.go
@@ -173,10 +173,6 @@ func sanitizeFilename(name string) string {
 		name = strings.ReplaceAll(name, ch, "_")
 	}
 
-	// Trim leading/trailing spaces and trailing periods (problematic on Windows)
-	name = strings.TrimSpace(name)
-	name = strings.TrimRight(name, ".")
-
 	// Remove unprintable control characters
 	var b strings.Builder
 	for _, c := range name {
@@ -185,7 +181,15 @@ func sanitizeFilename(name string) string {
 		}
 	}
 	name = b.String()
+
+	// Trim trailing spaces and periods (both invalid on Windows), after
+	// stripping control characters so a control char trailing the periods
+	// (e.g. "file.pdf.\x01") doesn't shield them. The TrimRight cutset clears
+	// interleaved trailing dots and spaces in one pass (e.g. "file. ." and the
+	// space re-exposed by removing a trailing period); TrimSpace also clears
+	// any leading whitespace.
 	name = strings.TrimSpace(name)
+	name = strings.TrimRight(name, ". ")
 
 	if name == "" {
 		return "_"

--- a/internal/utils/filename_test.go
+++ b/internal/utils/filename_test.go
@@ -51,6 +51,12 @@ func TestSanitizeFilename(t *testing.T) {
 		{"mid-length unicode filename", strings.Repeat("中", 100) + ".zip", strings.Repeat("中", 78) + ".zip"},
 		{"unicode filename over limit", strings.Repeat("中", 250) + ".zip", strings.Repeat("中", 78) + ".zip"},
 		{"unicode filename with long extension", strings.Repeat("中", 10) + "." + strings.Repeat("a", 250), strings.Repeat("中", 10) + "." + strings.Repeat("a", 209)},
+		{"trailing period shielded by control char", "file.pdf.\x01", "file.pdf"},
+		{"multiple trailing periods shielded by control char", "report..\x02", "report"},
+		{"trailing space after period", "file . ", "file"},
+		{"trailing period after space", "doc .", "doc"},
+		{"interleaved trailing periods and spaces", "file. .", "file"},
+		{"space-shielded period with control char", "file.txt .\x01", "file.txt"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## what

`sanitizeFilename` could leave a trailing period (or, for some inputs, a trailing space) on the sanitized name.

```go
sanitizeFilename("file.pdf.\x01") // was "file.pdf." -> now "file.pdf"
sanitizeFilename("file. .")       // was "file."     -> now "file"
sanitizeFilename("report..\x02")  // was "report.."   -> now "report"
```

## why

the trailing-period trim ran *before* the control-character strip, so a control char trailing the periods (`file.pdf.\x01`) shielded them: `TrimRight(".")` saw `\x01` as the last character and did nothing, then the control char was removed, leaving `file.pdf.`. trailing periods and spaces are both invalid on Windows (Explorer/NTFS strip them, so the on-disk name won't match what Surge wrote).

## fix

move the trim to after the control-character removal, and trim trailing periods and spaces together (cutset `". "`) so removing a trailing period can't re-expose an untrimmed trailing space, and interleaved cases like `file. .` collapse correctly. leading whitespace is still trimmed; ordinary names are unchanged.

## tests

`TestSanitizeFilename` gains cases for a control-shielded trailing period, a trailing space after a period, and interleaved periods/spaces. full suite stays green.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a bug in `sanitizeFilename` where a control character immediately following a trailing period would "shield" that period from being trimmed, leaving an invalid Windows filename like `file.pdf.`. The fix moves the trailing-trim step to after the control-character stripping loop and widens the cutset to `". "` so interleaved trailing dots and spaces are collapsed in a single pass.

- `internal/utils/filename.go`: Three-line reorder — the two `TrimSpace`/`TrimRight` calls now sit below the control-character loop instead of above it; `TrimRight(\".\")` is widened to `TrimRight(\". \")`.
- `internal/utils/filename_test.go`: Six new table-driven cases covering the control-char-shielded trailing period, multiple shielded trailing periods, trailing space after a period, trailing period after a space, interleaved dot-space sequences, and a space-plus-control-char combination.

<h3>Confidence Score: 4/5</h3>

The change is safe to merge; it tightens a filename sanitization edge case without touching any other code path.

The logic reordering is straightforward: the trim now observes the fully-cleaned string, which is the correct invariant. The new cutset correctly handles interleaved dot-space tails in one pass, and the existing empty-name guard still fires after the trim. The six new test cases directly exercise the bug scenarios described in the PR. A single minor comment clause restates what strings.TrimSpace already documents rather than explaining a design decision.

No files require special attention; both changed files are self-contained and narrowly scoped.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/utils/filename.go | Moves trailing-trim after the control-character loop and widens the cutset to `. ` — fix is correct, focused, and doesn't affect any other sanitizeFilename logic path. |
| internal/utils/filename_test.go | Adds six targeted table-driven cases covering the control-char-shielded period, multiple trailing periods, trailing space after period, and interleaved dot-space sequences — matches each scenario from the PR description. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/utils/filename.go:190
**Comment restates what `TrimSpace` obviously does**

The final clause `"TrimSpace also clears any leading whitespace"` is a literal restatement of `strings.TrimSpace`'s documented contract — any Go reader already knows this. The preceding sentences do a good job of explaining *why* the trim must come after control-character removal and why the cutset must include spaces; this last clause adds no insight into the design decision and can be dropped.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(utils): trim trailing periods and sp..."](https://github.com/surgedm/surge/commit/8d9dc88868c8fa05cf88164d4e6a55cb678c5bac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37790513)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->