### PR TITLE
feat: support precise per-task worker and chunk size overrides

### DIFF
--- a/cmd/connect_test.go
+++ b/cmd/connect_test.go
@@ -28,7 +28,7 @@ func (f *fakeRemoteDownloadService) History() ([]types.DownloadEntry, error) {
 	return nil, nil
 }
 
-func (f *fakeRemoteDownloadService) Add(url, path, filename string, mirrors []string, headers map[string]string, isExplicitCategory bool, totalSize int64, supportsRange bool) (string, error) {
+func (f *fakeRemoteDownloadService) Add(url, path, filename string, mirrors []string, headers map[string]string, isExplicitCategory bool, workers int, minChunkSize int64, totalSize int64, supportsRange bool) (string, error) {
 	f.addCalls++
 	f.lastURL = url
 	f.lastPath = path
@@ -37,7 +37,7 @@ func (f *fakeRemoteDownloadService) Add(url, path, filename string, mirrors []st
 	return "remote-add-id", nil
 }
 
-func (f *fakeRemoteDownloadService) AddWithID(url, path, filename string, mirrors []string, headers map[string]string, id string, totalSize int64, supportsRange bool) (string, error) {
+func (f *fakeRemoteDownloadService) AddWithID(url, path, filename string, mirrors []string, headers map[string]string, id string, workers int, minChunkSize int64, totalSize int64, supportsRange bool) (string, error) {
 	return id, nil
 }
 

--- a/cmd/headless_approval_test.go
+++ b/cmd/headless_approval_test.go
@@ -54,7 +54,7 @@ func TestHandleDownload_HeadlessMode_AutoApprovesNonDuplicate(t *testing.T) {
 	GlobalPool = download.NewWorkerPool(progressCh, 1)
 
 	// Mock lifecycle to bypass real downloads
-	GlobalLifecycle = processing.NewLifecycleManager(func(url, path, filename string, _ []string, headers map[string]string, explicit bool, totalSize int64, supportsRange bool) (string, error) {
+	GlobalLifecycle = processing.NewLifecycleManager(func(url, path, filename string, _ []string, headers map[string]string, explicit bool, workers int, minChunkSize int64, totalSize int64, supportsRange bool) (string, error) {
 		return "queued-id", nil
 	}, nil)
 

--- a/cmd/http_api_test.go
+++ b/cmd/http_api_test.go
@@ -48,11 +48,11 @@ func (s *httpAPITestService) History() ([]types.DownloadEntry, error) {
 	return s.history, nil
 }
 
-func (s *httpAPITestService) Add(string, string, string, []string, map[string]string, bool, int64, bool) (string, error) {
+func (s *httpAPITestService) Add(string, string, string, []string, map[string]string, bool, int, int64, int64, bool) (string, error) {
 	return "", errors.New("not implemented")
 }
 
-func (s *httpAPITestService) AddWithID(string, string, string, []string, map[string]string, string, int64, bool) (string, error) {
+func (s *httpAPITestService) AddWithID(string, string, string, []string, map[string]string, string, int, int64, int64, bool) (string, error) {
 	return "", errors.New("not implemented")
 }
 
@@ -109,7 +109,7 @@ type batchAddRecordingService struct {
 	failOn string
 }
 
-func (s *batchAddRecordingService) Add(url string, _ string, _ string, _ []string, _ map[string]string, _ bool, _ int64, _ bool) (string, error) {
+func (s *batchAddRecordingService) Add(url string, _ string, _ string, _ []string, _ map[string]string, _ bool, _ int, _ int64, _ int64, _ bool) (string, error) {
 	if url == s.failOn {
 		return "", errors.New("enqueue failed")
 	}

--- a/cmd/http_api_test.go
+++ b/cmd/http_api_test.go
@@ -827,10 +827,10 @@ type rateLimitWrapper struct {
 
 func (r *rateLimitWrapper) List() ([]types.DownloadStatus, error)   { return nil, nil }
 func (r *rateLimitWrapper) History() ([]types.DownloadEntry, error) { return nil, nil }
-func (r *rateLimitWrapper) Add(string, string, string, []string, map[string]string, bool, int64, bool) (string, error) {
+func (r *rateLimitWrapper) Add(string, string, string, []string, map[string]string, bool, int, int64, int64, bool) (string, error) {
 	return "", nil
 }
-func (r *rateLimitWrapper) AddWithID(string, string, string, []string, map[string]string, string, int64, bool) (string, error) {
+func (r *rateLimitWrapper) AddWithID(string, string, string, []string, map[string]string, string, int, int64, int64, bool) (string, error) {
 	return "", nil
 }
 func (r *rateLimitWrapper) Pause(string) error             { return nil }

--- a/cmd/http_handler_test.go
+++ b/cmd/http_handler_test.go
@@ -286,7 +286,7 @@ func TestHandleDownload_SkipApprovalUsesLifecycleEnqueue(t *testing.T) {
 	expectedFile := "from-extension.bin"
 
 	var addCalls int
-	GlobalLifecycle = processing.NewLifecycleManager(func(url, path, filename string, _ []string, headers map[string]string, explicit bool, totalSize int64, supportsRange bool) (string, error) {
+	GlobalLifecycle = processing.NewLifecycleManager(func(url, path, filename string, _ []string, headers map[string]string, explicit bool, workers int, minChunkSize int64, totalSize int64, supportsRange bool) (string, error) {
 		addCalls++
 		if url != probeServer.URL {
 			t.Fatalf("url = %q, want %q", url, probeServer.URL)
@@ -372,7 +372,7 @@ func TestHandleDownload_EnqueueError_RecordsPreflightError(t *testing.T) {
 
 	// Create a lifecycle manager whose addFunc should never be reached
 	// because the probe will fail first (invalid URL scheme).
-	GlobalLifecycle = processing.NewLifecycleManager(func(string, string, string, []string, map[string]string, bool, int64, bool) (string, error) {
+	GlobalLifecycle = processing.NewLifecycleManager(func(string, string, string, []string, map[string]string, bool, int, int64, int64, bool) (string, error) {
 		t.Fatal("addFunc should not be called when probe fails")
 		return "", nil
 	}, nil)

--- a/cmd/http_handler_test.go
+++ b/cmd/http_handler_test.go
@@ -412,6 +412,72 @@ func TestHandleDownload_EnqueueError_RecordsPreflightError(t *testing.T) {
 	}
 }
 
+func TestHandleDownload_ForwardsPerTaskOverridesToLifecycle(t *testing.T) {
+	setupIsolatedCmdState(t)
+
+	progressCh := make(chan any, 10)
+	GlobalProgressCh = progressCh
+	GlobalPool = download.NewWorkerPool(progressCh, 1)
+
+	origLifecycle := GlobalLifecycle
+	origService := GlobalService
+	t.Cleanup(func() {
+		GlobalLifecycle = origLifecycle
+		GlobalService = origService
+		GlobalPool = nil
+		GlobalProgressCh = nil
+	})
+
+	probeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Range", "bytes 0-0/1024")
+		w.Header().Set("Content-Length", "1")
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write([]byte("x"))
+	}))
+	defer probeServer.Close()
+
+	tempDir := t.TempDir()
+
+	var gotWorkers int
+	var gotMinChunkSize int64
+	GlobalLifecycle = processing.NewLifecycleManager(func(_, _, _ string, _ []string, _ map[string]string, _ bool, workers int, minChunkSize int64, _ int64, _ bool) (string, error) {
+		gotWorkers = workers
+		gotMinChunkSize = minChunkSize
+		return "override-id", nil
+	}, nil)
+
+	svc := core.NewLocalDownloadService(nil)
+	GlobalService = svc
+	t.Cleanup(func() {
+		_ = svc.Shutdown()
+	})
+
+	minChunk := int64(8 * 1024 * 1024)
+	body := fmt.Sprintf(`{
+		"url": %q,
+		"filename": "override-test.bin",
+		"path": %q,
+		"skip_approval": true,
+		"workers": 12,
+		"min_chunk_size": %d
+	}`, probeServer.URL, tempDir, minChunk)
+
+	req := httptest.NewRequest(http.MethodPost, "/download", bytes.NewBufferString(body))
+	rec := httptest.NewRecorder()
+
+	handleDownload(rec, req, "", svc)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if gotWorkers != 12 {
+		t.Fatalf("expected lifecycle addFunc to receive workers=12, got %d", gotWorkers)
+	}
+	if gotMinChunkSize != minChunk {
+		t.Fatalf("expected lifecycle addFunc to receive minChunkSize=%d, got %d", minChunk, gotMinChunkSize)
+	}
+}
+
 type failingPublishService struct {
 	fakeRemoteDownloadService
 	publishErr error

--- a/cmd/root_downloads.go
+++ b/cmd/root_downloads.go
@@ -189,12 +189,14 @@ func handleBatchDownload(w http.ResponseWriter, r *http.Request, defaultOutputDi
 		urlForAdd, mirrorsForAdd := normalizeDownloadTargets(validated.URL, validated.Mirrors)
 		itemPath := utils.EnsureAbsPath(resolveOutputDir(validated.Path, validated.RelativeToDefaultDir, defaultOutputDir, settings))
 		requests = append(requests, events.DownloadRequestMsg{
-			ID:       uuid.New().String(),
-			URL:      urlForAdd,
-			Filename: validated.Filename,
-			Path:     itemPath,
-			Mirrors:  mirrorsForAdd,
-			Headers:  validated.Headers,
+			ID:           uuid.New().String(),
+			URL:          urlForAdd,
+			Filename:     validated.Filename,
+			Path:         itemPath,
+			Mirrors:      mirrorsForAdd,
+			Headers:      validated.Headers,
+			Workers:      validated.Workers,
+			MinChunkSize: validated.MinChunkSize,
 		})
 	}
 
@@ -234,6 +236,8 @@ func handleBatchDownload(w http.ResponseWriter, r *http.Request, defaultOutputDi
 				Mirrors:      item.Mirrors,
 				SkipApproval: true,
 				Headers:      item.Headers,
+				Workers:      item.Workers,
+				MinChunkSize: item.MinChunkSize,
 			},
 			settings:      settings,
 			outPath:       item.Path,
@@ -349,12 +353,14 @@ func maybeRequireDownloadApproval(w http.ResponseWriter, service core.DownloadSe
 
 		downloadID := uuid.New().String()
 		if err := service.Publish(events.DownloadRequestMsg{
-			ID:       downloadID,
-			URL:      resolved.urlForAdd,
-			Filename: req.Filename,
-			Path:     resolved.outPath,
-			Mirrors:  resolved.mirrorsForAdd,
-			Headers:  req.Headers,
+			ID:           downloadID,
+			URL:          resolved.urlForAdd,
+			Filename:     req.Filename,
+			Path:         resolved.outPath,
+			Mirrors:      resolved.mirrorsForAdd,
+			Headers:      req.Headers,
+			Workers:      req.Workers,
+			MinChunkSize: req.MinChunkSize,
 		}); err != nil {
 			recordPreflightDownloadError(resolved.urlForAdd, resolved.outPath, err)
 			publishSystemLog(fmt.Sprintf("Error adding %s: %v", resolved.urlForAdd, err))

--- a/cmd/root_downloads.go
+++ b/cmd/root_downloads.go
@@ -28,6 +28,8 @@ type DownloadRequest struct {
 	SkipApproval         bool              `json:"skip_approval,omitempty"` // Extension validated request, skip TUI prompt
 	Headers              map[string]string `json:"headers,omitempty"`       // Custom HTTP headers from browser (cookies, auth, etc.)
 	IsExplicitCategory   bool              `json:"is_explicit_category,omitempty"`
+	Workers              int               `json:"workers,omitempty"`        // Per-task worker count override (bypasses √size heuristic when >0)
+	MinChunkSize         int64             `json:"min_chunk_size,omitempty"` // Per-task minimum chunk size override
 }
 
 type BatchDownloadRequest struct {
@@ -400,10 +402,12 @@ func enqueueDownloadRequest(r *http.Request, service core.DownloadService, resol
 			Headers:            req.Headers,
 			IsExplicitCategory: req.IsExplicitCategory,
 			SkipApproval:       req.SkipApproval,
+			Workers:            req.Workers,
+			MinChunkSize:       req.MinChunkSize,
 		})
 	}
 
-	id, err := service.Add(resolved.urlForAdd, resolved.outPath, req.Filename, resolved.mirrorsForAdd, req.Headers, req.IsExplicitCategory, 0, false)
+	id, err := service.Add(resolved.urlForAdd, resolved.outPath, req.Filename, resolved.mirrorsForAdd, req.Headers, req.IsExplicitCategory, req.Workers, req.MinChunkSize, 0, false)
 	return id, req.Filename, err
 }
 

--- a/cmd/root_lifecycle_test.go
+++ b/cmd/root_lifecycle_test.go
@@ -34,10 +34,10 @@ var _ core.DownloadService = (*countingLifecycleService)(nil)
 
 func (s *countingLifecycleService) List() ([]types.DownloadStatus, error)   { return nil, nil }
 func (s *countingLifecycleService) History() ([]types.DownloadEntry, error) { return nil, nil }
-func (s *countingLifecycleService) Add(string, string, string, []string, map[string]string, bool, int64, bool) (string, error) {
+func (s *countingLifecycleService) Add(string, string, string, []string, map[string]string, bool, int, int64, int64, bool) (string, error) {
 	return "", nil
 }
-func (s *countingLifecycleService) AddWithID(string, string, string, []string, map[string]string, string, int64, bool) (string, error) {
+func (s *countingLifecycleService) AddWithID(string, string, string, []string, map[string]string, string, int, int64, int64, bool) (string, error) {
 	return "", nil
 }
 func (s *countingLifecycleService) Pause(string) error             { return nil }
@@ -473,7 +473,7 @@ func TestProcessDownloads_UsesSharedEnqueueContext(t *testing.T) {
 
 	dispatchCalled := false
 	GlobalLifecycle = processing.NewLifecycleManager(
-		func(string, string, string, []string, map[string]string, bool, int64, bool) (string, error) {
+		func(string, string, string, []string, map[string]string, bool, int, int64, int64, bool) (string, error) {
 			dispatchCalled = true
 			return "", nil
 		},

--- a/internal/core/interface.go
+++ b/internal/core/interface.go
@@ -17,10 +17,10 @@ type DownloadService interface {
 	History() ([]types.DownloadEntry, error)
 
 	// Add queues a new download.
-	Add(url string, path string, filename string, mirrors []string, headers map[string]string, isExplicitCategory bool, totalSize int64, supportsRange bool) (string, error)
+	Add(url string, path string, filename string, mirrors []string, headers map[string]string, isExplicitCategory bool, workers int, minChunkSize int64, totalSize int64, supportsRange bool) (string, error)
 
 	// AddWithID queues a new download with a caller-provided ID.
-	AddWithID(url string, path string, filename string, mirrors []string, headers map[string]string, id string, totalSize int64, supportsRange bool) (string, error)
+	AddWithID(url string, path string, filename string, mirrors []string, headers map[string]string, id string, workers int, minChunkSize int64, totalSize int64, supportsRange bool) (string, error)
 
 	// Pause pauses an active download.
 	Pause(id string) error

--- a/internal/core/local_service.go
+++ b/internal/core/local_service.go
@@ -511,17 +511,17 @@ func (s *LocalDownloadService) List() ([]types.DownloadStatus, error) {
 }
 
 // Add queues a new download on the local pool without TUI confirmation.
-func (s *LocalDownloadService) Add(url string, path string, filename string, mirrors []string, headers map[string]string, isExplicitCategory bool, totalSize int64, supportsRange bool) (string, error) {
-	return s.add(url, path, filename, mirrors, headers, "", isExplicitCategory, totalSize, supportsRange)
+func (s *LocalDownloadService) Add(url string, path string, filename string, mirrors []string, headers map[string]string, isExplicitCategory bool, workers int, minChunkSize int64, totalSize int64, supportsRange bool) (string, error) {
+	return s.add(url, path, filename, mirrors, headers, "", isExplicitCategory, workers, minChunkSize, totalSize, supportsRange)
 }
 
 // AddWithID queues a new download using a caller-provided id when non-empty.
-func (s *LocalDownloadService) AddWithID(url string, path string, filename string, mirrors []string, headers map[string]string, id string, totalSize int64, supportsRange bool) (string, error) {
+func (s *LocalDownloadService) AddWithID(url string, path string, filename string, mirrors []string, headers map[string]string, id string, workers int, minChunkSize int64, totalSize int64, supportsRange bool) (string, error) {
 	// Remote or RPC-driven calls use preset IDs and should bypass interactive category routing.
-	return s.add(url, path, filename, mirrors, headers, id, false, totalSize, supportsRange)
+	return s.add(url, path, filename, mirrors, headers, id, false, workers, minChunkSize, totalSize, supportsRange)
 }
 
-func (s *LocalDownloadService) add(url string, path string, filename string, mirrors []string, headers map[string]string, requestedID string, isExplicitCategory bool, totalSize int64, supportsRange bool) (string, error) {
+func (s *LocalDownloadService) add(url string, path string, filename string, mirrors []string, headers map[string]string, requestedID string, isExplicitCategory bool, workers int, minChunkSize int64, totalSize int64, supportsRange bool) (string, error) {
 	if s.Pool == nil {
 		return "", types.ErrPoolNotInit
 	}
@@ -557,6 +557,12 @@ func (s *LocalDownloadService) add(url string, path string, filename string, mir
 	state.DestPath = filepath.Join(outPath, filename) // Best guess until download starts
 
 	runtime := settings.ToRuntimeConfig()
+	if workers > 0 {
+		runtime.Workers = workers
+	}
+	if minChunkSize > 0 {
+		runtime.MinChunkSize = minChunkSize
+	}
 
 	cfg := types.DownloadConfig{
 		URL:                url,

--- a/internal/core/local_service.go
+++ b/internal/core/local_service.go
@@ -558,6 +558,10 @@ func (s *LocalDownloadService) add(url string, path string, filename string, mir
 
 	runtime := settings.ToRuntimeConfig()
 	if workers > 0 {
+		maxConns := runtime.GetMaxConnectionsPerDownload()
+		if workers > maxConns {
+			workers = maxConns
+		}
 		runtime.Workers = workers
 	}
 	if minChunkSize > 0 {

--- a/internal/core/local_service_override_test.go
+++ b/internal/core/local_service_override_test.go
@@ -16,116 +16,80 @@ func findConfigByID(pool *download.WorkerPool, id string) *types.DownloadConfig 
 	return nil
 }
 
-func TestAdd_PerTaskOverride_ZeroValues(t *testing.T) {
-	ch := make(chan interface{}, 8)
-	pool := download.NewWorkerPool(ch, 1)
-	svc := NewLocalDownloadServiceWithInput(pool, ch)
-	defer func() { _ = svc.Shutdown() }()
-
-	outputDir := t.TempDir()
-	id, err := svc.Add("https://example.com/file.bin", outputDir, "file.bin", nil, nil, false, 0, 0, 0, false)
-	if err != nil {
-		t.Fatalf("Add failed: %v", err)
+func TestAdd_PerTaskOverride(t *testing.T) {
+	tests := []struct {
+		name            string
+		workers         int
+		minChunkSize    int64
+		wantWorkers     int
+		wantMinChunk    int64
+		checkClamped    bool
+	}{
+		{
+			name:         "zero/defaults",
+			workers:      0,
+			minChunkSize: 0,
+			wantWorkers:  0,
+			wantMinChunk: types.MinChunk,
+		},
+		{
+			name:         "workers-only",
+			workers:      16,
+			minChunkSize: 0,
+			wantWorkers:  16,
+			wantMinChunk: types.MinChunk,
+		},
+		{
+			name:         "minChunk-only",
+			workers:      0,
+			minChunkSize: 10 * types.MB,
+			wantWorkers:  0,
+			wantMinChunk: 10 * types.MB,
+		},
+		{
+			name:         "workers-clamped",
+			workers:      64,
+			minChunkSize: 0,
+			checkClamped: true,
+			wantMinChunk: types.MinChunk,
+		},
 	}
 
-	cfg := findConfigByID(pool, id)
-	if cfg == nil {
-		t.Fatal("expected config in pool")
-	}
-	if cfg.Runtime.Workers != 0 {
-		t.Fatalf("expected Runtime.Workers=0, got %d", cfg.Runtime.Workers)
-	}
-	if cfg.Runtime.MinChunkSize != types.MinChunk {
-		t.Fatalf("expected Runtime.MinChunkSize=%d (default), got %d", types.MinChunk, cfg.Runtime.MinChunkSize)
-	}
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ch := make(chan interface{}, 8)
+			pool := download.NewWorkerPool(ch, 1)
+			svc := NewLocalDownloadServiceWithInput(pool, ch)
+			defer func() { _ = svc.Shutdown() }()
 
-func TestAdd_PerTaskOverride_WorkersSet(t *testing.T) {
-	ch := make(chan interface{}, 8)
-	pool := download.NewWorkerPool(ch, 1)
-	svc := NewLocalDownloadServiceWithInput(pool, ch)
-	defer func() { _ = svc.Shutdown() }()
+			outputDir := t.TempDir()
+			id, err := svc.Add("https://example.com/file.bin", outputDir, "file.bin", nil, nil, false, tt.workers, tt.minChunkSize, 0, false)
+			if err != nil {
+				t.Fatalf("Add failed: %v", err)
+			}
 
-	outputDir := t.TempDir()
-	id, err := svc.Add("https://example.com/file.bin", outputDir, "file.bin", nil, nil, false, 16, 0, 0, false)
-	if err != nil {
-		t.Fatalf("Add failed: %v", err)
-	}
+			cfg := findConfigByID(pool, id)
+			if cfg == nil {
+				t.Fatal("expected config in pool")
+			}
 
-	cfg := findConfigByID(pool, id)
-	if cfg == nil {
-		t.Fatal("expected config in pool")
-	}
-	if cfg.Runtime.Workers != 16 {
-		t.Fatalf("expected Runtime.Workers=16, got %d", cfg.Runtime.Workers)
-	}
-}
+			if tt.checkClamped {
+				maxConns := cfg.Runtime.GetMaxConnectionsPerDownload()
+				if cfg.Runtime.Workers != maxConns {
+					t.Fatalf("expected Runtime.Workers=%d (clamped to MaxConns), got %d", maxConns, cfg.Runtime.Workers)
+				}
+				if cfg.Runtime.MinChunkSize != tt.wantMinChunk {
+					t.Fatalf("expected Runtime.MinChunkSize=%d (default), got %d", tt.wantMinChunk, cfg.Runtime.MinChunkSize)
+				}
+				return
+			}
 
-func TestAdd_PerTaskOverride_MinChunkSizeSet(t *testing.T) {
-	ch := make(chan interface{}, 8)
-	pool := download.NewWorkerPool(ch, 1)
-	svc := NewLocalDownloadServiceWithInput(pool, ch)
-	defer func() { _ = svc.Shutdown() }()
-
-	outputDir := t.TempDir()
-	minChunk := int64(10 * types.MB)
-	id, err := svc.Add("https://example.com/file.bin", outputDir, "file.bin", nil, nil, false, 0, minChunk, 0, false)
-	if err != nil {
-		t.Fatalf("Add failed: %v", err)
-	}
-
-	cfg := findConfigByID(pool, id)
-	if cfg == nil {
-		t.Fatal("expected config in pool")
-	}
-	if cfg.Runtime.MinChunkSize != minChunk {
-		t.Fatalf("expected Runtime.MinChunkSize=%d, got %d", minChunk, cfg.Runtime.MinChunkSize)
-	}
-}
-
-func TestAdd_PerTaskOverride_BothSet(t *testing.T) {
-	ch := make(chan interface{}, 8)
-	pool := download.NewWorkerPool(ch, 1)
-	svc := NewLocalDownloadServiceWithInput(pool, ch)
-	defer func() { _ = svc.Shutdown() }()
-
-	outputDir := t.TempDir()
-	minChunk := int64(5 * types.MB)
-	id, err := svc.Add("https://example.com/file.bin", outputDir, "file.bin", nil, nil, false, 8, minChunk, 0, false)
-	if err != nil {
-		t.Fatalf("Add failed: %v", err)
-	}
-
-	cfg := findConfigByID(pool, id)
-	if cfg == nil {
-		t.Fatal("expected config in pool")
-	}
-	if cfg.Runtime.Workers != 8 {
-		t.Fatalf("expected Runtime.Workers=8, got %d", cfg.Runtime.Workers)
-	}
-	if cfg.Runtime.MinChunkSize != minChunk {
-		t.Fatalf("expected Runtime.MinChunkSize=%d, got %d", minChunk, cfg.Runtime.MinChunkSize)
-	}
-}
-
-func TestAdd_PerTaskOverride_ClampsWorkersToMaxConnections(t *testing.T) {
-	ch := make(chan interface{}, 8)
-	pool := download.NewWorkerPool(ch, 1)
-	svc := NewLocalDownloadServiceWithInput(pool, ch)
-	defer func() { _ = svc.Shutdown() }()
-
-	outputDir := t.TempDir()
-	id, err := svc.Add("https://example.com/file.bin", outputDir, "file.bin", nil, nil, false, 64, 0, 0, false)
-	if err != nil {
-		t.Fatalf("Add failed: %v", err)
-	}
-
-	cfg := findConfigByID(pool, id)
-	if cfg == nil {
-		t.Fatal("expected config in pool")
-	}
-	maxConns := cfg.Runtime.GetMaxConnectionsPerDownload()
-	if cfg.Runtime.Workers != maxConns {
-		t.Fatalf("expected Runtime.Workers=%d (clamped to MaxConns), got %d", maxConns, cfg.Runtime.Workers)
+			if cfg.Runtime.Workers != tt.wantWorkers {
+				t.Fatalf("expected Runtime.Workers=%d, got %d", tt.wantWorkers, cfg.Runtime.Workers)
+			}
+			if cfg.Runtime.MinChunkSize != tt.wantMinChunk {
+				t.Fatalf("expected Runtime.MinChunkSize=%d, got %d", tt.wantMinChunk, cfg.Runtime.MinChunkSize)
+			}
+		})
 	}
 }

--- a/internal/core/local_service_override_test.go
+++ b/internal/core/local_service_override_test.go
@@ -1,0 +1,109 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/SurgeDM/Surge/internal/download"
+	"github.com/SurgeDM/Surge/internal/engine/types"
+)
+
+func findConfigByID(pool *download.WorkerPool, id string) *types.DownloadConfig {
+	for _, cfg := range pool.GetAll() {
+		if cfg.ID == id {
+			return &cfg
+		}
+	}
+	return nil
+}
+
+func TestAdd_PerTaskOverride_ZeroValues(t *testing.T) {
+	ch := make(chan interface{}, 8)
+	pool := download.NewWorkerPool(ch, 1)
+	svc := NewLocalDownloadServiceWithInput(pool, ch)
+	defer func() { _ = svc.Shutdown() }()
+
+	outputDir := t.TempDir()
+	id, err := svc.Add("https://example.com/file.bin", outputDir, "file.bin", nil, nil, false, 0, 0, 0, false)
+	if err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
+
+	cfg := findConfigByID(pool, id)
+	if cfg == nil {
+		t.Fatal("expected config in pool")
+	}
+	if cfg.Runtime.Workers != 0 {
+		t.Fatalf("expected Runtime.Workers=0, got %d", cfg.Runtime.Workers)
+	}
+	if cfg.Runtime.MinChunkSize != types.MinChunk {
+		t.Fatalf("expected Runtime.MinChunkSize=%d (default), got %d", types.MinChunk, cfg.Runtime.MinChunkSize)
+	}
+}
+
+func TestAdd_PerTaskOverride_WorkersSet(t *testing.T) {
+	ch := make(chan interface{}, 8)
+	pool := download.NewWorkerPool(ch, 1)
+	svc := NewLocalDownloadServiceWithInput(pool, ch)
+	defer func() { _ = svc.Shutdown() }()
+
+	outputDir := t.TempDir()
+	id, err := svc.Add("https://example.com/file.bin", outputDir, "file.bin", nil, nil, false, 16, 0, 0, false)
+	if err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
+
+	cfg := findConfigByID(pool, id)
+	if cfg == nil {
+		t.Fatal("expected config in pool")
+	}
+	if cfg.Runtime.Workers != 16 {
+		t.Fatalf("expected Runtime.Workers=16, got %d", cfg.Runtime.Workers)
+	}
+}
+
+func TestAdd_PerTaskOverride_MinChunkSizeSet(t *testing.T) {
+	ch := make(chan interface{}, 8)
+	pool := download.NewWorkerPool(ch, 1)
+	svc := NewLocalDownloadServiceWithInput(pool, ch)
+	defer func() { _ = svc.Shutdown() }()
+
+	outputDir := t.TempDir()
+	minChunk := int64(10 * types.MB)
+	id, err := svc.Add("https://example.com/file.bin", outputDir, "file.bin", nil, nil, false, 0, minChunk, 0, false)
+	if err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
+
+	cfg := findConfigByID(pool, id)
+	if cfg == nil {
+		t.Fatal("expected config in pool")
+	}
+	if cfg.Runtime.MinChunkSize != minChunk {
+		t.Fatalf("expected Runtime.MinChunkSize=%d, got %d", minChunk, cfg.Runtime.MinChunkSize)
+	}
+}
+
+func TestAdd_PerTaskOverride_BothSet(t *testing.T) {
+	ch := make(chan interface{}, 8)
+	pool := download.NewWorkerPool(ch, 1)
+	svc := NewLocalDownloadServiceWithInput(pool, ch)
+	defer func() { _ = svc.Shutdown() }()
+
+	outputDir := t.TempDir()
+	minChunk := int64(5 * types.MB)
+	id, err := svc.Add("https://example.com/file.bin", outputDir, "file.bin", nil, nil, false, 8, minChunk, 0, false)
+	if err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
+
+	cfg := findConfigByID(pool, id)
+	if cfg == nil {
+		t.Fatal("expected config in pool")
+	}
+	if cfg.Runtime.Workers != 8 {
+		t.Fatalf("expected Runtime.Workers=8, got %d", cfg.Runtime.Workers)
+	}
+	if cfg.Runtime.MinChunkSize != minChunk {
+		t.Fatalf("expected Runtime.MinChunkSize=%d, got %d", minChunk, cfg.Runtime.MinChunkSize)
+	}
+}

--- a/internal/core/local_service_override_test.go
+++ b/internal/core/local_service_override_test.go
@@ -107,3 +107,25 @@ func TestAdd_PerTaskOverride_BothSet(t *testing.T) {
 		t.Fatalf("expected Runtime.MinChunkSize=%d, got %d", minChunk, cfg.Runtime.MinChunkSize)
 	}
 }
+
+func TestAdd_PerTaskOverride_ClampsWorkersToMaxConnections(t *testing.T) {
+	ch := make(chan interface{}, 8)
+	pool := download.NewWorkerPool(ch, 1)
+	svc := NewLocalDownloadServiceWithInput(pool, ch)
+	defer func() { _ = svc.Shutdown() }()
+
+	outputDir := t.TempDir()
+	id, err := svc.Add("https://example.com/file.bin", outputDir, "file.bin", nil, nil, false, 64, 0, 0, false)
+	if err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
+
+	cfg := findConfigByID(pool, id)
+	if cfg == nil {
+		t.Fatal("expected config in pool")
+	}
+	maxConns := cfg.Runtime.GetMaxConnectionsPerDownload()
+	if cfg.Runtime.Workers != maxConns {
+		t.Fatalf("expected Runtime.Workers=%d (clamped to MaxConns), got %d", maxConns, cfg.Runtime.Workers)
+	}
+}

--- a/internal/core/local_service_test.go
+++ b/internal/core/local_service_test.go
@@ -122,7 +122,7 @@ func TestLocalDownloadService_Delete_ActiveWithoutDB_RemovesPartialFile(t *testi
 	if f, err := os.Create(filepath.Join(outputDir, filename) + ".surge"); err == nil {
 		_ = f.Close()
 	}
-	id, err := svc.Add(server.URL(), outputDir, filename, nil, nil, false, 0, false)
+	id, err := svc.Add(server.URL(), outputDir, filename, nil, nil, false, 0, 0, 0, false)
 	if err != nil {
 		t.Fatalf("failed to add download: %v", err)
 	}
@@ -279,7 +279,7 @@ func TestLocalDownloadService_AddWithID_UsesProvidedID(t *testing.T) {
 
 	requestID := "provided-id-001"
 	outputDir := t.TempDir()
-	gotID, err := svc.AddWithID("https://example.com/file.bin", outputDir, "file.bin", nil, nil, requestID, 0, false)
+	gotID, err := svc.AddWithID("https://example.com/file.bin", outputDir, "file.bin", nil, nil, requestID, 0, 0, 0, false)
 	if err != nil {
 		t.Fatalf("AddWithID failed: %v", err)
 	}
@@ -316,7 +316,7 @@ func TestLocalDownloadService_Shutdown_PersistsPausedState(t *testing.T) {
 	if f, err := os.Create(filepath.Join(outputDir, filename) + ".surge"); err == nil {
 		_ = f.Close()
 	}
-	id, err := svc.Add(server.URL(), outputDir, filename, nil, nil, false, fileSize, true)
+	id, err := svc.Add(server.URL(), outputDir, filename, nil, nil, false, 0, 0, fileSize, true)
 	if err != nil {
 		t.Fatalf("failed to add download: %v", err)
 	}
@@ -447,7 +447,7 @@ func TestLocalDownloadService_BatchProgress(t *testing.T) {
 	if f, err := os.Create(filepath.Join(tempDir, "test-file") + ".surge"); err == nil {
 		_ = f.Close()
 	}
-	_, err = svc.Add(ts.URL, tempDir, "test-file", nil, nil, false, 0, false)
+	_, err = svc.Add(ts.URL, tempDir, "test-file", nil, nil, false, 0, 0, 0, false)
 	if err != nil {
 		t.Fatalf("failed to add download: %v", err)
 	}
@@ -493,7 +493,7 @@ func TestLocalDownloadService_ResumeRejectedWhilePausing(t *testing.T) {
 	if f, err := os.Create(filepath.Join(outputDir, "resume-race.bin") + ".surge"); err == nil {
 		_ = f.Close()
 	}
-	id, err := svc.Add(server.URL(), outputDir, "resume-race.bin", nil, nil, false, 0, false)
+	id, err := svc.Add(server.URL(), outputDir, "resume-race.bin", nil, nil, false, 0, 0, 0, false)
 	if err != nil {
 		t.Fatalf("failed to add download: %v", err)
 	}

--- a/internal/core/pause_resume_integration_test.go
+++ b/internal/core/pause_resume_integration_test.go
@@ -178,7 +178,7 @@ func TestIntegration_PauseResume_HotPath_Aggregates(t *testing.T) {
 	if f, err := os.Create(destPath + ".surge"); err == nil {
 		_ = f.Close()
 	}
-	id, err := svc.Add(server.URL(), outputDir, filename, nil, nil, false, fileSize, true)
+	id, err := svc.Add(server.URL(), outputDir, filename, nil, nil, false, 0, 0, fileSize, true)
 	if err != nil {
 		t.Fatalf("add failed: %v", err)
 	}
@@ -343,7 +343,7 @@ func TestIntegration_PauseResume_ColdPath_StateContinuity(t *testing.T) {
 	if f, err := os.Create(destPath + ".surge"); err == nil {
 		_ = f.Close()
 	}
-	id, err := svc1.Add(server.URL(), outputDir, filename, nil, nil, false, fileSize, true)
+	id, err := svc1.Add(server.URL(), outputDir, filename, nil, nil, false, 0, 0, fileSize, true)
 	if err != nil {
 		t.Fatalf("add failed: %v", err)
 	}
@@ -578,7 +578,7 @@ func TestIntegration_PauseResume_StatusFormulaInvariants(t *testing.T) {
 	if f, err := os.Create(destPath + ".surge"); err == nil {
 		_ = f.Close()
 	}
-	id, err := svc.Add(server.URL(), outputDir, filename, nil, nil, false, fileSize, true)
+	id, err := svc.Add(server.URL(), outputDir, filename, nil, nil, false, 0, 0, fileSize, true)
 	if err != nil {
 		t.Fatalf("add failed: %v", err)
 	}
@@ -676,7 +676,7 @@ func TestIntegration_PauseResume_ConcreteSnapshotDebugString(t *testing.T) {
 	if f, err := os.Create(destPath + ".surge"); err == nil {
 		_ = f.Close()
 	}
-	id, err := svc.Add(server.URL(), outputDir, filename, nil, nil, false, fileSize, true)
+	id, err := svc.Add(server.URL(), outputDir, filename, nil, nil, false, 0, 0, fileSize, true)
 	if err != nil {
 		t.Fatalf("add failed: %v", err)
 	}
@@ -752,7 +752,7 @@ func TestIntegration_PauseResumeBatch_ColdPath(t *testing.T) {
 	if f, err := os.Create(destPath1 + ".surge"); err == nil {
 		_ = f.Close()
 	}
-	id1, err := svc1.Add(server.URL(), outputDir, "cold1.bin", nil, nil, false, fileSize, true)
+	id1, err := svc1.Add(server.URL(), outputDir, "cold1.bin", nil, nil, false, 0, 0, fileSize, true)
 	if err != nil {
 		t.Fatalf("add 1 failed: %v", err)
 	}
@@ -761,7 +761,7 @@ func TestIntegration_PauseResumeBatch_ColdPath(t *testing.T) {
 	if f, err := os.Create(destPath2 + ".surge"); err == nil {
 		_ = f.Close()
 	}
-	id2, err := svc1.Add(server.URL(), outputDir, "cold2.bin", nil, nil, false, fileSize, true)
+	id2, err := svc1.Add(server.URL(), outputDir, "cold2.bin", nil, nil, false, 0, 0, fileSize, true)
 	if err != nil {
 		t.Fatalf("add 2 failed: %v", err)
 	}
@@ -802,7 +802,7 @@ func TestIntegration_PauseResumeBatch_ColdPath(t *testing.T) {
 	if f, err := os.Create(destPathHot + ".surge"); err == nil {
 		_ = f.Close()
 	}
-	idHot, err := svc2.Add(server.URL(), outputDir, "hot1.bin", nil, nil, false, fileSize, true)
+	idHot, err := svc2.Add(server.URL(), outputDir, "hot1.bin", nil, nil, false, 0, 0, fileSize, true)
 	if err != nil {
 		t.Fatalf("add hot failed: %v", err)
 	}

--- a/internal/core/remote_service.go
+++ b/internal/core/remote_service.go
@@ -140,10 +140,14 @@ func (s *RemoteDownloadService) Add(url string, path string, filename string, mi
 		"headers":              headers,
 		"skip_approval":        true,
 		"is_explicit_category": isExplicitCategory,
-		"workers":              workers,
-		"min_chunk_size":       minChunkSize,
 		"total_size":           totalSize,
 		"supports_range":       supportsRange,
+	}
+	if workers > 0 {
+		req["workers"] = workers
+	}
+	if minChunkSize > 0 {
+		req["min_chunk_size"] = minChunkSize
 	}
 
 	resp, err := s.doRequest("POST", "/download", req)
@@ -169,10 +173,14 @@ func (s *RemoteDownloadService) AddWithID(url string, path string, filename stri
 		"headers":        headers,
 		"skip_approval":  true,
 		"id":             id,
-		"workers":        workers,
-		"min_chunk_size": minChunkSize,
 		"total_size":     totalSize,
 		"supports_range": supportsRange,
+	}
+	if workers > 0 {
+		req["workers"] = workers
+	}
+	if minChunkSize > 0 {
+		req["min_chunk_size"] = minChunkSize
 	}
 
 	resp, err := s.doRequest("POST", "/download", req)

--- a/internal/core/remote_service.go
+++ b/internal/core/remote_service.go
@@ -131,7 +131,7 @@ func (s *RemoteDownloadService) GetStatus(id string) (*types.DownloadStatus, err
 }
 
 // Add queues a new download.
-func (s *RemoteDownloadService) Add(url string, path string, filename string, mirrors []string, headers map[string]string, isExplicitCategory bool, totalSize int64, supportsRange bool) (string, error) {
+func (s *RemoteDownloadService) Add(url string, path string, filename string, mirrors []string, headers map[string]string, isExplicitCategory bool, workers int, minChunkSize int64, totalSize int64, supportsRange bool) (string, error) {
 	req := map[string]interface{}{
 		"url":                  url,
 		"path":                 path,
@@ -140,6 +140,8 @@ func (s *RemoteDownloadService) Add(url string, path string, filename string, mi
 		"headers":              headers,
 		"skip_approval":        true,
 		"is_explicit_category": isExplicitCategory,
+		"workers":              workers,
+		"min_chunk_size":       minChunkSize,
 		"total_size":           totalSize,
 		"supports_range":       supportsRange,
 	}
@@ -158,7 +160,7 @@ func (s *RemoteDownloadService) Add(url string, path string, filename string, mi
 }
 
 // AddWithID queues a new download with a caller-provided id.
-func (s *RemoteDownloadService) AddWithID(url string, path string, filename string, mirrors []string, headers map[string]string, id string, totalSize int64, supportsRange bool) (string, error) {
+func (s *RemoteDownloadService) AddWithID(url string, path string, filename string, mirrors []string, headers map[string]string, id string, workers int, minChunkSize int64, totalSize int64, supportsRange bool) (string, error) {
 	req := map[string]interface{}{
 		"url":            url,
 		"path":           path,
@@ -167,6 +169,8 @@ func (s *RemoteDownloadService) AddWithID(url string, path string, filename stri
 		"headers":        headers,
 		"skip_approval":  true,
 		"id":             id,
+		"workers":        workers,
+		"min_chunk_size": minChunkSize,
 		"total_size":     totalSize,
 		"supports_range": supportsRange,
 	}

--- a/internal/download/manager.go
+++ b/internal/download/manager.go
@@ -146,6 +146,8 @@ func TUIDownload(ctx context.Context, cfg *types.DownloadConfig) error {
 			State:        cfg.State,
 			RateLimit:    rateLimit,
 			RateLimitSet: rateLimitSet,
+			Workers:      cfg.Runtime.Workers,
+			MinChunkSize: cfg.Runtime.MinChunkSize,
 		})
 	}
 

--- a/internal/engine/concurrent/downloader.go
+++ b/internal/engine/concurrent/downloader.go
@@ -77,12 +77,12 @@ func (d *ConcurrentDownloader) getInitialConnections(fileSize int64) int {
 			workers = maxConns
 		}
 		if minChunkSize > 0 {
-			maxPossibleChunks := int(fileSize / minChunkSize)
+			maxPossibleChunks := fileSize / minChunkSize
 			if maxPossibleChunks < 1 {
 				maxPossibleChunks = 1
 			}
-			if workers > maxPossibleChunks {
-				workers = maxPossibleChunks
+			if int64(workers) > maxPossibleChunks {
+				workers = int(maxPossibleChunks)
 			}
 		}
 		return workers
@@ -96,12 +96,12 @@ func (d *ConcurrentDownloader) getInitialConnections(fileSize int64) int {
 	// 2. Hard constraint: Don't create chunks smaller than MinChunkSize
 	// If file is 20MB and MinChunk is 10MB, we strictly can't have more than 2 workers
 	if minChunkSize > 0 {
-		maxPossibleChunks := int(fileSize / minChunkSize)
+		maxPossibleChunks := fileSize / minChunkSize
 		if maxPossibleChunks < 1 {
 			maxPossibleChunks = 1
 		}
-		if calculatedWorkers > maxPossibleChunks {
-			calculatedWorkers = maxPossibleChunks
+		if int64(calculatedWorkers) > maxPossibleChunks {
+			calculatedWorkers = int(maxPossibleChunks)
 		}
 	}
 

--- a/internal/engine/concurrent/downloader.go
+++ b/internal/engine/concurrent/downloader.go
@@ -85,9 +85,6 @@ func (d *ConcurrentDownloader) getInitialConnections(fileSize int64) int {
 				workers = maxPossibleChunks
 			}
 		}
-		if workers < 1 {
-			return 1
-		}
 		return workers
 	}
 

--- a/internal/engine/concurrent/downloader.go
+++ b/internal/engine/concurrent/downloader.go
@@ -71,6 +71,26 @@ func (d *ConcurrentDownloader) getInitialConnections(fileSize int64) int {
 		return 1
 	}
 
+	// If caller specified exact worker count, bypass √size heuristic.
+	if workers := d.Runtime.GetWorkers(); workers > 0 {
+		if workers > maxConns {
+			workers = maxConns
+		}
+		if minChunkSize > 0 {
+			maxPossibleChunks := int(fileSize / minChunkSize)
+			if maxPossibleChunks < 1 {
+				maxPossibleChunks = 1
+			}
+			if workers > maxPossibleChunks {
+				workers = maxPossibleChunks
+			}
+		}
+		if workers < 1 {
+			return 1
+		}
+		return workers
+	}
+
 	// 1. Calculate ideal workers using the Square Root heuristic
 	// Convert to float first to avoid integer truncation on small files
 	sizeMB := float64(fileSize) / float64(types.MB)

--- a/internal/engine/concurrent/downloader.go
+++ b/internal/engine/concurrent/downloader.go
@@ -596,6 +596,8 @@ func (d *ConcurrentDownloader) handlePause(destPath string, fileSize int64, queu
 		ActualChunkSize: chunkSize,
 		RateLimit:       rateLimit,
 		RateLimitSet:    rateLimitSet,
+		Workers:         d.Runtime.Workers,
+		MinChunkSize:    d.Runtime.MinChunkSize,
 	}
 	if d.ProgressChan != nil {
 		d.ProgressChan <- events.DownloadPausedMsg{
@@ -605,6 +607,8 @@ func (d *ConcurrentDownloader) handlePause(destPath string, fileSize int64, queu
 			State:        s,
 			RateLimit:    rateLimit,
 			RateLimitSet: rateLimitSet,
+			Workers:      d.Runtime.Workers,
+			MinChunkSize: d.Runtime.MinChunkSize,
 		}
 	}
 

--- a/internal/engine/concurrent/downloader_helpers_test.go
+++ b/internal/engine/concurrent/downloader_helpers_test.go
@@ -18,8 +18,9 @@ func TestHandlePause_CompletionBoundary(t *testing.T) {
 	destPath := filepath.Join(tmpDir, "test.bin")
 	state := types.NewProgressState("test-id", fileSize)
 	downloader := &ConcurrentDownloader{
-		ID:    "test-id",
-		State: state,
+		ID:      "test-id",
+		State:   state,
+		Runtime: &types.RuntimeConfig{},
 	}
 
 	queue := NewTaskQueue()
@@ -43,8 +44,9 @@ func TestHandlePause_Normal(t *testing.T) {
 	destPath := filepath.Join(tmpDir, "test.bin")
 	state := types.NewProgressState("test-id", fileSize)
 	downloader := &ConcurrentDownloader{
-		ID:    "test-id",
-		State: state,
+		ID:      "test-id",
+		State:   state,
+		Runtime: &types.RuntimeConfig{},
 	}
 
 	queue := NewTaskQueue()
@@ -70,6 +72,7 @@ func TestHandlePause_UsesLiveRateLimitFromState(t *testing.T) {
 		URL:          "http://example.com/file.bin",
 		State:        state,
 		ProgressChan: progressCh,
+		Runtime:      &types.RuntimeConfig{},
 		RateLimitBps: 1,
 		RateLimitSet: false,
 	}

--- a/internal/engine/concurrent/get_initial_connections_test.go
+++ b/internal/engine/concurrent/get_initial_connections_test.go
@@ -1,0 +1,85 @@
+package concurrent
+
+import (
+	"testing"
+
+	"github.com/SurgeDM/Surge/internal/engine/types"
+)
+
+func TestGetInitialConnections_SqrtHeuristic(t *testing.T) {
+	d := &ConcurrentDownloader{
+		Runtime: &types.RuntimeConfig{},
+	}
+	// 100 MB file → √100 = 10 workers
+	fileSize := int64(100 * types.MB)
+	got := d.getInitialConnections(fileSize)
+	if got != 10 {
+		t.Fatalf("Workers=0, 100MB file: got %d, want 10 (√size)", got)
+	}
+}
+
+func TestGetInitialConnections_WorkersOverrideBypassesSqrt(t *testing.T) {
+	d := &ConcurrentDownloader{
+		Runtime: &types.RuntimeConfig{
+			Workers: 8,
+		},
+	}
+	// 100 MB file would give √100=10, but Workers=8 should bypass
+	fileSize := int64(100 * types.MB)
+	got := d.getInitialConnections(fileSize)
+	if got != 8 {
+		t.Fatalf("Workers=8, 100MB file: got %d, want 8 (bypass √size)", got)
+	}
+}
+
+func TestGetInitialConnections_WorkersClampedByMaxConnections(t *testing.T) {
+	d := &ConcurrentDownloader{
+		Runtime: &types.RuntimeConfig{
+			MaxConnectionsPerDownload: 32,
+			Workers:                   64,
+		},
+	}
+	fileSize := int64(100 * types.MB)
+	got := d.getInitialConnections(fileSize)
+	if got != 32 {
+		t.Fatalf("Workers=64, MaxConns=32: got %d, want 32 (clamped by ceiling)", got)
+	}
+}
+
+func TestGetInitialConnections_WorkersClampedByMinChunkSize(t *testing.T) {
+	d := &ConcurrentDownloader{
+		Runtime: &types.RuntimeConfig{
+			Workers:      16,
+			MinChunkSize: 2 * types.MB,
+		},
+	}
+	// 10 MB file / 2 MB min chunk = 5 max chunks
+	fileSize := int64(10 * types.MB)
+	got := d.getInitialConnections(fileSize)
+	if got != 5 {
+		t.Fatalf("Workers=16, 10MB file, MinChunk=2MB: got %d, want 5 (clamped by minChunkSize)", got)
+	}
+}
+
+func TestGetInitialConnections_WorkersMinimumOne(t *testing.T) {
+	d := &ConcurrentDownloader{
+		Runtime: &types.RuntimeConfig{
+			Workers: 1,
+		},
+	}
+	fileSize := int64(100 * types.MB)
+	got := d.getInitialConnections(fileSize)
+	if got != 1 {
+		t.Fatalf("Workers=1: got %d, want 1", got)
+	}
+}
+
+func TestGetInitialConnections_ZeroFileSize(t *testing.T) {
+	d := &ConcurrentDownloader{
+		Runtime: &types.RuntimeConfig{},
+	}
+	got := d.getInitialConnections(0)
+	if got != 1 {
+		t.Fatalf("fileSize=0: got %d, want 1", got)
+	}
+}

--- a/internal/engine/concurrent/get_initial_connections_test.go
+++ b/internal/engine/concurrent/get_initial_connections_test.go
@@ -83,3 +83,35 @@ func TestGetInitialConnections_ZeroFileSize(t *testing.T) {
 		t.Fatalf("fileSize=0: got %d, want 1", got)
 	}
 }
+
+func TestGetInitialConnections_LargeFileSizeNoOverflow(t *testing.T) {
+	d := &ConcurrentDownloader{
+		Runtime: &types.RuntimeConfig{
+			Workers:                   5,
+			MaxConnectionsPerDownload: 32,
+			MinChunkSize:              1,
+		},
+	}
+	// 10 GB file, 1 byte min chunk → ~1.07e10 chunks, exceeds int32 max (2.1e9)
+	// but fits in int64. Workers=5 should still return 5 (not overflowed value).
+	got := d.getInitialConnections(int64(10 * 1024 * 1024 * 1024))
+	if got != 5 {
+		t.Fatalf("expected 5 workers (no overflow), got %d", got)
+	}
+}
+
+func TestGetInitialConnections_LargeFileSizeSqrtHeuristicNoOverflow(t *testing.T) {
+	d := &ConcurrentDownloader{
+		Runtime: &types.RuntimeConfig{
+			MaxConnectionsPerDownload: 32,
+			MinChunkSize:              1,
+		},
+	}
+	// 10 GB file with √size heuristic and 1-byte min chunk.
+	// √(10*1024*1024) ≈ 3313, clamped to MaxConns=32.
+	// The maxPossibleChunks check should not overflow.
+	got := d.getInitialConnections(int64(10 * 1024 * 1024 * 1024))
+	if got != 32 {
+		t.Fatalf("expected 32 (clamped by MaxConns), got %d", got)
+	}
+}

--- a/internal/engine/events/events.go
+++ b/internal/engine/events/events.go
@@ -158,12 +158,14 @@ type BatchProgressMsg []ProgressMsg
 // DownloadRequestMsg signals a request to start a download (e.g. from extension)
 // that may need user confirmation or duplicate checking
 type DownloadRequestMsg struct {
-	ID       string
-	URL      string
-	Filename string
-	Path     string
-	Mirrors  []string
-	Headers  map[string]string
+	ID           string
+	URL          string
+	Filename     string
+	Path         string
+	Mirrors      []string
+	Headers      map[string]string
+	Workers      int
+	MinChunkSize int64
 }
 
 // BatchDownloadRequestMsg signals a batch request that should be confirmed once.

--- a/internal/engine/events/events.go
+++ b/internal/engine/events/events.go
@@ -104,10 +104,12 @@ type DownloadStartedMsg struct {
 	URL          string
 	Filename     string
 	Total        int64
-	DestPath     string               // Full path to the destination file
+	DestPath     string                // Full path to the destination file
 	State        *types.ProgressState `json:"-"`
 	RateLimit    int64
 	RateLimitSet bool
+	Workers      int
+	MinChunkSize int64
 }
 
 type DownloadPausedMsg struct {
@@ -117,6 +119,8 @@ type DownloadPausedMsg struct {
 	State        *types.DownloadState `json:"-"`
 	RateLimit    int64
 	RateLimitSet bool
+	Workers      int
+	MinChunkSize int64
 }
 
 type DownloadResumedMsg struct {
@@ -132,6 +136,8 @@ type DownloadQueuedMsg struct {
 	Mirrors      []string
 	RateLimit    int64
 	RateLimitSet bool
+	Workers      int
+	MinChunkSize int64
 }
 
 type DownloadRemovedMsg struct {

--- a/internal/engine/state/state.go
+++ b/internal/engine/state/state.go
@@ -124,6 +124,8 @@ func SaveStateWithOptions(url string, destPath string, state *types.DownloadStat
 			list.Downloads[i].TotalSize = state.TotalSize
 			list.Downloads[i].Downloaded = state.Downloaded
 			list.Downloads[i].TimeTaken = state.Elapsed / int64(time.Millisecond)
+			list.Downloads[i].Workers = state.Workers
+			list.Downloads[i].MinChunkSize = state.MinChunkSize
 			if err := saveMasterListLocked(list); err != nil {
 				return fmt.Errorf("failed to update master list: %w", err)
 			}

--- a/internal/engine/state/state_test.go
+++ b/internal/engine/state/state_test.go
@@ -1141,3 +1141,75 @@ func TestNormalizeStaleDownloads(t *testing.T) {
 		t.Errorf("ok-5 status = %q, want queued", dl5.Status)
 	}
 }
+
+func TestSaveLoadState_PreservesOverrideFields(t *testing.T) {
+	tmpDir := setupTestDB(t)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+	defer CloseDB()
+
+	testURL := "https://test.example.com/override-state.zip"
+	testDestPath := filepath.Join(tmpDir, "override-state.zip")
+	id := uuid.New().String()
+
+	originalState := &types.DownloadState{
+		ID:           id,
+		URL:          testURL,
+		DestPath:     testDestPath,
+		TotalSize:    1000000,
+		Downloaded:   500000,
+		Filename:     "override-state.zip",
+		Workers:      8,
+		MinChunkSize: 5 * types.MB,
+	}
+
+	if err := SaveState(testURL, testDestPath, originalState); err != nil {
+		t.Fatalf("SaveState failed: %v", err)
+	}
+	_ = AddToMasterList(types.DownloadEntry{ID: id, URL: testURL, DestPath: testDestPath, Status: "paused"})
+
+	loadedState, err := LoadState(testURL, testDestPath)
+	if err != nil {
+		t.Fatalf("LoadState failed: %v", err)
+	}
+	if loadedState.Workers != 8 {
+		t.Errorf("Workers = %d, want 8", loadedState.Workers)
+	}
+	if loadedState.MinChunkSize != 5*types.MB {
+		t.Errorf("MinChunkSize = %d, want %d", loadedState.MinChunkSize, 5*types.MB)
+	}
+}
+
+func TestAddGetDownload_PreservesOverrideFields(t *testing.T) {
+	tmpDir := setupTestDB(t)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+	defer CloseDB()
+
+	id := "override-entry-id"
+	entry := types.DownloadEntry{
+		ID:           id,
+		URL:          "https://test.example.com/override-entry.zip",
+		DestPath:     filepath.Join(tmpDir, "override-entry.zip"),
+		Filename:     "override-entry.zip",
+		Status:       "paused",
+		Workers:      8,
+		MinChunkSize: 5 * types.MB,
+	}
+
+	if err := AddToMasterList(entry); err != nil {
+		t.Fatalf("AddToMasterList failed: %v", err)
+	}
+
+	loaded, err := GetDownload(id)
+	if err != nil {
+		t.Fatalf("GetDownload failed: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("expected non-nil entry")
+	}
+	if loaded.Workers != 8 {
+		t.Errorf("Workers = %d, want 8", loaded.Workers)
+	}
+	if loaded.MinChunkSize != 5*types.MB {
+		t.Errorf("MinChunkSize = %d, want %d", loaded.MinChunkSize, 5*types.MB)
+	}
+}

--- a/internal/engine/types/config.go
+++ b/internal/engine/types/config.go
@@ -83,6 +83,7 @@ type ByteLimiter interface {
 // opt-out settings where disabling a behavior is meaningful.
 type RuntimeConfig struct {
 	MaxConnectionsPerDownload   int
+	Workers                     int
 	UserAgent                   string
 	ProxyURL                    string
 	CustomDNS                   string
@@ -114,6 +115,15 @@ func (r *RuntimeConfig) GetMaxConnectionsPerDownload() int {
 		return PerDownloadMax
 	}
 	return r.MaxConnectionsPerDownload
+}
+
+// GetWorkers returns the explicit worker count if set (>0), or 0 to indicate
+// "use heuristic" (caller must fall back to √size calculation).
+func (r *RuntimeConfig) GetWorkers() int {
+	if r == nil || r.Workers <= 0 {
+		return 0
+	}
+	return r.Workers
 }
 
 func (r *RuntimeConfig) GetMinChunkSize() int64 {
@@ -177,6 +187,7 @@ func (r *RuntimeConfig) GetSpeedEmaAlpha() float64 {
 func DefaultRuntimeConfig() *RuntimeConfig {
 	return &RuntimeConfig{
 		MaxConnectionsPerDownload:   PerDownloadMax,
+		Workers:                     0,
 		UserAgent:                   DefaultUserAgent,
 		ProxyURL:                    "",
 		CustomDNS:                   "",

--- a/internal/engine/types/models.go
+++ b/internal/engine/types/models.go
@@ -53,6 +53,9 @@ type DownloadState struct {
 	FileHash     string `json:"file_hash,omitempty"`
 	RateLimit    int64  `json:"rate_limit,omitempty"`
 	RateLimitSet bool   `json:"rate_limit_set,omitempty"`
+
+	Workers      int   `json:"workers,omitempty"`
+	MinChunkSize int64 `json:"min_chunk_size,omitempty"`
 }
 
 // DownloadEntry is the durable record used for history and lifecycle recovery.
@@ -71,6 +74,9 @@ type DownloadEntry struct {
 	Mirrors      []string `json:"mirrors,omitempty"`
 	RateLimit    int64    `json:"rate_limit,omitempty"`
 	RateLimitSet bool     `json:"rate_limit_set,omitempty"`
+
+	Workers      int   `json:"workers,omitempty"`
+	MinChunkSize int64 `json:"min_chunk_size,omitempty"`
 }
 
 // MasterList holds all tracked downloads.

--- a/internal/processing/events.go
+++ b/internal/processing/events.go
@@ -235,7 +235,7 @@ func (mgr *LifecycleManager) StartEventWorker(ch <-chan interface{}) {
 			// finalization failure must stay retryable instead of being recorded as done.
 			if err := finalizeCompletedFile(destPath); err != nil {
 				utils.Debug("Lifecycle: Failed to finalize completed file at %s: %v", destPath, err)
-				if err := state.AddToMasterList(types.DownloadEntry{
+				errEntry := types.DownloadEntry{
 					ID:           m.DownloadID,
 					URL:          url,
 					URLHash:      urlHash,
@@ -248,7 +248,12 @@ func (mgr *LifecycleManager) StartEventWorker(ch <-chan interface{}) {
 					AvgSpeed:     avgSpeed,
 					RateLimit:    m.RateLimit,
 					RateLimitSet: m.RateLimitSet,
-				}); err != nil {
+				}
+				if existing != nil {
+					errEntry.Workers = existing.Workers
+					errEntry.MinChunkSize = existing.MinChunkSize
+				}
+				if err := state.AddToMasterList(errEntry); err != nil {
 					utils.Debug("Lifecycle: Failed to persist finalization error state: %v", err)
 				}
 				if filename == "" {
@@ -264,7 +269,7 @@ func (mgr *LifecycleManager) StartEventWorker(ch <-chan interface{}) {
 				break
 			}
 
-			if err := state.AddToMasterList(types.DownloadEntry{
+			entry := types.DownloadEntry{
 				ID:           m.DownloadID,
 				URL:          url,
 				URLHash:      urlHash,
@@ -278,7 +283,12 @@ func (mgr *LifecycleManager) StartEventWorker(ch <-chan interface{}) {
 				AvgSpeed:     avgSpeed,
 				RateLimit:    m.RateLimit,
 				RateLimitSet: m.RateLimitSet,
-			}); err != nil {
+			}
+			if existing != nil {
+				entry.Workers = existing.Workers
+				entry.MinChunkSize = existing.MinChunkSize
+			}
+			if err := state.AddToMasterList(entry); err != nil {
 				utils.Debug("Lifecycle: Failed to persist completed download: %v", err)
 			}
 			if err := state.DeleteTasks(m.DownloadID); err != nil {

--- a/internal/processing/events.go
+++ b/internal/processing/events.go
@@ -91,6 +91,8 @@ func (mgr *LifecycleManager) StartEventWorker(ch <-chan interface{}) {
 				Downloaded:   0,
 				RateLimit:    m.RateLimit,
 				RateLimitSet: m.RateLimitSet,
+				Workers:      m.Workers,
+				MinChunkSize: m.MinChunkSize,
 			}
 			if existing, _ := state.GetDownload(m.DownloadID); existing != nil {
 				entry.Mirrors = append([]string(nil), existing.Mirrors...)
@@ -184,6 +186,8 @@ func (mgr *LifecycleManager) StartEventWorker(ch <-chan interface{}) {
 				TimeTaken:    snapshot.Elapsed / int64(time.Millisecond),
 				RateLimit:    m.RateLimit,
 				RateLimitSet: m.RateLimitSet,
+				Workers:      m.Workers,
+				MinChunkSize: m.MinChunkSize,
 			}
 			if existing != nil {
 				entry.URL = existing.URL
@@ -363,6 +367,8 @@ func (mgr *LifecycleManager) StartEventWorker(ch <-chan interface{}) {
 				Status:       "queued",
 				RateLimit:    m.RateLimit,
 				RateLimitSet: m.RateLimitSet,
+				Workers:      m.Workers,
+				MinChunkSize: m.MinChunkSize,
 			}); err != nil {
 				utils.Debug("Lifecycle: Failed to persist queued download: %v", err)
 			}

--- a/internal/processing/events_internal_test.go
+++ b/internal/processing/events_internal_test.go
@@ -72,12 +72,14 @@ func TestStartEventWorker_MarksCompletionAsErrorWhenFinalizationFails(t *testing
 	}
 
 	if err := state.AddToMasterList(types.DownloadEntry{
-		ID:       "download-1",
-		URL:      "https://example.com/video.mp4",
-		URLHash:  state.URLHash("https://example.com/video.mp4"),
-		DestPath: finalPath,
-		Filename: "video.mp4",
-		Status:   "downloading",
+		ID:          "download-1",
+		URL:         "https://example.com/video.mp4",
+		URLHash:     state.URLHash("https://example.com/video.mp4"),
+		DestPath:    finalPath,
+		Filename:    "video.mp4",
+		Status:      "downloading",
+		Workers:     8,
+		MinChunkSize: 4 * types.MB,
 	}); err != nil {
 		t.Fatalf("failed to seed download entry: %v", err)
 	}
@@ -147,6 +149,12 @@ func TestStartEventWorker_MarksCompletionAsErrorWhenFinalizationFails(t *testing
 	}
 	if calls[0].msg != "disk full" {
 		t.Fatalf("notification msg = %q, want %q", calls[0].msg, "disk full")
+	}
+	if entry.Workers != 8 {
+		t.Fatalf("Workers = %d, want 8 (preserved from existing entry)", entry.Workers)
+	}
+	if entry.MinChunkSize != 4*types.MB {
+		t.Fatalf("MinChunkSize = %d, want %d (preserved from existing entry)", entry.MinChunkSize, 4*types.MB)
 	}
 }
 

--- a/internal/processing/events_test.go
+++ b/internal/processing/events_test.go
@@ -85,6 +85,58 @@ func TestStartEventWorker_FinalizesCompletedFileUsingDestPath(t *testing.T) {
 	}
 }
 
+func TestStartEventWorker_CompletionPreservesOverrideMetadata(t *testing.T) {
+	tempDir := testutil.SetupStateDB(t)
+
+	finalPath := filepath.Join(tempDir, "video.mp4")
+	surgePath := finalPath + types.IncompleteSuffix
+	if err := os.WriteFile(surgePath, []byte("partial"), 0o644); err != nil {
+		t.Fatalf("failed to create incomplete file: %v", err)
+	}
+
+	if err := state.AddToMasterList(types.DownloadEntry{
+		ID:          "download-1",
+		URL:         "https://example.com/video.mp4",
+		URLHash:     state.URLHash("https://example.com/video.mp4"),
+		DestPath:    finalPath,
+		Filename:    "video.mp4",
+		Status:      "downloading",
+		Workers:     8,
+		MinChunkSize: 4 * types.MB,
+	}); err != nil {
+		t.Fatalf("failed to seed download entry: %v", err)
+	}
+
+	mgr := processing.NewLifecycleManager(nil, nil)
+	ch := make(chan interface{}, 1)
+	ch <- events.DownloadCompleteMsg{
+		DownloadID: "download-1",
+		Filename:   "video.mp4",
+		Elapsed:    2 * time.Second,
+		Total:      7,
+	}
+	close(ch)
+
+	mgr.StartEventWorker(ch)
+
+	entry, err := state.GetDownload("download-1")
+	if err != nil {
+		t.Fatalf("failed to reload completed entry: %v", err)
+	}
+	if entry == nil {
+		t.Fatal("expected completed entry to exist")
+	}
+	if entry.Status != "completed" {
+		t.Fatalf("status = %q, want completed", entry.Status)
+	}
+	if entry.Workers != 8 {
+		t.Fatalf("Workers = %d, want 8 (preserved from existing entry)", entry.Workers)
+	}
+	if entry.MinChunkSize != 4*types.MB {
+		t.Fatalf("MinChunkSize = %d, want %d (preserved from existing entry)", entry.MinChunkSize, 4*types.MB)
+	}
+}
+
 func TestStartEventWorker_PersistsQueuedMirrorsForResume(t *testing.T) {
 	tempDir := testutil.SetupStateDB(t)
 	finalPath := filepath.Join(tempDir, "video.mp4")

--- a/internal/processing/manager.go
+++ b/internal/processing/manager.go
@@ -20,10 +20,10 @@ import (
 )
 
 // AddDownloadFunc is the lifecycle's handoff into the engine-facing queue layer.
-type AddDownloadFunc func(string, string, string, []string, map[string]string, bool, int64, bool) (string, error)
+type AddDownloadFunc func(string, string, string, []string, map[string]string, bool, int, int64, int64, bool) (string, error)
 
 // AddDownloadWithIDFunc preserves caller-chosen ids when a remote/UI layer already owns them.
-type AddDownloadWithIDFunc func(string, string, string, []string, map[string]string, string, int64, bool) (string, error)
+type AddDownloadWithIDFunc func(string, string, string, []string, map[string]string, string, int, int64, int64, bool) (string, error)
 
 // IsNameActiveFunc lets routing treat in-flight downloads as filename conflicts within a directory.
 type IsNameActiveFunc func(dir, name string) bool
@@ -190,6 +190,8 @@ type DownloadRequest struct {
 	Headers            map[string]string
 	IsExplicitCategory bool
 	SkipApproval       bool
+	Workers            int
+	MinChunkSize       int64
 }
 
 // Enqueue probes and reserves a stable destination before dispatching to the queue layer.
@@ -207,6 +209,8 @@ func (mgr *LifecycleManager) Enqueue(ctx context.Context, req *DownloadRequest) 
 			req.Mirrors,
 			req.Headers,
 			req.IsExplicitCategory,
+			req.Workers,
+			req.MinChunkSize,
 			probe.FileSize,
 			probe.SupportsRange,
 		)
@@ -228,6 +232,8 @@ func (mgr *LifecycleManager) EnqueueWithID(ctx context.Context, req *DownloadReq
 			req.Mirrors,
 			req.Headers,
 			requestID,
+			req.Workers,
+			req.MinChunkSize,
 			probe.FileSize,
 			probe.SupportsRange,
 		)

--- a/internal/processing/manager.go
+++ b/internal/processing/manager.go
@@ -357,6 +357,8 @@ func (mgr *LifecycleManager) enqueueResolved(ctx context.Context, req *DownloadR
 				Mirrors:      append([]string(nil), req.Mirrors...),
 				RateLimit:    rateLimit,
 				RateLimitSet: rateLimitSet,
+				Workers:      req.Workers,
+				MinChunkSize: req.MinChunkSize,
 			})
 		}
 

--- a/internal/processing/manager_override_test.go
+++ b/internal/processing/manager_override_test.go
@@ -130,3 +130,129 @@ func TestEnqueue_PerTaskOverride_BothSet(t *testing.T) {
 		t.Fatalf("expected minChunkSize=%d, got %d", 5*1024*1024, gotMinChunkSize)
 	}
 }
+
+func TestEnqueueWithID_PerTaskOverride_ZeroValues(t *testing.T) {
+	mgr := newLifecycleManagerForTest()
+
+	var gotWorkers int
+	var gotMinChunkSize int64
+	mgr.addWithIDFunc = func(_, _, _ string, _ []string, _ map[string]string, _ string, workers int, minChunkSize int64, _ int64, _ bool) (string, error) {
+		gotWorkers = workers
+		gotMinChunkSize = minChunkSize
+		return "id", nil
+	}
+
+	server := newProbeTestServer(t, 1024)
+	defer server.Close()
+
+	_, _, err := mgr.EnqueueWithID(context.Background(), &DownloadRequest{
+		URL:      server.URL,
+		Filename: "test.bin",
+		Path:     t.TempDir(),
+	}, "req-1")
+	if err != nil {
+		t.Fatalf("EnqueueWithID failed: %v", err)
+	}
+	if gotWorkers != 0 {
+		t.Fatalf("expected workers=0, got %d", gotWorkers)
+	}
+	if gotMinChunkSize != 0 {
+		t.Fatalf("expected minChunkSize=0, got %d", gotMinChunkSize)
+	}
+}
+
+func TestEnqueueWithID_PerTaskOverride_WorkersOnly(t *testing.T) {
+	mgr := newLifecycleManagerForTest()
+
+	var gotWorkers int
+	var gotMinChunkSize int64
+	mgr.addWithIDFunc = func(_, _, _ string, _ []string, _ map[string]string, _ string, workers int, minChunkSize int64, _ int64, _ bool) (string, error) {
+		gotWorkers = workers
+		gotMinChunkSize = minChunkSize
+		return "id", nil
+	}
+
+	server := newProbeTestServer(t, 1024)
+	defer server.Close()
+
+	_, _, err := mgr.EnqueueWithID(context.Background(), &DownloadRequest{
+		URL:         server.URL,
+		Filename:    "test.bin",
+		Path:        t.TempDir(),
+		Workers:     16,
+		MinChunkSize: 0,
+	}, "req-2")
+	if err != nil {
+		t.Fatalf("EnqueueWithID failed: %v", err)
+	}
+	if gotWorkers != 16 {
+		t.Fatalf("expected workers=16, got %d", gotWorkers)
+	}
+	if gotMinChunkSize != 0 {
+		t.Fatalf("expected minChunkSize=0, got %d", gotMinChunkSize)
+	}
+}
+
+func TestEnqueueWithID_PerTaskOverride_MinChunkSizeOnly(t *testing.T) {
+	mgr := newLifecycleManagerForTest()
+
+	var gotWorkers int
+	var gotMinChunkSize int64
+	mgr.addWithIDFunc = func(_, _, _ string, _ []string, _ map[string]string, _ string, workers int, minChunkSize int64, _ int64, _ bool) (string, error) {
+		gotWorkers = workers
+		gotMinChunkSize = minChunkSize
+		return "id", nil
+	}
+
+	server := newProbeTestServer(t, 1024)
+	defer server.Close()
+
+	_, _, err := mgr.EnqueueWithID(context.Background(), &DownloadRequest{
+		URL:         server.URL,
+		Filename:    "test.bin",
+		Path:        t.TempDir(),
+		Workers:     0,
+		MinChunkSize: 10 * 1024 * 1024,
+	}, "req-3")
+	if err != nil {
+		t.Fatalf("EnqueueWithID failed: %v", err)
+	}
+	if gotWorkers != 0 {
+		t.Fatalf("expected workers=0, got %d", gotWorkers)
+	}
+	if gotMinChunkSize != 10*1024*1024 {
+		t.Fatalf("expected minChunkSize=%d, got %d", 10*1024*1024, gotMinChunkSize)
+	}
+}
+
+func TestEnqueueWithID_PerTaskOverride_BothSet(t *testing.T) {
+	mgr := newLifecycleManagerForTest()
+
+	var gotWorkers int
+	var gotMinChunkSize int64
+	mgr.addWithIDFunc = func(_, _, _ string, _ []string, _ map[string]string, _ string, workers int, minChunkSize int64, _ int64, _ bool) (string, error) {
+		gotWorkers = workers
+		gotMinChunkSize = minChunkSize
+		return "id", nil
+	}
+
+	server := newProbeTestServer(t, 1024)
+	defer server.Close()
+
+	_, _, err := mgr.EnqueueWithID(context.Background(), &DownloadRequest{
+		URL:         server.URL,
+		Filename:    "test.bin",
+		Path:        t.TempDir(),
+		Workers:     8,
+		MinChunkSize: 5 * 1024 * 1024,
+	}, "req-4")
+	if err != nil {
+		t.Fatalf("EnqueueWithID failed: %v", err)
+	}
+	if gotWorkers != 8 {
+		t.Fatalf("expected workers=8, got %d", gotWorkers)
+	}
+	if gotMinChunkSize != 5*1024*1024 {
+		t.Fatalf("expected minChunkSize=%d, got %d", 5*1024*1024, gotMinChunkSize)
+	}
+}

--- a/internal/processing/manager_override_test.go
+++ b/internal/processing/manager_override_test.go
@@ -1,0 +1,132 @@
+package processing
+
+import (
+	"context"
+	"testing"
+)
+
+func TestEnqueue_PerTaskOverride_ZeroValues(t *testing.T) {
+	mgr := newLifecycleManagerForTest()
+
+	var gotWorkers int
+	var gotMinChunkSize int64
+	mgr.addFunc = func(_, _, _ string, _ []string, _ map[string]string, _ bool, workers int, minChunkSize int64, _ int64, _ bool) (string, error) {
+		gotWorkers = workers
+		gotMinChunkSize = minChunkSize
+		return "id", nil
+	}
+
+	server := newProbeTestServer(t, 1024)
+	defer server.Close()
+
+	_, _, err := mgr.Enqueue(context.Background(), &DownloadRequest{
+		URL:      server.URL,
+		Filename: "test.bin",
+		Path:     t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Enqueue failed: %v", err)
+	}
+	if gotWorkers != 0 {
+		t.Fatalf("expected workers=0, got %d", gotWorkers)
+	}
+	if gotMinChunkSize != 0 {
+		t.Fatalf("expected minChunkSize=0, got %d", gotMinChunkSize)
+	}
+}
+
+func TestEnqueue_PerTaskOverride_WorkersOnly(t *testing.T) {
+	mgr := newLifecycleManagerForTest()
+
+	var gotWorkers int
+	var gotMinChunkSize int64
+	mgr.addFunc = func(_, _, _ string, _ []string, _ map[string]string, _ bool, workers int, minChunkSize int64, _ int64, _ bool) (string, error) {
+		gotWorkers = workers
+		gotMinChunkSize = minChunkSize
+		return "id", nil
+	}
+
+	server := newProbeTestServer(t, 1024)
+	defer server.Close()
+
+	_, _, err := mgr.Enqueue(context.Background(), &DownloadRequest{
+		URL:         server.URL,
+		Filename:    "test.bin",
+		Path:        t.TempDir(),
+		Workers:     16,
+		MinChunkSize: 0,
+	})
+	if err != nil {
+		t.Fatalf("Enqueue failed: %v", err)
+	}
+	if gotWorkers != 16 {
+		t.Fatalf("expected workers=16, got %d", gotWorkers)
+	}
+	if gotMinChunkSize != 0 {
+		t.Fatalf("expected minChunkSize=0, got %d", gotMinChunkSize)
+	}
+}
+
+func TestEnqueue_PerTaskOverride_MinChunkSizeOnly(t *testing.T) {
+	mgr := newLifecycleManagerForTest()
+
+	var gotWorkers int
+	var gotMinChunkSize int64
+	mgr.addFunc = func(_, _, _ string, _ []string, _ map[string]string, _ bool, workers int, minChunkSize int64, _ int64, _ bool) (string, error) {
+		gotWorkers = workers
+		gotMinChunkSize = minChunkSize
+		return "id", nil
+	}
+
+	server := newProbeTestServer(t, 1024)
+	defer server.Close()
+
+	_, _, err := mgr.Enqueue(context.Background(), &DownloadRequest{
+		URL:         server.URL,
+		Filename:    "test.bin",
+		Path:        t.TempDir(),
+		Workers:     0,
+		MinChunkSize: 10 * 1024 * 1024,
+	})
+	if err != nil {
+		t.Fatalf("Enqueue failed: %v", err)
+	}
+	if gotWorkers != 0 {
+		t.Fatalf("expected workers=0, got %d", gotWorkers)
+	}
+	if gotMinChunkSize != 10*1024*1024 {
+		t.Fatalf("expected minChunkSize=%d, got %d", 10*1024*1024, gotMinChunkSize)
+	}
+}
+
+func TestEnqueue_PerTaskOverride_BothSet(t *testing.T) {
+	mgr := newLifecycleManagerForTest()
+
+	var gotWorkers int
+	var gotMinChunkSize int64
+	mgr.addFunc = func(_, _, _ string, _ []string, _ map[string]string, _ bool, workers int, minChunkSize int64, _ int64, _ bool) (string, error) {
+		gotWorkers = workers
+		gotMinChunkSize = minChunkSize
+		return "id", nil
+	}
+
+	server := newProbeTestServer(t, 1024)
+	defer server.Close()
+
+	_, _, err := mgr.Enqueue(context.Background(), &DownloadRequest{
+		URL:         server.URL,
+		Filename:    "test.bin",
+		Path:        t.TempDir(),
+		Workers:     8,
+		MinChunkSize: 5 * 1024 * 1024,
+	})
+	if err != nil {
+		t.Fatalf("Enqueue failed: %v", err)
+	}
+	if gotWorkers != 8 {
+		t.Fatalf("expected workers=8, got %d", gotWorkers)
+	}
+	if gotMinChunkSize != 5*1024*1024 {
+		t.Fatalf("expected minChunkSize=%d, got %d", 5*1024*1024, gotMinChunkSize)
+	}
+}

--- a/internal/processing/manager_override_test.go
+++ b/internal/processing/manager_override_test.go
@@ -5,254 +5,120 @@ import (
 	"testing"
 )
 
-func TestEnqueue_PerTaskOverride_ZeroValues(t *testing.T) {
-	mgr := newLifecycleManagerForTest()
-
-	var gotWorkers int
-	var gotMinChunkSize int64
-	mgr.addFunc = func(_, _, _ string, _ []string, _ map[string]string, _ bool, workers int, minChunkSize int64, _ int64, _ bool) (string, error) {
-		gotWorkers = workers
-		gotMinChunkSize = minChunkSize
-		return "id", nil
+func TestEnqueue_PerTaskOverrideForwarding(t *testing.T) {
+	tests := []struct {
+		name          string
+		workers       int
+		minChunkSize  int64
+		wantWorkers   int
+		wantMinChunk  int64
+	}{
+		{
+			name:         "zero values stay zero",
+			workers:      0,
+			minChunkSize: 0,
+			wantWorkers:  0,
+			wantMinChunk: 0,
+		},
+		{
+			name:         "Enqueue forwards both fields",
+			workers:      8,
+			minChunkSize: 5 * 1024 * 1024,
+			wantWorkers:  8,
+			wantMinChunk: 5 * 1024 * 1024,
+		},
 	}
 
-	server := newProbeTestServer(t, 1024)
-	defer server.Close()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mgr := newLifecycleManagerForTest()
 
-	_, _, err := mgr.Enqueue(context.Background(), &DownloadRequest{
-		URL:      server.URL,
-		Filename: "test.bin",
-		Path:     t.TempDir(),
-	})
-	if err != nil {
-		t.Fatalf("Enqueue failed: %v", err)
-	}
-	if gotWorkers != 0 {
-		t.Fatalf("expected workers=0, got %d", gotWorkers)
-	}
-	if gotMinChunkSize != 0 {
-		t.Fatalf("expected minChunkSize=0, got %d", gotMinChunkSize)
-	}
-}
+			var gotWorkers int
+			var gotMinChunkSize int64
+			mgr.addFunc = func(_, _, _ string, _ []string, _ map[string]string, _ bool, workers int, minChunkSize int64, _ int64, _ bool) (string, error) {
+				gotWorkers = workers
+				gotMinChunkSize = minChunkSize
+				return "id", nil
+			}
 
-func TestEnqueue_PerTaskOverride_WorkersOnly(t *testing.T) {
-	mgr := newLifecycleManagerForTest()
+			server := newProbeTestServer(t, 1024)
+			defer server.Close()
 
-	var gotWorkers int
-	var gotMinChunkSize int64
-	mgr.addFunc = func(_, _, _ string, _ []string, _ map[string]string, _ bool, workers int, minChunkSize int64, _ int64, _ bool) (string, error) {
-		gotWorkers = workers
-		gotMinChunkSize = minChunkSize
-		return "id", nil
-	}
-
-	server := newProbeTestServer(t, 1024)
-	defer server.Close()
-
-	_, _, err := mgr.Enqueue(context.Background(), &DownloadRequest{
-		URL:         server.URL,
-		Filename:    "test.bin",
-		Path:        t.TempDir(),
-		Workers:     16,
-		MinChunkSize: 0,
-	})
-	if err != nil {
-		t.Fatalf("Enqueue failed: %v", err)
-	}
-	if gotWorkers != 16 {
-		t.Fatalf("expected workers=16, got %d", gotWorkers)
-	}
-	if gotMinChunkSize != 0 {
-		t.Fatalf("expected minChunkSize=0, got %d", gotMinChunkSize)
+			_, _, err := mgr.Enqueue(context.Background(), &DownloadRequest{
+				URL:          server.URL,
+				Filename:     "test.bin",
+				Path:         t.TempDir(),
+				Workers:      tt.workers,
+				MinChunkSize: tt.minChunkSize,
+			})
+			if err != nil {
+				t.Fatalf("Enqueue failed: %v", err)
+			}
+			if gotWorkers != tt.wantWorkers {
+				t.Fatalf("expected workers=%d, got %d", tt.wantWorkers, gotWorkers)
+			}
+			if gotMinChunkSize != tt.wantMinChunk {
+				t.Fatalf("expected minChunkSize=%d, got %d", tt.wantMinChunk, gotMinChunkSize)
+			}
+		})
 	}
 }
 
-func TestEnqueue_PerTaskOverride_MinChunkSizeOnly(t *testing.T) {
-	mgr := newLifecycleManagerForTest()
-
-	var gotWorkers int
-	var gotMinChunkSize int64
-	mgr.addFunc = func(_, _, _ string, _ []string, _ map[string]string, _ bool, workers int, minChunkSize int64, _ int64, _ bool) (string, error) {
-		gotWorkers = workers
-		gotMinChunkSize = minChunkSize
-		return "id", nil
+func TestEnqueueWithID_PerTaskOverrideForwarding(t *testing.T) {
+	tests := []struct {
+		name          string
+		workers       int
+		minChunkSize  int64
+		wantWorkers   int
+		wantMinChunk  int64
+	}{
+		{
+			name:         "zero values stay zero",
+			workers:      0,
+			minChunkSize: 0,
+			wantWorkers:  0,
+			wantMinChunk: 0,
+		},
+		{
+			name:         "EnqueueWithID forwards both fields",
+			workers:      8,
+			minChunkSize: 5 * 1024 * 1024,
+			wantWorkers:  8,
+			wantMinChunk: 5 * 1024 * 1024,
+		},
 	}
 
-	server := newProbeTestServer(t, 1024)
-	defer server.Close()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mgr := newLifecycleManagerForTest()
 
-	_, _, err := mgr.Enqueue(context.Background(), &DownloadRequest{
-		URL:         server.URL,
-		Filename:    "test.bin",
-		Path:        t.TempDir(),
-		Workers:     0,
-		MinChunkSize: 10 * 1024 * 1024,
-	})
-	if err != nil {
-		t.Fatalf("Enqueue failed: %v", err)
-	}
-	if gotWorkers != 0 {
-		t.Fatalf("expected workers=0, got %d", gotWorkers)
-	}
-	if gotMinChunkSize != 10*1024*1024 {
-		t.Fatalf("expected minChunkSize=%d, got %d", 10*1024*1024, gotMinChunkSize)
-	}
-}
+			var gotWorkers int
+			var gotMinChunkSize int64
+			mgr.addWithIDFunc = func(_, _, _ string, _ []string, _ map[string]string, _ string, workers int, minChunkSize int64, _ int64, _ bool) (string, error) {
+				gotWorkers = workers
+				gotMinChunkSize = minChunkSize
+				return "id", nil
+			}
 
-func TestEnqueue_PerTaskOverride_BothSet(t *testing.T) {
-	mgr := newLifecycleManagerForTest()
+			server := newProbeTestServer(t, 1024)
+			defer server.Close()
 
-	var gotWorkers int
-	var gotMinChunkSize int64
-	mgr.addFunc = func(_, _, _ string, _ []string, _ map[string]string, _ bool, workers int, minChunkSize int64, _ int64, _ bool) (string, error) {
-		gotWorkers = workers
-		gotMinChunkSize = minChunkSize
-		return "id", nil
-	}
-
-	server := newProbeTestServer(t, 1024)
-	defer server.Close()
-
-	_, _, err := mgr.Enqueue(context.Background(), &DownloadRequest{
-		URL:         server.URL,
-		Filename:    "test.bin",
-		Path:        t.TempDir(),
-		Workers:     8,
-		MinChunkSize: 5 * 1024 * 1024,
-	})
-	if err != nil {
-		t.Fatalf("Enqueue failed: %v", err)
-	}
-	if gotWorkers != 8 {
-		t.Fatalf("expected workers=8, got %d", gotWorkers)
-	}
-	if gotMinChunkSize != 5*1024*1024 {
-		t.Fatalf("expected minChunkSize=%d, got %d", 5*1024*1024, gotMinChunkSize)
-	}
-}
-
-func TestEnqueueWithID_PerTaskOverride_ZeroValues(t *testing.T) {
-	mgr := newLifecycleManagerForTest()
-
-	var gotWorkers int
-	var gotMinChunkSize int64
-	mgr.addWithIDFunc = func(_, _, _ string, _ []string, _ map[string]string, _ string, workers int, minChunkSize int64, _ int64, _ bool) (string, error) {
-		gotWorkers = workers
-		gotMinChunkSize = minChunkSize
-		return "id", nil
-	}
-
-	server := newProbeTestServer(t, 1024)
-	defer server.Close()
-
-	_, _, err := mgr.EnqueueWithID(context.Background(), &DownloadRequest{
-		URL:      server.URL,
-		Filename: "test.bin",
-		Path:     t.TempDir(),
-	}, "req-1")
-	if err != nil {
-		t.Fatalf("EnqueueWithID failed: %v", err)
-	}
-	if gotWorkers != 0 {
-		t.Fatalf("expected workers=0, got %d", gotWorkers)
-	}
-	if gotMinChunkSize != 0 {
-		t.Fatalf("expected minChunkSize=0, got %d", gotMinChunkSize)
-	}
-}
-
-func TestEnqueueWithID_PerTaskOverride_WorkersOnly(t *testing.T) {
-	mgr := newLifecycleManagerForTest()
-
-	var gotWorkers int
-	var gotMinChunkSize int64
-	mgr.addWithIDFunc = func(_, _, _ string, _ []string, _ map[string]string, _ string, workers int, minChunkSize int64, _ int64, _ bool) (string, error) {
-		gotWorkers = workers
-		gotMinChunkSize = minChunkSize
-		return "id", nil
-	}
-
-	server := newProbeTestServer(t, 1024)
-	defer server.Close()
-
-	_, _, err := mgr.EnqueueWithID(context.Background(), &DownloadRequest{
-		URL:         server.URL,
-		Filename:    "test.bin",
-		Path:        t.TempDir(),
-		Workers:     16,
-		MinChunkSize: 0,
-	}, "req-2")
-	if err != nil {
-		t.Fatalf("EnqueueWithID failed: %v", err)
-	}
-	if gotWorkers != 16 {
-		t.Fatalf("expected workers=16, got %d", gotWorkers)
-	}
-	if gotMinChunkSize != 0 {
-		t.Fatalf("expected minChunkSize=0, got %d", gotMinChunkSize)
-	}
-}
-
-func TestEnqueueWithID_PerTaskOverride_MinChunkSizeOnly(t *testing.T) {
-	mgr := newLifecycleManagerForTest()
-
-	var gotWorkers int
-	var gotMinChunkSize int64
-	mgr.addWithIDFunc = func(_, _, _ string, _ []string, _ map[string]string, _ string, workers int, minChunkSize int64, _ int64, _ bool) (string, error) {
-		gotWorkers = workers
-		gotMinChunkSize = minChunkSize
-		return "id", nil
-	}
-
-	server := newProbeTestServer(t, 1024)
-	defer server.Close()
-
-	_, _, err := mgr.EnqueueWithID(context.Background(), &DownloadRequest{
-		URL:         server.URL,
-		Filename:    "test.bin",
-		Path:        t.TempDir(),
-		Workers:     0,
-		MinChunkSize: 10 * 1024 * 1024,
-	}, "req-3")
-	if err != nil {
-		t.Fatalf("EnqueueWithID failed: %v", err)
-	}
-	if gotWorkers != 0 {
-		t.Fatalf("expected workers=0, got %d", gotWorkers)
-	}
-	if gotMinChunkSize != 10*1024*1024 {
-		t.Fatalf("expected minChunkSize=%d, got %d", 10*1024*1024, gotMinChunkSize)
-	}
-}
-
-func TestEnqueueWithID_PerTaskOverride_BothSet(t *testing.T) {
-	mgr := newLifecycleManagerForTest()
-
-	var gotWorkers int
-	var gotMinChunkSize int64
-	mgr.addWithIDFunc = func(_, _, _ string, _ []string, _ map[string]string, _ string, workers int, minChunkSize int64, _ int64, _ bool) (string, error) {
-		gotWorkers = workers
-		gotMinChunkSize = minChunkSize
-		return "id", nil
-	}
-
-	server := newProbeTestServer(t, 1024)
-	defer server.Close()
-
-	_, _, err := mgr.EnqueueWithID(context.Background(), &DownloadRequest{
-		URL:         server.URL,
-		Filename:    "test.bin",
-		Path:        t.TempDir(),
-		Workers:     8,
-		MinChunkSize: 5 * 1024 * 1024,
-	}, "req-4")
-	if err != nil {
-		t.Fatalf("EnqueueWithID failed: %v", err)
-	}
-	if gotWorkers != 8 {
-		t.Fatalf("expected workers=8, got %d", gotWorkers)
-	}
-	if gotMinChunkSize != 5*1024*1024 {
-		t.Fatalf("expected minChunkSize=%d, got %d", 5*1024*1024, gotMinChunkSize)
+			_, _, err := mgr.EnqueueWithID(context.Background(), &DownloadRequest{
+				URL:          server.URL,
+				Filename:     "test.bin",
+				Path:         t.TempDir(),
+				Workers:      tt.workers,
+				MinChunkSize: tt.minChunkSize,
+			}, "req-1")
+			if err != nil {
+				t.Fatalf("EnqueueWithID failed: %v", err)
+			}
+			if gotWorkers != tt.wantWorkers {
+				t.Fatalf("expected workers=%d, got %d", tt.wantWorkers, gotWorkers)
+			}
+			if gotMinChunkSize != tt.wantMinChunk {
+				t.Fatalf("expected minChunkSize=%d, got %d", tt.wantMinChunk, gotMinChunkSize)
+			}
+		})
 	}
 }

--- a/internal/processing/manager_test.go
+++ b/internal/processing/manager_test.go
@@ -58,7 +58,7 @@ func TestLifecycleManager_Enqueue_PrecreatesWorkingFileBeforeDispatch(t *testing
 	expectedID := "enqueue-id"
 
 	mgr := newLifecycleManagerForTest()
-	mgr.addFunc = func(url, path, filename string, _ []string, _ map[string]string, explicit bool, totalSize int64, supportsRange bool) (string, error) {
+	mgr.addFunc = func(url, path, filename string, _ []string, _ map[string]string, explicit bool, workers int, minChunkSize int64, totalSize int64, supportsRange bool) (string, error) {
 		if url != server.URL {
 			t.Fatalf("url = %q, want %q", url, server.URL)
 		}
@@ -116,7 +116,7 @@ func TestLifecycleManager_EnqueueWithID_PrecreatesWorkingFileBeforeDispatch(t *t
 	expectedID := "request-id"
 
 	mgr := newLifecycleManagerForTest()
-	mgr.addWithIDFunc = func(url, path, filename string, _ []string, _ map[string]string, requestID string, totalSize int64, supportsRange bool) (string, error) {
+	mgr.addWithIDFunc = func(url, path, filename string, _ []string, _ map[string]string, requestID string, workers int, minChunkSize int64, totalSize int64, supportsRange bool) (string, error) {
 		if url != server.URL {
 			t.Fatalf("url = %q, want %q", url, server.URL)
 		}
@@ -175,7 +175,7 @@ func TestLifecycleManager_EnqueueWithID_ProbeFailureStillDispatches(t *testing.T
 	expectedID := "request-id"
 
 	mgr := newLifecycleManagerForTest()
-	mgr.addWithIDFunc = func(url, path, filename string, _ []string, _ map[string]string, requestID string, totalSize int64, supportsRange bool) (string, error) {
+	mgr.addWithIDFunc = func(url, path, filename string, _ []string, _ map[string]string, requestID string, workers int, minChunkSize int64, totalSize int64, supportsRange bool) (string, error) {
 		if url != server.URL {
 			t.Fatalf("url = %q, want %q", url, server.URL)
 		}
@@ -222,7 +222,7 @@ func TestLifecycleManager_Enqueue_RemovesWorkingFileOnDispatchError(t *testing.T
 	expectedErr := errors.New("dispatch failed")
 
 	mgr := newLifecycleManagerForTest()
-	mgr.addFunc = func(string, string, string, []string, map[string]string, bool, int64, bool) (string, error) {
+	mgr.addFunc = func(string, string, string, []string, map[string]string, bool, int, int64, int64, bool) (string, error) {
 		return "", expectedErr
 	}
 
@@ -271,7 +271,7 @@ func TestLifecycleManager_Enqueue_RetriesWhenWorkingFileReservationCollides(t *t
 
 	mgr := newLifecycleManagerForTest()
 	var dispatchedFilename string
-	mgr.addFunc = func(url, path, filename string, _ []string, _ map[string]string, explicit bool, totalSize int64, supportsRange bool) (string, error) {
+	mgr.addFunc = func(url, path, filename string, _ []string, _ map[string]string, explicit bool, workers int, minChunkSize int64, totalSize int64, supportsRange bool) (string, error) {
 		dispatchedFilename = filename
 		if path != tempDir {
 			t.Fatalf("path = %q, want %q", path, tempDir)
@@ -344,7 +344,7 @@ func TestLifecycleManager_EnqueueWithID_RetriesWhenWorkingFileReservationCollide
 
 	mgr := newLifecycleManagerForTest()
 	var dispatchedFilename string
-	mgr.addWithIDFunc = func(url, path, filename string, _ []string, _ map[string]string, gotRequestID string, totalSize int64, supportsRange bool) (string, error) {
+	mgr.addWithIDFunc = func(url, path, filename string, _ []string, _ map[string]string, gotRequestID string, workers int, minChunkSize int64, totalSize int64, supportsRange bool) (string, error) {
 		dispatchedFilename = filename
 		if path != tempDir {
 			t.Fatalf("path = %q, want %q", path, tempDir)
@@ -396,7 +396,7 @@ func TestLifecycleManager_EnqueueWithID_RemovesWorkingFileOnDispatchError(t *tes
 	expectedErr := errors.New("dispatch failed")
 
 	mgr := newLifecycleManagerForTest()
-	mgr.addWithIDFunc = func(string, string, string, []string, map[string]string, string, int64, bool) (string, error) {
+	mgr.addWithIDFunc = func(string, string, string, []string, map[string]string, string, int, int64, int64, bool) (string, error) {
 		return "", expectedErr
 	}
 
@@ -437,7 +437,7 @@ func TestLifecycleManager_Enqueue_FailsAfterReservationAttemptLimit(t *testing.T
 	}
 
 	mgr := newLifecycleManagerForTest()
-	mgr.addFunc = func(string, string, string, []string, map[string]string, bool, int64, bool) (string, error) {
+	mgr.addFunc = func(string, string, string, []string, map[string]string, bool, int, int64, int64, bool) (string, error) {
 		t.Fatal("dispatch should not run when reservation never succeeds")
 		return "", nil
 	}
@@ -523,7 +523,7 @@ func TestLifecycleManager_Enqueue_ContextCancellationDuringProbe(t *testing.T) {
 	defer server.Close()
 
 	mgr := newLifecycleManagerForTest()
-	mgr.addFunc = func(string, string, string, []string, map[string]string, bool, int64, bool) (string, error) {
+	mgr.addFunc = func(string, string, string, []string, map[string]string, bool, int, int64, int64, bool) (string, error) {
 		t.Fatal("dispatch should not run when probe fails")
 		return "", nil
 	}
@@ -565,7 +565,7 @@ func TestLifecycleManager_EnqueueWithID_FailsAfterReservationAttemptLimit(t *tes
 	}
 
 	mgr := newLifecycleManagerForTest()
-	mgr.addWithIDFunc = func(string, string, string, []string, map[string]string, string, int64, bool) (string, error) {
+	mgr.addWithIDFunc = func(string, string, string, []string, map[string]string, string, int, int64, int64, bool) (string, error) {
 		t.Fatal("dispatch should not run when reservation never succeeds")
 		return "", nil
 	}
@@ -624,7 +624,7 @@ func TestLifecycleManager_Enqueue_ContextCancellationBeforeReservation(t *testin
 	defer server.Close()
 
 	mgr := newLifecycleManagerForTest()
-	mgr.addFunc = func(string, string, string, []string, map[string]string, bool, int64, bool) (string, error) {
+	mgr.addFunc = func(string, string, string, []string, map[string]string, bool, int, int64, int64, bool) (string, error) {
 		t.Fatal("dispatch should not run when context is canceled before reservation")
 		return "", nil
 	}
@@ -1072,7 +1072,7 @@ func TestLifecycleManager_ProbeSemaphore_LimitsInflight(t *testing.T) {
 	}()
 
 	mgr := newLifecycleManagerForTest()
-	mgr.addFunc = func(string, string, string, []string, map[string]string, bool, int64, bool) (string, error) {
+	mgr.addFunc = func(string, string, string, []string, map[string]string, bool, int, int64, int64, bool) (string, error) {
 		return "", fmt.Errorf("dispatch intentionally rejected for test")
 	}
 	settings := config.DefaultSettings()
@@ -1117,7 +1117,7 @@ func TestLifecycleManager_ProbeSemaphore_LimitsInflight(t *testing.T) {
 func TestLifecycleManager_ProbeSemaphore_CancelledContextAbortsWait(t *testing.T) {
 	// Build a manager and fill its semaphore completely so the next Enqueue blocks.
 	mgr := newLifecycleManagerForTest()
-	mgr.addFunc = func(string, string, string, []string, map[string]string, bool, int64, bool) (string, error) {
+	mgr.addFunc = func(string, string, string, []string, map[string]string, bool, int, int64, int64, bool) (string, error) {
 		t.Fatal("dispatch should not run when context is cancelled")
 		return "", nil
 	}

--- a/internal/processing/pause_resume.go
+++ b/internal/processing/pause_resume.go
@@ -339,6 +339,17 @@ func buildResumeConfig(id, outputPath string, entry *types.DownloadEntry, savedS
 		rateLimit = runtime.DefaultDownloadRateLimitBps
 	}
 
+	if savedState != nil && savedState.Workers > 0 {
+		runtime.Workers = savedState.Workers
+	} else if entry != nil && entry.Workers > 0 {
+		runtime.Workers = entry.Workers
+	}
+	if savedState != nil && savedState.MinChunkSize > 0 {
+		runtime.MinChunkSize = savedState.MinChunkSize
+	} else if entry != nil && entry.MinChunkSize > 0 {
+		runtime.MinChunkSize = entry.MinChunkSize
+	}
+
 	var mirrorURLs []string
 	var dmState *types.ProgressState
 

--- a/internal/processing/pause_resume_override_test.go
+++ b/internal/processing/pause_resume_override_test.go
@@ -59,6 +59,37 @@ func TestBuildResumeConfig_OverridesFallbackToEntry(t *testing.T) {
 	}
 }
 
+func TestBuildResumeConfig_SavedStatePriorityForMinChunkSize(t *testing.T) {
+	settings := config.DefaultSettings()
+	entry := &types.DownloadEntry{
+		ID:          "test-id",
+		URL:         "http://example.com/file.zip",
+		DestPath:    "/tmp/file.zip",
+		Filename:    "file.zip",
+		TotalSize:   1000,
+		Workers:     4,
+		MinChunkSize: 2 * types.MB,
+	}
+	savedState := &types.DownloadState{
+		ID:          "test-id",
+		URL:         "http://example.com/file.zip",
+		DestPath:    "/tmp/file.zip",
+		Filename:    "file.zip",
+		TotalSize:   1000,
+		Downloaded:  500,
+		Workers:     8,
+		MinChunkSize: 10 * types.MB,
+	}
+
+	cfg := buildResumeConfig("test-id", "/tmp", entry, savedState, settings)
+	if cfg.Runtime.Workers != 8 {
+		t.Fatalf("expected Runtime.Workers=8 (from savedState), got %d", cfg.Runtime.Workers)
+	}
+	if cfg.Runtime.MinChunkSize != 10*types.MB {
+		t.Fatalf("expected Runtime.MinChunkSize=%d (from savedState), got %d", 10*types.MB, cfg.Runtime.MinChunkSize)
+	}
+}
+
 func TestBuildResumeConfig_NoOverridesUsesDefaults(t *testing.T) {
 	settings := config.DefaultSettings()
 	entry := &types.DownloadEntry{

--- a/internal/processing/pause_resume_override_test.go
+++ b/internal/processing/pause_resume_override_test.go
@@ -1,0 +1,88 @@
+package processing
+
+import (
+	"testing"
+
+	"github.com/SurgeDM/Surge/internal/config"
+	"github.com/SurgeDM/Surge/internal/engine/types"
+)
+
+func TestBuildResumeConfig_OverridesFromSavedState(t *testing.T) {
+	settings := config.DefaultSettings()
+	entry := &types.DownloadEntry{
+		ID:        "test-id",
+		URL:       "http://example.com/file.zip",
+		DestPath:  "/tmp/file.zip",
+		Filename:  "file.zip",
+		TotalSize: 1000,
+		Workers:   4,
+		MinChunkSize: 5 * types.MB,
+	}
+	savedState := &types.DownloadState{
+		ID:          "test-id",
+		URL:         "http://example.com/file.zip",
+		DestPath:    "/tmp/file.zip",
+		Filename:    "file.zip",
+		TotalSize:   1000,
+		Downloaded:  500,
+		Workers:     8,
+		MinChunkSize: 5 * types.MB,
+	}
+
+	cfg := buildResumeConfig("test-id", "/tmp", entry, savedState, settings)
+	if cfg.Runtime.Workers != 8 {
+		t.Fatalf("expected Runtime.Workers=8 (from savedState), got %d", cfg.Runtime.Workers)
+	}
+	if cfg.Runtime.MinChunkSize != 5*types.MB {
+		t.Fatalf("expected Runtime.MinChunkSize=%d (from savedState), got %d", 5*types.MB, cfg.Runtime.MinChunkSize)
+	}
+}
+
+func TestBuildResumeConfig_OverridesFallbackToEntry(t *testing.T) {
+	settings := config.DefaultSettings()
+	entry := &types.DownloadEntry{
+		ID:        "test-id",
+		URL:       "http://example.com/file.zip",
+		DestPath:  "/tmp/file.zip",
+		Filename:  "file.zip",
+		TotalSize: 1000,
+		Workers:   8,
+		MinChunkSize: 5 * types.MB,
+	}
+
+	cfg := buildResumeConfig("test-id", "/tmp", entry, nil, settings)
+	if cfg.Runtime.Workers != 8 {
+		t.Fatalf("expected Runtime.Workers=8 (from entry fallback), got %d", cfg.Runtime.Workers)
+	}
+	if cfg.Runtime.MinChunkSize != 5*types.MB {
+		t.Fatalf("expected Runtime.MinChunkSize=%d (from entry fallback), got %d", 5*types.MB, cfg.Runtime.MinChunkSize)
+	}
+}
+
+func TestBuildResumeConfig_NoOverridesUsesDefaults(t *testing.T) {
+	settings := config.DefaultSettings()
+	entry := &types.DownloadEntry{
+		ID:        "test-id",
+		URL:       "http://example.com/file.zip",
+		DestPath:  "/tmp/file.zip",
+		Filename:  "file.zip",
+		TotalSize: 1000,
+	}
+	savedState := &types.DownloadState{
+		ID:        "test-id",
+		URL:       "http://example.com/file.zip",
+		DestPath:  "/tmp/file.zip",
+		Filename:  "file.zip",
+		TotalSize: 1000,
+		Downloaded: 500,
+	}
+
+	cfg := buildResumeConfig("test-id", "/tmp", entry, savedState, settings)
+	if cfg.Runtime.Workers != 0 {
+		t.Fatalf("expected Runtime.Workers=0 (unset), got %d", cfg.Runtime.Workers)
+	}
+	defaultRuntime := settings.ToRuntimeConfig()
+	if cfg.Runtime.MinChunkSize != defaultRuntime.MinChunkSize {
+		t.Fatalf("expected Runtime.MinChunkSize=%d (global default), got %d", defaultRuntime.MinChunkSize, cfg.Runtime.MinChunkSize)
+	}
+}

--- a/internal/tui/category_regressions_test.go
+++ b/internal/tui/category_regressions_test.go
@@ -38,7 +38,7 @@ func TestStartDownload_RoutesDefaultPathWithURLDerivedFilename(t *testing.T) {
 	}
 
 	m := newCategoryTestModel(t, settings)
-	m, _ = m.startDownload("https://example.com/screenshot.jpg", nil, nil, rootDir, true, "", "")
+	m, _ = m.startDownload("https://example.com/screenshot.jpg", nil, nil, rootDir, true, "", "", 0, 0)
 
 	if len(m.downloads) != 1 {
 		t.Fatalf("expected 1 download, got %d", len(m.downloads))

--- a/internal/tui/delete_resilience_test.go
+++ b/internal/tui/delete_resilience_test.go
@@ -26,10 +26,10 @@ func (m *mockService) Purge(id string) error {
 
 func (m *mockService) List() ([]types.DownloadStatus, error)   { return nil, nil }
 func (m *mockService) History() ([]types.DownloadEntry, error) { return nil, nil }
-func (m *mockService) Add(url string, path string, filename string, mirrors []string, headers map[string]string, isExplicitCategory bool, totalSize int64, supportsRange bool) (string, error) {
+func (m *mockService) Add(url string, path string, filename string, mirrors []string, headers map[string]string, isExplicitCategory bool, workers int, minChunkSize int64, totalSize int64, supportsRange bool) (string, error) {
 	return "", nil
 }
-func (m *mockService) AddWithID(url string, path string, filename string, mirrors []string, headers map[string]string, id string, totalSize int64, supportsRange bool) (string, error) {
+func (m *mockService) AddWithID(url string, path string, filename string, mirrors []string, headers map[string]string, id string, workers int, minChunkSize int64, totalSize int64, supportsRange bool) (string, error) {
 	return "", nil
 }
 func (m *mockService) ResumeBatch(ids []string) []error { return nil }

--- a/internal/tui/download_requests.go
+++ b/internal/tui/download_requests.go
@@ -32,6 +32,8 @@ func (m RootModel) handleDownloadRequestMsg(msg events.DownloadRequestMsg, queue
 		m.pendingPath = path
 		m.pendingIsDefaultPath = isDefaultPath
 		m.pendingFilename = msg.Filename
+		m.pendingWorkers = msg.Workers
+		m.pendingMinChunkSize = msg.MinChunkSize
 		m.duplicateInfo = duplicate.Filename
 		m.state = DuplicateWarningState
 		return m, nil
@@ -44,6 +46,8 @@ func (m RootModel) handleDownloadRequestMsg(msg events.DownloadRequestMsg, queue
 		m.pendingPath = path
 		m.pendingIsDefaultPath = isDefaultPath
 		m.pendingFilename = msg.Filename
+		m.pendingWorkers = msg.Workers
+		m.pendingMinChunkSize = msg.MinChunkSize
 		m.inputs[2].SetValue(path)
 		m.inputs[3].SetValue(msg.Filename)
 		m.focusedInput = 2
@@ -55,7 +59,7 @@ func (m RootModel) handleDownloadRequestMsg(msg events.DownloadRequestMsg, queue
 		return m, nil
 	}
 
-	return m.startDownload(msg.URL, msg.Mirrors, msg.Headers, path, isDefaultPath, msg.Filename, msg.ID)
+	return m.startDownload(msg.URL, msg.Mirrors, msg.Headers, path, isDefaultPath, msg.Filename, msg.ID, msg.Workers, msg.MinChunkSize)
 }
 
 func (m RootModel) handleBatchDownloadRequestMsg(msg events.BatchDownloadRequestMsg, queueIfBusy bool) (tea.Model, tea.Cmd) {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -149,6 +149,8 @@ type RootModel struct {
 	pendingFilename      string   // Filename pending confirmation
 	pendingMirrors       []string // Mirrors pending confirmation
 	pendingHeaders       map[string]string
+	pendingWorkers       int    // Per-task worker override pending confirmation
+	pendingMinChunkSize  int64  // Per-task min chunk size override pending confirmation
 	duplicateInfo        string // Info about the duplicate
 
 	// Graph Data

--- a/internal/tui/override_threading_test.go
+++ b/internal/tui/override_threading_test.go
@@ -1,0 +1,254 @@
+package tui
+
+import (
+	"context"
+	"testing"
+
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"github.com/SurgeDM/Surge/internal/config"
+	"github.com/SurgeDM/Surge/internal/core"
+	"github.com/SurgeDM/Surge/internal/download"
+	"github.com/SurgeDM/Surge/internal/engine/events"
+	"github.com/SurgeDM/Surge/internal/processing"
+)
+
+func newOverrideTestModel(t *testing.T, addFunc processing.AddDownloadFunc) RootModel {
+	t.Helper()
+	ch := make(chan any, 16)
+	pool := download.NewWorkerPool(ch, 1)
+	svc := core.NewLocalDownloadServiceWithInput(pool, ch)
+	t.Cleanup(func() { _ = svc.Shutdown() })
+
+	orchestrator := processing.NewLifecycleManager(addFunc, nil)
+	return RootModel{
+		Settings:      config.DefaultSettings(),
+		Service:       svc,
+		Orchestrator:  orchestrator,
+		list:          NewDownloadList(80, 20),
+		keys:          config.DefaultKeyMap(),
+		inputs:        []textinput.Model{textinput.New(), textinput.New(), textinput.New(), textinput.New()},
+		enqueueCtx:    context.Background(),
+		cancelEnqueue: func() {},
+	}
+}
+
+func executeCmds(cmd tea.Cmd) {
+	if cmd == nil {
+		return
+	}
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, c := range batch {
+			executeCmds(c)
+		}
+	}
+}
+
+func TestOverride_ExtensionConfirmPreservesWorkersAndMinChunkSize(t *testing.T) {
+	var capturedWorkers int
+	var capturedMinChunkSize int64
+
+	addFunc := func(url, path, filename string, mirrors []string, headers map[string]string, isExplicit bool, workers int, minChunkSize int64, fileSize int64, supportsRange bool) (string, error) {
+		capturedWorkers = workers
+		capturedMinChunkSize = minChunkSize
+		return "real-id", nil
+	}
+
+	m := newOverrideTestModel(t, addFunc)
+	m.Settings.Extension.ExtensionPrompt.Value = true
+	m.Settings.General.WarnOnDuplicate.Value = false
+
+	msg := events.DownloadRequestMsg{
+		URL:          "http://example.com/file.zip",
+		Filename:     "file.zip",
+		Path:         t.TempDir(),
+		Workers:      8,
+		MinChunkSize: 1 << 20,
+	}
+
+	updated, _ := m.Update(msg)
+	root := updated.(RootModel)
+
+	if root.state != ExtensionConfirmationState {
+		t.Fatalf("expected ExtensionConfirmationState, got %v", root.state)
+	}
+	if root.pendingWorkers != 8 {
+		t.Fatalf("pendingWorkers = %d, want 8", root.pendingWorkers)
+	}
+	if root.pendingMinChunkSize != 1<<20 {
+		t.Fatalf("pendingMinChunkSize = %d, want %d", root.pendingMinChunkSize, 1<<20)
+	}
+
+	root.inputs[2].SetValue(msg.Path)
+	root.inputs[3].SetValue(msg.Filename)
+
+	updated, cmd := root.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	root = updated.(RootModel)
+	executeCmds(cmd)
+
+	if capturedWorkers != 8 {
+		t.Fatalf("capturedWorkers = %d, want 8", capturedWorkers)
+	}
+	if capturedMinChunkSize != 1<<20 {
+		t.Fatalf("capturedMinChunkSize = %d, want %d", capturedMinChunkSize, 1<<20)
+	}
+}
+
+func TestOverride_DuplicateContinuePreservesWorkersAndMinChunkSize(t *testing.T) {
+	var capturedWorkers int
+	var capturedMinChunkSize int64
+
+	addFunc := func(url, path, filename string, mirrors []string, headers map[string]string, isExplicit bool, workers int, minChunkSize int64, fileSize int64, supportsRange bool) (string, error) {
+		capturedWorkers = workers
+		capturedMinChunkSize = minChunkSize
+		return "real-id", nil
+	}
+
+	m := newOverrideTestModel(t, addFunc)
+	m.Settings.Extension.ExtensionPrompt.Value = false
+	m.Settings.General.WarnOnDuplicate.Value = true
+
+	m.downloads = append(m.downloads, &DownloadModel{
+		URL:      "http://example.com/file.zip",
+		Filename: "file.zip",
+	})
+
+	msg := events.DownloadRequestMsg{
+		URL:          "http://example.com/file.zip",
+		Filename:     "file.zip",
+		Path:         t.TempDir(),
+		Workers:      4,
+		MinChunkSize: 512 * 1024,
+	}
+
+	updated, _ := m.Update(msg)
+	root := updated.(RootModel)
+
+	if root.state != DuplicateWarningState {
+		t.Fatalf("expected DuplicateWarningState, got %v", root.state)
+	}
+	if root.pendingWorkers != 4 {
+		t.Fatalf("pendingWorkers = %d, want 4", root.pendingWorkers)
+	}
+	if root.pendingMinChunkSize != 512*1024 {
+		t.Fatalf("pendingMinChunkSize = %d, want %d", root.pendingMinChunkSize, 512*1024)
+	}
+
+	updated, cmd := root.Update(tea.KeyPressMsg{Code: 'c', Text: "c"})
+	root = updated.(RootModel)
+	executeCmds(cmd)
+
+	if capturedWorkers != 4 {
+		t.Fatalf("capturedWorkers = %d, want 4", capturedWorkers)
+	}
+	if capturedMinChunkSize != 512*1024 {
+		t.Fatalf("capturedMinChunkSize = %d, want %d", capturedMinChunkSize, 512*1024)
+	}
+}
+
+func TestOverride_ManualURLDuplicateDoesNotInheritStaleOverride(t *testing.T) {
+	var capturedWorkers int
+	var capturedMinChunkSize int64
+
+	addFunc := func(url, path, filename string, mirrors []string, headers map[string]string, isExplicit bool, workers int, minChunkSize int64, fileSize int64, supportsRange bool) (string, error) {
+		capturedWorkers = workers
+		capturedMinChunkSize = minChunkSize
+		return "real-id", nil
+	}
+
+	m := newOverrideTestModel(t, addFunc)
+	m.Settings.Extension.ExtensionPrompt.Value = false
+	m.Settings.General.WarnOnDuplicate.Value = true
+
+	m.pendingWorkers = 16
+	m.pendingMinChunkSize = 2 << 20
+
+	m.downloads = append(m.downloads, &DownloadModel{
+		URL:      "http://example.com/dup.zip",
+		Filename: "dup.zip",
+	})
+
+	m.state = InputState
+	m.focusedInput = 3
+	m.inputs[0].SetValue("http://example.com/dup.zip")
+	m.inputs[2].SetValue(t.TempDir())
+	m.inputs[3].SetValue("dup.zip")
+
+	updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	root := updated.(RootModel)
+
+	if root.state != DuplicateWarningState {
+		t.Fatalf("expected DuplicateWarningState, got %v", root.state)
+	}
+	if root.pendingWorkers != 0 {
+		t.Fatalf("pendingWorkers = %d, want 0 (stale override leaked)", root.pendingWorkers)
+	}
+	if root.pendingMinChunkSize != 0 {
+		t.Fatalf("pendingMinChunkSize = %d, want 0 (stale override leaked)", root.pendingMinChunkSize)
+	}
+
+	updated, cmd := root.Update(tea.KeyPressMsg{Code: 'c', Text: "c"})
+	root = updated.(RootModel)
+	executeCmds(cmd)
+
+	if capturedWorkers != 0 {
+		t.Fatalf("capturedWorkers = %d, want 0 (stale override leaked to engine)", capturedWorkers)
+	}
+	if capturedMinChunkSize != 0 {
+		t.Fatalf("capturedMinChunkSize = %d, want 0 (stale override leaked to engine)", capturedMinChunkSize)
+	}
+}
+
+func TestOverride_BatchConfirmPreservesWorkersAndMinChunkSize(t *testing.T) {
+	var captured []struct {
+		workers      int
+		minChunkSize int64
+	}
+
+	addFunc := func(url, path, filename string, mirrors []string, headers map[string]string, isExplicit bool, workers int, minChunkSize int64, fileSize int64, supportsRange bool) (string, error) {
+		captured = append(captured, struct {
+			workers      int
+			minChunkSize int64
+		}{workers, minChunkSize})
+		return "real-id-" + url, nil
+	}
+
+	m := newOverrideTestModel(t, addFunc)
+	m.Settings.General.WarnOnDuplicate.Value = false
+
+	batchPath := t.TempDir()
+	batchMsg := events.BatchDownloadRequestMsg{
+		Path: batchPath,
+		Requests: []events.DownloadRequestMsg{
+			{URL: "http://example.com/one.zip", Filename: "one.zip", Path: batchPath, Workers: 2, MinChunkSize: 256 * 1024},
+			{URL: "http://example.com/two.zip", Filename: "two.zip", Path: batchPath, Workers: 6, MinChunkSize: 1 << 20},
+		},
+	}
+
+	updated, _ := m.Update(batchMsg)
+	root := updated.(RootModel)
+
+	if root.state != BatchConfirmState {
+		t.Fatalf("expected BatchConfirmState, got %v", root.state)
+	}
+	if len(root.pendingBatchRequests) != 2 {
+		t.Fatalf("expected 2 pending batch requests, got %d", len(root.pendingBatchRequests))
+	}
+
+	root.inputs[2].SetValue(batchPath)
+
+	updated, cmd := root.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	root = updated.(RootModel)
+	executeCmds(cmd)
+
+	if len(captured) != 2 {
+		t.Fatalf("expected 2 captured enqueues, got %d", len(captured))
+	}
+	if captured[0].workers != 2 || captured[0].minChunkSize != 256*1024 {
+		t.Fatalf("item 0: workers=%d minChunkSize=%d, want 2 and %d", captured[0].workers, captured[0].minChunkSize, 256*1024)
+	}
+	if captured[1].workers != 6 || captured[1].minChunkSize != 1<<20 {
+		t.Fatalf("item 1: workers=%d minChunkSize=%d, want 6 and %d", captured[1].workers, captured[1].minChunkSize, 1<<20)
+	}
+}

--- a/internal/tui/path_test.go
+++ b/internal/tui/path_test.go
@@ -31,7 +31,7 @@ func TestStartDownload_EnforcesAbsolutePath(t *testing.T) {
 	relPath := "subdir"
 	url := "http://example.com/file.zip"
 
-	m, _ = m.startDownload(url, nil, nil, relPath, false, "file.zip", "test-id-1")
+	m, _ = m.startDownload(url, nil, nil, relPath, false, "file.zip", "test-id-1", 0, 0)
 
 	// We expect the new download to be appended
 	if len(m.downloads) != 1 {

--- a/internal/tui/process.go
+++ b/internal/tui/process.go
@@ -78,7 +78,7 @@ func (m *RootModel) processProgressMsg(msg events.ProgressMsg) tea.Cmd {
 }
 
 // startDownload initiates a new download
-func (m RootModel) startDownload(url string, mirrors []string, headers map[string]string, path string, isDefaultPath bool, filename, id string) (RootModel, tea.Cmd) {
+func (m RootModel) startDownload(url string, mirrors []string, headers map[string]string, path string, isDefaultPath bool, filename, id string, workers int, minChunkSize int64) (RootModel, tea.Cmd) {
 	if m.Service == nil {
 		m.addLogEntry(LogStyleError.Render("\u2716 Service unavailable"))
 		return m, nil
@@ -114,6 +114,8 @@ func (m RootModel) startDownload(url string, mirrors []string, headers map[strin
 		Headers:            headers,
 		IsExplicitCategory: !isDefaultPath,
 		SkipApproval:       true,
+		Workers:            workers,
+		MinChunkSize:       minChunkSize,
 	}
 
 	optimisticID := requestID
@@ -155,8 +157,8 @@ func (m RootModel) startDownload(url string, mirrors []string, headers map[strin
 				mirrors,
 				headers,
 				requestID,
-				0,
-				0,
+				workers,
+				minChunkSize,
 				0,
 				false,
 			)
@@ -168,8 +170,8 @@ func (m RootModel) startDownload(url string, mirrors []string, headers map[strin
 				mirrors,
 				headers,
 				!isDefaultPath,
-				0,
-				0,
+				workers,
+				minChunkSize,
 				0,
 				false,
 			)

--- a/internal/tui/process.go
+++ b/internal/tui/process.go
@@ -156,6 +156,8 @@ func (m RootModel) startDownload(url string, mirrors []string, headers map[strin
 				headers,
 				requestID,
 				0,
+				0,
+				0,
 				false,
 			)
 		} else {
@@ -166,6 +168,8 @@ func (m RootModel) startDownload(url string, mirrors []string, headers map[strin
 				mirrors,
 				headers,
 				!isDefaultPath,
+				0,
+				0,
 				0,
 				false,
 			)

--- a/internal/tui/resume_lifecycle_test.go
+++ b/internal/tui/resume_lifecycle_test.go
@@ -65,7 +65,7 @@ func TestResume_RespectsOriginalPath_WhenDefaultChanges(t *testing.T) {
 	testFilename := "file.zip"
 
 	// Start download with relative path "."
-	m, _ = m.startDownload(testURL, nil, nil, ".", true, testFilename, "id-1")
+	m, _ = m.startDownload(testURL, nil, nil, ".", true, testFilename, "id-1", 0, 0)
 
 	// 4. Verify Immediate State
 	if len(m.downloads) != 1 {

--- a/internal/tui/update_input.go
+++ b/internal/tui/update_input.go
@@ -104,6 +104,8 @@ func (m RootModel) submitInputForm() (tea.Model, tea.Cmd) {
 		m.pendingPath = path
 		m.pendingIsDefaultPath = isDefaultPath
 		m.pendingFilename = filename
+		m.pendingWorkers = 0
+		m.pendingMinChunkSize = 0
 		m.duplicateInfo = d.Filename
 		m.state = DuplicateWarningState
 		return m, nil
@@ -115,7 +117,7 @@ func (m RootModel) submitInputForm() (tea.Model, tea.Cmd) {
 	m.inputs[2].SetValue(path) // Keep path for next download
 	m.inputs[3].SetValue("")
 
-	return m.startDownload(url, mirrors, nil, path, isDefaultPath, filename, "")
+	return m.startDownload(url, mirrors, nil, path, isDefaultPath, filename, "", 0, 0)
 }
 
 // parseURLInput splits a comma-separated URL string into a primary URL and mirrors.
@@ -172,7 +174,7 @@ func (m RootModel) updateExtensionConfirmation(msg tea.KeyPressMsg) (tea.Model, 
 		}
 
 		m.state = DashboardState
-		updated, cmd := m.startDownload(m.pendingURL, m.pendingMirrors, m.pendingHeaders, m.pendingPath, m.pendingIsDefaultPath, m.pendingFilename, "")
+		updated, cmd := m.startDownload(m.pendingURL, m.pendingMirrors, m.pendingHeaders, m.pendingPath, m.pendingIsDefaultPath, m.pendingFilename, "", m.pendingWorkers, m.pendingMinChunkSize)
 		nextModel, nextCmd := updated.showNextPendingRequest()
 		return nextModel, tea.Batch(cmd, nextCmd)
 	}

--- a/internal/tui/update_modals.go
+++ b/internal/tui/update_modals.go
@@ -165,7 +165,7 @@ func (m RootModel) updateDuplicateWarning(msg tea.KeyPressMsg) (tea.Model, tea.C
 	if key.Matches(msg, m.keys.Duplicate.Continue) {
 		// Continue anyway - startDownload handles unique filename generation
 		m.state = DashboardState
-		updated, cmd := m.startDownload(m.pendingURL, m.pendingMirrors, m.pendingHeaders, m.pendingPath, m.pendingIsDefaultPath, m.pendingFilename, "")
+		updated, cmd := m.startDownload(m.pendingURL, m.pendingMirrors, m.pendingHeaders, m.pendingPath, m.pendingIsDefaultPath, m.pendingFilename, "", m.pendingWorkers, m.pendingMinChunkSize)
 		nextModel, nextCmd := updated.showNextPendingRequest()
 		return nextModel, tea.Batch(cmd, nextCmd)
 	}
@@ -251,7 +251,7 @@ func (m RootModel) updateBatchConfirm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 				continue
 			}
 			var cmd tea.Cmd
-			m, cmd = m.startDownload(request.URL, request.Mirrors, request.Headers, requestPath, isDefaultPath, request.Filename, request.ID)
+			m, cmd = m.startDownload(request.URL, request.Mirrors, request.Headers, requestPath, isDefaultPath, request.Filename, request.ID, request.Workers, request.MinChunkSize)
 			if cmd != nil {
 				batchCmds = append(batchCmds, cmd)
 			}
@@ -264,7 +264,7 @@ func (m RootModel) updateBatchConfirm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 				continue
 			}
 			var cmd tea.Cmd
-			m, cmd = m.startDownload(url, nil, nil, path, true, "", "")
+			m, cmd = m.startDownload(url, nil, nil, path, true, "", "", 0, 0)
 			if cmd != nil {
 				batchCmds = append(batchCmds, cmd)
 			}

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -677,7 +677,7 @@ func TestStartDownload_UsesProvidedIDWhenServiceSupportsIt(t *testing.T) {
 	}
 
 	requestID := "request-id-123"
-	updated, _ := m.startDownload("https://example.com/file.bin", nil, nil, t.TempDir(), false, "file.bin", requestID)
+	updated, _ := m.startDownload("https://example.com/file.bin", nil, nil, t.TempDir(), false, "file.bin", requestID, 0, 0)
 
 	if len(updated.downloads) != 1 {
 		t.Fatalf("expected 1 queued download, got %d", len(updated.downloads))
@@ -714,7 +714,7 @@ func TestStartDownload_UsesModelEnqueueContext(t *testing.T) {
 		logViewport:   viewport.New(viewport.WithWidth(40), viewport.WithHeight(5)),
 	}
 
-	updated, cmd := m.startDownload("https://example.com/file.bin", nil, nil, t.TempDir(), false, "file.bin", "")
+	updated, cmd := m.startDownload("https://example.com/file.bin", nil, nil, t.TempDir(), false, "file.bin", "", 0, 0)
 	if cmd == nil {
 		t.Fatal("expected enqueue command")
 	}
@@ -754,7 +754,7 @@ func TestStartDownload_GuessesFilenameOptimisticallyWhenProvidedOrInferred(t *te
 		logViewport:  viewport.New(viewport.WithWidth(40), viewport.WithHeight(5)),
 	}
 
-	updated, _ := m.startDownload("https://example.com/100MB.bin", nil, nil, targetDir, true, "", "")
+	updated, _ := m.startDownload("https://example.com/100MB.bin", nil, nil, targetDir, true, "", "", 0, 0)
 
 	if len(updated.downloads) != 1 {
 		t.Fatalf("expected 1 optimistic queued download, got %d", len(updated.downloads))
@@ -790,7 +790,7 @@ func TestStartDownload_UsesGenericQueuedNameForExplicitFilenameUntilLifecycleCon
 		logViewport:  viewport.New(viewport.WithWidth(40), viewport.WithHeight(5)),
 	}
 
-	updated, _ := m.startDownload("https://example.com/archive.zip", nil, nil, targetDir, false, "archive.zip", "")
+	updated, _ := m.startDownload("https://example.com/archive.zip", nil, nil, targetDir, false, "archive.zip", "", 0, 0)
 
 	if len(updated.downloads) != 1 {
 		t.Fatalf("expected 1 optimistic queued download, got %d", len(updated.downloads))
@@ -1067,7 +1067,7 @@ func TestWithEnqueueContext_OverridesStartDownloadContext(t *testing.T) {
 	m := InitialRootModel(1700, "test-version", svc, orchestrator, false)
 	m = m.WithEnqueueContext(ctx, func() {})
 
-	_, cmd := m.startDownload("https://example.com/file.bin", nil, nil, t.TempDir(), false, "file.bin", "")
+	_, cmd := m.startDownload("https://example.com/file.bin", nil, nil, t.TempDir(), false, "file.bin", "", 0, 0)
 	if cmd == nil {
 		t.Fatal("expected enqueue command")
 	}

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -697,7 +697,7 @@ func TestStartDownload_UsesModelEnqueueContext(t *testing.T) {
 	cancel()
 
 	orchestrator := processing.NewLifecycleManager(
-		func(string, string, string, []string, map[string]string, bool, int64, bool) (string, error) {
+		func(string, string, string, []string, map[string]string, bool, int, int64, int64, bool) (string, error) {
 			t.Fatal("enqueue dispatch should not run after context cancellation")
 			return "", nil
 		},
@@ -739,7 +739,7 @@ func TestStartDownload_GuessesFilenameOptimisticallyWhenProvidedOrInferred(t *te
 	})
 
 	orchestrator := processing.NewLifecycleManager(
-		func(string, string, string, []string, map[string]string, bool, int64, bool) (string, error) {
+		func(string, string, string, []string, map[string]string, bool, int, int64, int64, bool) (string, error) {
 			return "real-id", nil
 		},
 		nil,
@@ -775,7 +775,7 @@ func TestStartDownload_UsesGenericQueuedNameForExplicitFilenameUntilLifecycleCon
 	})
 
 	orchestrator := processing.NewLifecycleManager(
-		func(string, string, string, []string, map[string]string, bool, int64, bool) (string, error) {
+		func(string, string, string, []string, map[string]string, bool, int, int64, int64, bool) (string, error) {
 			return "real-id", nil
 		},
 		nil,
@@ -1057,7 +1057,7 @@ func TestWithEnqueueContext_OverridesStartDownloadContext(t *testing.T) {
 	cancel()
 
 	orchestrator := processing.NewLifecycleManager(
-		func(string, string, string, []string, map[string]string, bool, int64, bool) (string, error) {
+		func(string, string, string, []string, map[string]string, bool, int, int64, int64, bool) (string, error) {
 			t.Fatal("enqueue dispatch should not run after shared context cancellation")
 			return "", nil
 		},


### PR DESCRIPTION
Hi Surge team! Thanks for building such an incredibly robust and fast engine. We are building a project that integrates with Surge's backend, and we love the direction it's heading. We'd like to contribute a small but impactful enhancement to the download request pipeline.

### Motivation
When integrating with download engines via RPC, external orchestrators often require deterministic control over worker allocation and chunk sizes. Rather than relying solely on static file-size heuristics, client applications may need to dynamically allocate threads based on available bandwidth, specific server restrictions, or real-time network conditions.

Currently, Surge’s backend beautifully handles maximum global connections, but it strictly relies on a `√size` heuristic for per-task worker allocation. We've introduced a minimal, backward-compatible override that allows API callers to inject precise `Workers` and `MinChunkSize` parameters per download. This aligns Surge with universal daemon patterns (similar to `aria2c`'s `split` and `min-split-size` RPC parameters) while seamlessly falling back to the default heuristic when unset.

**Target vs Ceiling:** 
A key design decision here is that `Workers` specifies a precise **target**, not a ceiling. When set, the engine uses *exactly* that many connections (still safely clamped by `MaxConnectionsPerDownload` and `MinChunkSize`), rather than dynamically computing them via the `√size` heuristic. This allows external applications to strictly enforce thread counts without racing against global configuration changes.

### Alignment with Engine Roadmap
Noting the discussion in **#331** regarding the roadmap to eventually **"extract surge core"** for GUI wrappers, exposing these granular parameters is a foundational step. 
- **For extracted engines:** When an engine operates as an independent library or daemon, external GUIs need exact target values to implement predictable, deterministic scheduling, rather than just setting a ceiling and letting the engine guess.
- **For dynamic scaling:** Laying the groundwork for per-task overrides opens the door for future dynamic parameter tuning (e.g., adaptive thread scaling mid-flight) by ensuring the underlying engine can accept and strictly respect external constraints.

### Verification & Testing
- **Manual Debugging**: We temporarily injected a probe into `downloader.go` immediately following `getInitialConnections` and ran the daemon in `server` mode. We dispatched a ~23MB download via the API with `workers: 16` and `min_chunk_size: 1048576`. The engine successfully overrode the heuristic and spawned exactly 16 workers, completing the task at ~17.6MB/s.
- **Unit Tests**: Added comprehensive test coverage for the heuristic override, bounds clamping, parameter threading, and configuration overlay. 
- **Automated Tests**: `go test ./...` and `go test -race ./...` both pass successfully for our modified packages. *(Note: A pre-existing environment-specific failure exists in `TestWindowsPathsIgnoreRelativeAppData` on Windows, which is orthogonal to these core engine changes).*

---

*(The following technical summary was generated by AI)*

## Summary

Add optional per-task `Workers` and `MinChunkSize` fields to Surge's download pipeline, enabling external callers to specify exact worker counts and chunk sizes on a per-download basis. When unset (zero-value), behavior is unchanged.

- **engine/types**: New `Workers` field on `RuntimeConfig` with zero-value sentinel for "use heuristic"
- **engine/concurrent**: `getInitialConnections()` overrides √size heuristic when `Workers > 0`, still clamped by `MaxConnectionsPerDownload` and `MinChunkSize`
- **processing**: `DownloadRequest` gains `Workers`/`MinChunkSize` fields; function signatures and `Enqueue`/`EnqueueWithID` thread them through
- **core**: `DownloadService` interface updated; `LocalDownloadService` overlays non-zero values onto `RuntimeConfig` per task; `RemoteDownloadService` forwards them in HTTP payloads
- **cmd**: HTTP API `DownloadRequest` gains `workers`/`min_chunk_size` JSON fields
- **tui**: Legacy call sites pass zero values (no TUI support yet)
- **tests**: All mocks/signatures updated; new unit tests cover √size override, clamping, override threading, and RuntimeConfig overlay

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds optional per-task `Workers` and `MinChunkSize` overrides to Surge's download pipeline, enabling API callers to specify exact worker counts and chunk sizes on a per-download basis. When the fields are zero (the default), all existing heuristic behaviour is unchanged.

- `RuntimeConfig` gains a `Workers` field (zero = use √size heuristic); `getInitialConnections` checks it before the heuristic path and still clamps by `MaxConnectionsPerDownload` and `MinChunkSize`.
- `DownloadRequest`, `DownloadState`, `DownloadEntry`, and every event message in the lifecycle chain are extended with `Workers`/`MinChunkSize`; values are persisted through pause/resume via `buildResumeConfig`, which prefers `savedState` over the master-list `entry`.
- The HTTP API, TUI, and `LocalDownloadService`/`RemoteDownloadService` are all updated; TUI call sites pass zero (no UI for these fields yet) while API-initiated paths forward the caller-provided values end-to-end.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the feature is purely additive with zero-value fallback to existing behaviour, and the full lifecycle path (enqueue → start → pause → resume → complete) is covered by the new tests.

The override values are threaded consistently through all dispatch paths, persisted in both DownloadState and DownloadEntry, and correctly restored by buildResumeConfig. The download/manager.go correctly populates Workers/MinChunkSize in DownloadStartedMsg from cfg.Runtime, so the master list is never silently zeroed after start. All changed call sites compile with the new signatures, and the new test files cover the key correctness properties including clamping, zero-value passthrough, savedState priority, and entry fallback.

No files require special attention; the one minor observation (redundant maxConns clamp in local_service.go vs getInitialConnections) is non-blocking.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/engine/concurrent/downloader.go | Adds Workers override path in getInitialConnections; clamped by maxConns and minChunkSize. Also persists Workers/MinChunkSize to DownloadState on pause. |
| internal/engine/types/config.go | Adds Workers field to RuntimeConfig with zero-value-means-heuristic sentinel; GetWorkers() helper; DefaultRuntimeConfig sets Workers=0. |
| internal/engine/types/models.go | Adds Workers/MinChunkSize fields (with omitempty) to DownloadState and DownloadEntry for persistence and resume recovery. |
| internal/core/local_service.go | Threads workers/minChunkSize through the add() call chain; clamps workers against MaxConnectionsPerDownload before setting runtime.Workers. |
| internal/core/remote_service.go | Conditionally includes workers/min_chunk_size in HTTP payloads only when > 0; correct opt-in serialization. |
| internal/processing/events.go | Propagates Workers/MinChunkSize through all lifecycle event handlers (queued, started, paused, completed, finalization error). |
| internal/processing/pause_resume.go | buildResumeConfig restores Workers/MinChunkSize from savedState (preferred) or entry fallback, correctly re-applying overrides on resume. |
| internal/processing/manager.go | Extends AddDownloadFunc/AddDownloadWithIDFunc signatures; threads Workers/MinChunkSize through Enqueue and EnqueueWithID into the queue layer. |
| cmd/root_downloads.go | HTTP DownloadRequest gains workers/min_chunk_size JSON fields; forwarded through all dispatch paths (single, batch, approval, enqueue). |
| internal/tui/process.go | startDownload signature gains workers/minChunkSize parameters; TUI form calls pass 0,0 while API-initiated calls forward the received overrides. |
| internal/engine/state/state.go | SaveStateWithOptions now copies Workers/MinChunkSize from DownloadState into the master list entry when updating state. |
| internal/engine/concurrent/get_initial_connections_test.go | New test file covering workers override, maxConns clamping, minChunkSize clamping, and heuristic fallback paths. |
| internal/processing/pause_resume_override_test.go | New test file verifying buildResumeConfig restores overrides from savedState (priority) or entry fallback, and defaults when neither is set. |
| internal/tui/override_threading_test.go | New test file (254 lines) covering end-to-end threading of override values through extension confirmation, duplicate-warning, and batch-confirm TUI flows. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `internal/tui/process.go`, line 156-177 ([link](https://github.com/surgedm/surge/blob/2c4091df596bd22586a2af78af1f12ad6a399ec0/internal/tui/process.go#L156-L177)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Positional zero arguments reduce call-site legibility**

   Both TUI call sites now pass `0, 0, 0, false` as the last four positional arguments (`workers`, `minChunkSize`, `totalSize`, `supportsRange`). The same pattern appears across several other stubs (e.g., `connect_test.go`, `headless_approval_test.go`). As the `AddDownloadFunc`/`AddWithIDFunc` types accumulate parameters, callers become hard to audit without consulting the definition.

   Consider introducing a lightweight `DownloadParams` struct (or reusing `processing.DownloadRequest`) so call sites read as named fields rather than ordered literals — similar to how other parts of the engine use `types.DownloadConfig`.

   **Rule Used:** # Code Review Rule: Suggest Architectural Improvem... ([source](https://app.greptile.com/surge-org-3/-/custom-context?memory=4d82344e-33c4-4e14-bbc7-81d79af11b7e))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: internal/tui/process.go
   Line: 156-177
   
   Comment:
   **Positional zero arguments reduce call-site legibility**
   
   Both TUI call sites now pass `0, 0, 0, false` as the last four positional arguments (`workers`, `minChunkSize`, `totalSize`, `supportsRange`). The same pattern appears across several other stubs (e.g., `connect_test.go`, `headless_approval_test.go`). As the `AddDownloadFunc`/`AddWithIDFunc` types accumulate parameters, callers become hard to audit without consulting the definition.
   
   Consider introducing a lightweight `DownloadParams` struct (or reusing `processing.DownloadRequest`) so call sites read as named fields rather than ordered literals — similar to how other parts of the engine use `types.DownloadConfig`.
   
   **Rule Used:** # Code Review Rule: Suggest Architectural Improvem... ([source](https://app.greptile.com/surge-org-3/-/custom-context?memory=4d82344e-33c4-4e14-bbc7-81d79af11b7e))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

2. `internal/core/remote_service.go`, line 448-460 ([link](https://github.com/surgedm/surge/blob/2c4091df596bd22586a2af78af1f12ad6a399ec0/internal/core/remote_service.go#L448-L460)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Zero-value fields are always serialised in the HTTP payload**

   Both `Add` and `AddWithID` unconditionally include `"workers": 0` and `"min_chunk_size": 0` in the JSON map even when the caller provides no overrides. The server side is safe (the `> 0` guard in `local_service.go` ignores zeros), but the payload carries unnecessary keys on every remote call. Conditional inclusion (only when `> 0`) or omitting them altogether when zero would keep the wire format minimal and prevent confusion if a future server version interprets an explicit `0` differently from an absent field.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/core/remote_service.go
   Line: 448-460

   Comment:
   **Zero-value fields are always serialised in the HTTP payload**

   Both `Add` and `AddWithID` unconditionally include `"workers": 0` and `"min_chunk_size": 0` in the JSON map even when the caller provides no overrides. The server side is safe (the `> 0` guard in `local_service.go` ignores zeros), but the payload carries unnecessary keys on every remote call. Conditional inclusion (only when `> 0`) or omitting them altogether when zero would keep the wire format minimal and prevent confusion if a future server version interprets an explicit `0` differently from an absent field.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["test: add MinChunkSize savedState&gt;entry ..."](https://github.com/surgedm/surge/commit/3521ae7cd42e7921facf803dbde9352973fd9250) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38818782)</sub>

**Context used:**

- Rule used - What: Eliminate duplicate logic, functions, or cod... ([source](https://app.greptile.com/surge-org-3/-/custom-context?memory=f0a796a9-684f-4dfb-a5cf-8c99c16b63a1))

<!-- /greptile_comment -->