### PR TITLE
fix: strip caller-supplied Range header in single downloader

### DIFF
--- a/internal/engine/single/downloader.go
+++ b/internal/engine/single/downloader.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -58,9 +59,10 @@ func (d *SingleDownloader) applyClientSettings(client *http.Client) {
 		}
 		if d.Headers != nil {
 			for key, val := range d.Headers {
-				if key != "Range" {
-					req.Header.Set(key, val)
+				if strings.EqualFold(key, "Range") {
+					continue
 				}
+				req.Header.Set(key, val)
 			}
 		}
 		return nil
@@ -88,6 +90,13 @@ func (d *SingleDownloader) Download(ctx context.Context, rawurl, destPath string
 	}
 
 	for key, val := range d.Headers {
+		// Never forward a caller-supplied Range header. This downloader fetches
+		// the whole file in one connection, so a range-capable server would
+		// reply 206 and the strict 200 check below would abort a valid download.
+		// The worker, probe and redirect paths strip Range for the same reason.
+		if strings.EqualFold(key, "Range") {
+			continue
+		}
 		req.Header.Set(key, val)
 	}
 	req.Header.Set("User-Agent", d.Runtime.GetUserAgent())

--- a/internal/engine/single/downloader_test.go
+++ b/internal/engine/single/downloader_test.go
@@ -384,6 +384,54 @@ func TestSingleDownloader_Download_Success(t *testing.T) {
 	}
 }
 
+func TestSingleDownloader_StripsCallerRangeHeader(t *testing.T) {
+	// Regression: a caller-supplied Range header (e.g. forwarded from the
+	// browser) must NOT be sent by the single downloader. Otherwise a
+	// range-capable server replies 206 and the strict 200 check aborts an
+	// otherwise valid download with "unexpected status code: 206".
+	tmpDir, cleanup, err := testutil.TempDir("surge-single-range")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	fileSize := int64(64 * 1024)
+	server := testutil.NewMockServerT(t,
+		testutil.WithFileSize(fileSize),
+		testutil.WithRangeSupport(true), // server WOULD answer 206 if Range leaks through
+		testutil.WithFilename("range_test.bin"),
+	)
+	defer server.Close()
+
+	destPath := filepath.Join(tmpDir, "range_test.bin")
+	state := types.NewProgressState("range-test", fileSize)
+	runtime := &types.RuntimeConfig{WorkerBufferSize: 8 * types.KB}
+
+	downloader := NewSingleDownloader("range-id", nil, state, runtime)
+	downloader.Headers = map[string]string{"Range": "bytes=100-"}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Pre-create incomplete file (simulating processing layer)
+	if f, err := os.Create(destPath + ".surge"); err == nil {
+		_ = f.Close()
+	}
+
+	err = downloader.Download(ctx, server.URL(), destPath, fileSize, "range_test.bin")
+	if err != nil {
+		t.Fatalf("Download failed; caller Range header should have been stripped: %v", err)
+	}
+
+	// Whole file should be fetched, not a partial range.
+	if err := testutil.VerifyFileSize(destPath+types.IncompleteSuffix, fileSize); err != nil {
+		t.Error(err)
+	}
+	if state.Downloaded.Load() != fileSize {
+		t.Errorf("Downloaded %d != fileSize %d", state.Downloaded.Load(), fileSize)
+	}
+}
+
 func TestSingleDownloader_Download_Cancellation(t *testing.T) {
 	tmpDir, cleanup, _ := testutil.TempDir("surge-cancel-single")
 	defer cleanup()

--- a/internal/engine/single/downloader_test.go
+++ b/internal/engine/single/downloader_test.go
@@ -388,47 +388,53 @@ func TestSingleDownloader_StripsCallerRangeHeader(t *testing.T) {
 	// Regression: a caller-supplied Range header (e.g. forwarded from the
 	// browser) must NOT be sent by the single downloader. Otherwise a
 	// range-capable server replies 206 and the strict 200 check aborts an
-	// otherwise valid download with "unexpected status code: 206".
-	tmpDir, cleanup, err := testutil.TempDir("surge-single-range")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cleanup()
+	// otherwise valid download with "unexpected status code: 206". The fix uses
+	// strings.EqualFold, so non-canonical casings (some clients/proxies forward
+	// a lowercase "range") must be stripped as well.
+	for _, headerKey := range []string{"Range", "range", "RANGE"} {
+		t.Run(headerKey, func(t *testing.T) {
+			tmpDir, cleanup, err := testutil.TempDir("surge-single-range")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer cleanup()
 
-	fileSize := int64(64 * 1024)
-	server := testutil.NewMockServerT(t,
-		testutil.WithFileSize(fileSize),
-		testutil.WithRangeSupport(true), // server WOULD answer 206 if Range leaks through
-		testutil.WithFilename("range_test.bin"),
-	)
-	defer server.Close()
+			fileSize := int64(64 * 1024)
+			server := testutil.NewMockServerT(t,
+				testutil.WithFileSize(fileSize),
+				testutil.WithRangeSupport(true), // server WOULD answer 206 if Range leaks through
+				testutil.WithFilename("range_test.bin"),
+			)
+			defer server.Close()
 
-	destPath := filepath.Join(tmpDir, "range_test.bin")
-	state := types.NewProgressState("range-test", fileSize)
-	runtime := &types.RuntimeConfig{WorkerBufferSize: 8 * types.KB}
+			destPath := filepath.Join(tmpDir, "range_test.bin")
+			state := types.NewProgressState("range-test", fileSize)
+			runtime := &types.RuntimeConfig{WorkerBufferSize: 8 * types.KB}
 
-	downloader := NewSingleDownloader("range-id", nil, state, runtime)
-	downloader.Headers = map[string]string{"Range": "bytes=100-"}
+			downloader := NewSingleDownloader("range-id", nil, state, runtime)
+			downloader.Headers = map[string]string{headerKey: "bytes=100-"}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
 
-	// Pre-create incomplete file (simulating processing layer)
-	if f, err := os.Create(destPath + ".surge"); err == nil {
-		_ = f.Close()
-	}
+			// Pre-create incomplete file (simulating processing layer)
+			if f, err := os.Create(destPath + ".surge"); err == nil {
+				_ = f.Close()
+			}
 
-	err = downloader.Download(ctx, server.URL(), destPath, fileSize, "range_test.bin")
-	if err != nil {
-		t.Fatalf("Download failed; caller Range header should have been stripped: %v", err)
-	}
+			err = downloader.Download(ctx, server.URL(), destPath, fileSize, "range_test.bin")
+			if err != nil {
+				t.Fatalf("Download failed; caller %q header should have been stripped: %v", headerKey, err)
+			}
 
-	// Whole file should be fetched, not a partial range.
-	if err := testutil.VerifyFileSize(destPath+types.IncompleteSuffix, fileSize); err != nil {
-		t.Error(err)
-	}
-	if state.Downloaded.Load() != fileSize {
-		t.Errorf("Downloaded %d != fileSize %d", state.Downloaded.Load(), fileSize)
+			// Whole file should be fetched, not a partial range.
+			if err := testutil.VerifyFileSize(destPath+types.IncompleteSuffix, fileSize); err != nil {
+				t.Error(err)
+			}
+			if state.Downloaded.Load() != fileSize {
+				t.Errorf("Downloaded %d != fileSize %d", state.Downloaded.Load(), fileSize)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

The single-connection downloader copied every caller-supplied header (including a browser-forwarded `Range`) into its request and then strictly required HTTP `200`, so a range-capable server replied `206` and the download aborted with `unexpected status code: 206`.

Fixes #495.

## Root cause

The main request loop in `Download()` forwarded `Range` verbatim. Every other header-copy site in the codebase strips it (the concurrent worker, the probe, and even the redirect handler in this same file), making this loop the sole outlier.

## Change

- `internal/engine/single/downloader.go`: skip `Range` case-insensitively in the request header loop; make the redirect handler's existing `Range` check case-insensitive too (`strings.EqualFold`).
- `internal/engine/single/downloader_test.go`: regression test using a range-capable mock server that returns `206` if the caller's `Range` leaks through.

## Testing

```
go test ./...   # all packages pass
```

The new test fails on `main` (`unexpected status code: 206`) and passes with this change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where the single-connection downloader forwarded caller-supplied `Range` headers verbatim, causing range-capable servers to respond with `206 Partial Content` — which the strict `200` check then rejected as an error.

- **`downloader.go`**: Adds `strings.EqualFold` Range-stripping in the main `Download()` header loop (the missing site), and upgrades the existing redirect handler's case-sensitive `!=` check to `EqualFold` for consistency with all other header-copy paths in the codebase.
- **`downloader_test.go`**: Adds a regression test exercising `"Range"`, `"range"`, and `"RANGE"` against a mock server configured to return `206` when the header leaks through, verifying the full file is downloaded correctly in all three cases.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is minimal, targeted, and consistent with how every other header-copy site in the codebase already handles Range.

Two-line logic fix with a well-scoped regression test that actively fails on the unfixed code and covers three casing variants. No other code paths are touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/engine/single/downloader.go | Adds case-insensitive Range header stripping in both the main Download loop and the redirect handler, fixing the 206 abort bug |
| internal/engine/single/downloader_test.go | Adds regression test covering canonical, lowercase, and uppercase Range header variants against a range-capable mock server |

</details>

<sub>Reviews (2): Last reviewed commit: ["test: cover non-canonical Range header c..."](https://github.com/surgedm/surge/commit/1cebe84a88b5e9687959c34cc3a61b6703265c50) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37871906)</sub>

<!-- /greptile_comment -->