### PR TITLE
fix: keep Content-Disposition filename when header carries extra RFC 6266 params

### DIFF
--- a/internal/utils/filename.go
+++ b/internal/utils/filename.go
@@ -31,7 +31,11 @@ func DetermineFilename(rawurl string, resp *http.Response) (string, io.Reader, e
 	var candidate string
 
 	// 1. Content-Disposition
-	if _, name, err := httpheader.ContentDisposition(resp.Header); err == nil && name != "" {
+	// httpheader.ContentDisposition returns (dtype, filename, params); the third
+	// value is the parameter map, not an error. Guarding on it being nil would
+	// drop the filename whenever the header carries any extra RFC 6266 parameter
+	// (creation-date, size, ...), so only the filename string is checked here.
+	if _, name, _ := httpheader.ContentDisposition(resp.Header); name != "" {
 		candidate = name
 		Debug("Filename from Content-Disposition: %s", candidate)
 	}

--- a/internal/utils/filename_test.go
+++ b/internal/utils/filename_test.go
@@ -168,6 +168,54 @@ func TestDetermineFilename_PriorityOrder(t *testing.T) {
 	}
 }
 
+func TestDetermineFilename_ContentDispositionExtraParams(t *testing.T) {
+	// Regression: the server-supplied Content-Disposition filename must win even
+	// when the header carries extra RFC 6266 parameters (creation-date, size, ...).
+	pdfContent := []byte("%PDF-1.4\n")
+
+	tests := []struct {
+		name     string
+		url      string
+		headers  http.Header
+		expected string
+	}{
+		{
+			name: "filename kept with creation-date param",
+			url:  "https://example.com/download?filename=wrong.txt",
+			headers: http.Header{
+				"Content-Disposition": []string{`attachment; filename="report.pdf"; creation-date="Wed, 12 Feb 1997 16:29:51 -0500"`},
+			},
+			expected: "report.pdf",
+		},
+		{
+			name: "filename kept with size param",
+			url:  "https://example.com/download?filename=wrong.txt",
+			headers: http.Header{
+				"Content-Disposition": []string{`attachment; filename="archive.zip"; size=12345`},
+			},
+			expected: "archive.zip",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &http.Response{
+				Header: tt.headers,
+				Body:   io.NopCloser(bytes.NewReader(pdfContent)),
+			}
+
+			filename, _, err := DetermineFilename(tt.url, resp)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if filename != tt.expected {
+				t.Errorf("got %q, want %q", filename, tt.expected)
+			}
+		})
+	}
+}
+
 func TestDetermineFilename_LoggingIntegration(t *testing.T) {
 	// Setup temp dir for logs
 	tempDir, err := os.MkdirTemp("", "surge-debug-integration")


### PR DESCRIPTION
## Summary

`DetermineFilename` discarded the server-supplied `Content-Disposition` filename whenever the header carried any extra RFC 6266 parameter (`creation-date`, `size`, ...), saving the file under a wrong URL/MIME-derived name.

Fixes #493.

## Root cause

`github.com/vfaronov/httpheader`'s `ContentDisposition` returns `(dtype, filename string, params map[string]string)` — the third value is the **parameter map, not an error**. The code named it `err` and gated on `err == nil`, which compiles (a map is comparable to `nil`) but actually means *"no extra params"*, so the filename was dropped whenever any extra parameter was present.

## Change

- `internal/utils/filename.go`: discard the params map with `_` and check only the filename string; added a comment documenting the API.
- `internal/utils/filename_test.go`: regression cases for `creation-date` and `size` parameters.

## Testing

```
go test ./...   # all packages pass
```

The new test fails on `main` (the filename falls back to the URL query param) and passes with this change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a subtle Go type-mismatch bug in `DetermineFilename`: the third return value of `httpheader.ContentDisposition` is a `map[string]string` (extra params), not an error, but it was stored in a variable named `err` and guarded with `err == nil` — dropping the server-supplied filename whenever any RFC 6266 extra parameter was present.

- **`filename.go`**: replaces `err == nil` guard with `_` discard and adds a comment explaining the `ContentDisposition` API contract, so the filename is now preserved regardless of extra params.
- **`filename_test.go`**: adds two targeted regression cases (`creation-date` and `size` params) that fail on `main` and pass with the fix.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a one-line correction to a mistaken nil-map guard, touching only the Content-Disposition branch of filename resolution.

The fix is minimal, precisely targets the reported bug, leaves all other filename-resolution logic untouched, and is covered by new regression tests that directly demonstrate the before/after behaviour.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/utils/filename.go | One-line fix: discard the params map (third return value of `httpheader.ContentDisposition`) with `_` instead of treating it as an error; adds an explanatory comment. Change is correct and minimal. |
| internal/utils/filename_test.go | Adds two table-driven regression cases covering `creation-date` and `size` extra RFC 6266 parameters; both would fail on `main` and pass with the fix. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test: cover Content-Disposition filename..."](https://github.com/surgedm/surge/commit/cd8752324eefa2da0924dfacf0df2659fd5df2e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37871379)</sub>

<!-- /greptile_comment -->