### PR TITLE
feat(extension): add server profile switcher

### DIFF
--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -4,6 +4,7 @@ import { DownloadStatus, HistoryEntry } from './popup/store/types';
 import {
   STORAGE_KEYS,
   readStoredNumber,
+  parseServerProfiles,
   migrateServerProfiles,
   resolveActiveServerUrl,
 } from '../lib/storage';
@@ -133,17 +134,15 @@ async function loadPersistedState(): Promise<void> {
 }
 
 async function reresolveActiveServerUrl(): Promise<void> {
-  const [serverUrl, profiles, activeProfileId] = await Promise.all([
-    storageGet(STORAGE_KEYS.SERVER_URL),
+  const [profiles, activeProfileId] = await Promise.all([
     storageGetRaw(STORAGE_KEYS.PROFILES),
     storageGet(STORAGE_KEYS.ACTIVE_PROFILE_ID),
   ]);
-  const migration = migrateServerProfiles({
-    [STORAGE_KEYS.SERVER_URL]: serverUrl,
-    [STORAGE_KEYS.PROFILES]: profiles,
-    [STORAGE_KEYS.ACTIVE_PROFILE_ID]: activeProfileId,
-  });
-  const activeServerUrl = resolveActiveServerUrl(migration.profiles, migration.activeId);
+  // Use parseServerProfiles (not migrateServerProfiles) — migration is a startup
+  // concern handled once in loadPersistedState. The change listener only needs to
+  // read the already-persisted profile list and resolve the active URL.
+  const parsed = parseServerProfiles({ [STORAGE_KEYS.PROFILES]: profiles });
+  const activeServerUrl = resolveActiveServerUrl(parsed, activeProfileId ?? '');
   setCachedServerUrlState(normalizeServerUrl(activeServerUrl) || null);
   lastHealthCheck = 0;
   lastBaseUrlFailureAt = 0;
@@ -930,4 +929,5 @@ export const __test__ = {
     processedIds.clear();
   },
   handleDownloadCreated,
+  reresolveActiveServerUrl,
 };

--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -1,7 +1,12 @@
 import { defineBackground } from 'wxt/utils/define-background';
 import { normalizeToken, normalizeServerUrl } from './popup/lib/utils';
 import { DownloadStatus, HistoryEntry } from './popup/store/types';
-import { STORAGE_KEYS, readStoredNumber } from '../lib/storage';
+import {
+  STORAGE_KEYS,
+  readStoredNumber,
+  migrateServerProfiles,
+  resolveActiveServerUrl,
+} from '../lib/storage';
 import {
   buildDownloadRequestBody,
   buildEventStreamHeaders,
@@ -67,6 +72,11 @@ async function storageGet(key: string): Promise<string | undefined> {
   return typeof result[key] === 'string' ? result[key] : undefined;
 }
 
+async function storageGetRaw(key: string): Promise<unknown> {
+  const result = await browser.storage.local.get(key);
+  return result[key];
+}
+
 async function storageGetBoolean(key: string): Promise<boolean | undefined> {
   const result = await browser.storage.local.get(key);
   return coerceStoredBoolean(result[key]);
@@ -93,21 +103,50 @@ function setCachedDiscoveredServerUrlState(url: string | null): void {
 }
 
 async function loadPersistedState(): Promise<void> {
-  const [token, serverUrl, discoveredServerUrl] = await Promise.all([
+  const [token, serverUrl, discoveredServerUrl, profiles, activeProfileId] = await Promise.all([
     storageGet(STORAGE_KEYS.TOKEN),
     storageGet(STORAGE_KEYS.SERVER_URL),
     storageGet(STORAGE_KEYS.DISCOVERED_SERVER_URL),
+    storageGetRaw(STORAGE_KEYS.PROFILES),
+    storageGet(STORAGE_KEYS.ACTIVE_PROFILE_ID),
   ]);
+
+  // Resolve the active server URL from the profile list, transparently treating a
+  // legacy single SERVER_URL as a default profile. The popup persists the migrated
+  // profile list; the background only reads to stay a passive consumer of storage.
+  const migration = migrateServerProfiles({
+    [STORAGE_KEYS.SERVER_URL]: serverUrl,
+    [STORAGE_KEYS.PROFILES]: profiles,
+    [STORAGE_KEYS.ACTIVE_PROFILE_ID]: activeProfileId,
+  });
+  const activeServerUrl = resolveActiveServerUrl(migration.profiles, migration.activeId);
 
   if (!hasHydratedAuthToken) {
     setCachedAuthTokenState(token || null);
   }
   if (!hasHydratedServerUrl) {
-    setCachedServerUrlState(serverUrl || null);
+    setCachedServerUrlState(activeServerUrl || null);
   }
   if (!hasHydratedDiscoveredServerUrl) {
     setCachedDiscoveredServerUrlState(discoveredServerUrl || null);
   }
+}
+
+async function reresolveActiveServerUrl(): Promise<void> {
+  const [serverUrl, profiles, activeProfileId] = await Promise.all([
+    storageGet(STORAGE_KEYS.SERVER_URL),
+    storageGetRaw(STORAGE_KEYS.PROFILES),
+    storageGet(STORAGE_KEYS.ACTIVE_PROFILE_ID),
+  ]);
+  const migration = migrateServerProfiles({
+    [STORAGE_KEYS.SERVER_URL]: serverUrl,
+    [STORAGE_KEYS.PROFILES]: profiles,
+    [STORAGE_KEYS.ACTIVE_PROFILE_ID]: activeProfileId,
+  });
+  const activeServerUrl = resolveActiveServerUrl(migration.profiles, migration.activeId);
+  setCachedServerUrlState(normalizeServerUrl(activeServerUrl) || null);
+  lastHealthCheck = 0;
+  lastBaseUrlFailureAt = 0;
 }
 
 function ensurePersistedStateLoaded(): Promise<void> {
@@ -787,7 +826,10 @@ export default defineBackground(() => {
   // Storage change propagation
   browser.storage.onChanged.addListener((changes, areaName) => {
     if (areaName !== 'local') return;
-    if (changes[STORAGE_KEYS.SERVER_URL]?.newValue !== undefined) {
+    // Re-resolve the active server URL when the profile list or selection changes.
+    if (changes[STORAGE_KEYS.PROFILES] || changes[STORAGE_KEYS.ACTIVE_PROFILE_ID]) {
+      void reresolveActiveServerUrl();
+    } else if (changes[STORAGE_KEYS.SERVER_URL]?.newValue !== undefined) {
       setCachedServerUrlState(normalizeServerUrl(changes[STORAGE_KEYS.SERVER_URL].newValue as string) || null);
       lastHealthCheck = 0;
       lastBaseUrlFailureAt = 0;

--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -205,17 +205,20 @@ async function persistDiscoveredServerUrl(url: string | null): Promise<void> {
 // ---------------------------------------------------------------------------
 
 async function discoverBaseUrl(): Promise<string | null> {
-  // Try the user-configured URL first and only.
+  let baseHost = '127.0.0.1';
   if (cachedServerUrl) {
     const ok = await healthCheck(cachedServerUrl);
     if (ok) return cachedServerUrl;
-    return null;
+    try {
+      baseHost = new URL(cachedServerUrl).hostname || '127.0.0.1';
+    } catch { /* ignore */ }
   }
 
   const candidates = buildPortScanCandidates(
     DEFAULT_PORT,
     MAX_PORT_SCAN,
-    [cachedDiscoveredServerUrl],
+    [cachedServerUrl, cachedDiscoveredServerUrl],
+    baseHost
   );
 
   const token = cachedAuthToken;
@@ -227,20 +230,23 @@ async function discoverBaseUrl(): Promise<string | null> {
 }
 
 async function discoverBaseUrlForToken(token: string): Promise<{ base: string | null; sawUnauthorized: boolean; sawReachable: boolean }> {
+  let baseHost = '127.0.0.1';
   if (cachedServerUrl) {
-    if (!await healthCheck(cachedServerUrl)) return { base: null, sawUnauthorized: false, sawReachable: false };
-    const auth = await checkAuthAtBaseUrl(cachedServerUrl, token);
-    return {
-      base: auth.ok ? cachedServerUrl : null,
-      sawUnauthorized: auth.status === 401,
-      sawReachable: true,
-    };
+    if (await healthCheck(cachedServerUrl)) {
+      const auth = await checkAuthAtBaseUrl(cachedServerUrl, token);
+      if (auth.ok) return { base: cachedServerUrl, sawUnauthorized: false, sawReachable: true };
+      if (auth.status === 401) return { base: null, sawUnauthorized: true, sawReachable: true };
+    }
+    try {
+      baseHost = new URL(cachedServerUrl).hostname || '127.0.0.1';
+    } catch { /* ignore */ }
   }
 
   const candidates = buildPortScanCandidates(
     DEFAULT_PORT,
     MAX_PORT_SCAN,
-    [cachedDiscoveredServerUrl],
+    [cachedServerUrl, cachedDiscoveredServerUrl],
+    baseHost
   );
 
   let sawUnauthorized = false;
@@ -674,9 +680,16 @@ function handleMessage(message: Record<string, any>): Promise<unknown> | unknown
       return (async () => {
         const url = normalizeServerUrl(message.url || '');
         const token = normalizeToken(message.token || '');
-        if (!url || !token) return { ok: false, error: 'invalid_input' };
+        if (!token) return { ok: false, error: 'invalid_input' };
         
-        const candidates = buildPortScanCandidates(DEFAULT_PORT, MAX_PORT_SCAN, [url]);
+        let baseHost = '127.0.0.1';
+        if (url) {
+          try {
+            baseHost = new URL(url).hostname || '127.0.0.1';
+          } catch { /* ignore */ }
+        }
+
+        const candidates = buildPortScanCandidates(DEFAULT_PORT, MAX_PORT_SCAN, [url], baseHost);
         let sawUnauthorized = false;
         for (let index = 0; index < candidates.length; index += PORT_SCAN_BATCH_SIZE) {
           const batch = candidates.slice(index, index + PORT_SCAN_BATCH_SIZE);

--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -670,6 +670,36 @@ function handleMessage(message: Record<string, any>): Promise<unknown> | unknown
     // Health / connection
     case 'checkHealth': return checkHealthSilent().then(healthy => ({ healthy }));
 
+    case 'testConnection':
+      return (async () => {
+        const url = normalizeServerUrl(message.url || '');
+        const token = normalizeToken(message.token || '');
+        if (!url || !token) return { ok: false, error: 'invalid_input' };
+        
+        const candidates = buildPortScanCandidates(DEFAULT_PORT, MAX_PORT_SCAN, [url]);
+        let sawUnauthorized = false;
+        for (let index = 0; index < candidates.length; index += PORT_SCAN_BATCH_SIZE) {
+          const batch = candidates.slice(index, index + PORT_SCAN_BATCH_SIZE);
+          const results = await Promise.all(batch.map(async (candidate) => {
+            try {
+              const r1 = await fetch(`${candidate}/health`, { signal: AbortSignal.timeout(300) });
+              if (!r1.ok) return { candidate, ok: false, status: 0 };
+              const r2 = await fetch(`${candidate}/list`, {
+                headers: { Authorization: `Bearer ${token}` },
+                signal: AbortSignal.timeout(1000),
+              });
+              return { candidate, ok: r2.ok, status: r2.status };
+            } catch { return { candidate, ok: false, status: 0 }; }
+          }));
+
+          for (const result of results) {
+            if (result.status === 401) sawUnauthorized = true;
+            if (result.ok) return { ok: true, url: result.candidate };
+          }
+        }
+        return { ok: false, error: sawUnauthorized ? 'invalid_token' : 'no_server' };
+      })();
+
     case 'validateAuth':
       return (async () => {
         const token = normalizeToken(message.token || '');

--- a/extension/entrypoints/popup/App.tsx
+++ b/extension/entrypoints/popup/App.tsx
@@ -1,5 +1,12 @@
 import { createSignal, onMount, onCleanup } from 'solid-js';
-import { readStoredBoolean, readStoredString, readStoredNumber, STORAGE_KEYS } from '../../lib/storage';
+import {
+  readStoredBoolean,
+  readStoredString,
+  readStoredNumber,
+  STORAGE_KEYS,
+  migrateServerProfiles,
+  resolveActiveServerUrl,
+} from '../../lib/storage';
 import {
   serverConnected,
   setServerConnected,
@@ -14,6 +21,8 @@ import {
   handleSseEvent,
   setServerUrl,
   setServerUrlLocked,
+  setServerProfiles,
+  setActiveProfileId,
   setAuthToken,
   setAuthTokenLocked,
   authValid,
@@ -59,6 +68,8 @@ export default function App() {
     try {
       const storedValues = await browser.storage.local.get([
         STORAGE_KEYS.SERVER_URL,
+        STORAGE_KEYS.PROFILES,
+        STORAGE_KEYS.ACTIVE_PROFILE_ID,
         STORAGE_KEYS.TOKEN,
         STORAGE_KEYS.VERIFIED,
         STORAGE_KEYS.INTERCEPT,
@@ -66,12 +77,23 @@ export default function App() {
         STORAGE_KEYS.MIN_FILE_SIZE,
       ]);
 
-      const storedServerUrl = readStoredString(storedValues, STORAGE_KEYS.SERVER_URL);
+      // Migrate the legacy single SERVER_URL into a default profile when needed.
+      const migration = migrateServerProfiles(storedValues);
+      if (migration.migrated) {
+        await browser.storage.local.set({
+          [STORAGE_KEYS.PROFILES]: migration.profiles,
+          [STORAGE_KEYS.ACTIVE_PROFILE_ID]: migration.activeId,
+        });
+      }
+
+      setServerProfiles(migration.profiles);
+      setActiveProfileId(migration.activeId);
+
+      const activeServerUrl = resolveActiveServerUrl(migration.profiles, migration.activeId);
+      setServerUrl(activeServerUrl);
+      setServerUrlLocked(activeServerUrl.trim().length > 0);
+
       const storedToken = readStoredString(storedValues, STORAGE_KEYS.TOKEN);
-
-      setServerUrl(storedServerUrl);
-      setServerUrlLocked(storedServerUrl.trim().length > 0);
-
       setAuthToken(storedToken);
       setAuthTokenLocked(storedToken.trim().length > 0);
       setAuthValid(readStoredBoolean(storedValues, STORAGE_KEYS.VERIFIED, false));

--- a/extension/entrypoints/popup/components/SettingsView.tsx
+++ b/extension/entrypoints/popup/components/SettingsView.tsx
@@ -87,6 +87,7 @@ export default function SettingsView() {
       { name: newProfileName(), url: newProfileUrl(), token: newProfileToken() },
       makeStore(),
       browser.storage.local,
+      true, // Set authValid = true because we just successfully connected!
     );
     if (result.ok) {
       setNewProfileName('');
@@ -187,7 +188,7 @@ export default function SettingsView() {
               >
                 <For each={serverProfiles()}>
                   {(profile) => (
-                    <option value={profile.id}>{profile.name} ({profile.url})</option>
+                    <option value={profile.id}>{profile.name} ({profile.url || 'localhost'})</option>
                   )}
                 </For>
               </select>

--- a/extension/entrypoints/popup/components/SettingsView.tsx
+++ b/extension/entrypoints/popup/components/SettingsView.tsx
@@ -6,14 +6,13 @@ import {
   serverConnected,
   serverProfiles, setServerProfiles,
   activeProfileId, setActiveProfileId,
-  authToken, setAuthToken,
-  authTokenLocked, setAuthTokenLocked,
+  setAuthToken,
+  setAuthTokenLocked,
   authValid, setAuthValid,
   interceptEnabled, setInterceptEnabled,
   notificationsEnabled, setNotificationsEnabled,
   minFileSize, setMinFileSize,
 } from '../store';
-import { normalizeToken } from '../lib/utils';
 import {
   handleAddProfile as _handleAddProfile,
   handleSwitchProfile as _handleSwitchProfile,
@@ -33,14 +32,15 @@ function saveStatusSignal() {
 
 export default function SettingsView() {
   const [serverStatus, showServerStatus] = saveStatusSignal();
-  const [tokenStatus, showTokenStatus] = saveStatusSignal();
-  const [tokenFocused, setTokenFocused] = createSignal(false);
   const [newProfileName, setNewProfileName] = createSignal('');
   const [newProfileUrl, setNewProfileUrl] = createSignal('');
+  const [newProfileToken, setNewProfileToken] = createSignal('');
+  const [isConnecting, setIsConnecting] = createSignal(false);
+  const [connectionValid, setConnectionValid] = createSignal(false);
+
   const extensionVersion = browser.runtime.getManifest().version;
   const isFirefox = (browser.runtime.getURL as (path?: string) => string)('').startsWith('moz-extension:');
 
-  // Build the store accessor / setter bag required by the extracted handler logic.
   const makeStore = () => ({
     getProfiles: serverProfiles,
     getActiveId: activeProfileId,
@@ -48,18 +48,52 @@ export default function SettingsView() {
     setActiveId: setActiveProfileId,
     setServerUrl,
     setServerUrlLocked,
+    setAuthToken,
+    setAuthTokenLocked,
+    setAuthValid,
   });
 
-  const handleAddProfile = async () => {
-    showServerStatus('Saving...');
+  const handleConnect = async () => {
+    const url = newProfileUrl().trim();
+    const token = newProfileToken().trim();
+    if (!url || !token) {
+      showServerStatus('Enter URL and Token');
+      return;
+    }
+
+    setIsConnecting(true);
+    showServerStatus('Connecting...', 0); // Keep showing until done
+    
+    try {
+      const res = await browser.runtime.sendMessage({ type: 'testConnection', url, token }).catch(() => null) as { ok?: boolean; url?: string; error?: string } | null;
+      if (res?.ok) {
+        if (res.url) setNewProfileUrl(res.url);
+        setConnectionValid(true);
+        showServerStatus('Connected');
+      } else if (res?.error === 'invalid_token') {
+        showServerStatus('Invalid Token');
+      } else {
+        showServerStatus('Server unavailable');
+      }
+    } catch {
+      showServerStatus('Server unavailable');
+    } finally {
+      setIsConnecting(false);
+    }
+  };
+
+  const handleSaveProfile = async () => {
+    showServerStatus('Saving...', 0);
     const result = await _handleAddProfile(
-      { name: newProfileName(), url: newProfileUrl() },
+      { name: newProfileName(), url: newProfileUrl(), token: newProfileToken() },
       makeStore(),
       browser.storage.local,
     );
     if (result.ok) {
       setNewProfileName('');
       setNewProfileUrl('');
+      setNewProfileToken('');
+      setConnectionValid(false);
       showServerStatus('Saved');
     } else {
       showServerStatus(result.error ?? 'Failed to save');
@@ -67,57 +101,15 @@ export default function SettingsView() {
   };
 
   const handleSwitchProfile = async (profileId: string) => {
-    showServerStatus('Switching...');
+    showServerStatus('Switching...', 0);
     const result = await _handleSwitchProfile(profileId, makeStore(), browser.storage.local);
     showServerStatus(result.ok ? 'Switched' : (result.error ?? 'Failed to switch'));
   };
 
   const handleDeleteProfile = async () => {
-    showServerStatus('Removing...');
+    showServerStatus('Removing...', 0);
     const result = await _handleDeleteProfile(makeStore(), browser.storage.local);
     showServerStatus(result.ok ? 'Removed' : (result.error ?? 'Failed to remove'));
-  };
-
-  const handleSaveToken = async () => {
-    const token = normalizeToken(authToken());
-    setAuthToken(token);
-    showTokenStatus('Saving...');
-    try {
-      await browser.storage.local.set({
-        [STORAGE_KEYS.TOKEN]: token,
-        [STORAGE_KEYS.VERIFIED]: 'false',
-      });
-      setAuthTokenLocked(token.length > 0);
-      showTokenStatus('Saved');
-      const res = await browser.runtime.sendMessage({ type: 'validateAuth', token }).catch(() => null) as { ok?: boolean; error?: string } | null;
-      setAuthValid(res?.ok ?? false);
-      if (res?.ok) {
-        await browser.storage.local.set({ [STORAGE_KEYS.VERIFIED]: 'true' });
-      } else if (res?.error === 'no_server') {
-        showTokenStatus('Server unavailable');
-      } else if (res?.error === 'invalid_token') {
-        showTokenStatus('Invalid Token');
-      }
-    } catch {
-      showTokenStatus('Failed to save');
-    }
-  };
-
-  const handleDeleteToken = async () => {
-    setAuthToken('');
-    setAuthTokenLocked(false);
-    setAuthValid(false);
-    showTokenStatus('Removing...');
-    try {
-      await browser.storage.local.set({
-        [STORAGE_KEYS.TOKEN]: '',
-        [STORAGE_KEYS.VERIFIED]: 'false',
-      });
-      showTokenStatus('Removed');
-    } catch {
-      setAuthTokenLocked(true);
-      showTokenStatus('Failed to remove');
-    }
   };
 
   const handleInterceptToggle = async (checked: boolean) => {
@@ -202,72 +194,68 @@ export default function SettingsView() {
               </select>
               <button onClick={() => { void handleDeleteProfile(); }}>Delete</button>
             </div>
+            <div class="settings-help" style="margin-top: 10px; display: flex; align-items: center; gap: 6px;">
+              <strong>Status:</strong> {
+                !serverConnected() ? <span class="auth-status err" style="margin: 0;">Disconnected</span> :
+                !authValid() ? <span class="auth-status err" style="margin: 0;">Invalid Token</span> :
+                <span class="auth-status ok" style="margin: 0;">Connected</span>
+              }
+            </div>
           </div>
         </Show>
 
-        <div class="settings-field">
-          <label class="settings-label" for="profile-name">
-            {serverProfiles().length > 0 ? 'Add a Server' : 'Server URL'}
+        <div class="settings-field" style={serverProfiles().length > 0 ? "margin-top: 24px; padding-top: 16px; border-top: 1px solid var(--border-subtle);" : ""}>
+          <label class="settings-label">
+            {serverProfiles().length > 0 ? 'Add a Server' : 'Connect to a Server'}
           </label>
-          <div class="auth-input settings-input-row">
-            <input
-              id="profile-name"
-              type="text"
-              value={newProfileName()}
-              placeholder="Name (e.g. Home PC)"
-              onInput={(e) => { setNewProfileName((e.target as HTMLInputElement).value); }}
-            />
-          </div>
-          <div class="auth-input settings-input-row" style="margin-top: 0.5rem;">
+          
+          <div class="auth-input settings-input-row" style="margin-bottom: 8px;">
             <input
               id="profile-url"
               type="text"
               value={newProfileUrl()}
-              placeholder="http://127.0.0.1:1700"
-              onInput={(e) => { setNewProfileUrl((e.target as HTMLInputElement).value); }}
+              placeholder="Server URL (e.g. http://127.0.0.1:1700)"
+              onInput={(e) => { setNewProfileUrl((e.target as HTMLInputElement).value); setConnectionValid(false); }}
+              disabled={isConnecting()}
             />
-            <button onClick={() => { void handleAddProfile(); }}>Add</button>
           </div>
-          {serverStatus() && (
-            <div class={`auth-status below${serverStatus() === 'Saved' || serverStatus() === 'Removed' || serverStatus() === 'Switched' ? ' ok' : serverStatus().endsWith('...') ? '' : ' err'}`}>{serverStatus()}</div>
-          )}
-        </div>
-
-        <div class="settings-field">
-          <label class="settings-label" for="auth-token">Auth Token</label>
+          
           <div class="auth-input settings-input-row">
             <input
-              id="auth-token"
+              id="profile-token"
               type="password"
-              value={authToken()}
-              placeholder="Enter your token"
-              disabled={authTokenLocked()}
-              onInput={(e) => {
-                setAuthToken((e.target as HTMLInputElement).value);
-                showTokenStatus('');
-              }}
-              onFocus={() => setTokenFocused(true)}
-              onBlur={() => setTokenFocused(false)}
+              value={newProfileToken()}
+              placeholder="Auth Token"
+              onInput={(e) => { setNewProfileToken((e.target as HTMLInputElement).value); setConnectionValid(false); }}
+              disabled={isConnecting()}
             />
-            <button onClick={() => { void (authTokenLocked() ? handleDeleteToken() : handleSaveToken()); }}>
-              {authTokenLocked() ? 'Delete' : 'Save'}
+            <button onClick={() => { void handleConnect(); }} disabled={isConnecting() || !newProfileUrl() || !newProfileToken()}>
+              {isConnecting() ? '...' : 'Connect'}
             </button>
           </div>
-          <div class="settings-help">
-            Token can be obtained from <strong>TUI &gt; Settings &gt; Extension</strong>
-          </div>
-          {tokenStatus() && !tokenFocused() && (
-            <div class={`auth-status below${tokenStatus() === 'Saved' || tokenStatus() === 'Removed' ? ' ok' : tokenStatus().endsWith('...') ? '' : ' err'}`}>{tokenStatus()}</div>
+          
+          {serverStatus() && !connectionValid() && (
+            <div class={`auth-status below${serverStatus() === 'Connected' || serverStatus() === 'Saved' || serverStatus() === 'Removed' || serverStatus() === 'Switched' ? ' ok' : serverStatus().endsWith('...') ? '' : ' err'}`}>{serverStatus()}</div>
           )}
-          {authTokenLocked() && !authValid() && serverConnected() && !tokenFocused() && !tokenStatus() && (
-            <div class="auth-status below err">Invalid Token</div>
-          )}
-          {authTokenLocked() && !authValid() && !serverConnected() && !tokenFocused() && !tokenStatus() && (
-            <div class="auth-status below err">Server unavailable</div>
-          )}
-          {!authToken() && !tokenFocused() && !tokenStatus() && (
-            <div class="auth-status below err">Token is Required</div>
-          )}
+
+          <Show when={connectionValid()}>
+            <div style="margin-top: 16px; padding: 14px; background: var(--bg-surface); border-radius: var(--radius-md); border: 1px solid var(--border-default);">
+              <label class="settings-label" for="profile-name" style="margin-bottom: 10px;">Save Profile</label>
+              <div class="auth-input settings-input-row">
+                <input
+                  id="profile-name"
+                  type="text"
+                  value={newProfileName()}
+                  placeholder="Name (e.g. Home PC)"
+                  onInput={(e) => { setNewProfileName((e.target as HTMLInputElement).value); }}
+                />
+                <button onClick={() => { void handleSaveProfile(); }}>Save</button>
+              </div>
+              {serverStatus() && (
+                 <div class={`auth-status below${serverStatus() === 'Saved' ? ' ok' : serverStatus().endsWith('...') ? '' : ' err'}`}>{serverStatus()}</div>
+              )}
+            </div>
+          </Show>
         </div>
       </div>
 

--- a/extension/entrypoints/popup/components/SettingsView.tsx
+++ b/extension/entrypoints/popup/components/SettingsView.tsx
@@ -1,9 +1,17 @@
-import { createSignal } from 'solid-js';
-import { STORAGE_KEYS } from '../../../lib/storage';
+import { createSignal, For, Show } from 'solid-js';
 import {
-  serverUrl, setServerUrl,
-  serverUrlLocked, setServerUrlLocked,
+  STORAGE_KEYS,
+  addServerProfile,
+  removeServerProfile,
+  resolveActiveServerUrl,
+  type ServerProfile,
+} from '../../../lib/storage';
+import {
+  setServerUrl,
+  setServerUrlLocked,
   serverConnected,
+  serverProfiles, setServerProfiles,
+  activeProfileId, setActiveProfileId,
   authToken, setAuthToken,
   authTokenLocked, setAuthTokenLocked,
   authValid, setAuthValid,
@@ -28,31 +36,62 @@ export default function SettingsView() {
   const [serverStatus, showServerStatus] = saveStatusSignal();
   const [tokenStatus, showTokenStatus] = saveStatusSignal();
   const [tokenFocused, setTokenFocused] = createSignal(false);
+  const [newProfileName, setNewProfileName] = createSignal('');
+  const [newProfileUrl, setNewProfileUrl] = createSignal('');
   const extensionVersion = browser.runtime.getManifest().version;
   const isFirefox = (browser.runtime.getURL as (path?: string) => string)('').startsWith('moz-extension:');
 
-  const handleServerSave = async () => {
-    const url = normalizeServerUrl(serverUrl());
-    setServerUrl(url);
+  // Persist the profile list + active selection and keep the resolved server URL in sync.
+  const persistProfiles = async (profiles: ServerProfile[], activeId: string) => {
+    setServerProfiles(profiles);
+    setActiveProfileId(activeId);
+    const resolvedUrl = resolveActiveServerUrl(profiles, activeId);
+    setServerUrl(resolvedUrl);
+    setServerUrlLocked(resolvedUrl.length > 0);
+    await browser.storage.local.set({
+      [STORAGE_KEYS.PROFILES]: profiles,
+      [STORAGE_KEYS.ACTIVE_PROFILE_ID]: activeId,
+      // Mirror the active URL into the legacy key so older code paths stay consistent.
+      [STORAGE_KEYS.SERVER_URL]: resolvedUrl,
+    });
+  };
+
+  const handleAddProfile = async () => {
+    const url = normalizeServerUrl(newProfileUrl());
+    if (!url) {
+      showServerStatus('Enter a server URL');
+      return;
+    }
+    const name = newProfileName().trim() || url;
     showServerStatus('Saving...');
     try {
-      await browser.storage.local.set({ [STORAGE_KEYS.SERVER_URL]: url });
-      setServerUrlLocked(url.length > 0);
+      const { profiles, activeId } = addServerProfile(serverProfiles(), { name, url });
+      await persistProfiles(profiles, activeId);
+      setNewProfileName('');
+      setNewProfileUrl('');
       showServerStatus('Saved');
     } catch {
       showServerStatus('Failed to save');
     }
   };
 
-  const handleServerDelete = async () => {
-    setServerUrl('');
-    setServerUrlLocked(false);
+  const handleSwitchProfile = async (profileId: string) => {
+    showServerStatus('Switching...');
+    try {
+      await persistProfiles(serverProfiles(), profileId);
+      showServerStatus('Switched');
+    } catch {
+      showServerStatus('Failed to switch');
+    }
+  };
+
+  const handleDeleteProfile = async () => {
     showServerStatus('Removing...');
     try {
-      await browser.storage.local.set({ [STORAGE_KEYS.SERVER_URL]: '' });
+      const { profiles, activeId } = removeServerProfile(serverProfiles(), activeProfileId(), activeProfileId());
+      await persistProfiles(profiles, activeId);
       showServerStatus('Removed');
     } catch {
-      setServerUrlLocked(true);
       showServerStatus('Failed to remove');
     }
   };
@@ -163,23 +202,52 @@ export default function SettingsView() {
 
       <div class="settings-group">
         <h3 class="settings-group-title">Server</h3>
+
+        <Show when={serverProfiles().length > 0}>
+          <div class="settings-field">
+            <label class="settings-label" for="server-profile">Active Server</label>
+            <div class="auth-input settings-input-row">
+              <select
+                id="server-profile"
+                value={activeProfileId()}
+                onChange={(e) => { void handleSwitchProfile((e.target as HTMLSelectElement).value); }}
+              >
+                <For each={serverProfiles()}>
+                  {(profile) => (
+                    <option value={profile.id}>{profile.name} ({profile.url})</option>
+                  )}
+                </For>
+              </select>
+              <button onClick={() => { void handleDeleteProfile(); }}>Delete</button>
+            </div>
+          </div>
+        </Show>
+
         <div class="settings-field">
-          <label class="settings-label" for="server-url">Server URL</label>
+          <label class="settings-label" for="profile-name">
+            {serverProfiles().length > 0 ? 'Add a Server' : 'Server URL'}
+          </label>
           <div class="auth-input settings-input-row">
             <input
-              id="server-url"
+              id="profile-name"
               type="text"
-              value={serverUrl()}
-              placeholder="http://127.0.0.1:1700"
-              disabled={serverUrlLocked()}
-              onInput={(e) => { setServerUrl((e.target as HTMLInputElement).value); }}
+              value={newProfileName()}
+              placeholder="Name (e.g. Home PC)"
+              onInput={(e) => { setNewProfileName((e.target as HTMLInputElement).value); }}
             />
-            <button onClick={() => { void (serverUrlLocked() ? handleServerDelete() : handleServerSave()); }}>
-              {serverUrlLocked() ? 'Delete' : 'Save'}
-            </button>
+          </div>
+          <div class="auth-input settings-input-row" style="margin-top: 0.5rem;">
+            <input
+              id="profile-url"
+              type="text"
+              value={newProfileUrl()}
+              placeholder="http://127.0.0.1:1700"
+              onInput={(e) => { setNewProfileUrl((e.target as HTMLInputElement).value); }}
+            />
+            <button onClick={() => { void handleAddProfile(); }}>Add</button>
           </div>
           {serverStatus() && (
-            <div class={`auth-status below${serverStatus() === 'Saved' || serverStatus() === 'Removed' ? ' ok' : serverStatus().endsWith('...') ? '' : ' err'}`}>{serverStatus()}</div>
+            <div class={`auth-status below${serverStatus() === 'Saved' || serverStatus() === 'Removed' || serverStatus() === 'Switched' ? ' ok' : serverStatus().endsWith('...') ? '' : ' err'}`}>{serverStatus()}</div>
           )}
         </div>
 

--- a/extension/entrypoints/popup/components/SettingsView.tsx
+++ b/extension/entrypoints/popup/components/SettingsView.tsx
@@ -1,11 +1,5 @@
 import { createSignal, For, Show } from 'solid-js';
-import {
-  STORAGE_KEYS,
-  addServerProfile,
-  removeServerProfile,
-  resolveActiveServerUrl,
-  type ServerProfile,
-} from '../../../lib/storage';
+import { STORAGE_KEYS } from '../../../lib/storage';
 import {
   setServerUrl,
   setServerUrlLocked,
@@ -19,7 +13,12 @@ import {
   notificationsEnabled, setNotificationsEnabled,
   minFileSize, setMinFileSize,
 } from '../store';
-import { normalizeToken, normalizeServerUrl } from '../lib/utils';
+import { normalizeToken } from '../lib/utils';
+import {
+  handleAddProfile as _handleAddProfile,
+  handleSwitchProfile as _handleSwitchProfile,
+  handleDeleteProfile as _handleDeleteProfile,
+} from '../lib/settings-handlers';
 
 function saveStatusSignal() {
   const [status, setStatus] = createSignal('');
@@ -41,59 +40,42 @@ export default function SettingsView() {
   const extensionVersion = browser.runtime.getManifest().version;
   const isFirefox = (browser.runtime.getURL as (path?: string) => string)('').startsWith('moz-extension:');
 
-  // Persist the profile list + active selection and keep the resolved server URL in sync.
-  const persistProfiles = async (profiles: ServerProfile[], activeId: string) => {
-    setServerProfiles(profiles);
-    setActiveProfileId(activeId);
-    const resolvedUrl = resolveActiveServerUrl(profiles, activeId);
-    setServerUrl(resolvedUrl);
-    setServerUrlLocked(resolvedUrl.length > 0);
-    await browser.storage.local.set({
-      [STORAGE_KEYS.PROFILES]: profiles,
-      [STORAGE_KEYS.ACTIVE_PROFILE_ID]: activeId,
-      // Mirror the active URL into the legacy key so older code paths stay consistent.
-      [STORAGE_KEYS.SERVER_URL]: resolvedUrl,
-    });
-  };
+  // Build the store accessor / setter bag required by the extracted handler logic.
+  const makeStore = () => ({
+    getProfiles: serverProfiles,
+    getActiveId: activeProfileId,
+    setProfiles: setServerProfiles,
+    setActiveId: setActiveProfileId,
+    setServerUrl,
+    setServerUrlLocked,
+  });
 
   const handleAddProfile = async () => {
-    const url = normalizeServerUrl(newProfileUrl());
-    if (!url) {
-      showServerStatus('Enter a server URL');
-      return;
-    }
-    const name = newProfileName().trim() || url;
     showServerStatus('Saving...');
-    try {
-      const { profiles, activeId } = addServerProfile(serverProfiles(), { name, url });
-      await persistProfiles(profiles, activeId);
+    const result = await _handleAddProfile(
+      { name: newProfileName(), url: newProfileUrl() },
+      makeStore(),
+      browser.storage.local,
+    );
+    if (result.ok) {
       setNewProfileName('');
       setNewProfileUrl('');
       showServerStatus('Saved');
-    } catch {
-      showServerStatus('Failed to save');
+    } else {
+      showServerStatus(result.error ?? 'Failed to save');
     }
   };
 
   const handleSwitchProfile = async (profileId: string) => {
     showServerStatus('Switching...');
-    try {
-      await persistProfiles(serverProfiles(), profileId);
-      showServerStatus('Switched');
-    } catch {
-      showServerStatus('Failed to switch');
-    }
+    const result = await _handleSwitchProfile(profileId, makeStore(), browser.storage.local);
+    showServerStatus(result.ok ? 'Switched' : (result.error ?? 'Failed to switch'));
   };
 
   const handleDeleteProfile = async () => {
     showServerStatus('Removing...');
-    try {
-      const { profiles, activeId } = removeServerProfile(serverProfiles(), activeProfileId(), activeProfileId());
-      await persistProfiles(profiles, activeId);
-      showServerStatus('Removed');
-    } catch {
-      showServerStatus('Failed to remove');
-    }
+    const result = await _handleDeleteProfile(makeStore(), browser.storage.local);
+    showServerStatus(result.ok ? 'Removed' : (result.error ?? 'Failed to remove'));
   };
 
   const handleSaveToken = async () => {

--- a/extension/entrypoints/popup/components/SettingsView.tsx
+++ b/extension/entrypoints/popup/components/SettingsView.tsx
@@ -56,8 +56,8 @@ export default function SettingsView() {
   const handleConnect = async () => {
     const url = newProfileUrl().trim();
     const token = newProfileToken().trim();
-    if (!url || !token) {
-      showServerStatus('Enter URL and Token');
+    if (!token) {
+      showServerStatus('Enter an Auth Token');
       return;
     }
 
@@ -67,7 +67,6 @@ export default function SettingsView() {
     try {
       const res = await browser.runtime.sendMessage({ type: 'testConnection', url, token }).catch(() => null) as { ok?: boolean; url?: string; error?: string } | null;
       if (res?.ok) {
-        if (res.url) setNewProfileUrl(res.url);
         setConnectionValid(true);
         showServerStatus('Connected');
       } else if (res?.error === 'invalid_token') {
@@ -229,7 +228,7 @@ export default function SettingsView() {
               onInput={(e) => { setNewProfileToken((e.target as HTMLInputElement).value); setConnectionValid(false); }}
               disabled={isConnecting()}
             />
-            <button onClick={() => { void handleConnect(); }} disabled={isConnecting() || !newProfileUrl() || !newProfileToken()}>
+            <button onClick={() => { void handleConnect(); }} disabled={isConnecting() || !newProfileToken()}>
               {isConnecting() ? '...' : 'Connect'}
             </button>
           </div>

--- a/extension/entrypoints/popup/lib/settings-handlers.ts
+++ b/extension/entrypoints/popup/lib/settings-handlers.ts
@@ -11,9 +11,10 @@ import {
   addServerProfile,
   removeServerProfile,
   resolveActiveServerUrl,
+  resolveActiveServerToken,
   type ServerProfile,
 } from '../../../lib/storage';
-import { normalizeServerUrl } from './utils';
+import { normalizeServerUrl, normalizeToken } from './utils';
 
 export interface ProfileStore {
   getProfiles: () => ServerProfile[];
@@ -22,6 +23,9 @@ export interface ProfileStore {
   setActiveId: (id: string) => void;
   setServerUrl: (url: string) => void;
   setServerUrlLocked: (locked: boolean) => void;
+  setAuthToken: (token: string) => void;
+  setAuthTokenLocked: (locked: boolean) => void;
+  setAuthValid: (valid: boolean) => void;
 }
 
 export interface StorageApi {
@@ -40,16 +44,21 @@ export async function persistProfiles(
   storage: StorageApi,
 ): Promise<void> {
   const resolvedUrl = resolveActiveServerUrl(profiles, activeId);
+  const resolvedToken = resolveActiveServerToken(profiles, activeId);
   await storage.set({
     [STORAGE_KEYS.PROFILES]: profiles,
     [STORAGE_KEYS.ACTIVE_PROFILE_ID]: activeId,
     [STORAGE_KEYS.SERVER_URL]: resolvedUrl,
+    [STORAGE_KEYS.TOKEN]: resolvedToken,
   });
   // Only reached when the write succeeded — update reactive state.
   store.setProfiles(profiles);
   store.setActiveId(activeId);
   store.setServerUrl(resolvedUrl);
   store.setServerUrlLocked(resolvedUrl.length > 0);
+  store.setAuthToken(resolvedToken);
+  store.setAuthTokenLocked(resolvedToken.length > 0);
+  store.setAuthValid(false);
 }
 
 /**
@@ -57,17 +66,18 @@ export async function persistProfiles(
  * Returns an object describing the outcome so callers can show status messages.
  */
 export async function handleAddProfile(
-  input: { name: string; url: string },
+  input: { name: string; url: string; token: string },
   store: ProfileStore,
   storage: StorageApi,
 ): Promise<{ ok: boolean; error?: string }> {
   const url = normalizeServerUrl(input.url);
+  const token = normalizeToken(input.token);
   if (!url) {
     return { ok: false, error: 'Enter a server URL' };
   }
   const name = input.name.trim() || url;
   try {
-    const { profiles, activeId } = addServerProfile(store.getProfiles(), { name, url });
+    const { profiles, activeId } = addServerProfile(store.getProfiles(), { name, url, token });
     await persistProfiles(profiles, activeId, store, storage);
     return { ok: true };
   } catch {

--- a/extension/entrypoints/popup/lib/settings-handlers.ts
+++ b/extension/entrypoints/popup/lib/settings-handlers.ts
@@ -72,10 +72,7 @@ export async function handleAddProfile(
 ): Promise<{ ok: boolean; error?: string }> {
   const url = normalizeServerUrl(input.url);
   const token = normalizeToken(input.token);
-  if (!url) {
-    return { ok: false, error: 'Enter a server URL' };
-  }
-  const name = input.name.trim() || url;
+  const name = input.name.trim() || url || 'Auto-Discover (Localhost)';
   try {
     const { profiles, activeId } = addServerProfile(store.getProfiles(), { name, url, token });
     await persistProfiles(profiles, activeId, store, storage);

--- a/extension/entrypoints/popup/lib/settings-handlers.ts
+++ b/extension/entrypoints/popup/lib/settings-handlers.ts
@@ -1,0 +1,112 @@
+/**
+ * Pure handler logic for SettingsView profile management.
+ *
+ * Each function receives its store accessors and the browser storage API as
+ * explicit arguments, making the logic fully unit-testable without SolidJS
+ * rendering or a DOM environment.
+ */
+
+import {
+  STORAGE_KEYS,
+  addServerProfile,
+  removeServerProfile,
+  resolveActiveServerUrl,
+  type ServerProfile,
+} from '../../../lib/storage';
+import { normalizeServerUrl } from './utils';
+
+export interface ProfileStore {
+  getProfiles: () => ServerProfile[];
+  getActiveId: () => string;
+  setProfiles: (p: ServerProfile[]) => void;
+  setActiveId: (id: string) => void;
+  setServerUrl: (url: string) => void;
+  setServerUrlLocked: (locked: boolean) => void;
+}
+
+export interface StorageApi {
+  set: (items: Record<string, unknown>) => Promise<void>;
+}
+
+/**
+ * Write the new profile list and active id to storage, then update reactive
+ * signals. If storage write fails the signals remain unchanged (automatic
+ * rollback).
+ */
+export async function persistProfiles(
+  profiles: ServerProfile[],
+  activeId: string,
+  store: ProfileStore,
+  storage: StorageApi,
+): Promise<void> {
+  const resolvedUrl = resolveActiveServerUrl(profiles, activeId);
+  await storage.set({
+    [STORAGE_KEYS.PROFILES]: profiles,
+    [STORAGE_KEYS.ACTIVE_PROFILE_ID]: activeId,
+    [STORAGE_KEYS.SERVER_URL]: resolvedUrl,
+  });
+  // Only reached when the write succeeded — update reactive state.
+  store.setProfiles(profiles);
+  store.setActiveId(activeId);
+  store.setServerUrl(resolvedUrl);
+  store.setServerUrlLocked(resolvedUrl.length > 0);
+}
+
+/**
+ * Validate, create, and persist a new server profile.
+ * Returns an object describing the outcome so callers can show status messages.
+ */
+export async function handleAddProfile(
+  input: { name: string; url: string },
+  store: ProfileStore,
+  storage: StorageApi,
+): Promise<{ ok: boolean; error?: string }> {
+  const url = normalizeServerUrl(input.url);
+  if (!url) {
+    return { ok: false, error: 'Enter a server URL' };
+  }
+  const name = input.name.trim() || url;
+  try {
+    const { profiles, activeId } = addServerProfile(store.getProfiles(), { name, url });
+    await persistProfiles(profiles, activeId, store, storage);
+    return { ok: true };
+  } catch {
+    return { ok: false, error: 'Failed to save' };
+  }
+}
+
+/**
+ * Switch the active profile and persist the change.
+ */
+export async function handleSwitchProfile(
+  profileId: string,
+  store: ProfileStore,
+  storage: StorageApi,
+): Promise<{ ok: boolean; error?: string }> {
+  try {
+    await persistProfiles(store.getProfiles(), profileId, store, storage);
+    return { ok: true };
+  } catch {
+    return { ok: false, error: 'Failed to switch' };
+  }
+}
+
+/**
+ * Remove the currently-active profile and persist the change.
+ */
+export async function handleDeleteProfile(
+  store: ProfileStore,
+  storage: StorageApi,
+): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const { profiles, activeId } = removeServerProfile(
+      store.getProfiles(),
+      store.getActiveId(),
+      store.getActiveId(),
+    );
+    await persistProfiles(profiles, activeId, store, storage);
+    return { ok: true };
+  } catch {
+    return { ok: false, error: 'Failed to remove' };
+  }
+}

--- a/extension/entrypoints/popup/lib/settings-handlers.ts
+++ b/extension/entrypoints/popup/lib/settings-handlers.ts
@@ -42,6 +42,7 @@ export async function persistProfiles(
   activeId: string,
   store: ProfileStore,
   storage: StorageApi,
+  authValid: boolean = false,
 ): Promise<void> {
   const resolvedUrl = resolveActiveServerUrl(profiles, activeId);
   const resolvedToken = resolveActiveServerToken(profiles, activeId);
@@ -58,7 +59,7 @@ export async function persistProfiles(
   store.setServerUrlLocked(resolvedUrl.length > 0);
   store.setAuthToken(resolvedToken);
   store.setAuthTokenLocked(resolvedToken.length > 0);
-  store.setAuthValid(false);
+  store.setAuthValid(authValid);
 }
 
 /**
@@ -69,13 +70,14 @@ export async function handleAddProfile(
   input: { name: string; url: string; token: string },
   store: ProfileStore,
   storage: StorageApi,
+  authValid: boolean = false,
 ): Promise<{ ok: boolean; error?: string }> {
   const url = normalizeServerUrl(input.url);
   const token = normalizeToken(input.token);
   const name = input.name.trim() || url || 'Auto-Discover (Localhost)';
   try {
     const { profiles, activeId } = addServerProfile(store.getProfiles(), { name, url, token });
-    await persistProfiles(profiles, activeId, store, storage);
+    await persistProfiles(profiles, activeId, store, storage, authValid);
     return { ok: true };
   } catch {
     return { ok: false, error: 'Failed to save' };

--- a/extension/entrypoints/popup/lib/utils.ts
+++ b/extension/entrypoints/popup/lib/utils.ts
@@ -89,9 +89,6 @@ export function normalizeToken(token: string | undefined): string {
   return token.replace(/\s+/g, '');
 }
 
-export function normalizeServerUrl(url: string): string {
-  if (!url) return '';
-  url = url.trim();
-  if (url && !/^https?:\/\//i.test(url)) url = 'http://' + url;
-  return url.replace(/\/+$/, '');
-}
+// Re-exported from the canonical source in lib/storage.ts to avoid duplicating
+// the normalization logic between popup and background contexts.
+export { normalizeServerUrl } from '../../../lib/storage';

--- a/extension/entrypoints/popup/popup.css
+++ b/extension/entrypoints/popup/popup.css
@@ -43,6 +43,7 @@ html, body, #app {
   width: 360px;
   height: 540px;
   overflow: hidden;
+  color-scheme: dark;
 }
 
 body {
@@ -802,7 +803,8 @@ body {
   gap: 6px;
 }
 
-.auth-input input {
+.auth-input input,
+.auth-input select {
   flex: 1;
   min-width: 0;
   height: 28px;
@@ -812,6 +814,16 @@ body {
   background: var(--bg-elevated);
   color: var(--text-primary);
   font-size: 12px;
+}
+
+.auth-input select {
+  cursor: pointer;
+  outline: none;
+}
+
+.auth-input select:focus,
+.auth-input input:focus {
+  border-color: var(--accent-primary);
 }
 
 .auth-input button {

--- a/extension/entrypoints/popup/store/index.ts
+++ b/extension/entrypoints/popup/store/index.ts
@@ -5,6 +5,7 @@
 
 import { createSignal } from 'solid-js';
 import { MB } from '../lib/utils';
+import type { ServerProfile } from '../../../lib/storage';
 import type {
   DownloadStatus,
   HistoryEntry,
@@ -89,11 +90,17 @@ export { notificationsEnabled, setNotificationsEnabled };
 const [minFileSize, setMinFileSize] = createSignal(10);
 export { minFileSize, setMinFileSize };
 
-// Surge server URL for API requests
+// Surge server URL for API requests (resolved from the active server profile)
 const [serverUrl, setServerUrl] = createSignal('');
 export { serverUrl, setServerUrl };
 const [serverUrlLocked, setServerUrlLocked] = createSignal(false);
 export { serverUrlLocked, setServerUrlLocked };
+
+// Named server profiles and the active selection
+const [serverProfiles, setServerProfiles] = createSignal<ServerProfile[]>([]);
+export { serverProfiles, setServerProfiles };
+const [activeProfileId, setActiveProfileId] = createSignal('');
+export { activeProfileId, setActiveProfileId };
 
 const [authToken, setAuthToken] = createSignal('');
 export { authToken, setAuthToken };

--- a/extension/lib/background-logic.ts
+++ b/extension/lib/background-logic.ts
@@ -49,6 +49,7 @@ export function buildPortScanCandidates(
   startPort: number,
   portCount: number,
   preferredUrls: Array<string | null | undefined> = [],
+  baseHost: string = '127.0.0.1',
 ): string[] {
   const candidates: string[] = [];
   const seen = new Set<string>();
@@ -62,7 +63,7 @@ export function buildPortScanCandidates(
 
   preferredUrls.forEach(addCandidate);
   for (let port = startPort; port < startPort + portCount; port++) {
-    addCandidate(`http://127.0.0.1:${port}`);
+    addCandidate(`http://${baseHost}:${port}`);
   }
 
   return candidates;

--- a/extension/lib/storage.ts
+++ b/extension/lib/storage.ts
@@ -6,6 +6,8 @@ export const STORAGE_KEYS = {
   DISCOVERED_SERVER_URL: 'discoveredServerUrl',
   NOTIFICATIONS: 'notificationsEnabled',
   MIN_FILE_SIZE: 'minFileSize',
+  PROFILES: 'serverProfiles',
+  ACTIVE_PROFILE_ID: 'activeServerProfileId',
 } as const;
 
 export function readStoredString(
@@ -41,4 +43,130 @@ export function readStoredNumber(
     if (!isNaN(parsed)) return parsed;
   }
   return fallback;
+}
+
+// ---------------------------------------------------------------------------
+// Server profiles
+//
+// A profile is a named (name + URL) Surge server. The extension persists a
+// list of profiles plus an active-profile id, and the rest of the extension
+// resolves the active profile's URL instead of the single legacy SERVER_URL.
+// The legacy SERVER_URL key is kept for backward compatibility and is migrated
+// into a default profile on first read (see migrateServerProfiles).
+// ---------------------------------------------------------------------------
+
+export interface ServerProfile {
+  id: string;
+  name: string;
+  url: string;
+}
+
+export interface ServerProfilesState {
+  profiles: ServerProfile[];
+  activeId: string;
+}
+
+// Local copy of the URL normalization used by popup/background so this module
+// stays free of UI imports and can be loaded from the background service worker.
+function normalizeProfileUrl(url: string): string {
+  const trimmed = (url ?? '').trim();
+  if (!trimmed) return '';
+  const withScheme = /^https?:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
+  return withScheme.replace(/\/+$/, '');
+}
+
+function isServerProfile(value: unknown): value is ServerProfile {
+  if (typeof value !== 'object' || value === null) return false;
+  const record = value as Record<string, unknown>;
+  return typeof record.id === 'string'
+    && record.id.length > 0
+    && typeof record.name === 'string'
+    && typeof record.url === 'string';
+}
+
+/** Read and sanitize the stored profiles array, normalizing URLs and dropping malformed entries. */
+export function parseServerProfiles(values: Record<string, unknown>): ServerProfile[] {
+  const raw = values[STORAGE_KEYS.PROFILES];
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter(isServerProfile)
+    .map((profile) => ({
+      id: profile.id,
+      name: profile.name,
+      url: normalizeProfileUrl(profile.url),
+    }))
+    .filter((profile) => profile.url.length > 0);
+}
+
+/** Resolve the active profile by id, falling back to the first profile, or null when empty. */
+export function resolveActiveProfile(
+  profiles: ServerProfile[],
+  activeId: string,
+): ServerProfile | null {
+  if (profiles.length === 0) return null;
+  return profiles.find((profile) => profile.id === activeId) ?? profiles[0];
+}
+
+/** Resolve the active profile's URL. Empty string when there is no active profile. */
+export function resolveActiveServerUrl(profiles: ServerProfile[], activeId: string): string {
+  return resolveActiveProfile(profiles, activeId)?.url ?? '';
+}
+
+let profileIdCounter = 0;
+
+function generateProfileId(): string {
+  profileIdCounter += 1;
+  const random = Math.random().toString(36).slice(2, 8);
+  return `profile_${Date.now().toString(36)}_${profileIdCounter}_${random}`;
+}
+
+/** Append a new profile (with a generated id) and make it the active one. */
+export function addServerProfile(
+  profiles: ServerProfile[],
+  input: { name: string; url: string },
+): ServerProfilesState {
+  const profile: ServerProfile = {
+    id: generateProfileId(),
+    name: input.name.trim() || 'Server',
+    url: normalizeProfileUrl(input.url),
+  };
+  const next = [...profiles, profile];
+  return { profiles: next, activeId: profile.id };
+}
+
+/** Remove a profile, re-pointing the active id to the first remaining profile when needed. */
+export function removeServerProfile(
+  profiles: ServerProfile[],
+  removeId: string,
+  activeId: string,
+): ServerProfilesState {
+  const next = profiles.filter((profile) => profile.id !== removeId);
+  if (next.length === 0) return { profiles: next, activeId: '' };
+  const stillActive = next.some((profile) => profile.id === activeId);
+  return { profiles: next, activeId: stillActive ? activeId : next[0].id };
+}
+
+/**
+ * Backward-compatibility migration. When no profiles are stored yet but a legacy
+ * single SERVER_URL exists, wrap it in a "Default" profile and make it active.
+ * Returns migrated: false when nothing needs to change.
+ */
+export function migrateServerProfiles(values: Record<string, unknown>): ServerProfilesState & { migrated: boolean } {
+  const existing = parseServerProfiles(values);
+  if (existing.length > 0) {
+    const storedActiveId = readStoredString(values, STORAGE_KEYS.ACTIVE_PROFILE_ID);
+    return {
+      profiles: existing,
+      activeId: resolveActiveProfile(existing, storedActiveId)?.id ?? '',
+      migrated: false,
+    };
+  }
+
+  const legacyUrl = normalizeProfileUrl(readStoredString(values, STORAGE_KEYS.SERVER_URL));
+  if (!legacyUrl) {
+    return { profiles: [], activeId: '', migrated: false };
+  }
+
+  const { profiles, activeId } = addServerProfile([], { name: 'Default', url: legacyUrl });
+  return { profiles, activeId, migrated: true };
 }

--- a/extension/lib/storage.ts
+++ b/extension/lib/storage.ts
@@ -96,8 +96,7 @@ export function parseServerProfiles(values: Record<string, unknown>): ServerProf
       name: profile.name,
       url: normalizeServerUrl(profile.url),
       token: profile.token || '',
-    }))
-    .filter((profile) => profile.url.length > 0);
+    }));
 }
 
 /** Resolve the active profile by id, falling back to the first profile, or null when empty. */
@@ -136,7 +135,6 @@ export function addServerProfile(
   input: { name: string; url: string; token: string },
 ): ServerProfilesState {
   const url = normalizeServerUrl(input.url);
-  if (!url) throw new Error('Profile URL must not be empty after normalization');
   const profile: ServerProfile = {
     id: generateProfileId(),
     name: input.name.trim() || 'Server',

--- a/extension/lib/storage.ts
+++ b/extension/lib/storage.ts
@@ -66,9 +66,9 @@ export interface ServerProfilesState {
   activeId: string;
 }
 
-// Local copy of the URL normalization used by popup/background so this module
-// stays free of UI imports and can be loaded from the background service worker.
-function normalizeProfileUrl(url: string): string {
+// Canonical URL normalization shared by popup and background contexts.
+// Exported so that popup/lib/utils.ts can re-export it without duplicating the logic.
+export function normalizeServerUrl(url: string): string {
   const trimmed = (url ?? '').trim();
   if (!trimmed) return '';
   const withScheme = /^https?:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
@@ -93,7 +93,7 @@ export function parseServerProfiles(values: Record<string, unknown>): ServerProf
     .map((profile) => ({
       id: profile.id,
       name: profile.name,
-      url: normalizeProfileUrl(profile.url),
+      url: normalizeServerUrl(profile.url),
     }))
     .filter((profile) => profile.url.length > 0);
 }
@@ -120,15 +120,20 @@ function generateProfileId(): string {
   return `profile_${Date.now().toString(36)}_${profileIdCounter}_${random}`;
 }
 
-/** Append a new profile (with a generated id) and make it the active one. */
+/**
+ * Append a new profile (with a generated id) and make it the active one.
+ * Throws if the URL is empty after normalization.
+ */
 export function addServerProfile(
   profiles: ServerProfile[],
   input: { name: string; url: string },
 ): ServerProfilesState {
+  const url = normalizeServerUrl(input.url);
+  if (!url) throw new Error('Profile URL must not be empty after normalization');
   const profile: ServerProfile = {
     id: generateProfileId(),
     name: input.name.trim() || 'Server',
-    url: normalizeProfileUrl(input.url),
+    url,
   };
   const next = [...profiles, profile];
   return { profiles: next, activeId: profile.id };
@@ -162,7 +167,7 @@ export function migrateServerProfiles(values: Record<string, unknown>): ServerPr
     };
   }
 
-  const legacyUrl = normalizeProfileUrl(readStoredString(values, STORAGE_KEYS.SERVER_URL));
+  const legacyUrl = normalizeServerUrl(readStoredString(values, STORAGE_KEYS.SERVER_URL));
   if (!legacyUrl) {
     return { profiles: [], activeId: '', migrated: false };
   }

--- a/extension/lib/storage.ts
+++ b/extension/lib/storage.ts
@@ -59,6 +59,7 @@ export interface ServerProfile {
   id: string;
   name: string;
   url: string;
+  token: string;
 }
 
 export interface ServerProfilesState {
@@ -94,6 +95,7 @@ export function parseServerProfiles(values: Record<string, unknown>): ServerProf
       id: profile.id,
       name: profile.name,
       url: normalizeServerUrl(profile.url),
+      token: profile.token || '',
     }))
     .filter((profile) => profile.url.length > 0);
 }
@@ -112,6 +114,11 @@ export function resolveActiveServerUrl(profiles: ServerProfile[], activeId: stri
   return resolveActiveProfile(profiles, activeId)?.url ?? '';
 }
 
+/** Resolve the active profile's token. Empty string when there is no active profile. */
+export function resolveActiveServerToken(profiles: ServerProfile[], activeId: string): string {
+  return resolveActiveProfile(profiles, activeId)?.token ?? '';
+}
+
 let profileIdCounter = 0;
 
 function generateProfileId(): string {
@@ -126,7 +133,7 @@ function generateProfileId(): string {
  */
 export function addServerProfile(
   profiles: ServerProfile[],
-  input: { name: string; url: string },
+  input: { name: string; url: string; token: string },
 ): ServerProfilesState {
   const url = normalizeServerUrl(input.url);
   if (!url) throw new Error('Profile URL must not be empty after normalization');
@@ -134,6 +141,7 @@ export function addServerProfile(
     id: generateProfileId(),
     name: input.name.trim() || 'Server',
     url,
+    token: input.token || '',
   };
   const next = [...profiles, profile];
   return { profiles: next, activeId: profile.id };
@@ -157,13 +165,27 @@ export function removeServerProfile(
  * Returns migrated: false when nothing needs to change.
  */
 export function migrateServerProfiles(values: Record<string, unknown>): ServerProfilesState & { migrated: boolean } {
-  const existing = parseServerProfiles(values);
+  let existing = parseServerProfiles(values);
+  const legacyToken = readStoredString(values, STORAGE_KEYS.TOKEN);
+
   if (existing.length > 0) {
     const storedActiveId = readStoredString(values, STORAGE_KEYS.ACTIVE_PROFILE_ID);
+    const activeId = resolveActiveProfile(existing, storedActiveId)?.id ?? '';
+
+    let migrated = false;
+    if (activeId && legacyToken) {
+      const activeIdx = existing.findIndex(p => p.id === activeId);
+      if (activeIdx !== -1 && !existing[activeIdx].token) {
+        existing = [...existing];
+        existing[activeIdx] = { ...existing[activeIdx], token: legacyToken };
+        migrated = true;
+      }
+    }
+
     return {
       profiles: existing,
-      activeId: resolveActiveProfile(existing, storedActiveId)?.id ?? '',
-      migrated: false,
+      activeId,
+      migrated,
     };
   }
 
@@ -172,6 +194,6 @@ export function migrateServerProfiles(values: Record<string, unknown>): ServerPr
     return { profiles: [], activeId: '', migrated: false };
   }
 
-  const { profiles, activeId } = addServerProfile([], { name: 'Default', url: legacyUrl });
+  const { profiles, activeId } = addServerProfile([], { name: 'Default', url: legacyUrl, token: legacyToken });
   return { profiles, activeId, migrated: true };
 }

--- a/extension/test/background-server-url.test.ts
+++ b/extension/test/background-server-url.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Unit tests for background.ts server URL state synchronization.
+ *
+ * Specifically covers reresolveActiveServerUrl — the function called by the
+ * storage.onChanged listener when profile-related keys change. The key
+ * correctness properties verified here are:
+ *
+ *   1. It resolves the correct URL from the stored profiles list.
+ *   2. It does NOT invoke migrateServerProfiles (a startup-only concern) —
+ *      instead it uses parseServerProfiles for the cheap read path.
+ *   3. It resets the health-check timers so a fresh connection attempt is made.
+ *   4. Changing unrelated keys (e.g. TOKEN) does NOT affect cachedServerUrl.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { STORAGE_KEYS } from '../lib/storage';
+
+vi.mock('wxt/utils/define-background', () => ({
+  defineBackground: (callback: () => void) => callback,
+}));
+
+import { __test__ } from '../entrypoints/background';
+
+// ---------------------------------------------------------------------------
+// Shared browser stub
+// ---------------------------------------------------------------------------
+
+function makeBrowserStub(overrides?: {
+  profiles?: unknown;
+  activeProfileId?: string;
+}) {
+  const profiles = overrides?.profiles ?? [];
+  const activeProfileId = overrides?.activeProfileId ?? '';
+
+  return {
+    storage: {
+      local: {
+        get: vi.fn(async (key: string) => {
+          switch (key) {
+            case STORAGE_KEYS.PROFILES:
+              return { [STORAGE_KEYS.PROFILES]: profiles };
+            case STORAGE_KEYS.ACTIVE_PROFILE_ID:
+              return { [STORAGE_KEYS.ACTIVE_PROFILE_ID]: activeProfileId };
+            default:
+              return {};
+          }
+        }),
+        set: vi.fn().mockResolvedValue(undefined),
+      },
+      onChanged: { addListener: vi.fn() },
+    },
+    downloads: {
+      onCreated: { addListener: vi.fn() },
+    },
+    webRequest: {
+      onBeforeSendHeaders: { addListener: vi.fn() },
+    },
+    runtime: {
+      onMessage: { addListener: vi.fn() },
+      getURL: vi.fn().mockReturnValue('chrome-extension://test/'),
+    },
+    action: {
+      setBadgeText: vi.fn(),
+      setBadgeBackgroundColor: vi.fn(),
+    },
+    notifications: { create: vi.fn() },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('background reresolveActiveServerUrl', () => {
+  beforeEach(() => {
+    __test__.resetState();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete (globalThis as typeof globalThis & { browser?: unknown }).browser;
+  });
+
+  it('resolves the active profile URL from the stored profiles list', async () => {
+    const profiles = [
+      { id: 'a', name: 'Local', url: 'http://127.0.0.1:1700' },
+      { id: 'b', name: 'Remote', url: 'http://remote:1700' },
+    ];
+
+    (globalThis as typeof globalThis & { browser: unknown }).browser =
+      makeBrowserStub({ profiles, activeProfileId: 'b' });
+
+    await __test__.reresolveActiveServerUrl();
+
+    expect(__test__.getCachedState().serverUrl).toBe('http://remote:1700');
+  });
+
+  it('falls back to the first profile when the active id is not found', async () => {
+    const profiles = [
+      { id: 'a', name: 'Local', url: 'http://127.0.0.1:1700' },
+    ];
+
+    (globalThis as typeof globalThis & { browser: unknown }).browser =
+      makeBrowserStub({ profiles, activeProfileId: 'missing' });
+
+    await __test__.reresolveActiveServerUrl();
+
+    expect(__test__.getCachedState().serverUrl).toBe('http://127.0.0.1:1700');
+  });
+
+  it('sets cachedServerUrl to null when there are no profiles', async () => {
+    (globalThis as typeof globalThis & { browser: unknown }).browser =
+      makeBrowserStub({ profiles: [], activeProfileId: '' });
+
+    await __test__.reresolveActiveServerUrl();
+
+    expect(__test__.getCachedState().serverUrl).toBeNull();
+  });
+
+  it('normalizes the URL (strips trailing slash, adds scheme)', async () => {
+    const profiles = [
+      { id: 'a', name: 'Local', url: '127.0.0.1:1700/' },
+    ];
+
+    (globalThis as typeof globalThis & { browser: unknown }).browser =
+      makeBrowserStub({ profiles, activeProfileId: 'a' });
+
+    await __test__.reresolveActiveServerUrl();
+
+    expect(__test__.getCachedState().serverUrl).toBe('http://127.0.0.1:1700');
+  });
+
+  it('does NOT call migrateServerProfiles — only reads current profiles', async () => {
+    // We spy on migrateServerProfiles via the storage module to confirm it is
+    // NOT called from reresolveActiveServerUrl (it should only run at startup).
+    const storageMod = await import('../lib/storage');
+    const migrateSpy = vi.spyOn(storageMod, 'migrateServerProfiles');
+
+    const profiles = [{ id: 'a', name: 'Local', url: 'http://127.0.0.1:1700' }];
+    (globalThis as typeof globalThis & { browser: unknown }).browser =
+      makeBrowserStub({ profiles, activeProfileId: 'a' });
+
+    await __test__.reresolveActiveServerUrl();
+
+    expect(migrateSpy).not.toHaveBeenCalled();
+  });
+
+  it('changes cachedServerUrl when a different profile becomes active', async () => {
+    const profiles = [
+      { id: 'a', name: 'Local', url: 'http://127.0.0.1:1700' },
+      { id: 'b', name: 'Remote', url: 'http://remote:9000' },
+    ];
+
+    // First resolve to profile 'a'
+    const browserStub = makeBrowserStub({ profiles, activeProfileId: 'a' });
+    (globalThis as typeof globalThis & { browser: unknown }).browser = browserStub;
+    await __test__.reresolveActiveServerUrl();
+    expect(__test__.getCachedState().serverUrl).toBe('http://127.0.0.1:1700');
+
+    // Simulate profile switch: active becomes 'b'
+    browserStub.storage.local.get = vi.fn(async (key: string) => {
+      switch (key) {
+        case STORAGE_KEYS.PROFILES:
+          return { [STORAGE_KEYS.PROFILES]: profiles };
+        case STORAGE_KEYS.ACTIVE_PROFILE_ID:
+          return { [STORAGE_KEYS.ACTIVE_PROFILE_ID]: 'b' };
+        default:
+          return {};
+      }
+    });
+
+    await __test__.reresolveActiveServerUrl();
+    expect(__test__.getCachedState().serverUrl).toBe('http://remote:9000');
+  });
+});

--- a/extension/test/intercept.test.ts
+++ b/extension/test/intercept.test.ts
@@ -236,7 +236,7 @@ describe('download interception naming', () => {
     });
 
     it('intercepts everything when minFileSize is 0', async () => {
-      (browser.storage.local.get as any).mockImplementation((key: string) => {
+      vi.mocked(browser.storage.local.get).mockImplementation((key: string) => {
         if (key === 'intercept') return Promise.resolve({ intercept: true });
         if (key === 'serverUrl') return Promise.resolve({ serverUrl: 'http://127.0.0.1:1700' });
         if (key === 'minFileSize') return Promise.resolve({ minFileSize: 0 });

--- a/extension/test/intercept.test.ts
+++ b/extension/test/intercept.test.ts
@@ -236,7 +236,7 @@ describe('download interception naming', () => {
     });
 
     it('intercepts everything when minFileSize is 0', async () => {
-      vi.mocked(browser.storage.local.get).mockImplementation((key: string) => {
+      (browser.storage.local.get as import('vitest').Mock).mockImplementation((key: string) => {
         if (key === 'intercept') return Promise.resolve({ intercept: true });
         if (key === 'serverUrl') return Promise.resolve({ serverUrl: 'http://127.0.0.1:1700' });
         if (key === 'minFileSize') return Promise.resolve({ minFileSize: 0 });

--- a/extension/test/settings-view.test.ts
+++ b/extension/test/settings-view.test.ts
@@ -134,27 +134,28 @@ describe('persistProfiles', () => {
 // ---------------------------------------------------------------------------
 
 describe('handleAddProfile', () => {
-  it('returns an error without touching storage when the URL is empty', async () => {
+  it('allows adding a profile with an empty URL (auto-discover)', async () => {
     const store = makeStore();
     const storage = okStorage();
 
     const result = await handleAddProfile({ name: 'Home', url: '', token: '' }, store, storage);
 
-    expect(result.ok).toBe(false);
-    expect(result.error).toBe('Enter a server URL');
-    expect(storage.set).not.toHaveBeenCalled();
-    expect(store.profiles).toHaveLength(0);
+    expect(result.ok).toBe(true);
+    expect(storage.set).toHaveBeenCalledOnce();
+    expect(store.profiles).toHaveLength(1);
+    expect(store.profiles[0].url).toBe('');
   });
 
-  it('returns an error without touching storage when the URL is whitespace only', async () => {
+  it('allows adding a profile with a whitespace-only URL (auto-discover)', async () => {
     const store = makeStore();
     const storage = okStorage();
 
     const result = await handleAddProfile({ name: 'Home', url: '   ', token: '' }, store, storage);
 
-    expect(result.ok).toBe(false);
-    expect(result.error).toBe('Enter a server URL');
-    expect(storage.set).not.toHaveBeenCalled();
+    expect(result.ok).toBe(true);
+    expect(storage.set).toHaveBeenCalledOnce();
+    expect(store.profiles).toHaveLength(1);
+    expect(store.profiles[0].url).toBe('');
   });
 
   it('adds a profile and updates signals on success', async () => {
@@ -194,13 +195,13 @@ describe('handleAddProfile', () => {
     expect(store.activeId).toBe('');
   });
 
-  it('falls back to the URL as profile name when name is empty', async () => {
+  it('falls back to Auto-Discover when name and url are both empty', async () => {
     const store = makeStore();
     const storage = okStorage();
 
-    await handleAddProfile({ name: '', url: 'http://host:9000', token: '' }, store, storage);
+    await handleAddProfile({ name: '', url: '', token: '' }, store, storage);
 
-    expect(store.profiles[0].name).toBe('http://host:9000');
+    expect(store.profiles[0].name).toBe('Auto-Discover (Localhost)');
   });
 });
 

--- a/extension/test/settings-view.test.ts
+++ b/extension/test/settings-view.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Unit tests for SettingsView profile management logic.
+ *
+ * The handler functions are tested via the extracted settings-handlers module
+ * (popup/lib/settings-handlers.ts) rather than by rendering the SolidJS
+ * component, keeping the test environment as plain Node (no DOM/jsdom needed).
+ *
+ * Each test injects a fake ProfileStore and a fake StorageApi so we can verify:
+ *   - that signals are NOT mutated when storage write fails (rollback)
+ *   - that invalid URL inputs are rejected before any storage write
+ *   - that signals ARE updated correctly after a successful write
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { ServerProfile } from '../lib/storage';
+import {
+  persistProfiles,
+  handleAddProfile,
+  handleSwitchProfile,
+  handleDeleteProfile,
+  type ProfileStore,
+  type StorageApi,
+} from '../entrypoints/popup/lib/settings-handlers';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProfile(id: string, url: string): ServerProfile {
+  return { id, name: id, url };
+}
+
+function makeStore(initial?: {
+  profiles?: ServerProfile[];
+  activeId?: string;
+}): ProfileStore & {
+  profiles: ServerProfile[];
+  activeId: string;
+  serverUrl: string;
+  locked: boolean;
+} {
+  let profiles = initial?.profiles ?? [];
+  let activeId = initial?.activeId ?? '';
+  let serverUrl = '';
+  let locked = false;
+
+  return {
+    // Readable state (for assertions)
+    get profiles() { return profiles; },
+    get activeId() { return activeId; },
+    get serverUrl() { return serverUrl; },
+    get locked() { return locked; },
+    // ProfileStore interface
+    getProfiles: () => profiles,
+    getActiveId: () => activeId,
+    setProfiles: (p) => { profiles = p; },
+    setActiveId: (id) => { activeId = id; },
+    setServerUrl: (url) => { serverUrl = url; },
+    setServerUrlLocked: (l) => { locked = l; },
+  };
+}
+
+function okStorage(): StorageApi {
+  return { set: vi.fn().mockResolvedValue(undefined) };
+}
+
+function failingStorage(): StorageApi {
+  return { set: vi.fn().mockRejectedValue(new Error('QuotaExceededError')) };
+}
+
+// ---------------------------------------------------------------------------
+// persistProfiles
+// ---------------------------------------------------------------------------
+
+describe('persistProfiles', () => {
+  it('writes storage then updates signals on success', async () => {
+    const store = makeStore();
+    const storage = okStorage();
+    const profiles = [makeProfile('a', 'http://a:1700')];
+
+    await persistProfiles(profiles, 'a', store, storage);
+
+    expect(store.profiles).toEqual(profiles);
+    expect(store.activeId).toBe('a');
+    expect(store.serverUrl).toBe('http://a:1700');
+    expect(store.locked).toBe(true);
+    expect(storage.set).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT update signals when storage write fails', async () => {
+    const initialProfiles = [makeProfile('old', 'http://old:1700')];
+    const store = makeStore({ profiles: initialProfiles, activeId: 'old' });
+    const storage = failingStorage();
+
+    await expect(
+      persistProfiles([makeProfile('new', 'http://new:1700')], 'new', store, storage),
+    ).rejects.toThrow();
+
+    // Signals must still reflect the pre-call state
+    expect(store.profiles).toEqual(initialProfiles);
+    expect(store.activeId).toBe('old');
+    expect(store.serverUrl).toBe('');  // never set
+    expect(store.locked).toBe(false);  // never set
+  });
+
+  it('sets serverUrlLocked to false when there is no active profile', async () => {
+    const store = makeStore();
+    const storage = okStorage();
+
+    await persistProfiles([], '', store, storage);
+
+    expect(store.serverUrl).toBe('');
+    expect(store.locked).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleAddProfile
+// ---------------------------------------------------------------------------
+
+describe('handleAddProfile', () => {
+  it('returns an error without touching storage when the URL is empty', async () => {
+    const store = makeStore();
+    const storage = okStorage();
+
+    const result = await handleAddProfile({ name: 'Home', url: '' }, store, storage);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('Enter a server URL');
+    expect(storage.set).not.toHaveBeenCalled();
+    expect(store.profiles).toHaveLength(0);
+  });
+
+  it('returns an error without touching storage when the URL is whitespace only', async () => {
+    const store = makeStore();
+    const storage = okStorage();
+
+    const result = await handleAddProfile({ name: 'Home', url: '   ' }, store, storage);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('Enter a server URL');
+    expect(storage.set).not.toHaveBeenCalled();
+  });
+
+  it('adds a profile and updates signals on success', async () => {
+    const store = makeStore();
+    const storage = okStorage();
+
+    const result = await handleAddProfile(
+      { name: 'Home', url: '127.0.0.1:1700' },
+      store,
+      storage,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(store.profiles).toHaveLength(1);
+    expect(store.profiles[0].url).toBe('http://127.0.0.1:1700');
+    expect(store.activeId).toBe(store.profiles[0].id);
+    expect(store.locked).toBe(true);
+    expect(storage.set).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT update signals when storage write fails', async () => {
+    const store = makeStore();
+    const storage = failingStorage();
+
+    const result = await handleAddProfile(
+      { name: 'Home', url: 'http://host:1700' },
+      store,
+      storage,
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('Failed to save');
+    // Signals must remain at initial state (rollback)
+    expect(store.profiles).toHaveLength(0);
+    expect(store.activeId).toBe('');
+  });
+
+  it('falls back to the URL as profile name when name is empty', async () => {
+    const store = makeStore();
+    const storage = okStorage();
+
+    await handleAddProfile({ name: '', url: 'http://host:9000' }, store, storage);
+
+    expect(store.profiles[0].name).toBe('http://host:9000');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleSwitchProfile
+// ---------------------------------------------------------------------------
+
+describe('handleSwitchProfile', () => {
+  const existingProfiles = [
+    makeProfile('a', 'http://a:1700'),
+    makeProfile('b', 'http://b:1700'),
+  ];
+
+  it('switches the active profile on success', async () => {
+    const store = makeStore({ profiles: existingProfiles, activeId: 'a' });
+    const storage = okStorage();
+
+    const result = await handleSwitchProfile('b', store, storage);
+
+    expect(result.ok).toBe(true);
+    expect(store.activeId).toBe('b');
+    expect(store.serverUrl).toBe('http://b:1700');
+  });
+
+  it('does NOT update signals when storage write fails', async () => {
+    const store = makeStore({ profiles: existingProfiles, activeId: 'a' });
+    const storage = failingStorage();
+
+    const result = await handleSwitchProfile('b', store, storage);
+
+    expect(result.ok).toBe(false);
+    // activeId must remain 'a'
+    expect(store.activeId).toBe('a');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleDeleteProfile
+// ---------------------------------------------------------------------------
+
+describe('handleDeleteProfile', () => {
+  it('removes the active profile and falls back to the first remaining one', async () => {
+    const profiles = [
+      makeProfile('a', 'http://a:1700'),
+      makeProfile('b', 'http://b:1700'),
+    ];
+    const store = makeStore({ profiles, activeId: 'a' });
+    const storage = okStorage();
+
+    const result = await handleDeleteProfile(store, storage);
+
+    expect(result.ok).toBe(true);
+    expect(store.profiles.map((p) => p.id)).toEqual(['b']);
+    expect(store.activeId).toBe('b');
+  });
+
+  it('results in an empty profile list when the last profile is deleted', async () => {
+    const store = makeStore({
+      profiles: [makeProfile('only', 'http://only:1700')],
+      activeId: 'only',
+    });
+    const storage = okStorage();
+
+    await handleDeleteProfile(store, storage);
+
+    expect(store.profiles).toHaveLength(0);
+    expect(store.activeId).toBe('');
+    expect(store.locked).toBe(false);
+  });
+
+  it('does NOT update signals when storage write fails', async () => {
+    const profiles = [
+      makeProfile('a', 'http://a:1700'),
+      makeProfile('b', 'http://b:1700'),
+    ];
+    const store = makeStore({ profiles, activeId: 'a' });
+    const storage = failingStorage();
+
+    const result = await handleDeleteProfile(store, storage);
+
+    expect(result.ok).toBe(false);
+    // Signals must remain at their initial values
+    expect(store.profiles).toHaveLength(2);
+    expect(store.activeId).toBe('a');
+  });
+});

--- a/extension/test/settings-view.test.ts
+++ b/extension/test/settings-view.test.ts
@@ -26,8 +26,8 @@ import {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeProfile(id: string, url: string): ServerProfile {
-  return { id, name: id, url };
+function makeProfile(id: string, url: string, token: string = ''): ServerProfile {
+  return { id, name: id, url, token };
 }
 
 function makeStore(initial?: {
@@ -38,11 +38,17 @@ function makeStore(initial?: {
   activeId: string;
   serverUrl: string;
   locked: boolean;
+  authToken: string;
+  authTokenLocked: boolean;
+  authValid: boolean;
 } {
   let profiles = initial?.profiles ?? [];
   let activeId = initial?.activeId ?? '';
   let serverUrl = '';
   let locked = false;
+  let authToken = '';
+  let authTokenLocked = false;
+  let authValid = false;
 
   return {
     // Readable state (for assertions)
@@ -50,6 +56,9 @@ function makeStore(initial?: {
     get activeId() { return activeId; },
     get serverUrl() { return serverUrl; },
     get locked() { return locked; },
+    get authToken() { return authToken; },
+    get authTokenLocked() { return authTokenLocked; },
+    get authValid() { return authValid; },
     // ProfileStore interface
     getProfiles: () => profiles,
     getActiveId: () => activeId,
@@ -57,6 +66,9 @@ function makeStore(initial?: {
     setActiveId: (id) => { activeId = id; },
     setServerUrl: (url) => { serverUrl = url; },
     setServerUrlLocked: (l) => { locked = l; },
+    setAuthToken: (t) => { authToken = t; },
+    setAuthTokenLocked: (l) => { authTokenLocked = l; },
+    setAuthValid: (v) => { authValid = v; },
   };
 }
 
@@ -76,14 +88,17 @@ describe('persistProfiles', () => {
   it('writes storage then updates signals on success', async () => {
     const store = makeStore();
     const storage = okStorage();
-    const profiles = [makeProfile('a', 'http://a:1700')];
+    const profiles = [makeProfile('a', 'http://a:1700', 'secret')];
 
     await persistProfiles(profiles, 'a', store, storage);
 
     expect(store.profiles).toEqual(profiles);
     expect(store.activeId).toBe('a');
     expect(store.serverUrl).toBe('http://a:1700');
+    expect(store.authToken).toBe('secret');
     expect(store.locked).toBe(true);
+    expect(store.authTokenLocked).toBe(true);
+    expect(store.authValid).toBe(false);
     expect(storage.set).toHaveBeenCalledOnce();
   });
 
@@ -123,7 +138,7 @@ describe('handleAddProfile', () => {
     const store = makeStore();
     const storage = okStorage();
 
-    const result = await handleAddProfile({ name: 'Home', url: '' }, store, storage);
+    const result = await handleAddProfile({ name: 'Home', url: '', token: '' }, store, storage);
 
     expect(result.ok).toBe(false);
     expect(result.error).toBe('Enter a server URL');
@@ -135,7 +150,7 @@ describe('handleAddProfile', () => {
     const store = makeStore();
     const storage = okStorage();
 
-    const result = await handleAddProfile({ name: 'Home', url: '   ' }, store, storage);
+    const result = await handleAddProfile({ name: 'Home', url: '   ', token: '' }, store, storage);
 
     expect(result.ok).toBe(false);
     expect(result.error).toBe('Enter a server URL');
@@ -147,7 +162,7 @@ describe('handleAddProfile', () => {
     const storage = okStorage();
 
     const result = await handleAddProfile(
-      { name: 'Home', url: '127.0.0.1:1700' },
+      { name: 'Home', url: '127.0.0.1:1700', token: 'secret' },
       store,
       storage,
     );
@@ -155,8 +170,10 @@ describe('handleAddProfile', () => {
     expect(result.ok).toBe(true);
     expect(store.profiles).toHaveLength(1);
     expect(store.profiles[0].url).toBe('http://127.0.0.1:1700');
+    expect(store.profiles[0].token).toBe('secret');
     expect(store.activeId).toBe(store.profiles[0].id);
     expect(store.locked).toBe(true);
+    expect(store.authToken).toBe('secret');
     expect(storage.set).toHaveBeenCalledOnce();
   });
 
@@ -165,7 +182,7 @@ describe('handleAddProfile', () => {
     const storage = failingStorage();
 
     const result = await handleAddProfile(
-      { name: 'Home', url: 'http://host:1700' },
+      { name: 'Home', url: 'http://host:1700', token: '' },
       store,
       storage,
     );
@@ -181,7 +198,7 @@ describe('handleAddProfile', () => {
     const store = makeStore();
     const storage = okStorage();
 
-    await handleAddProfile({ name: '', url: 'http://host:9000' }, store, storage);
+    await handleAddProfile({ name: '', url: 'http://host:9000', token: '' }, store, storage);
 
     expect(store.profiles[0].name).toBe('http://host:9000');
   });

--- a/extension/test/storage-profiles.test.ts
+++ b/extension/test/storage-profiles.test.ts
@@ -106,6 +106,25 @@ describe('server profile storage', () => {
       expect(second.profiles[0].id).not.toBe(second.profiles[1].id);
       expect(second.activeId).toBe(second.profiles[1].id);
     });
+
+    it('throws when the url is an empty string', () => {
+      expect(() => addServerProfile([], { name: 'X', url: '' })).toThrow(
+        'Profile URL must not be empty after normalization',
+      );
+    });
+
+    it('throws when the url is whitespace only', () => {
+      expect(() => addServerProfile([], { name: 'X', url: '   ' })).toThrow(
+        'Profile URL must not be empty after normalization',
+      );
+    });
+
+    it('throws when the url normalizes to an empty string', () => {
+      // A url that is blank after trimming still normalizes to ''
+      expect(() => addServerProfile([], { name: 'X', url: '\t\n' })).toThrow(
+        'Profile URL must not be empty after normalization',
+      );
+    });
   });
 
   describe('removeServerProfile', () => {

--- a/extension/test/storage-profiles.test.ts
+++ b/extension/test/storage-profiles.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest';
+import {
+  STORAGE_KEYS,
+  parseServerProfiles,
+  resolveActiveProfile,
+  resolveActiveServerUrl,
+  addServerProfile,
+  removeServerProfile,
+  migrateServerProfiles,
+  type ServerProfile,
+} from '../lib/storage';
+
+function profile(id: string, name: string, url: string): ServerProfile {
+  return { id, name, url };
+}
+
+describe('server profile storage', () => {
+  it('exposes profile storage keys', () => {
+    expect(STORAGE_KEYS.PROFILES).toBe('serverProfiles');
+    expect(STORAGE_KEYS.ACTIVE_PROFILE_ID).toBe('activeServerProfileId');
+  });
+
+  describe('parseServerProfiles', () => {
+    it('reads a well-formed profiles array from stored values', () => {
+      const values = {
+        [STORAGE_KEYS.PROFILES]: [
+          profile('a', 'Local', 'http://127.0.0.1:1700'),
+          profile('b', 'Remote', 'http://remote:1700'),
+        ],
+      };
+      expect(parseServerProfiles(values)).toEqual([
+        profile('a', 'Local', 'http://127.0.0.1:1700'),
+        profile('b', 'Remote', 'http://remote:1700'),
+      ]);
+    });
+
+    it('drops malformed entries and normalizes urls', () => {
+      const values = {
+        [STORAGE_KEYS.PROFILES]: [
+          profile('a', 'Local', '127.0.0.1:1700'),
+          { id: 'b', name: 'no url' },
+          { name: 'no id', url: 'http://x' },
+          'garbage',
+          profile('', 'empty id', 'http://y'),
+        ],
+      };
+      expect(parseServerProfiles(values)).toEqual([
+        profile('a', 'Local', 'http://127.0.0.1:1700'),
+      ]);
+    });
+
+    it('returns an empty array when nothing is stored', () => {
+      expect(parseServerProfiles({})).toEqual([]);
+      expect(parseServerProfiles({ [STORAGE_KEYS.PROFILES]: 'nope' })).toEqual([]);
+    });
+  });
+
+  describe('resolveActiveProfile', () => {
+    const profiles = [
+      profile('a', 'Local', 'http://127.0.0.1:1700'),
+      profile('b', 'Remote', 'http://remote:1700'),
+    ];
+
+    it('returns the profile matching the active id', () => {
+      expect(resolveActiveProfile(profiles, 'b')).toEqual(profiles[1]);
+    });
+
+    it('falls back to the first profile when the active id is unknown', () => {
+      expect(resolveActiveProfile(profiles, 'missing')).toEqual(profiles[0]);
+      expect(resolveActiveProfile(profiles, '')).toEqual(profiles[0]);
+    });
+
+    it('returns null when there are no profiles', () => {
+      expect(resolveActiveProfile([], 'a')).toBeNull();
+    });
+  });
+
+  describe('resolveActiveServerUrl', () => {
+    it("returns the active profile's url", () => {
+      const profiles = [
+        profile('a', 'Local', 'http://127.0.0.1:1700'),
+        profile('b', 'Remote', 'http://remote:1700'),
+      ];
+      expect(resolveActiveServerUrl(profiles, 'b')).toBe('http://remote:1700');
+    });
+
+    it('returns an empty string when there is no active profile', () => {
+      expect(resolveActiveServerUrl([], 'b')).toBe('');
+    });
+  });
+
+  describe('addServerProfile', () => {
+    it('appends a normalized profile and returns it as active', () => {
+      const result = addServerProfile([], { name: 'Local', url: '127.0.0.1:1700' });
+      expect(result.profiles).toHaveLength(1);
+      expect(result.profiles[0].name).toBe('Local');
+      expect(result.profiles[0].url).toBe('http://127.0.0.1:1700');
+      expect(result.profiles[0].id).toBeTruthy();
+      expect(result.activeId).toBe(result.profiles[0].id);
+    });
+
+    it('assigns unique ids across additions', () => {
+      const first = addServerProfile([], { name: 'A', url: 'http://a:1700' });
+      const second = addServerProfile(first.profiles, { name: 'B', url: 'http://b:1700' });
+      expect(second.profiles).toHaveLength(2);
+      expect(second.profiles[0].id).not.toBe(second.profiles[1].id);
+      expect(second.activeId).toBe(second.profiles[1].id);
+    });
+  });
+
+  describe('removeServerProfile', () => {
+    const profiles = [
+      profile('a', 'Local', 'http://127.0.0.1:1700'),
+      profile('b', 'Remote', 'http://remote:1700'),
+      profile('c', 'Third', 'http://third:1700'),
+    ];
+
+    it('removes the profile and keeps the active id when another is active', () => {
+      const result = removeServerProfile(profiles, 'a', 'b');
+      expect(result.profiles.map((p) => p.id)).toEqual(['b', 'c']);
+      expect(result.activeId).toBe('b');
+    });
+
+    it('re-points the active id to the first remaining profile when the active one is removed', () => {
+      const result = removeServerProfile(profiles, 'b', 'b');
+      expect(result.profiles.map((p) => p.id)).toEqual(['a', 'c']);
+      expect(result.activeId).toBe('a');
+    });
+
+    it('returns an empty active id when the last profile is removed', () => {
+      const result = removeServerProfile([profiles[0]], 'a', 'a');
+      expect(result.profiles).toEqual([]);
+      expect(result.activeId).toBe('');
+    });
+  });
+
+  describe('migrateServerProfiles (backward compat)', () => {
+    it('migrates an existing single SERVER_URL into a default profile', () => {
+      const values = {
+        [STORAGE_KEYS.SERVER_URL]: 'http://127.0.0.1:1700',
+      };
+      const result = migrateServerProfiles(values);
+      expect(result.migrated).toBe(true);
+      expect(result.profiles).toHaveLength(1);
+      expect(result.profiles[0].name).toBe('Default');
+      expect(result.profiles[0].url).toBe('http://127.0.0.1:1700');
+      expect(result.activeId).toBe(result.profiles[0].id);
+    });
+
+    it('normalizes the legacy url during migration', () => {
+      const result = migrateServerProfiles({ [STORAGE_KEYS.SERVER_URL]: '127.0.0.1:1700/' });
+      expect(result.profiles[0].url).toBe('http://127.0.0.1:1700');
+    });
+
+    it('does not migrate when profiles already exist', () => {
+      const values = {
+        [STORAGE_KEYS.SERVER_URL]: 'http://127.0.0.1:1700',
+        [STORAGE_KEYS.PROFILES]: [profile('a', 'Local', 'http://127.0.0.1:1700')],
+        [STORAGE_KEYS.ACTIVE_PROFILE_ID]: 'a',
+      };
+      const result = migrateServerProfiles(values);
+      expect(result.migrated).toBe(false);
+      expect(result.profiles).toEqual([profile('a', 'Local', 'http://127.0.0.1:1700')]);
+      expect(result.activeId).toBe('a');
+    });
+
+    it('does not migrate when there is no legacy url and no profiles', () => {
+      const result = migrateServerProfiles({});
+      expect(result.migrated).toBe(false);
+      expect(result.profiles).toEqual([]);
+      expect(result.activeId).toBe('');
+    });
+
+    it('resolves the active url end-to-end after migration', () => {
+      const result = migrateServerProfiles({ [STORAGE_KEYS.SERVER_URL]: 'http://remote:9000' });
+      expect(resolveActiveServerUrl(result.profiles, result.activeId)).toBe('http://remote:9000');
+    });
+  });
+});

--- a/extension/test/storage-profiles.test.ts
+++ b/extension/test/storage-profiles.test.ts
@@ -10,8 +10,8 @@ import {
   type ServerProfile,
 } from '../lib/storage';
 
-function profile(id: string, name: string, url: string): ServerProfile {
-  return { id, name, url };
+function profile(id: string, name: string, url: string, token: string = ''): ServerProfile {
+  return { id, name, url, token };
 }
 
 describe('server profile storage', () => {
@@ -91,37 +91,38 @@ describe('server profile storage', () => {
 
   describe('addServerProfile', () => {
     it('appends a normalized profile and returns it as active', () => {
-      const result = addServerProfile([], { name: 'Local', url: '127.0.0.1:1700' });
+      const result = addServerProfile([], { name: 'Local', url: '127.0.0.1:1700', token: 'secret' });
       expect(result.profiles).toHaveLength(1);
       expect(result.profiles[0].name).toBe('Local');
       expect(result.profiles[0].url).toBe('http://127.0.0.1:1700');
+      expect(result.profiles[0].token).toBe('secret');
       expect(result.profiles[0].id).toBeTruthy();
       expect(result.activeId).toBe(result.profiles[0].id);
     });
 
     it('assigns unique ids across additions', () => {
-      const first = addServerProfile([], { name: 'A', url: 'http://a:1700' });
-      const second = addServerProfile(first.profiles, { name: 'B', url: 'http://b:1700' });
+      const first = addServerProfile([], { name: 'A', url: 'http://a:1700', token: '' });
+      const second = addServerProfile(first.profiles, { name: 'B', url: 'http://b:1700', token: '' });
       expect(second.profiles).toHaveLength(2);
       expect(second.profiles[0].id).not.toBe(second.profiles[1].id);
       expect(second.activeId).toBe(second.profiles[1].id);
     });
 
     it('throws when the url is an empty string', () => {
-      expect(() => addServerProfile([], { name: 'X', url: '' })).toThrow(
+      expect(() => addServerProfile([], { name: 'X', url: '', token: '' })).toThrow(
         'Profile URL must not be empty after normalization',
       );
     });
 
     it('throws when the url is whitespace only', () => {
-      expect(() => addServerProfile([], { name: 'X', url: '   ' })).toThrow(
+      expect(() => addServerProfile([], { name: 'X', url: '   ', token: '' })).toThrow(
         'Profile URL must not be empty after normalization',
       );
     });
 
     it('throws when the url normalizes to an empty string', () => {
       // A url that is blank after trimming still normalizes to ''
-      expect(() => addServerProfile([], { name: 'X', url: '\t\n' })).toThrow(
+      expect(() => addServerProfile([], { name: 'X', url: '\t\n', token: '' })).toThrow(
         'Profile URL must not be empty after normalization',
       );
     });
@@ -157,12 +158,14 @@ describe('server profile storage', () => {
     it('migrates an existing single SERVER_URL into a default profile', () => {
       const values = {
         [STORAGE_KEYS.SERVER_URL]: 'http://127.0.0.1:1700',
+        [STORAGE_KEYS.TOKEN]: 'legacy-token',
       };
       const result = migrateServerProfiles(values);
       expect(result.migrated).toBe(true);
       expect(result.profiles).toHaveLength(1);
       expect(result.profiles[0].name).toBe('Default');
       expect(result.profiles[0].url).toBe('http://127.0.0.1:1700');
+      expect(result.profiles[0].token).toBe('legacy-token');
       expect(result.activeId).toBe(result.profiles[0].id);
     });
 

--- a/extension/test/storage-profiles.test.ts
+++ b/extension/test/storage-profiles.test.ts
@@ -108,23 +108,22 @@ describe('server profile storage', () => {
       expect(second.activeId).toBe(second.profiles[1].id);
     });
 
-    it('throws when the url is an empty string', () => {
-      expect(() => addServerProfile([], { name: 'X', url: '', token: '' })).toThrow(
-        'Profile URL must not be empty after normalization',
-      );
+    it('allows an empty string url (auto-discover)', () => {
+      const profiles = addServerProfile([], { name: 'X', url: '', token: '' });
+      expect(profiles.activeId).not.toBe('');
+      expect(profiles.profiles[0].url).toBe('');
     });
 
-    it('throws when the url is whitespace only', () => {
-      expect(() => addServerProfile([], { name: 'X', url: '   ', token: '' })).toThrow(
-        'Profile URL must not be empty after normalization',
-      );
+    it('allows a whitespace only url (auto-discover)', () => {
+      const profiles = addServerProfile([], { name: 'X', url: '   ', token: '' });
+      expect(profiles.activeId).not.toBe('');
+      expect(profiles.profiles[0].url).toBe('');
     });
 
-    it('throws when the url normalizes to an empty string', () => {
-      // A url that is blank after trimming still normalizes to ''
-      expect(() => addServerProfile([], { name: 'X', url: '\t\n', token: '' })).toThrow(
-        'Profile URL must not be empty after normalization',
-      );
+    it('allows a url that normalizes to an empty string (auto-discover)', () => {
+      const profiles = addServerProfile([], { name: 'X', url: '\t\n', token: '' });
+      expect(profiles.activeId).not.toBe('');
+      expect(profiles.profiles[0].url).toBe('');
     });
   });
 


### PR DESCRIPTION
## Summary

The extension persisted a single `SERVER_URL`, so there was no way to keep and switch between multiple server instances (#412).

## Fix

- `extension/lib/storage.ts`: a named server-profile layer (`ServerProfile`, parse/sanitize, add/remove, resolve-active) plus backward-compat migration that wraps an existing `serverUrl` into a `Default` profile. UI-import-free so the background service worker can use it.
- `SettingsView.tsx`: replaced the single URL field with an "Active Server" dropdown + Delete + an "Add a Server" (name + URL) form.
- `background.ts`: re-resolves the active base URL and resets health/retry timers when the active profile changes.

Adds 19 storage-profile unit tests (parse, add/remove, active resolution, the three migration cases).

Closes #412

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the extension's single persisted `SERVER_URL` with a named server-profile system, letting users keep and switch between multiple Surge instances. The storage layer, background service worker, and settings UI are all updated together with 19+ new unit tests.

- **`lib/storage.ts`**: new `ServerProfile` type, parse/sanitize/add/remove/resolve helpers, and a backward-compat migration that wraps a legacy `serverUrl` into a \"Default\" profile on first load.
- **`SettingsView.tsx`**: replaces the flat URL + token fields with an \"Active Server\" dropdown and a Connect → Save Profile flow.
- **`background.ts`**: re-reads the active profile on storage changes, resets health/retry timers on switch, adds a `testConnection` handler, and extends port scanning to use the configured server's hostname.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the discovered-URL discarding bug in the add-server flow.

The storage layer, migration path, and handler rollback semantics are solid and well-tested. The one concrete defect is in SettingsView: when testConnection discovers the server on a different port than what the user typed, res.url is discarded and the profile is saved with the wrong URL, leading to permanently misconfigured profile data.

extension/entrypoints/popup/components/SettingsView.tsx — the handleConnect / handleSaveProfile interaction around res.url.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| extension/entrypoints/popup/components/SettingsView.tsx | Replaced single URL/token fields with profile switcher + add-server flow; `res.url` from `testConnection` is not used when saving, so profiles can be stored with the wrong URL when port-scanning discovers a different address than entered. |
| extension/lib/storage.ts | New profile layer (parse/sanitize, add/remove, resolve-active, migration) is well-structured; minor stale JSDoc on `addServerProfile` says it throws on empty URL but intentionally allows it. |
| extension/entrypoints/background.ts | Storage change listener and startup loading updated for profiles; `testConnection` handler duplicates the port-scan-with-auth loop already present in `discoverBaseUrlForToken`. |
| extension/entrypoints/popup/lib/settings-handlers.ts | New pure handler module with correct storage-first / signal-second ordering for rollback safety; cleanly testable without DOM. |
| extension/entrypoints/popup/App.tsx | Startup hydration updated to run migration and set profile signals; migration write is gated on `migration.migrated` correctly. |

</details>

<sub>Reviews (4): Last reviewed commit: ["test: update vitest mock casting for bro..."](https://github.com/surgedm/surge/commit/5299bbc961fb20f78302bc46edf8b4208e4b7295) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38755710)</sub>

<!-- /greptile_comment -->