### PR TITLE
feat: apply worker size heuristic to resumed download

### DIFF
--- a/internal/engine/concurrent/downloader.go
+++ b/internal/engine/concurrent/downloader.go
@@ -258,7 +258,19 @@ func (d *ConcurrentDownloader) Download(ctx context.Context, rawurl string, cand
 	}
 	d.TotalSize = fileSize
 
-	numConns := d.getInitialConnections(fileSize)
+	// Load saved state early to determine remaining size for connection count heuristic
+	savedState, err := state.LoadState(d.URL, destPath)
+	isResume := err == nil && savedState != nil && len(savedState.Tasks) > 0
+
+	effectiveSizeForWorkers := fileSize
+	if isResume && savedState.TotalSize > 0 {
+		effectiveSizeForWorkers = savedState.TotalSize - savedState.Downloaded
+		if effectiveSizeForWorkers < 0 {
+			effectiveSizeForWorkers = 0
+		}
+	}
+
+	numConns := d.getInitialConnections(effectiveSizeForWorkers)
 	chunkSize := d.determineChunkSize(fileSize, numConns)
 
 	workerMirrors := d.getWorkerMirrors(activeMirrors)
@@ -285,7 +297,7 @@ func (d *ConcurrentDownloader) Download(ctx context.Context, rawurl string, cand
 		d.State.InitBitmap(fileSize, chunkSize)
 	}
 
-	tasks, err := d.setupTasks(destPath, fileSize, chunkSize, outFile)
+	tasks, err := d.setupTasks(destPath, fileSize, chunkSize, outFile, savedState, isResume)
 	if err != nil {
 		return err
 	}
@@ -377,9 +389,7 @@ func (d *ConcurrentDownloader) getWorkerMirrors(activeMirrors []string) []string
 	return mirrors
 }
 
-func (d *ConcurrentDownloader) setupTasks(destPath string, fileSize, chunkSize int64, outFile *os.File) ([]types.Task, error) {
-	savedState, err := state.LoadState(d.URL, destPath)
-	isResume := err == nil && savedState != nil && len(savedState.Tasks) > 0
+func (d *ConcurrentDownloader) setupTasks(destPath string, fileSize, chunkSize int64, outFile *os.File, savedState *types.DownloadState, isResume bool) ([]types.Task, error) {
 
 	if isResume {
 		if d.State != nil {

--- a/internal/engine/concurrent/downloader.go
+++ b/internal/engine/concurrent/downloader.go
@@ -262,13 +262,7 @@ func (d *ConcurrentDownloader) Download(ctx context.Context, rawurl string, cand
 	savedState, err := state.LoadState(d.URL, destPath)
 	isResume := err == nil && savedState != nil && len(savedState.Tasks) > 0
 
-	effectiveSizeForWorkers := fileSize
-	if isResume && savedState.TotalSize > 0 {
-		effectiveSizeForWorkers = savedState.TotalSize - savedState.Downloaded
-		if effectiveSizeForWorkers < 0 {
-			effectiveSizeForWorkers = 0
-		}
-	}
+	effectiveSizeForWorkers := d.getEffectiveSizeForWorkers(fileSize, savedState, isResume)
 
 	numConns := d.getInitialConnections(effectiveSizeForWorkers)
 	chunkSize := d.determineChunkSize(fileSize, numConns)
@@ -387,6 +381,17 @@ func (d *ConcurrentDownloader) getWorkerMirrors(activeMirrors []string) []string
 		}
 	}
 	return mirrors
+}
+
+func (d *ConcurrentDownloader) getEffectiveSizeForWorkers(fileSize int64, savedState *types.DownloadState, isResume bool) int64 {
+	if isResume && savedState != nil && savedState.TotalSize > 0 {
+		eff := savedState.TotalSize - savedState.Downloaded
+		if eff < 0 {
+			return 0
+		}
+		return eff
+	}
+	return fileSize
 }
 
 func (d *ConcurrentDownloader) setupTasks(destPath string, fileSize, chunkSize int64, outFile *os.File, savedState *types.DownloadState, isResume bool) ([]types.Task, error) {

--- a/internal/engine/concurrent/downloader.go
+++ b/internal/engine/concurrent/downloader.go
@@ -303,7 +303,7 @@ func (d *ConcurrentDownloader) Download(ctx context.Context, rawurl string, cand
 	d.startHelpers(downloadCtx, &wgHelpers, queue, fileSize, numConns)
 
 	// Execute download workers
-	downloadErr := d.executeWorkers(downloadCtx, client, outFile, queue, fileSize, workerMirrors, numConns)
+	downloadErr := d.executeWorkers(downloadCtx, cancel, client, outFile, queue, fileSize, workerMirrors, numConns)
 
 	// Handle pause request: must return types.ErrPaused to prevent finalization
 	if d.State != nil && d.State.IsPaused() {
@@ -315,13 +315,11 @@ func (d *ConcurrentDownloader) Download(ctx context.Context, rawurl string, cand
 		return pauseErr
 	}
 
-	// Handle cancel: context was cancelled but not via Pause()
-	// Propagate cancellation so callers don't treat this as a successful completion.
-	if downloadCtx.Err() == context.Canceled {
-		return context.Canceled
-	}
 	if downloadErr != nil {
 		return downloadErr
+	}
+	if downloadCtx.Err() != nil {
+		return downloadCtx.Err()
 	}
 
 	// Note: Download completion notifications are handled by the TUI via DownloadCompleteMsg
@@ -516,7 +514,7 @@ func (d *ConcurrentDownloader) runHealthMonitor(ctx context.Context) {
 	}
 }
 
-func (d *ConcurrentDownloader) executeWorkers(ctx context.Context, client *http.Client, outFile *os.File, queue *TaskQueue, fileSize int64, workerMirrors []string, numConns int) error {
+func (d *ConcurrentDownloader) executeWorkers(ctx context.Context, cancel context.CancelFunc, client *http.Client, outFile *os.File, queue *TaskQueue, fileSize int64, workerMirrors []string, numConns int) error {
 	var wg sync.WaitGroup
 	workerErrors := make(chan error, numConns)
 
@@ -526,8 +524,9 @@ func (d *ConcurrentDownloader) executeWorkers(ctx context.Context, client *http.
 		go func(workerID int) {
 			defer wg.Done()
 			err := d.worker(ctx, workerID, workerMirrors, outFile, queue, fileSize, client)
-			if err != nil && err != context.Canceled {
+			if err != nil && !errors.Is(err, context.Canceled) {
 				workerErrors <- err
+				cancel()
 			}
 		}(i)
 	}

--- a/internal/engine/concurrent/downloader_helpers_test.go
+++ b/internal/engine/concurrent/downloader_helpers_test.go
@@ -122,7 +122,7 @@ func TestSetupTasks_NewDownload(t *testing.T) {
 		Runtime: &types.RuntimeConfig{},
 	}
 
-	tasks, err := downloader.setupTasks(destPath, fileSize, chunkSize, f)
+	tasks, err := downloader.setupTasks(destPath, fileSize, chunkSize, f, nil, false)
 	if err != nil {
 		t.Fatalf("setupTasks failed: %v", err)
 	}
@@ -227,7 +227,7 @@ func TestSetupTasks_BitmapRestoration(t *testing.T) {
 	// 1. InitBitmap
 	progState.InitBitmap(fileSize, chunkSize)
 	// 2. setupTasks (which calls RestoreBitmap)
-	_, err := downloader.setupTasks(destPath, fileSize, chunkSize, f)
+	_, err := downloader.setupTasks(destPath, fileSize, chunkSize, f, savedState, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/engine/concurrent/get_initial_connections_test.go
+++ b/internal/engine/concurrent/get_initial_connections_test.go
@@ -115,3 +115,38 @@ func TestGetInitialConnections_LargeFileSizeSqrtHeuristicNoOverflow(t *testing.T
 		t.Fatalf("expected 32 (clamped by MaxConns), got %d", got)
 	}
 }
+
+func TestGetEffectiveSizeForWorkers_FreshDownload(t *testing.T) {
+	d := &ConcurrentDownloader{}
+	fileSize := int64(100 * types.MB)
+	got := d.getEffectiveSizeForWorkers(fileSize, nil, false)
+	if got != fileSize {
+		t.Fatalf("Fresh download: got %d, want %d", got, fileSize)
+	}
+}
+
+func TestGetEffectiveSizeForWorkers_Resume(t *testing.T) {
+	d := &ConcurrentDownloader{}
+	fileSize := int64(100 * types.MB)
+	savedState := &types.DownloadState{
+		TotalSize:  fileSize,
+		Downloaded: int64(98 * types.MB),
+	}
+	got := d.getEffectiveSizeForWorkers(fileSize, savedState, true)
+	if got != int64(2*types.MB) {
+		t.Fatalf("Resume: got %d, want %d", got, int64(2*types.MB))
+	}
+}
+
+func TestGetEffectiveSizeForWorkers_ResumeNegative(t *testing.T) {
+	d := &ConcurrentDownloader{}
+	fileSize := int64(100 * types.MB)
+	savedState := &types.DownloadState{
+		TotalSize:  fileSize,
+		Downloaded: int64(102 * types.MB), // Downloaded more than total size somehow
+	}
+	got := d.getEffectiveSizeForWorkers(fileSize, savedState, true)
+	if got != 0 {
+		t.Fatalf("Resume negative: got %d, want 0", got)
+	}
+}

--- a/internal/engine/concurrent/worker.go
+++ b/internal/engine/concurrent/worker.go
@@ -173,11 +173,8 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 		}
 
 		if lastErr != nil {
-			// Log failed task but continue with next task
-			// If we modified StopAt we should probably reset it or push the remaining part?
-			// TODO: Could optimize by pushing only remaining part if we track that.
-			queue.Push(task)
-			utils.Debug("task at offset %d failed after %d retries: %v", task.Offset, maxRetries, lastErr)
+			utils.Debug("Worker %d: task at offset %d failed after %d retries: %v", id, task.Offset, maxRetries, lastErr)
+			return lastErr
 		}
 	}
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves resumed downloads by computing the worker count heuristic against the remaining bytes rather than the full file size, preventing over-spawning workers for a nearly-complete download. It also fixes a latent bug where a task that exhausted all per-worker retries was silently re-queued indefinitely; workers now return the error, which triggers cancellation of the entire download.

- **Resume heuristic**: `state.LoadState` is called earlier in `Download()` to derive `effectiveSizeForWorkers` (remaining bytes), which is fed into `getInitialConnections` instead of the total file size. The `setupTasks` signature is updated to accept the pre-loaded state, removing a redundant `LoadState` call.
- **Fail-fast on unrecoverable task failure**: `worker()` now returns `lastErr` after exhausting retries. `executeWorkers` receives a `cancel` func and calls it on the first non-cancellation worker error, stopping all sibling workers promptly.
- **Context-error ordering fix**: The post-`executeWorkers` checks now prioritize `downloadErr` over `downloadCtx.Err()`, which is correct now that `cancel()` is called internally on failure.

<h3>Confidence Score: 4/5</h3>

Safe to merge; no correctness regressions were found. The resume heuristic and the fail-fast error propagation are both logically sound.

The resume heuristic correctly computes remaining bytes and the worker-count decision is purely advisory. The fail-fast change is a real improvement over the old infinite-requeue pattern. The main gaps are the absence of integration tests for the new worker-failure code path and the silent discard of the live `fileSize` during a resume if the server-reported size differs from the saved state.

`worker.go` — the behavioral shift from re-queuing to returning errors is the highest-impact change and currently has no test coverage. `downloader.go` (`getEffectiveSizeForWorkers`) silently ignores the freshly-probed file size when resuming, which could obscure a stale or corrupt state file.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/engine/concurrent/downloader.go | Loads saved state earlier to feed a new `getEffectiveSizeForWorkers` heuristic; threads `cancel` into `executeWorkers`; improves context-error propagation ordering. Two P2 issues: bundled concerns and `fileSize` being silently unused in the resume branch. |
| internal/engine/concurrent/worker.go | Replaces the silent task-re-queue-on-failure pattern with an immediate error return, enabling the new cancel-on-failure mechanism. Significant behavior change with no new test coverage. |
| internal/engine/concurrent/get_initial_connections_test.go | Adds three unit tests for `getEffectiveSizeForWorkers` covering fresh download, normal resume, and the negative-effective-size guard. Coverage is adequate for the new function itself. |
| internal/engine/concurrent/downloader_helpers_test.go | Mechanical signature updates to `setupTasks` call sites to pass the now-explicit `savedState` and `isResume` parameters; no logic changes. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
internal/engine/concurrent/worker.go:173-178
**Missing test for fail-fast worker behavior**

The change from re-queuing failed tasks to returning the error (and cancelling all workers) is the most significant behavioral shift in this PR. Previously a task that exhausted all retries was silently pushed back to the queue; now it causes the entire download to abort. There are no tests covering this new code path — no test verifies that a worker error surfaces in the returned `error` from `executeWorkers`, cancels the context, and terminates sibling workers. Per the project's testing rule, edge cases and integration points between components should have explicit coverage.

### Issue 2 of 3
internal/engine/concurrent/downloader.go:261-294
**Mixed concerns: resume heuristic and worker error propagation**

This PR bundles two independent changes: (1) the resumed-download size heuristic (`getEffectiveSizeForWorkers`, early `LoadState`) and (2) a significant error-propagation overhaul (`cancel()` threaded into `executeWorkers`, workers now returning errors instead of re-queuing). The error-propagation change is self-contained and can be reasoned about separately; if either half needs to be reverted it requires touching both. Splitting them into separate commits or PRs would make each easier to review, test, and revert independently.

### Issue 3 of 3
internal/engine/concurrent/downloader.go:384-393
**`fileSize` parameter is unused when `isResume` is true**

`getEffectiveSizeForWorkers` accepts `fileSize` but never reads it in the `isResume` branch — it derives the remaining size solely from `savedState.TotalSize - savedState.Downloaded`. If the live server reports a different file size than what was saved (e.g., a CMS updated the asset between pause and resume), the caller's freshly-probed `fileSize` is silently ignored for the heuristic, which may cause a surprising mismatch with the `chunkSize` calculation that still uses the live `fileSize`. Consider at least a debug log when `savedState.TotalSize != fileSize`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: propagate worker errors to dow..."](https://github.com/surgedm/surge/commit/26bf317984b3d9835bebbc1046246145dcc879e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39244616)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Rule used - What: Flag commits that bundle unnecessary changes... ([source](https://app.greptile.com/surge-org-3/-/custom-context?memory=74a28159-60fc-4201-a661-331594ebaf90))
- Rule used - What: All code changes must include tests for edge... ([source](https://app.greptile.com/surge-org-3/-/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))

<!-- /greptile_comment -->