### PR TITLE
fix: config backwards compatibility

### DIFF
--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -70,6 +71,26 @@ type PerformanceSettings struct {
 type CategorySettings struct {
 	CategoryEnabled *Setting   `json:"category_enabled"`
 	Categories      []Category `json:"categories"`
+}
+
+// UnmarshalJSON handles both the new struct format and the old array format for Categories
+// to prevent config wipes when upgrading from older versions.
+func (c *CategorySettings) UnmarshalJSON(data []byte) error {
+	data = bytes.TrimSpace(data)
+	if len(data) > 0 && data[0] == '[' {
+		// Old format: direct array of categories
+		var oldCats []Category
+		if err := json.Unmarshal(data, &oldCats); err != nil {
+			return err
+		}
+		c.Categories = oldCats
+		return nil
+	}
+
+	// New format: CategorySettings object
+	type alias CategorySettings
+	aux := (*alias)(c)
+	return json.Unmarshal(data, aux)
 }
 
 type ExtensionSettings struct {

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -484,3 +484,74 @@ func TestResolveGeneric(t *testing.T) {
 		t.Errorf("Resolve[time.Duration] got %v, want 15s", val)
 	}
 }
+
+func TestCategorySettings_UnmarshalJSON_BackwardCompatibility(t *testing.T) {
+	// Test the old array format
+	oldJSON := []byte(`[
+		{"name": "Videos", "pattern": ".*\\.mp4"},
+		{"name": "Music", "pattern": ".*\\.mp3"}
+	]`)
+
+	var cs CategorySettings
+	err := json.Unmarshal(oldJSON, &cs)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal old array format: %v", err)
+	}
+
+	if len(cs.Categories) != 2 {
+		t.Fatalf("Expected 2 categories, got %d", len(cs.Categories))
+	}
+	if cs.Categories[0].Name != "Videos" {
+		t.Errorf("Expected first category to be 'Videos', got '%s'", cs.Categories[0].Name)
+	}
+
+	// Test the new struct format
+	newJSON := []byte(`{
+		"category_enabled": true,
+		"categories": [
+			{"name": "Documents", "pattern": ".*\\.pdf"}
+		]
+	}`)
+
+	fullJSON := []byte(`{
+		"categories": ` + string(newJSON) + `
+	}`)
+
+	s := DefaultSettings()
+	err = json.Unmarshal(fullJSON, s)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal new struct format: %v", err)
+	}
+
+	if len(s.Categories.Categories) != 1 {
+		t.Fatalf("Expected 1 category, got %d", len(s.Categories.Categories))
+	}
+	if s.Categories.Categories[0].Name != "Documents" {
+		t.Errorf("Expected 'Documents', got '%s'", s.Categories.Categories[0].Name)
+	}
+	if !Resolve[bool](s.Categories.CategoryEnabled) {
+		t.Errorf("Expected category_enabled to be true")
+	}
+
+	// Test full settings with old format
+	fullOldJSON := []byte(`{
+		"categories": ` + string(oldJSON) + `
+	}`)
+
+	s2 := DefaultSettings()
+	err = json.Unmarshal(fullOldJSON, s2)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal full old format: %v", err)
+	}
+
+	if len(s2.Categories.Categories) != 2 {
+		t.Fatalf("Expected 2 categories, got %d", len(s2.Categories.Categories))
+	}
+	if s2.Categories.Categories[0].Name != "Videos" {
+		t.Errorf("Expected 'Videos', got '%s'", s2.Categories.Categories[0].Name)
+	}
+	// CategoryEnabled should remain default (false)
+	if Resolve[bool](s2.Categories.CategoryEnabled) {
+		t.Errorf("Expected category_enabled to remain false")
+	}
+}

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -485,6 +485,95 @@ func TestResolveGeneric(t *testing.T) {
 	}
 }
 
+func TestCategorySettings_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name        string
+		json        string
+		wantErr     bool
+		assertState func(t *testing.T, cs *CategorySettings)
+	}{
+		{
+			name:    "Old array format",
+			json:    `[{"name": "Videos", "pattern": ".*\\.mp4"}]`,
+			wantErr: false,
+			assertState: func(t *testing.T, cs *CategorySettings) {
+				if len(cs.Categories) != 1 {
+					t.Fatalf("Expected 1 category, got %d", len(cs.Categories))
+				}
+				if cs.Categories[0].Name != "Videos" {
+					t.Errorf("Expected 'Videos', got '%s'", cs.Categories[0].Name)
+				}
+			},
+		},
+		{
+			name:    "New struct format",
+			json:    `{"category_enabled": true, "categories": [{"name": "Documents", "pattern": ".*\\.pdf"}]}`,
+			wantErr: false,
+			assertState: func(t *testing.T, cs *CategorySettings) {
+				if len(cs.Categories) != 1 {
+					t.Fatalf("Expected 1 category, got %d", len(cs.Categories))
+				}
+				if cs.Categories[0].Name != "Documents" {
+					t.Errorf("Expected 'Documents', got '%s'", cs.Categories[0].Name)
+				}
+				if cs.CategoryEnabled == nil {
+					t.Fatalf("Expected CategoryEnabled to be non-nil")
+				}
+				if Resolve[bool](cs.CategoryEnabled) != true {
+					t.Errorf("Expected CategoryEnabled to be true")
+				}
+			},
+		},
+		{
+			name:    "Null value",
+			json:    `null`,
+			wantErr: false,
+			assertState: func(t *testing.T, cs *CategorySettings) {
+				if len(cs.Categories) != 0 {
+					t.Errorf("Expected 0 categories, got %d", len(cs.Categories))
+				}
+			},
+		},
+		{
+			name:    "Empty array",
+			json:    `[]`,
+			wantErr: false,
+			assertState: func(t *testing.T, cs *CategorySettings) {
+				if len(cs.Categories) != 0 {
+					t.Errorf("Expected 0 categories, got %d", len(cs.Categories))
+				}
+			},
+		},
+		{
+			name:        "Invalid JSON array",
+			json:        `[{"name": "Videos"`,
+			wantErr:     true,
+			assertState: nil,
+		},
+		{
+			name:        "Invalid JSON object",
+			json:        `{"categories": [{"name": "Videos"}`,
+			wantErr:     true,
+			assertState: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cs CategorySettings
+			err := json.Unmarshal([]byte(tt.json), &cs)
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Unmarshal() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if !tt.wantErr && tt.assertState != nil {
+				tt.assertState(t, &cs)
+			}
+		})
+	}
+}
+
 func TestCategorySettings_UnmarshalJSON_BackwardCompatibility(t *testing.T) {
 	// Test the old array format
 	oldJSON := []byte(`[

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -310,15 +311,22 @@ func InitialRootModel(serverPort int, currentVersion string, service core.Downlo
 	applyFilepickerTheme(&fp)
 
 	// Load settings for auto resume
-	settings, _ := config.LoadSettings()
+	settings, errSettings := config.LoadSettings()
 	if settings == nil {
 		settings = config.DefaultSettings()
 	}
+	if errSettings != nil {
+		settings.StartupWarnings = append(settings.StartupWarnings, fmt.Sprintf("Failed to load settings: %v", errSettings))
+	}
 
-	keys, _ := config.LoadKeyMap()
+	keys, errKeys := config.LoadKeyMap()
 	if keys == nil {
 		keys = config.DefaultKeyMap()
 	}
+	if errKeys != nil {
+		keys.StartupWarnings = append(keys.StartupWarnings, fmt.Sprintf("Failed to load keymap: %v", errKeys))
+	}
+
 	var keyMapModTime time.Time
 	if info, err := os.Stat(config.GetKeyMapConfigPath()); err == nil {
 		keyMapModTime = info.ModTime()


### PR DESCRIPTION
- **feat: add custom UnmarshalJSON to CategorySettings to support backward compatibility for category arrays**
- **test: add backward compatibility tests for CategorySettings JSON unmarshaling**

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds backward compatibility for `CategorySettings` JSON unmarshaling so that configs written in the old array format are not wiped when users upgrade, and improves error visibility in the TUI startup path.

- `CategorySettings.UnmarshalJSON` uses the standard Go alias pattern to detect and handle the old `[]Category` array format vs. the new struct format without infinite recursion; null and empty-array inputs are also handled correctly.
- Tests cover both happy paths and edge cases (null, empty array, invalid JSON for both formats), and the integration test verifies the full `Settings` struct round-trip.
- `model.go` replaces silent `_` error discards on `LoadSettings`/`LoadKeyMap` with captured errors appended to `StartupWarnings`, consistent with the existing warning infrastructure.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the backward-compat unmarshaler is well-scoped, the alias pattern correctly prevents infinite recursion, and errors that were previously swallowed silently are now surfaced as startup warnings.

All three changed files are straightforward and correct. The UnmarshalJSON uses the idiomatic Go alias trick, handles null/empty/invalid inputs gracefully, and is backed by a thorough test suite. The model.go change is a strict improvement with no regressions.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/config/settings.go | Adds a custom UnmarshalJSON to CategorySettings using the standard alias pattern to support backward compatibility with old array-format configs; implementation is correct and idiomatic Go. |
| internal/config/settings_test.go | Adds table-driven and integration tests covering old array format, new struct format, null, empty array, and invalid JSON inputs for the new UnmarshalJSON method. |
| internal/tui/model.go | Replaces silent error discarding (`_`) on LoadSettings/LoadKeyMap with captured errors surfaced as StartupWarnings; consistent with the existing warning infrastructure. |

</details>

<sub>Reviews (2): Last reviewed commit: ["feat: implement custom UnmarshalJSON for..."](https://github.com/surgedm/surge/commit/13e8a17e6249578edb2df4ab1bb384a30514c5a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38064679)</sub>

<!-- /greptile_comment -->