### PR TITLE
perf: optimize HTTP response handling by skipping body drainage for large payloads and throttling keep-alive activity updates

### DIFF
--- a/internal/engine/concurrent/downloader.go
+++ b/internal/engine/concurrent/downloader.go
@@ -728,8 +728,11 @@ func (d *ConcurrentDownloader) prewarmConnections(ctx context.Context, client *h
 				return
 			}
 
-			// Drain body and close to return connection to idle pool, then signal readiness.
-			_, _ = io.Copy(io.Discard, resp.Body)
+			// If the server ignores the Range request (returns 200 OK) or the content is unexpectedly large,
+			// do NOT drain the body. Draining a large body just to pool the connection is extremely wasteful.
+			if resp.StatusCode == http.StatusPartialContent && resp.ContentLength <= types.AlignSize {
+				_, _ = io.Copy(io.Discard, resp.Body)
+			}
 			_ = resp.Body.Close()
 			ready <- struct{}{}
 		}(i)

--- a/internal/engine/concurrent/worker.go
+++ b/internal/engine/concurrent/worker.go
@@ -282,6 +282,7 @@ func (d *ConcurrentDownloader) downloadTask(ctx context.Context, rawurl string, 
 
 		readSoFar := 0
 		var readErr error
+		lastActivityUpdateBytes := 0
 
 		for readSoFar < int(readSize) {
 			n, err := resp.Body.Read(buf[readSoFar:readSize])
@@ -289,9 +290,13 @@ func (d *ConcurrentDownloader) downloadTask(ctx context.Context, rawurl string, 
 				readSoFar += n
 				// CONTINUOUS HEALTH KEEPALIVE:
 				// Update LastActivity directly off the TCP socket instead of waiting for the buffer
-				// to completely fill and hit disk. This prevents the Health Monitor from killing
-				// workers on slightly slower networks during the 500KB buffer acquisition.
-				activeTask.LastActivity.Store(time.Now().UnixNano())
+				// to completely fill and hit disk. To prevent excessive syscalls on fast networks,
+				// we only update the timestamp every 64KB. This is frequent enough to prevent the
+				// Health Monitor from killing workers on slow networks.
+				if readSoFar-lastActivityUpdateBytes >= 64*1024 {
+					activeTask.LastActivity.Store(time.Now().UnixNano())
+					lastActivityUpdateBytes = readSoFar
+				}
 			}
 			if err != nil {
 				readErr = err


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR applies two micro-optimizations: skipping HTTP body drainage in `prewarmConnections` when the server returns a full 200 OK or an unexpectedly large 206, and throttling `LastActivity` timestamp updates in the inner read loop to once per 64 KB instead of once per read call.

- **downloader.go** — The body-drain skip is a sound fix for a latent hazard (draining a complete file just to pool one connection), but the `ContentLength <= AlignSize` guard passes when `ContentLength == -1` (chunked), letting the drain run for any 206 response whose length is unknown; adding an explicit non-negative check or capping with `io.LimitReader` would close this gap.
- **worker.go** — The 64 KB batching reduces syscall pressure on fast networks but sets an implicit minimum throughput floor of ~21 KB/s (64 KB / StallTimeout of 3 s) for workers to survive health-monitor checks; the original comment explicitly named slow-network protection as the reason for per-read updates, and connections below that threshold will be repeatedly false-stalled and killed.

<h3>Confidence Score: 3/5</h3>

The worker.go change introduces a real regression for slow connections — the health monitor's stall timeout effectively becomes a minimum-throughput requirement of ~21 KB/s, which was not the case before.

The downloader.go body-drain optimization is directionally correct, but the ContentLength == -1 edge case is unguarded. More critically, the 64 KB activity-update gate in worker.go directly undercuts the slow-network health-monitor protection that was the original justification for per-read updates; downloads on throttled or congested connections slower than ~21 KB/s will be continuously killed and restarted.

worker.go deserves the most scrutiny — the interaction between the 64 KB threshold and the health monitor stall timeout needs to be validated against real-world slow-network scenarios before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/engine/concurrent/worker.go | Introduces 64 KB throttle for LastActivity updates; can cause false stall detection (~21 KB/s effective floor) for slow connections, reversing the explicit slow-network protection documented in the original code. |
| internal/engine/concurrent/downloader.go | Correctly avoids draining large bodies on non-Range responses; ContentLength == -1 edge case silently bypasses the intended guard and falls through to drain for unknown-length chunked 206 responses. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
internal/engine/concurrent/worker.go:296-299
**False stall detection on slow connections**

The 64 KB gate means `LastActivity` is only refreshed after every 64 KB of incoming data. With the default `StallTimeout` of 3 seconds, any connection delivering less than ~21 KB/s will go 3+ seconds without an update and be cancelled by the health monitor — even though data is actively flowing. The original code comment explicitly named "slightly slower networks during the 500 KB buffer acquisition" as the scenario this keepalive was designed to protect. Raising the threshold from per-read to 64 KB removes that protection: a connection at 10 KB/s will trigger a false stall every 6+ seconds, continuously killing and restarting workers.

### Issue 2 of 3
internal/engine/concurrent/downloader.go:733-735
**`ContentLength == -1` silently falls through to drain**

When a server responds with 206 Partial Content but omits the `Content-Length` header (chunked transfer encoding), `resp.ContentLength` is `-1`. Because `-1 <= types.AlignSize` evaluates to `true`, the guard lets the drain path execute unconditionally for any chunked 206 response — including a theoretically misbehaving server that streams far more than 1 byte after a `Range: bytes=0-0` request. Consider adding an explicit guard (`resp.ContentLength >= 0`) or capping the drain with `io.LimitReader` to prevent an unexpectedly long chunked body from being fully consumed here.

### Issue 3 of 3
internal/engine/concurrent/worker.go:285-299
**No tests for the new activity throttling boundary**

This change introduces an observable behavioral threshold — workers on low-throughput connections behave differently from fast ones — but no tests were added to cover the edge case where a full buffer read finishes under 64 KB (e.g., a tail chunk), the case where total throughput is just below the effective stall floor, or interaction with the rate limiter path. Per the team rule, edge cases and integration points between components should be tested.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf: optimize HTTP response handling by..."](https://github.com/surgedm/surge/commit/4fcf32688c6fac1f8419f3a45d087c36034ffd88) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38994833)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->