### PR TITLE
concurrent: avoid data race on hedged SharedMaxOffset

### DIFF
--- a/internal/config/keymaps_test.go
+++ b/internal/config/keymaps_test.go
@@ -52,10 +52,10 @@ func TestKeyMapConversion(t *testing.T) {
 
 	// Verify reflection-based conversion
 	km2 := DefaultKeyMap()
-
+	
 	// Remove original exact-case key to test case-insensitive matching
 	delete(cfg.Dashboard, "Quit")
-
+	
 	// Change a key in config using mixed case
 	cfg.Dashboard["qUiT"] = KeyBindingConfig{
 		Keys: []string{"ctrl+x"},
@@ -66,7 +66,7 @@ func TestKeyMapConversion(t *testing.T) {
 		Keys: []string{"ctrl+z"},
 		Help: "exit alt",
 	}
-
+	
 	km2.ApplyConfig(cfg)
 
 	appliedKey := km2.Dashboard.Quit.Keys()[0]

--- a/internal/config/keymaps_test.go
+++ b/internal/config/keymaps_test.go
@@ -52,10 +52,10 @@ func TestKeyMapConversion(t *testing.T) {
 
 	// Verify reflection-based conversion
 	km2 := DefaultKeyMap()
-	
+
 	// Remove original exact-case key to test case-insensitive matching
 	delete(cfg.Dashboard, "Quit")
-	
+
 	// Change a key in config using mixed case
 	cfg.Dashboard["qUiT"] = KeyBindingConfig{
 		Keys: []string{"ctrl+x"},
@@ -66,7 +66,7 @@ func TestKeyMapConversion(t *testing.T) {
 		Keys: []string{"ctrl+z"},
 		Help: "exit alt",
 	}
-	
+
 	km2.ApplyConfig(cfg)
 
 	appliedKey := km2.Dashboard.Quit.Keys()[0]

--- a/internal/engine/concurrent/hedge_race_test.go
+++ b/internal/engine/concurrent/hedge_race_test.go
@@ -53,7 +53,8 @@ func TestHedgeSharedMaxOffsetRace(t *testing.T) {
 
 	wg.Wait()
 
-	// Consume any hedged tasks to avoid leaking goroutines
+	// Close the queue and drain remaining tasks without blocking.
+	queue.Close()
 	for {
 		tsk, ok := queue.Pop()
 		if !ok {

--- a/internal/engine/concurrent/hedge_race_test.go
+++ b/internal/engine/concurrent/hedge_race_test.go
@@ -38,8 +38,10 @@ func TestHedgeSharedMaxOffsetRace(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < 500; i++ {
-			// Read without taking the init mutex to emulate pre-fix reader behavior.
+			// Read under the task's RLock, matching production downloadTask behaviour.
+			active.SharedMaxOffsetMu.RLock()
 			ptr := active.SharedMaxOffset
+			active.SharedMaxOffsetMu.RUnlock()
 			if ptr != nil {
 				_ = ptr.Load()
 				// harmless CAS attempt

--- a/internal/engine/concurrent/hedge_race_test.go
+++ b/internal/engine/concurrent/hedge_race_test.go
@@ -3,7 +3,6 @@ package concurrent
 import (
 	"github.com/SurgeDM/Surge/internal/engine/types"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 )

--- a/internal/engine/concurrent/hedge_race_test.go
+++ b/internal/engine/concurrent/hedge_race_test.go
@@ -1,0 +1,67 @@
+package concurrent
+
+import (
+	"github.com/SurgeDM/Surge/internal/engine/types"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestHedgeSharedMaxOffsetRace exercises concurrent hedging and pointer reads.
+// It runs HedgeWork in parallel with a reader that repeatedly accesses
+// ActiveTask.SharedMaxOffset to ensure there is no data race under -race.
+func TestHedgeSharedMaxOffsetRace(t *testing.T) {
+	var d ConcurrentDownloader
+	d.activeTasks = make(map[int]*ActiveTask)
+
+	active := &ActiveTask{}
+	active.CurrentOffset.Store(0)
+	active.StopAt.Store(1 << 20)
+
+	d.activeTasks[0] = active
+
+	queue := NewTaskQueue()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Hedge goroutine
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 500; i++ {
+			d.HedgeWork(queue)
+			time.Sleep(time.Microsecond)
+		}
+	}()
+
+	// Reader goroutine: repeatedly read the shared pointer (mimics downloadTask access)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 500; i++ {
+			// Read without taking the init mutex to emulate pre-fix reader behavior.
+			ptr := active.SharedMaxOffset
+			if ptr != nil {
+				_ = ptr.Load()
+				// harmless CAS attempt
+				ptr.CompareAndSwap(ptr.Load(), ptr.Load())
+			}
+			time.Sleep(time.Microsecond)
+		}
+	}()
+
+	wg.Wait()
+
+	// Consume any hedged tasks to avoid leaking goroutines
+	for {
+		tsk, ok := queue.Pop()
+		if !ok {
+			break
+		}
+		_ = tsk // ignore
+	}
+
+	// Ensure the task type still matches expectations
+	var sample types.Task
+	_ = sample
+}

--- a/internal/engine/concurrent/task.go
+++ b/internal/engine/concurrent/task.go
@@ -28,7 +28,9 @@ type ActiveTask struct {
 
 	// Hedged request tracking
 	Hedged           atomic.Int32  // 1 if an idle worker is already racing this task
-	SharedMaxOffset  *atomic.Int64 // Highest offset reached by any racing worker
+    // SharedMaxOffset points to the highest offset reached by any racing worker.
+    // Use atomic.Pointer to allow safe concurrent initialization and reads.
+    SharedMaxOffset  atomic.Pointer[atomic.Int64]
 	// Set while blocked on rate limiter so health monitor doesn't treat it as stalled
 	WaitingOnLimiter atomic.Bool
 }

--- a/internal/engine/concurrent/task.go
+++ b/internal/engine/concurrent/task.go
@@ -29,8 +29,9 @@ type ActiveTask struct {
 	// Hedged request tracking
 	Hedged atomic.Int32 // 1 if an idle worker is already racing this task
 	// SharedMaxOffset points to the highest offset reached by any racing worker.
-	// Use atomic.Pointer to allow safe concurrent initialization and reads.
-	SharedMaxOffset atomic.Pointer[atomic.Int64]
+	// Protected by SharedMaxOffsetMu for safe concurrent initialization.
+	SharedMaxOffsetMu sync.RWMutex
+	SharedMaxOffset   *atomic.Int64
 	// Set while blocked on rate limiter so health monitor doesn't treat it as stalled
 	WaitingOnLimiter atomic.Bool
 }

--- a/internal/engine/concurrent/task.go
+++ b/internal/engine/concurrent/task.go
@@ -27,10 +27,10 @@ type ActiveTask struct {
 	WindowBytes atomic.Int64 // Bytes downloaded in current window
 
 	// Hedged request tracking
-	Hedged           atomic.Int32  // 1 if an idle worker is already racing this task
-    // SharedMaxOffset points to the highest offset reached by any racing worker.
-    // Use atomic.Pointer to allow safe concurrent initialization and reads.
-    SharedMaxOffset  atomic.Pointer[atomic.Int64]
+	Hedged atomic.Int32 // 1 if an idle worker is already racing this task
+	// SharedMaxOffset points to the highest offset reached by any racing worker.
+	// Use atomic.Pointer to allow safe concurrent initialization and reads.
+	SharedMaxOffset atomic.Pointer[atomic.Int64]
 	// Set while blocked on rate limiter so health monitor doesn't treat it as stalled
 	WaitingOnLimiter atomic.Bool
 }

--- a/internal/engine/concurrent/worker.go
+++ b/internal/engine/concurrent/worker.go
@@ -62,17 +62,18 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 			// Register active task with per-task cancellable context
 			taskCtx, taskCancel := context.WithCancel(ctx)
 			now := time.Now()
-			activeTask := &ActiveTask{
-				Task:            task,
-				StartTime:       now,
-				Cancel:          taskCancel,
-				WindowStart:     now, // Initialize sliding window
-				SharedMaxOffset: task.SharedMaxOffset,
-			}
-			if task.SharedMaxOffset != nil {
-				// Prevent infinite hedging of hedged tasks.
-				activeTask.Hedged.Store(1)
-			}
+            activeTask := &ActiveTask{
+                Task:        task,
+                StartTime:   now,
+                Cancel:      taskCancel,
+                WindowStart: now, // Initialize sliding window
+            }
+            // If the incoming Task carried a shared pointer, copy it into the active task atomically
+            if ptr := task.SharedMaxOffset.Load(); ptr != nil {
+                activeTask.SharedMaxOffset.Store(ptr)
+                // Prevent infinite hedging of hedged tasks.
+                activeTask.Hedged.Store(1)
+            }
 			activeTask.CurrentOffset.Store(task.Offset)
 			activeTask.StopAt.Store(task.Offset + task.Length)
 			activeTask.LastActivity.Store(now.UnixNano())
@@ -337,31 +338,32 @@ func (d *ConcurrentDownloader) downloadTask(ctx context.Context, rawurl string, 
 
 			// Compute newly written bytes deduplicated across racing workers
 			var newlyWritten int64
-			if activeTask.SharedMaxOffset != nil {
-				for {
-					maxOff := activeTask.SharedMaxOffset.Load()
-					if offset <= maxOff {
-						// This exact byte range was already reported by the racing worker!
-						newlyWritten = 0
-						break
-					}
-					if rangeStart >= maxOff {
-						// Entirely new progress
-						if activeTask.SharedMaxOffset.CompareAndSwap(maxOff, offset) {
-							newlyWritten = int64(readSoFar)
-							break
-						}
-					} else {
-						// Partially new progress
-						if activeTask.SharedMaxOffset.CompareAndSwap(maxOff, offset) {
-							newlyWritten = offset - maxOff
-							break
-						}
-					}
-				}
-			} else {
-				newlyWritten = int64(readSoFar)
-			}
+            // Dereference the shared pointer atomically for race-free access
+            if ptr := activeTask.SharedMaxOffset.Load(); ptr != nil {
+                for {
+                    maxOff := ptr.Load()
+                    if offset <= maxOff {
+                        // This exact byte range was already reported by the racing worker!
+                        newlyWritten = 0
+                        break
+                    }
+                    if rangeStart >= maxOff {
+                        // Entirely new progress
+                        if ptr.CompareAndSwap(maxOff, offset) {
+                            newlyWritten = int64(readSoFar)
+                            break
+                        }
+                    } else {
+                        // Partially new progress
+                        if ptr.CompareAndSwap(maxOff, offset) {
+                            newlyWritten = offset - maxOff
+                            break
+                        }
+                    }
+                }
+            } else {
+                newlyWritten = int64(readSoFar)
+            }
 
 			activeTask.CurrentOffset.Store(offset)
 			activeTask.WindowBytes.Add(newlyWritten)
@@ -529,19 +531,22 @@ func (d *ConcurrentDownloader) HedgeWork(queue *TaskQueue) bool {
 		return false
 	}
 
-	// Initialize the shared deduplication state for both tasks
-	if bestActive.SharedMaxOffset == nil {
-		maxOff := &atomic.Int64{}
-		maxOff.Store(current)
-		bestActive.SharedMaxOffset = maxOff
-	}
+    // Initialize the shared deduplication state for both tasks
+    if bestActive.SharedMaxOffset.Load() == nil {
+        maxOff := &atomic.Int64{}
+        maxOff.Store(current)
+        bestActive.SharedMaxOffset.Store(maxOff)
+    }
 
-	// Create a duplicate task for the remaining byte range
-	hedgedTask := types.Task{
-		Offset:          current,
-		Length:          stopAt - current,
-		SharedMaxOffset: bestActive.SharedMaxOffset,
-	}
+    // Create a duplicate task for the remaining byte range
+    hedgedTask := types.Task{
+        Offset: current,
+        Length: stopAt - current,
+    }
+    // Point the hedged task at the same shared pointer
+    if ptr := bestActive.SharedMaxOffset.Load(); ptr != nil {
+        hedgedTask.SharedMaxOffset.Store(ptr)
+    }
 
 	queue.Push(hedgedTask)
 	utils.Debug("Balancer: hedged %s (range: %d-%d) - idle worker will race on fresh connection",

--- a/internal/engine/concurrent/worker.go
+++ b/internal/engine/concurrent/worker.go
@@ -537,7 +537,6 @@ func (d *ConcurrentDownloader) HedgeWork(queue *TaskQueue) bool {
 	}
 
 	// Initialize the shared deduplication state for both tasks
-	// Initialize the shared deduplication state for both tasks.
 	bestActive.SharedMaxOffsetMu.Lock()
 	if bestActive.SharedMaxOffset == nil {
 		maxOff := &atomic.Int64{}

--- a/internal/engine/concurrent/worker.go
+++ b/internal/engine/concurrent/worker.go
@@ -68,9 +68,11 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 				Cancel:      taskCancel,
 				WindowStart: now, // Initialize sliding window
 			}
-			// If the incoming Task carried a shared pointer, copy it into the active task atomically
-			if ptr := task.SharedMaxOffset.Load(); ptr != nil {
-				activeTask.SharedMaxOffset.Store(ptr)
+			// If the incoming Task carried a shared pointer, copy it into the active task
+			if task.SharedMaxOffset != nil {
+				activeTask.SharedMaxOffsetMu.Lock()
+				activeTask.SharedMaxOffset = task.SharedMaxOffset
+				activeTask.SharedMaxOffsetMu.Unlock()
 				// Prevent infinite hedging of hedged tasks.
 				activeTask.Hedged.Store(1)
 			}
@@ -338,8 +340,11 @@ func (d *ConcurrentDownloader) downloadTask(ctx context.Context, rawurl string, 
 
 			// Compute newly written bytes deduplicated across racing workers
 			var newlyWritten int64
-			// Dereference the shared pointer atomically for race-free access
-			if ptr := activeTask.SharedMaxOffset.Load(); ptr != nil {
+			// Read pointer under RLock to avoid racing with hedger initialization
+			activeTask.SharedMaxOffsetMu.RLock()
+			ptr := activeTask.SharedMaxOffset
+			activeTask.SharedMaxOffsetMu.RUnlock()
+			if ptr != nil {
 				for {
 					maxOff := ptr.Load()
 					if offset <= maxOff {
@@ -532,21 +537,20 @@ func (d *ConcurrentDownloader) HedgeWork(queue *TaskQueue) bool {
 	}
 
 	// Initialize the shared deduplication state for both tasks
-	if bestActive.SharedMaxOffset.Load() == nil {
+	// Initialize the shared deduplication state for both tasks.
+	bestActive.SharedMaxOffsetMu.Lock()
+	if bestActive.SharedMaxOffset == nil {
 		maxOff := &atomic.Int64{}
 		maxOff.Store(current)
-		bestActive.SharedMaxOffset.Store(maxOff)
+		bestActive.SharedMaxOffset = maxOff
 	}
-
 	// Create a duplicate task for the remaining byte range
 	hedgedTask := types.Task{
-		Offset: current,
-		Length: stopAt - current,
+		Offset:          current,
+		Length:          stopAt - current,
+		SharedMaxOffset: bestActive.SharedMaxOffset,
 	}
-	// Point the hedged task at the same shared pointer
-	if ptr := bestActive.SharedMaxOffset.Load(); ptr != nil {
-		hedgedTask.SharedMaxOffset.Store(ptr)
-	}
+	bestActive.SharedMaxOffsetMu.Unlock()
 
 	queue.Push(hedgedTask)
 	utils.Debug("Balancer: hedged %s (range: %d-%d) - idle worker will race on fresh connection",

--- a/internal/engine/concurrent/worker.go
+++ b/internal/engine/concurrent/worker.go
@@ -62,18 +62,18 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 			// Register active task with per-task cancellable context
 			taskCtx, taskCancel := context.WithCancel(ctx)
 			now := time.Now()
-            activeTask := &ActiveTask{
-                Task:        task,
-                StartTime:   now,
-                Cancel:      taskCancel,
-                WindowStart: now, // Initialize sliding window
-            }
-            // If the incoming Task carried a shared pointer, copy it into the active task atomically
-            if ptr := task.SharedMaxOffset.Load(); ptr != nil {
-                activeTask.SharedMaxOffset.Store(ptr)
-                // Prevent infinite hedging of hedged tasks.
-                activeTask.Hedged.Store(1)
-            }
+			activeTask := &ActiveTask{
+				Task:        task,
+				StartTime:   now,
+				Cancel:      taskCancel,
+				WindowStart: now, // Initialize sliding window
+			}
+			// If the incoming Task carried a shared pointer, copy it into the active task atomically
+			if ptr := task.SharedMaxOffset.Load(); ptr != nil {
+				activeTask.SharedMaxOffset.Store(ptr)
+				// Prevent infinite hedging of hedged tasks.
+				activeTask.Hedged.Store(1)
+			}
 			activeTask.CurrentOffset.Store(task.Offset)
 			activeTask.StopAt.Store(task.Offset + task.Length)
 			activeTask.LastActivity.Store(now.UnixNano())
@@ -338,32 +338,32 @@ func (d *ConcurrentDownloader) downloadTask(ctx context.Context, rawurl string, 
 
 			// Compute newly written bytes deduplicated across racing workers
 			var newlyWritten int64
-            // Dereference the shared pointer atomically for race-free access
-            if ptr := activeTask.SharedMaxOffset.Load(); ptr != nil {
-                for {
-                    maxOff := ptr.Load()
-                    if offset <= maxOff {
-                        // This exact byte range was already reported by the racing worker!
-                        newlyWritten = 0
-                        break
-                    }
-                    if rangeStart >= maxOff {
-                        // Entirely new progress
-                        if ptr.CompareAndSwap(maxOff, offset) {
-                            newlyWritten = int64(readSoFar)
-                            break
-                        }
-                    } else {
-                        // Partially new progress
-                        if ptr.CompareAndSwap(maxOff, offset) {
-                            newlyWritten = offset - maxOff
-                            break
-                        }
-                    }
-                }
-            } else {
-                newlyWritten = int64(readSoFar)
-            }
+			// Dereference the shared pointer atomically for race-free access
+			if ptr := activeTask.SharedMaxOffset.Load(); ptr != nil {
+				for {
+					maxOff := ptr.Load()
+					if offset <= maxOff {
+						// This exact byte range was already reported by the racing worker!
+						newlyWritten = 0
+						break
+					}
+					if rangeStart >= maxOff {
+						// Entirely new progress
+						if ptr.CompareAndSwap(maxOff, offset) {
+							newlyWritten = int64(readSoFar)
+							break
+						}
+					} else {
+						// Partially new progress
+						if ptr.CompareAndSwap(maxOff, offset) {
+							newlyWritten = offset - maxOff
+							break
+						}
+					}
+				}
+			} else {
+				newlyWritten = int64(readSoFar)
+			}
 
 			activeTask.CurrentOffset.Store(offset)
 			activeTask.WindowBytes.Add(newlyWritten)
@@ -531,22 +531,22 @@ func (d *ConcurrentDownloader) HedgeWork(queue *TaskQueue) bool {
 		return false
 	}
 
-    // Initialize the shared deduplication state for both tasks
-    if bestActive.SharedMaxOffset.Load() == nil {
-        maxOff := &atomic.Int64{}
-        maxOff.Store(current)
-        bestActive.SharedMaxOffset.Store(maxOff)
-    }
+	// Initialize the shared deduplication state for both tasks
+	if bestActive.SharedMaxOffset.Load() == nil {
+		maxOff := &atomic.Int64{}
+		maxOff.Store(current)
+		bestActive.SharedMaxOffset.Store(maxOff)
+	}
 
-    // Create a duplicate task for the remaining byte range
-    hedgedTask := types.Task{
-        Offset: current,
-        Length: stopAt - current,
-    }
-    // Point the hedged task at the same shared pointer
-    if ptr := bestActive.SharedMaxOffset.Load(); ptr != nil {
-        hedgedTask.SharedMaxOffset.Store(ptr)
-    }
+	// Create a duplicate task for the remaining byte range
+	hedgedTask := types.Task{
+		Offset: current,
+		Length: stopAt - current,
+	}
+	// Point the hedged task at the same shared pointer
+	if ptr := bestActive.SharedMaxOffset.Load(); ptr != nil {
+		hedgedTask.SharedMaxOffset.Store(ptr)
+	}
 
 	queue.Push(hedgedTask)
 	utils.Debug("Balancer: hedged %s (range: %d-%d) - idle worker will race on fresh connection",

--- a/internal/engine/concurrent/worker.go
+++ b/internal/engine/concurrent/worker.go
@@ -70,9 +70,9 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 			}
 			// If the incoming Task carried a shared pointer, copy it into the active task
 			if task.SharedMaxOffset != nil {
-				activeTask.SharedMaxOffsetMu.Lock()
+				// activeTask is newly allocated and not yet visible to other goroutines,
+				// so this assignment does not need mutex protection.
 				activeTask.SharedMaxOffset = task.SharedMaxOffset
-				activeTask.SharedMaxOffsetMu.Unlock()
 				// Prevent infinite hedging of hedged tasks.
 				activeTask.Hedged.Store(1)
 			}

--- a/internal/engine/types/models.go
+++ b/internal/engine/types/models.go
@@ -4,9 +4,9 @@ import "sync/atomic"
 
 // Task represents a byte range to download.
 type Task struct {
-	Offset          int64         `json:"offset"`
-	Length          int64         `json:"length"`
-	SharedMaxOffset *atomic.Int64 `json:"-"`
+    Offset          int64                           `json:"offset"`
+    Length          int64                           `json:"length"`
+    SharedMaxOffset atomic.Pointer[atomic.Int64]    `json:"-"`
 }
 
 // DownloadState is the persisted snapshot used to resume a download.

--- a/internal/engine/types/models.go
+++ b/internal/engine/types/models.go
@@ -4,9 +4,9 @@ import "sync/atomic"
 
 // Task represents a byte range to download.
 type Task struct {
-    Offset          int64                           `json:"offset"`
-    Length          int64                           `json:"length"`
-    SharedMaxOffset atomic.Pointer[atomic.Int64]    `json:"-"`
+	Offset          int64                        `json:"offset"`
+	Length          int64                        `json:"length"`
+	SharedMaxOffset atomic.Pointer[atomic.Int64] `json:"-"`
 }
 
 // DownloadState is the persisted snapshot used to resume a download.

--- a/internal/engine/types/models.go
+++ b/internal/engine/types/models.go
@@ -4,9 +4,9 @@ import "sync/atomic"
 
 // Task represents a byte range to download.
 type Task struct {
-	Offset          int64                        `json:"offset"`
-	Length          int64                        `json:"length"`
-	SharedMaxOffset atomic.Pointer[atomic.Int64] `json:"-"`
+	Offset          int64         `json:"offset"`
+	Length          int64         `json:"length"`
+	SharedMaxOffset *atomic.Int64 `json:"-"`
 }
 
 // DownloadState is the persisted snapshot used to resume a download.

--- a/internal/tui/speed_limits_regressions_test.go
+++ b/internal/tui/speed_limits_regressions_test.go
@@ -55,7 +55,7 @@ func TestUpdateSpeedLimits_EscClearsError(t *testing.T) {
 func TestUpdateSpeedLimits_ArrowNavClearsError(t *testing.T) {
 	m := newSpeedLimitsTestModel(t)
 	m.speedLimitsError = "some error"
-	
+
 	// Test Up arrow
 	updatedUp, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyUp})
 	mUp := updatedUp.(RootModel)

--- a/internal/tui/speed_limits_regressions_test.go
+++ b/internal/tui/speed_limits_regressions_test.go
@@ -55,7 +55,7 @@ func TestUpdateSpeedLimits_EscClearsError(t *testing.T) {
 func TestUpdateSpeedLimits_ArrowNavClearsError(t *testing.T) {
 	m := newSpeedLimitsTestModel(t)
 	m.speedLimitsError = "some error"
-
+	
 	// Test Up arrow
 	updatedUp, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyUp})
 	mUp := updatedUp.(RootModel)

--- a/internal/tui/update_modals.go
+++ b/internal/tui/update_modals.go
@@ -26,7 +26,7 @@ func (m RootModel) updateSpeedLimits(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			metaList := m.getSpeedLimitsMetadata()
 			if m.speedLimitsCursor >= 0 && m.speedLimitsCursor < len(metaList) {
 				meta := metaList[m.speedLimitsCursor]
-				
+
 				valueStr := strings.TrimSpace(value)
 				if !utils.IsRateLimitInherit(valueStr) {
 					if _, err := strconv.ParseFloat(valueStr, 64); err != nil {
@@ -40,19 +40,19 @@ func (m RootModel) updateSpeedLimits(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 				oldValues := m.getSpeedLimitsValues()
 				oldVal := oldValues[meta.Key]
-				
+
 				if err := m.setSpeedLimitValue(meta.Key, valueStr); err != nil {
 					m.speedLimitsError = err.Error()
 					return m, nil
 				}
 				m.speedLimitsError = ""
-				
+
 				newValues := m.getSpeedLimitsValues()
 				newVal := newValues[meta.Key]
-				
+
 				oldStr := strings.ReplaceAll(fmt.Sprintf("%v", oldVal), "\u221E", "0 MB/s")
 				newStr := strings.ReplaceAll(fmt.Sprintf("%v", newVal), "\u221E", "0 MB/s")
-				
+
 				m.addLogEntry(LogStyleComplete.Render(fmt.Sprintf("\u2714 %s updated: %s \u2192 %s", meta.Label, oldStr, newStr)))
 			}
 			m.speedLimitsIsEditing = false
@@ -139,19 +139,19 @@ func (m RootModel) updateSpeedLimits(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.speedLimitsError = ""
 		if m.speedLimitsCursor >= 0 && m.speedLimitsCursor < len(metaList) {
 			meta := metaList[m.speedLimitsCursor]
-			
+
 			oldValues := m.getSpeedLimitsValues()
 			oldVal := oldValues[meta.Key]
-			
+
 			if err := m.resetSpeedLimitToDefault(meta.Key, config.DefaultSettings()); err != nil {
 				m.addLogEntry(LogStyleError.Render("\u2716 Reset failed: " + err.Error()))
 			} else {
 				newValues := m.getSpeedLimitsValues()
 				newVal := newValues[meta.Key]
-				
+
 				oldStr := strings.ReplaceAll(fmt.Sprintf("%v", oldVal), "\u221E", "0 MB/s")
 				newStr := strings.ReplaceAll(fmt.Sprintf("%v", newVal), "\u221E", "0 MB/s")
-				
+
 				m.addLogEntry(LogStyleComplete.Render(fmt.Sprintf("\u2714 %s reset: %s \u2192 %s", meta.Label, oldStr, newStr)))
 			}
 		}

--- a/internal/tui/update_modals.go
+++ b/internal/tui/update_modals.go
@@ -26,7 +26,7 @@ func (m RootModel) updateSpeedLimits(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			metaList := m.getSpeedLimitsMetadata()
 			if m.speedLimitsCursor >= 0 && m.speedLimitsCursor < len(metaList) {
 				meta := metaList[m.speedLimitsCursor]
-
+				
 				valueStr := strings.TrimSpace(value)
 				if !utils.IsRateLimitInherit(valueStr) {
 					if _, err := strconv.ParseFloat(valueStr, 64); err != nil {
@@ -40,19 +40,19 @@ func (m RootModel) updateSpeedLimits(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 				oldValues := m.getSpeedLimitsValues()
 				oldVal := oldValues[meta.Key]
-
+				
 				if err := m.setSpeedLimitValue(meta.Key, valueStr); err != nil {
 					m.speedLimitsError = err.Error()
 					return m, nil
 				}
 				m.speedLimitsError = ""
-
+				
 				newValues := m.getSpeedLimitsValues()
 				newVal := newValues[meta.Key]
-
+				
 				oldStr := strings.ReplaceAll(fmt.Sprintf("%v", oldVal), "\u221E", "0 MB/s")
 				newStr := strings.ReplaceAll(fmt.Sprintf("%v", newVal), "\u221E", "0 MB/s")
-
+				
 				m.addLogEntry(LogStyleComplete.Render(fmt.Sprintf("\u2714 %s updated: %s \u2192 %s", meta.Label, oldStr, newStr)))
 			}
 			m.speedLimitsIsEditing = false
@@ -139,19 +139,19 @@ func (m RootModel) updateSpeedLimits(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.speedLimitsError = ""
 		if m.speedLimitsCursor >= 0 && m.speedLimitsCursor < len(metaList) {
 			meta := metaList[m.speedLimitsCursor]
-
+			
 			oldValues := m.getSpeedLimitsValues()
 			oldVal := oldValues[meta.Key]
-
+			
 			if err := m.resetSpeedLimitToDefault(meta.Key, config.DefaultSettings()); err != nil {
 				m.addLogEntry(LogStyleError.Render("\u2716 Reset failed: " + err.Error()))
 			} else {
 				newValues := m.getSpeedLimitsValues()
 				newVal := newValues[meta.Key]
-
+				
 				oldStr := strings.ReplaceAll(fmt.Sprintf("%v", oldVal), "\u221E", "0 MB/s")
 				newStr := strings.ReplaceAll(fmt.Sprintf("%v", newVal), "\u221E", "0 MB/s")
-
+				
 				m.addLogEntry(LogStyleComplete.Render(fmt.Sprintf("\u2714 %s reset: %s \u2192 %s", meta.Label, oldStr, newStr)))
 			}
 		}


### PR DESCRIPTION
Fix data race where the balancer could assign SharedMaxOffset while workers read it. Add per-task RWMutex to protect pointer initialization and reads.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a data race on `ActiveTask.SharedMaxOffset` where the balancer's `HedgeWork` could write the pointer concurrently with `downloadTask` reading it. A `sync.RWMutex` (`SharedMaxOffsetMu`) is added to `ActiveTask` to protect pointer initialization and reads, and a new race-detector test is included.

- `task.go` gains `SharedMaxOffsetMu sync.RWMutex`; `worker.go` wraps the pointer write in `HedgeWork` with a full lock and wraps the pointer read in `downloadTask` with an RLock — the critical sections are minimal and the lock ordering is straightforward.
- The accompanying `hedge_race_test.go` mirrors production access patterns and will catch regressions under `go test -race`, though its hedge goroutine only triggers a real initialization on the first of 500 iterations (see inline comment).
- The remaining file changes (`update_modals.go`, `speed_limits_regressions_test.go`, `keymaps_test.go`) are trailing-whitespace removals with no functional effect.

<h3>Confidence Score: 5/5</h3>

The concurrency fix is mechanically correct and safe to merge.

The mutex is placed around exactly the pointer write and read sites, no existing lock ordering is disturbed, and the new test exercises the race under -race. All findings are test nits with no production impact.

internal/engine/concurrent/hedge_race_test.go — the hedge goroutine only exercises real initialization once per run; the test would be more effective with the reset suggested inline.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/engine/concurrent/task.go | Adds SharedMaxOffsetMu (sync.RWMutex) to ActiveTask and updates the comment for SharedMaxOffset to describe its protection semantics — straightforward struct change. |
| internal/engine/concurrent/worker.go | HedgeWork now wraps pointer initialization in SharedMaxOffsetMu.Lock/Unlock; downloadTask wraps the pointer read in RLock/RUnlock — the race fix is correct and the critical section is tight. |
| internal/engine/concurrent/hedge_race_test.go | New race-detector test; correctly mirrors production access patterns, but active.Hedged is set to 1 after the first HedgeWork call so the hedge goroutine only exercises real hedging once out of 500 iterations. Import ordering also violates Go conventions. |
| internal/tui/update_modals.go | Trailing-whitespace-only changes; no functional impact. |
| internal/tui/speed_limits_regressions_test.go | Trailing-whitespace-only changes; no functional impact. |
| internal/config/keymaps_test.go | Trailing-whitespace-only changes; no functional impact. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `internal/engine/concurrent/worker.go`, line 537-560 ([link](https://github.com/surgedm/surge/blob/386d54b12320031ee2be22bb775516e616c6adb7/internal/engine/concurrent/worker.go#L537-L560)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **No concurrent test for the fixed race**

   The PR fixes a documented data race between `HedgeWork`'s pointer write and `downloadTask`'s pointer read, but the test files only contain unrelated whitespace cleanups. A `TestHedgeDataRace` or similar test run under `-race` (or a table-driven concurrent test that calls both `HedgeWork` and `downloadTask` in parallel) would catch regressions here and prove the fix under the race detector. Per the project's testing standards, edge cases and integration points between concurrently-running components should be exercised.

   **Rule Used:** What: All code changes must include tests for edge... ([source](https://app.greptile.com/surge-org-3/-/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: internal/engine/concurrent/worker.go
   Line: 537-560
   
   Comment:
   **No concurrent test for the fixed race**
   
   The PR fixes a documented data race between `HedgeWork`'s pointer write and `downloadTask`'s pointer read, but the test files only contain unrelated whitespace cleanups. A `TestHedgeDataRace` or similar test run under `-race` (or a table-driven concurrent test that calls both `HedgeWork` and `downloadTask` in parallel) would catch regressions here and prove the fix under the race detector. Per the project's testing standards, edge cases and integration points between concurrently-running components should be exercised.
   
   **Rule Used:** What: All code changes must include tests for edge... ([source](https://app.greptile.com/surge-org-3/-/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

2. `internal/tui/update_modals.go`, line 26-60 ([link](https://github.com/surgedm/surge/blob/386d54b12320031ee2be22bb775516e616c6adb7/internal/tui/update_modals.go#L26-L60)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Unrelated whitespace changes bundled with the concurrency fix**

   The changes to `update_modals.go`, `speed_limits_regressions_test.go`, and `keymaps_test.go` are pure trailing-whitespace removals with no functional impact. Bundling cosmetic cleanups alongside a targeted concurrency fix makes the diff harder to review and harder to bisect if the whitespace changes ever need to be reverted independently of the race fix.

   **Rule Used:** What: Flag commits that bundle unnecessary changes... ([source](https://app.greptile.com/surge-org-3/-/custom-context?memory=74a28159-60fc-4201-a661-331594ebaf90))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: internal/tui/update_modals.go
   Line: 26-60
   
   Comment:
   **Unrelated whitespace changes bundled with the concurrency fix**
   
   The changes to `update_modals.go`, `speed_limits_regressions_test.go`, and `keymaps_test.go` are pure trailing-whitespace removals with no functional impact. Bundling cosmetic cleanups alongside a targeted concurrency fix makes the diff harder to review and harder to bisect if the whitespace changes ever need to be reverted independently of the race fix.
   
   **Rule Used:** What: Flag commits that bundle unnecessary changes... ([source](https://app.greptile.com/surge-org-3/-/custom-context?memory=74a28159-60fc-4201-a661-331594ebaf90))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["style: gofmt"](https://github.com/surgedm/surge/commit/80c476a928b9cd73e305dd5cac61d05ed37e1030) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37864597)</sub>

<!-- /greptile_comment -->