### PR TITLE
fix: use the first server of a comma-separated custom DNS list

### DIFF
--- a/internal/utils/dns.go
+++ b/internal/utils/dns.go
@@ -11,19 +11,27 @@ import (
 // and the in-app help text), so only the first server is used here; a missing
 // port defaults to 53.
 func normalizeDNSAddr(customAddr string) string {
-	// Use the first server of a possibly comma-separated list. Without this the
-	// whole list would be treated as one host:port and net.SplitHostPort would
-	// fail, producing an invalid dial target like "[1.1.1.1:53, 8.8.8.8:53]:53"
-	// that breaks every DNS lookup.
-	if i := strings.IndexByte(customAddr, ','); i >= 0 {
-		customAddr = customAddr[:i]
+	// Use the first non-empty server of a possibly comma-separated list. Without
+	// this the whole list would be treated as one host:port and net.SplitHostPort
+	// would fail, producing an invalid dial target like "[1.1.1.1:53, 8.8.8.8:53]:53"
+	// that breaks every DNS lookup. Skipping empty entries also handles stray
+	// commas/whitespace (e.g. ", 8.8.8.8:53") gracefully; an empty result means
+	// no usable server was provided.
+	first := ""
+	for _, part := range strings.Split(customAddr, ",") {
+		if p := strings.TrimSpace(part); p != "" {
+			first = p
+			break
+		}
 	}
-	customAddr = strings.TrimSpace(customAddr)
+	if first == "" {
+		return ""
+	}
 
 	// Ensure there is a port in the address. If not, default to 53.
-	host, port, err := net.SplitHostPort(customAddr)
+	host, port, err := net.SplitHostPort(first)
 	if err != nil {
-		host = customAddr
+		host = first
 		port = "53"
 	}
 	return net.JoinHostPort(host, port)
@@ -38,6 +46,11 @@ func ConfigureDialer(dialer *net.Dialer, customAddr string) {
 	}
 
 	target := normalizeDNSAddr(customAddr)
+	if target == "" {
+		// The value was only separators/whitespace: no usable server, so leave
+		// the dialer's default resolver in place rather than installing a broken one.
+		return
+	}
 
 	dialer.Resolver = &net.Resolver{
 		PreferGo: true,

--- a/internal/utils/dns.go
+++ b/internal/utils/dns.go
@@ -6,6 +6,29 @@ import (
 	"strings"
 )
 
+// normalizeDNSAddr turns the custom DNS setting into a single dial target
+// (host:port). The setting accepts a comma-separated list (see ValidateDNSList
+// and the in-app help text), so only the first server is used here; a missing
+// port defaults to 53.
+func normalizeDNSAddr(customAddr string) string {
+	// Use the first server of a possibly comma-separated list. Without this the
+	// whole list would be treated as one host:port and net.SplitHostPort would
+	// fail, producing an invalid dial target like "[1.1.1.1:53, 8.8.8.8:53]:53"
+	// that breaks every DNS lookup.
+	if i := strings.IndexByte(customAddr, ','); i >= 0 {
+		customAddr = customAddr[:i]
+	}
+	customAddr = strings.TrimSpace(customAddr)
+
+	// Ensure there is a port in the address. If not, default to 53.
+	host, port, err := net.SplitHostPort(customAddr)
+	if err != nil {
+		host = customAddr
+		port = "53"
+	}
+	return net.JoinHostPort(host, port)
+}
+
 // ConfigureDialer modifies the provided net.Dialer to route all DNS lookups
 // through the specified custom DNS server address.
 // customAddr should include the port, e.g., "1.1.1.1:53".
@@ -14,13 +37,7 @@ func ConfigureDialer(dialer *net.Dialer, customAddr string) {
 		return
 	}
 
-	// Ensure there is a port in the address. If not, default to 53.
-	host, port, err := net.SplitHostPort(customAddr)
-	if err != nil {
-		host = customAddr
-		port = "53"
-	}
-	customAddr = net.JoinHostPort(host, port)
+	target := normalizeDNSAddr(customAddr)
 
 	dialer.Resolver = &net.Resolver{
 		PreferGo: true,
@@ -28,7 +45,7 @@ func ConfigureDialer(dialer *net.Dialer, customAddr string) {
 			// Use a clean dialer with no custom resolver to avoid recursive resolution
 			// when customAddr is a hostname rather than a literal IP.
 			d := net.Dialer{Timeout: dialer.Timeout}
-			return d.DialContext(ctx, "udp", customAddr)
+			return d.DialContext(ctx, "udp", target)
 		},
 	}
 }

--- a/internal/utils/dns_test.go
+++ b/internal/utils/dns_test.go
@@ -1,0 +1,36 @@
+package utils
+
+import (
+	"net"
+	"testing"
+)
+
+func TestNormalizeDNSAddr(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"single with port", "1.1.1.1:53", "1.1.1.1:53"},
+		{"single without port defaults to 53", "1.1.1.1", "1.1.1.1:53"},
+		{"comma-separated list uses first server", "1.1.1.1:53, 94.140.14.14:53", "1.1.1.1:53"},
+		{"comma-separated without ports", "8.8.8.8, 8.8.4.4", "8.8.8.8:53"},
+		{"leading whitespace is trimmed", "  9.9.9.9:53  ", "9.9.9.9:53"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange: a custom DNS value (single server or comma-separated list)
+			// Act: normalize it to a single dial target
+			got := normalizeDNSAddr(tt.input)
+
+			// Assert: it equals the first server and is a valid host:port
+			if got != tt.want {
+				t.Errorf("normalizeDNSAddr(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+			if _, _, err := net.SplitHostPort(got); err != nil {
+				t.Errorf("normalizeDNSAddr(%q) = %q, which is not a valid host:port: %v", tt.input, got, err)
+			}
+		})
+	}
+}

--- a/internal/utils/dns_test.go
+++ b/internal/utils/dns_test.go
@@ -16,20 +16,23 @@ func TestNormalizeDNSAddr(t *testing.T) {
 		{"comma-separated list uses first server", "1.1.1.1:53, 94.140.14.14:53", "1.1.1.1:53"},
 		{"comma-separated without ports", "8.8.8.8, 8.8.4.4", "8.8.8.8:53"},
 		{"leading whitespace is trimmed", "  9.9.9.9:53  ", "9.9.9.9:53"},
+		{"leading comma skips the empty entry", ", 8.8.8.8:53", "8.8.8.8:53"},
+		{"only separators yield empty", " , ", ""},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Arrange: a custom DNS value (single server or comma-separated list)
-			// Act: normalize it to a single dial target
 			got := normalizeDNSAddr(tt.input)
-
-			// Assert: it equals the first server and is a valid host:port
 			if got != tt.want {
 				t.Errorf("normalizeDNSAddr(%q) = %q, want %q", tt.input, got, tt.want)
 			}
-			if _, _, err := net.SplitHostPort(got); err != nil {
-				t.Errorf("normalizeDNSAddr(%q) = %q, which is not a valid host:port: %v", tt.input, got, err)
+			// A non-empty result must be dialable. SplitHostPort catches
+			// malformed values (e.g. ":53" or "[a, b]:53") that would pass the
+			// string comparison above but still fail when the resolver dials.
+			if got != "" {
+				if _, _, err := net.SplitHostPort(got); err != nil {
+					t.Errorf("normalizeDNSAddr(%q) = %q, which is not a valid host:port: %v", tt.input, got, err)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

The Custom DNS setting is validated as a comma-separated list (`ValidateDNSList`) and the in-app help text suggests two servers (`1.1.1.1:53, 94.140.14.14:53`), but `ConfigureDialer` ran `net.SplitHostPort` on the whole string and never split on `,`. The documented example therefore became the invalid dial target `[1.1.1.1:53, 94.140.14.14:53]:53`, silently breaking every DNS lookup (and thus every download).

Fixes #497.

## Change

- `internal/utils/dns.go`: extract a `normalizeDNSAddr` helper that uses the first (trimmed) server of a possibly comma-separated list before defaulting the port; `ConfigureDialer` now uses it. This makes the address-normalization logic unit-testable without touching the network.
- `internal/utils/dns_test.go`: table-driven regression test (single/list inputs, missing ports, surrounding whitespace).

## Testing

```
go test ./...   # all packages pass
```

On `main` the helper logic produces `[1.1.1.1:53, 94.140.14.14:53]:53` for the list case (test fails); with this change it returns `1.1.1.1:53` (test passes).

## Note

This is the minimal safe fix (use the primary server). Round-robin / failover across all listed servers could be a follow-up if desired.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a silent DNS breakage where passing the documented comma-separated list (`1.1.1.1:53, 94.140.14.14:53`) to `ConfigureDialer` produced the invalid dial target `[1.1.1.1:53, 94.140.14.14:53]:53`, breaking every DNS lookup and therefore every download.

- **`internal/utils/dns.go`**: Extracts `normalizeDNSAddr`, which splits on `,`, skips empty/whitespace entries, picks the first usable server, and defaults the port to 53. `ConfigureDialer` now delegates to it and adds a second early-return guard for all-separator inputs (e.g., `" , "`) that would pass the existing `TrimSpace` check but produce no valid server.
- **`internal/utils/dns_test.go`**: Adds a table-driven test with 7 cases (single address, comma list, missing port, surrounding whitespace, leading comma, all-separators) plus a secondary `net.SplitHostPort` dialability assertion on every non-empty result.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, focused fix with comprehensive tests and no regressions.

The extraction of normalizeDNSAddr correctly handles all documented input forms (single address, comma-separated list, missing port, stray whitespace). The two-guard structure in ConfigureDialer ensures that degenerate inputs like " , " that slip past the original TrimSpace check are still handled gracefully. Test coverage is thorough, including a secondary dialability assertion on every non-empty output. No existing behavior for well-formed single-address inputs is changed.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/utils/dns.go | Extracts normalizeDNSAddr helper to correctly parse the first entry of a comma-separated DNS list before dialing; adds a second early-return guard for all-separator inputs. |
| internal/utils/dns_test.go | New table-driven test for normalizeDNSAddr covering 7 cases including comma lists, missing ports, whitespace, and a secondary SplitHostPort dialability check on each non-empty result. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test: cover leading-comma and separator-..."](https://github.com/surgedm/surge/commit/3e20e6a36bc4d681b578d8dc3b1ba2b7701b3ef5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37872495)</sub>

<!-- /greptile_comment -->