### PR TITLE
ci: implement automatic upload to chrome webstore

### DIFF
--- a/.github/workflows/extension.yml
+++ b/.github/workflows/extension.yml
@@ -69,6 +69,16 @@ jobs:
           FIREFOX_JWT_ISSUER: ${{ secrets.AMO_JWT_ISSUER }}
           FIREFOX_JWT_SECRET: ${{ secrets.AMO_JWT_SECRET }}
           FIREFOX_EXTENSION_ID: surge@surge-downloader.com
+      - name: Submit to Chrome Web Store
+        if: matrix.browser == 'chrome' && startsWith(github.ref, 'refs/tags/ext-v')
+        run: |
+          npx wxt submit \
+            --chrome-zip output/*-chrome.zip
+        env:
+          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
 
   release:
     name: Create Release

--- a/.github/workflows/extension.yml
+++ b/.github/workflows/extension.yml
@@ -59,26 +59,7 @@ jobs:
           name: extension-${{ matrix.browser }}
           path: extension/output/*.zip
           if-no-files-found: error
-      - name: Submit to AMO
-        if: matrix.browser == 'firefox' && startsWith(github.ref, 'refs/tags/ext-v')
-        run: |
-          npx wxt submit \
-            --firefox-zip output/*-firefox.zip \
-            --firefox-sources-zip output/*-sources.zip
-        env:
-          FIREFOX_JWT_ISSUER: ${{ secrets.AMO_JWT_ISSUER }}
-          FIREFOX_JWT_SECRET: ${{ secrets.AMO_JWT_SECRET }}
-          FIREFOX_EXTENSION_ID: surge@surge-downloader.com
-      - name: Submit to Chrome Web Store
-        if: matrix.browser == 'chrome' && startsWith(github.ref, 'refs/tags/ext-v')
-        run: |
-          npx wxt submit \
-            --chrome-zip output/*-chrome.zip
-        env:
-          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
-          CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
-          CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
-          CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+
 
   release:
     name: Create Release
@@ -100,3 +81,51 @@ jobs:
           generate_release_notes: true
           draft: false
           prerelease: false
+
+  submit:
+    name: Submit (${{ matrix.browser }})
+    needs: release
+    if: startsWith(github.ref, 'refs/tags/ext-v')
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chrome, firefox]
+    defaults:
+      run:
+        working-directory: extension
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: extension/package-lock.json
+      - run: npm ci
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: extension/output
+          pattern: extension-${{ matrix.browser }}
+          merge-multiple: true
+      - name: Submit to AMO
+        if: matrix.browser == 'firefox'
+        run: |
+          npx wxt submit \
+            --firefox-zip output/*-firefox.zip \
+            --firefox-sources-zip output/*-sources.zip
+        env:
+          FIREFOX_JWT_ISSUER: ${{ secrets.AMO_JWT_ISSUER }}
+          FIREFOX_JWT_SECRET: ${{ secrets.AMO_JWT_SECRET }}
+          FIREFOX_EXTENSION_ID: surge@surge-downloader.com
+      - name: Submit to Chrome Web Store
+        if: matrix.browser == 'chrome'
+        run: |
+          npx wxt submit \
+            --chrome-zip output/*-chrome.zip
+        env:
+          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ The Surge extension intercepts browser downloads and sends them straight to your
 
 ### Chrome / Edge / Brave
 
-1. **Stable:** [Get the Extension from Chrome Web Store](https://chrome.google.com/webstore/detail/surge) *(Pending Approval)*
+1. **Stable:** [Get the Extension from Chrome Web Store](https://chromewebstore.google.com/detail/surgedm/cakjmkhlofkhjmfkjlclgbfdklhdnkgl)
 2. **Development:**
    - Download `extension-chrome.zip` from the latest GitHub release.
    - Unzip it somewhere on disk.

--- a/README.md
+++ b/README.md
@@ -242,13 +242,15 @@ The Surge extension intercepts browser downloads and sends them straight to your
 
 ### Chrome / Edge / Brave
 
-1. Download `extension-chrome.zip` from the latest GitHub release.
-2. Unzip it somewhere on disk.
-3. Open your browser and navigate to `chrome://extensions`.
-4. Enable **"Developer mode"** in the top right corner.
-5. Click **"Load unpacked"**.
-6. Select the unzipped `extension-chrome` folder.
-7. Click the Surge icon in your browser toolbar and enter your **Auth Token** in the settings.
+1. **Stable:** [Get the Extension from Chrome Web Store](https://chrome.google.com/webstore/detail/surge) *(Pending Approval)*
+2. **Development:**
+   - Download `extension-chrome.zip` from the latest GitHub release.
+   - Unzip it somewhere on disk.
+   - Open your browser and navigate to `chrome://extensions`.
+   - Enable **"Developer mode"** in the top right corner.
+   - Click **"Load unpacked"**.
+   - Select the unzipped `extension-chrome` folder.
+   - Click the Surge icon in your browser toolbar and enter your **Auth Token** in the settings.
 
 ### Firefox
 


### PR DESCRIPTION
- **ci: add chrome web store auto-upload workflow**
- **docs: update chrome extension installation instructions**

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds automatic Chrome Web Store submission to the CI/CD pipeline and updates the README installation instructions for the Chrome extension.

- Extracts all store-submission logic from the `build` matrix into a new dedicated `submit` job that runs after `release`, with `fail-fast: false` so a failure on one store does not block the other. The Firefox AMO step migrates unchanged and the Chrome Web Store step is newly added using `wxt submit` with the four required OAuth secrets.
- Updates the Chrome/Edge/Brave README section to surface the published Chrome Web Store link as the primary (stable) install path, with the existing developer/unpacked flow demoted to a secondary option.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the workflow restructure is correct and the README link is well-formed.

The new `submit` job correctly runs after `release`, downloads the pre-built artifacts, uses `fail-fast: false` so one store's failure doesn't block the other, and wires up all four required Chrome Web Store secrets. The working-directory/artifact-path alignment is consistent with the existing Firefox AMO step. The README Chrome Web Store URL includes the full extension ID on the canonical domain.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/extension.yml | Moves store submission out of the build matrix into a new dedicated `submit` job that runs after `release`, with `fail-fast: false` and a matrix covering chrome and firefox; adds Chrome Web Store submission step with secrets. |
| README.md | Adds a stable Chrome Web Store install link (`chromewebstore.google.com`) with the full extension ID, and demotes the manual unpacked-extension steps under a "Development" sub-option. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: resolve review comments on store su..."](https://github.com/surgedm/surge/commit/57bc05c6160082e6c82a08e319a732d11ff52dc1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38908158)</sub>

<!-- /greptile_comment -->