### PR TITLE
fix: shorten extension description for Chrome Web Store limit

### DIFF
--- a/extension/wxt.config.ts
+++ b/extension/wxt.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     const base: Record<string, unknown> = {
       name: 'Surge Download Manager',
       description:
-        'High-performance download acceleration with live progress tracking. Intercepts downloads and accelerates them using Surge\'s multi-connection engine.',
+        'High-performance download acceleration. Intercepts and routes browser downloads to Surge\'s multi-connection engine.',
       permissions: ['downloads', 'storage', 'notifications', 'webRequest'],
       host_permissions: ['http://127.0.0.1/*', '<all_urls>'],
     };


### PR DESCRIPTION
Fixes PKG_MANIFEST_SUMMARY_TOO_LONG error on CWS submission.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR trims the Chrome extension's manifest description to fix a `PKG_MANIFEST_SUMMARY_TOO_LONG` rejection from the Chrome Web Store submission pipeline.

- The old description ("High-performance download acceleration with live progress tracking. Intercepts downloads and accelerates them using Surge's multi-connection engine.") was ~152 characters, exceeding the CWS 132-character limit; the new one is ~115 characters.
- The reworded description preserves the key value propositions while dropping "with live progress tracking" — a minor loss of information that is an acceptable trade-off for store compliance.

<h3>Confidence Score: 5/5</h3>

Single-line description change; no logic or runtime behavior is affected.

The change is isolated to a manifest description string. It resolves a real CWS submission error and does not touch any code paths, permissions, or functionality.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| extension/wxt.config.ts | Shortens the Chrome extension description from ~152 to ~115 characters to comply with the Chrome Web Store's 132-character limit for the PKG_MANIFEST_SUMMARY_TOO_LONG error. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(extension): shorten manifest descr..."](https://github.com/surgedm/surge/commit/8e94dd81813dd4ccea8c499c37a757cda6b58fb8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38910085)</sub>

<!-- /greptile_comment -->