### PR TITLE
fix: premature cancel on worker failure and rate limit backoff

### DIFF
--- a/cmd/root_startup.go
+++ b/cmd/root_startup.go
@@ -50,6 +50,7 @@ func initializeGlobalState() error {
 
 	// Config logging
 	utils.ConfigureDebug(logsDir)
+	utils.Debug("Surge Version: %s, Commit: %s", Version, Commit)
 
 	// Clean up old logs (keeping retention-1 because a new log will be created immediately after)
 	retention := config.Resolve[int](getSettings().General.LogRetentionCount)

--- a/internal/download/manager.go
+++ b/internal/download/manager.go
@@ -202,6 +202,9 @@ func TUIDownload(ctx context.Context, cfg *types.DownloadConfig) error {
 		d.Limiter = cfg.Limiter
 		d.RateLimitBps = cfg.RateLimitBps
 		d.RateLimitSet = cfg.RateLimitSet
+		if cfg.Global429 != nil {
+			d.SetShared429Count(cfg.Global429)
+		}
 		utils.Debug("Calling Download with mirrors: %v", mirrors)
 		// Pass effectiveTotalSize to avoid unnecessary bootstrap if state already knows the size
 		downloadErr = d.Download(ctx, cfg.URL, mirrors, activeMirrors, finalDestPath, effectiveTotalSize)

--- a/internal/download/pool.go
+++ b/internal/download/pool.go
@@ -40,6 +40,7 @@ type WorkerPool struct {
 	globalLimiter               *engine.RateLimiter
 	downloadLimiters            map[string]*engine.RateLimiter
 	defaultDownloadRateLimitBps int64
+	global429Count              atomic.Int32
 }
 
 var (
@@ -474,9 +475,17 @@ func (p *WorkerPool) Cancel(downloadID string) types.CancelResult {
 
 		// Best effort: wait for worker to exit so delete cleanup doesn't race with
 		// downloader startup that can recreate the .surge file after removal.
-		deadline := time.Now().Add(cancelStopWaitTimeout)
-		for ad.running.Load() && time.Now().Before(deadline) {
-			time.Sleep(cancelStopPollInterval)
+		ctx, cancelFunc := context.WithTimeout(context.Background(), cancelStopWaitTimeout)
+		defer cancelFunc()
+		ticker := time.NewTicker(cancelStopPollInterval)
+		defer ticker.Stop()
+	waitLoop:
+		for ad.running.Load() {
+			select {
+			case <-ticker.C:
+			case <-ctx.Done():
+				break waitLoop
+			}
 		}
 
 		// Mark as done to stop polling
@@ -596,6 +605,7 @@ func (p *WorkerPool) worker() {
 
 		// Make a local copy for TUIDownload to mutate safely
 		localCfg := ad.config
+		localCfg.Global429 = &p.global429Count
 		p.mu.Unlock()
 
 		err := TUIDownload(ctx, &localCfg)

--- a/internal/engine/concurrent/downloader.go
+++ b/internal/engine/concurrent/downloader.go
@@ -796,7 +796,7 @@ func (d *ConcurrentDownloader) clear429() {
 	}
 }
 
-func (d *ConcurrentDownloader) sleepBackoff(ctx context.Context, attempt int, numConns int) {
+func (d *ConcurrentDownloader) sleepBackoff(ctx context.Context, attempt int) {
 	base := time.Duration(1<<attempt) * types.RetryBaseDelay
 	active429 := d.active429Count.Load()
 	if active429 > 2 {

--- a/internal/engine/concurrent/downloader.go
+++ b/internal/engine/concurrent/downloader.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/SurgeDM/Surge/internal/engine"
@@ -40,6 +41,7 @@ type ConcurrentDownloader struct {
 	bufPool          sync.Pool
 	taskRequeueCount map[int64]int
 	taskRequeueMu    sync.Mutex
+	active429Count   atomic.Int32
 }
 
 // NewConcurrentDownloader creates a new concurrent downloader with all required parameters
@@ -542,7 +544,6 @@ func (d *ConcurrentDownloader) executeWorkers(ctx context.Context, cancel contex
 		orphanCount = queue.Len()
 		queue.Close()
 		close(workerErrors)
-		_ = cancel
 	}()
 
 	var downloadErr error
@@ -783,4 +784,30 @@ func (d *ConcurrentDownloader) prewarmConnections(ctx context.Context, client *h
 
 	utils.Debug("Pre-warming complete: %d connections hot", completed)
 	// Remaining pings will be cancelled by defer cancelPings()
+}
+
+func (d *ConcurrentDownloader) report429() {
+	d.active429Count.Add(1)
+}
+
+func (d *ConcurrentDownloader) clear429() {
+	if d.active429Count.Load() > 0 {
+		d.active429Count.Add(-1)
+	}
+}
+
+func (d *ConcurrentDownloader) sleepBackoff(ctx context.Context, attempt int, numConns int) {
+	base := time.Duration(1<<attempt) * types.RetryBaseDelay
+	active429 := d.active429Count.Load()
+	if active429 > 2 {
+		scale := active429
+		if scale > 8 {
+			scale = 8
+		}
+		base *= time.Duration(scale)
+	}
+	select {
+	case <-time.After(base):
+	case <-ctx.Done():
+	}
 }

--- a/internal/engine/concurrent/downloader.go
+++ b/internal/engine/concurrent/downloader.go
@@ -23,20 +23,23 @@ import (
 
 // ConcurrentDownloader handles multi-connection downloads
 type ConcurrentDownloader struct {
-	ProgressChan chan<- any           // Channel for events (start/complete/error)
-	ID           string               // Download ID
-	State        *types.ProgressState // Shared state for TUI polling
-	activeTasks  map[int]*ActiveTask
-	activeMu     sync.Mutex
-	URL          string // For pause/resume
-	DestPath     string // For pause/resume
+	URL          string
+	DestPath     string
+	ID           string
+	TotalSize    int64
+	ProgressChan chan<- any
+	State        *types.ProgressState
 	Runtime      *types.RuntimeConfig
+	Headers      map[string]string // Custom HTTP headers (cookies, auth, etc.)
 	Limiter      types.ByteLimiter
 	RateLimitBps int64
 	RateLimitSet bool
-	TotalSize    int64
-	bufPool      sync.Pool
-	Headers      map[string]string // Custom HTTP headers from browser (cookies, auth, etc.)
+
+	activeTasks      map[int]*ActiveTask
+	activeMu         sync.Mutex
+	bufPool          sync.Pool
+	taskRequeueCount map[int64]int
+	taskRequeueMu    sync.Mutex
 }
 
 // NewConcurrentDownloader creates a new concurrent downloader with all required parameters
@@ -46,11 +49,12 @@ func NewConcurrentDownloader(id string, progressCh chan<- any, progState *types.
 	}
 
 	return &ConcurrentDownloader{
-		ID:           id,
-		ProgressChan: progressCh,
-		State:        progState,
-		activeTasks:  make(map[int]*ActiveTask),
-		Runtime:      runtime,
+		ID:               id,
+		ProgressChan:     progressCh,
+		State:            progState,
+		activeTasks:      make(map[int]*ActiveTask),
+		taskRequeueCount: make(map[int64]int),
+		Runtime:          runtime,
 		bufPool: sync.Pool{
 			New: func() any {
 				// Use configured buffer size
@@ -518,27 +522,29 @@ func (d *ConcurrentDownloader) executeWorkers(ctx context.Context, cancel contex
 	var wg sync.WaitGroup
 	workerErrors := make(chan error, numConns)
 
-	// Start workers
 	for i := 0; i < numConns; i++ {
 		wg.Add(1)
 		go func(workerID int) {
 			defer wg.Done()
 			err := d.worker(ctx, workerID, workerMirrors, outFile, queue, fileSize, client)
-			if err != nil && !errors.Is(err, context.Canceled) {
+			if err != nil {
+				if errors.Is(err, context.Canceled) {
+					return
+				}
 				workerErrors <- err
-				cancel()
 			}
 		}(i)
 	}
 
-	// Wait for all workers to complete
+	var orphanCount int
 	go func() {
 		wg.Wait()
-		close(workerErrors)
+		orphanCount = queue.Len()
 		queue.Close()
+		close(workerErrors)
+		_ = cancel
 	}()
 
-	// Check for errors or pause
 	var downloadErr error
 	seenErrors := make(map[string]bool)
 	for err := range workerErrors {
@@ -550,6 +556,16 @@ func (d *ConcurrentDownloader) executeWorkers(ctx context.Context, cancel contex
 			}
 		}
 	}
+
+	if orphanCount > 0 && ctx.Err() == nil {
+		orphanErr := fmt.Errorf("%d chunk(s) could not be completed", orphanCount)
+		downloadErr = errors.Join(downloadErr, orphanErr)
+	}
+
+	if downloadErr != nil {
+		cancel()
+	}
+
 	return downloadErr
 }
 

--- a/internal/engine/concurrent/downloader.go
+++ b/internal/engine/concurrent/downloader.go
@@ -42,6 +42,7 @@ type ConcurrentDownloader struct {
 	taskRequeueCount map[int64]int
 	taskRequeueMu    sync.Mutex
 	active429Count   atomic.Int32
+	shared429Count   *atomic.Int32
 }
 
 // NewConcurrentDownloader creates a new concurrent downloader with all required parameters
@@ -787,16 +788,17 @@ func (d *ConcurrentDownloader) prewarmConnections(ctx context.Context, client *h
 }
 
 func (d *ConcurrentDownloader) report429() {
-	d.active429Count.Add(1)
+	d.get429Counter().Add(1)
 }
 
 func (d *ConcurrentDownloader) clear429() {
+	counter := d.get429Counter()
 	for {
-		old := d.active429Count.Load()
+		old := counter.Load()
 		if old <= 0 {
 			return
 		}
-		if d.active429Count.CompareAndSwap(old, old-1) {
+		if counter.CompareAndSwap(old, old-1) {
 			return
 		}
 	}
@@ -804,7 +806,7 @@ func (d *ConcurrentDownloader) clear429() {
 
 func (d *ConcurrentDownloader) sleepBackoff(ctx context.Context, attempt int) {
 	base := time.Duration(1<<attempt) * types.RetryBaseDelay
-	active429 := d.active429Count.Load()
+	active429 := d.get429Counter().Load()
 	if active429 > 2 {
 		scale := active429
 		if scale > 8 {
@@ -816,4 +818,15 @@ func (d *ConcurrentDownloader) sleepBackoff(ctx context.Context, attempt int) {
 	case <-time.After(base):
 	case <-ctx.Done():
 	}
+}
+
+func (d *ConcurrentDownloader) SetShared429Count(counter *atomic.Int32) {
+	d.shared429Count = counter
+}
+
+func (d *ConcurrentDownloader) get429Counter() *atomic.Int32 {
+	if d.shared429Count != nil {
+		return d.shared429Count
+	}
+	return &d.active429Count
 }

--- a/internal/engine/concurrent/downloader.go
+++ b/internal/engine/concurrent/downloader.go
@@ -787,6 +787,8 @@ func (d *ConcurrentDownloader) prewarmConnections(ctx context.Context, client *h
 	// Remaining pings will be cancelled by defer cancelPings()
 }
 
+var ErrRateLimited = fmt.Errorf("rate limited (429)")
+
 func (d *ConcurrentDownloader) report429() {
 	d.get429Counter().Add(1)
 }

--- a/internal/engine/concurrent/downloader.go
+++ b/internal/engine/concurrent/downloader.go
@@ -538,10 +538,10 @@ func (d *ConcurrentDownloader) executeWorkers(ctx context.Context, cancel contex
 		}(i)
 	}
 
-	var orphanCount int
+	var orphanCount atomic.Int64
 	go func() {
 		wg.Wait()
-		orphanCount = queue.Len()
+		orphanCount.Store(int64(queue.Len()))
 		queue.Close()
 		close(workerErrors)
 	}()
@@ -558,8 +558,8 @@ func (d *ConcurrentDownloader) executeWorkers(ctx context.Context, cancel contex
 		}
 	}
 
-	if orphanCount > 0 && ctx.Err() == nil {
-		orphanErr := fmt.Errorf("%d chunk(s) could not be completed", orphanCount)
+	if orphanCount.Load() > 0 && ctx.Err() == nil {
+		orphanErr := fmt.Errorf("%d chunk(s) could not be completed", orphanCount.Load())
 		downloadErr = errors.Join(downloadErr, orphanErr)
 	}
 
@@ -791,8 +791,14 @@ func (d *ConcurrentDownloader) report429() {
 }
 
 func (d *ConcurrentDownloader) clear429() {
-	if d.active429Count.Load() > 0 {
-		d.active429Count.Add(-1)
+	for {
+		old := d.active429Count.Load()
+		if old <= 0 {
+			return
+		}
+		if d.active429Count.CompareAndSwap(old, old-1) {
+			return
+		}
 	}
 }
 

--- a/internal/engine/concurrent/requeue_test.go
+++ b/internal/engine/concurrent/requeue_test.go
@@ -1,0 +1,229 @@
+package concurrent
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/SurgeDM/Surge/internal/engine/types"
+	"github.com/SurgeDM/Surge/internal/testutil"
+)
+
+// serveFileData writes the requested byte range from a zero-filled buffer
+// to the response writer with proper Content-Length and Content-Range headers.
+func serveFileData(w http.ResponseWriter, r *http.Request, fileSize int64) {
+	rangeHeader := r.Header.Get("Range")
+	start := int64(0)
+	end := fileSize - 1
+	if rangeHeader != "" {
+		parts := strings.SplitN(strings.TrimPrefix(rangeHeader, "bytes="), "-", 2)
+		start = parseRangeInt(parts[0])
+		if len(parts) > 1 && parts[1] != "" {
+			end = parseRangeInt(parts[1])
+		}
+	}
+	length := end - start + 1
+	w.Header().Set("Content-Length", strconv.FormatInt(length, 10))
+	w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, fileSize))
+	if rangeHeader != "" {
+		w.WriteHeader(http.StatusPartialContent)
+	} else {
+		w.WriteHeader(http.StatusOK)
+	}
+	buf := make([]byte, 64*1024)
+	remaining := length
+	for remaining > 0 {
+		chunk := buf
+		if int64(len(chunk)) > remaining {
+			chunk = buf[:remaining]
+		}
+		nw, _ := w.Write(chunk)
+		remaining -= int64(nw)
+	}
+}
+
+func parseRangeInt(s string) int64 {
+	if s == "" {
+		return 0
+	}
+	n, _ := strconv.ParseInt(s, 10, 64)
+	return n
+}
+
+// TestConcurrentDownloader_SingleWorker429DoesNotKillSession verifies that
+// when a single worker exhausts its retries on a chunk (e.g. hitting 429),
+// the chunk is re-queued and completed by another worker instead of
+// cancelling all workers and falling back to single-threaded.
+func TestConcurrentDownloader_SingleWorker429DoesNotKillSession(t *testing.T) {
+	tmpDir, cleanup := initTestState(t)
+	defer cleanup()
+
+	fileSize := int64(4 * types.MB)
+
+	var reqCount atomic.Int64
+	// Odd requests → 429, even requests → success.
+	// Worker 1 (3 retries = 3 odd requests) fails → re-queues.
+	// Worker 2 picks up, 4th request (even) → succeeds.
+	server := testutil.NewMockServerT(t,
+		testutil.WithFileSize(fileSize),
+		testutil.WithRangeSupport(true),
+		testutil.WithHandler(func(w http.ResponseWriter, r *http.Request) {
+			n := reqCount.Add(1)
+			if n%2 == 1 {
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			}
+			serveFileData(w, r, fileSize)
+		}),
+	)
+	defer server.Close()
+
+	destPath := filepath.Join(tmpDir, "single429_nokill.bin")
+	state := types.NewProgressState("single429-nokill", fileSize)
+
+	runtime := &types.RuntimeConfig{
+		MaxConnectionsPerDownload: 2,
+		MaxTaskRetries:            3,
+		MinChunkSize:              1 * types.MB,
+		DialHedgeCount:            0,
+	}
+
+	downloader := NewConcurrentDownloader("single429-nokill-id", nil, state, runtime)
+
+	if f, err := os.Create(destPath + ".surge"); err == nil {
+		_ = f.Close()
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	err := downloader.Download(ctx, server.URL(), nil, nil, destPath, fileSize)
+	if err != nil {
+		t.Fatalf("download should have succeeded via re-queue, got: %v", err)
+	}
+
+	if err := testutil.VerifyFileSize(destPath+types.IncompleteSuffix, fileSize); err != nil {
+		t.Error(err)
+	}
+}
+
+// TestConcurrentDownloader_AllMirrors429FailsAfterRequeueLimit verifies the
+// circuit breaker: when all requests return 429 and every chunk keeps being
+// re-queued, the download eventually fails after the global re-queue limit
+// is exhausted.
+func TestConcurrentDownloader_AllMirrors429FailsAfterRequeueLimit(t *testing.T) {
+	tmpDir, cleanup := initTestState(t)
+	defer cleanup()
+
+	fileSize := int64(1 * types.MB)
+
+	server := testutil.NewMockServerT(t,
+		testutil.WithFileSize(fileSize),
+		testutil.WithRangeSupport(true),
+		testutil.WithHandler(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusTooManyRequests)
+		}),
+	)
+	defer server.Close()
+
+	destPath := filepath.Join(tmpDir, "all429_fail.bin")
+	state := types.NewProgressState("all429-fail", fileSize)
+
+	runtime := &types.RuntimeConfig{
+		MaxConnectionsPerDownload: 2,
+		MaxTaskRetries:            2,
+		MinChunkSize:              256 * types.KB,
+		DialHedgeCount:            0,
+	}
+
+	downloader := NewConcurrentDownloader("all429-fail-id", nil, state, runtime)
+
+	if f, err := os.Create(destPath + ".surge"); err == nil {
+		_ = f.Close()
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	err := downloader.Download(ctx, server.URL(), nil, nil, destPath, fileSize)
+	if err == nil {
+		t.Fatal("expected download to fail after re-queue limit, but it succeeded")
+	}
+
+	if !strings.Contains(err.Error(), "requeue attempts") {
+		t.Errorf("expected error about requeue attempts, got: %v", err)
+	}
+}
+
+// TestConcurrentDownloader_MidTransfer429KeepsCompletedChunks verifies that
+// when one chunk hits 429 and is re-queued, the chunks already completed
+// by other workers are NOT discarded (i.e. the session doesn't fall back
+// to single-threaded from scratch).
+func TestConcurrentDownloader_MidTransfer429KeepsCompletedChunks(t *testing.T) {
+	tmpDir, cleanup := initTestState(t)
+	defer cleanup()
+
+	fileSize := int64(4 * types.MB)
+
+	// First chunk (offset 0) always 429. All other chunks succeed.
+	server := testutil.NewMockServerT(t,
+		testutil.WithFileSize(fileSize),
+		testutil.WithRangeSupport(true),
+		testutil.WithHandler(func(w http.ResponseWriter, r *http.Request) {
+			rangeHeader := r.Header.Get("Range")
+			if strings.HasPrefix(rangeHeader, "bytes=0-") {
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			}
+			serveFileData(w, r, fileSize)
+		}),
+	)
+	defer server.Close()
+
+	destPath := filepath.Join(tmpDir, "mid429_keep.bin")
+	state := types.NewProgressState("mid429-keep", fileSize)
+
+	// 2 workers: both pick up chunks. Worker 1 gets chunk at offset 0 (always 429),
+	// exhausts retries, re-queues. Worker 2 also picks it up, gets 429, exhausts,
+	// re-queues. The re-queue count eventually hits the limit and fails.
+	// But we verify that chunks at non-zero offsets were written (file is > 0 size).
+	runtime := &types.RuntimeConfig{
+		MaxConnectionsPerDownload: 2,
+		MaxTaskRetries:            2,
+		MinChunkSize:              1 * types.MB,
+		DialHedgeCount:            0,
+	}
+
+	downloader := NewConcurrentDownloader("mid429-keep-id", nil, state, runtime)
+
+	if f, err := os.Create(destPath + ".surge"); err == nil {
+		_ = f.Close()
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	err := downloader.Download(ctx, server.URL(), nil, nil, destPath, fileSize)
+	if err != nil {
+		// Expected: chunk at offset 0 keeps failing, re-queue limit hit.
+		t.Logf("download failed as expected (chunk 0 permanently 429): %v", err)
+	}
+
+	// Even though the download failed overall, chunks at non-zero offsets
+	// should have been written to the file by other workers.
+	fi, err := os.Stat(destPath + ".surge")
+	if err != nil {
+		t.Fatalf("cannot stat .surge file: %v", err)
+	}
+	if fi.Size() <= 0 {
+		t.Error("expected .surge file to contain data from completed chunks, but file is empty")
+	}
+	t.Logf(".surge file size: %d (expected > 0, < %d)", fi.Size(), fileSize)
+}

--- a/internal/engine/concurrent/requeue_test.go
+++ b/internal/engine/concurrent/requeue_test.go
@@ -227,3 +227,63 @@ func TestConcurrentDownloader_MidTransfer429KeepsCompletedChunks(t *testing.T) {
 	}
 	t.Logf(".surge file size: %d (expected > 0, < %d)", fi.Size(), fileSize)
 }
+
+// TestConcurrentDownloader_429CounterReturnsToZero verifies that the 429
+// counter is incremented during rate-limited requests and returns to zero
+// after the download completes (or fails with the circuit-breaker).
+func TestConcurrentDownloader_429CounterReturnsToZero(t *testing.T) {
+	tmpDir, cleanup := initTestState(t)
+	defer cleanup()
+
+	fileSize := int64(1 * types.MB)
+
+	var reqCount atomic.Int64
+	// First 3 requests → 429, subsequent requests → success.
+	server := testutil.NewMockServerT(t,
+		testutil.WithFileSize(fileSize),
+		testutil.WithRangeSupport(true),
+		testutil.WithHandler(func(w http.ResponseWriter, r *http.Request) {
+			n := reqCount.Add(1)
+			if n <= 3 {
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			}
+			serveFileData(w, r, fileSize)
+		}),
+	)
+	defer server.Close()
+
+	destPath := filepath.Join(tmpDir, "429counter_test.bin")
+	state := types.NewProgressState("429counter-test", fileSize)
+
+	runtime := &types.RuntimeConfig{
+		MaxConnectionsPerDownload: 1,
+		MaxTaskRetries:            3,
+		MinChunkSize:              512 * types.KB,
+		DialHedgeCount:            0,
+	}
+
+	downloader := NewConcurrentDownloader("429counter-test-id", nil, state, runtime)
+
+	if f, err := os.Create(destPath + ".surge"); err == nil {
+		_ = f.Close()
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	err := downloader.Download(ctx, server.URL(), nil, nil, destPath, fileSize)
+	if err != nil {
+		t.Fatalf("download should have succeeded, got: %v", err)
+	}
+
+	if err := testutil.VerifyFileSize(destPath+types.IncompleteSuffix, fileSize); err != nil {
+		t.Error(err)
+	}
+
+	// The counter should have returned to zero — every report429 was balanced
+	// by a clear429.
+	if c := downloader.active429Count.Load(); c != 0 {
+		t.Errorf("expected 429 counter to return to zero after successful download, got %d", c)
+	}
+}

--- a/internal/engine/concurrent/worker.go
+++ b/internal/engine/concurrent/worker.go
@@ -46,7 +46,7 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 			if attempt > 0 {
 
 				if len(mirrors) == 1 {
-					d.sleepBackoff(ctx, attempt, len(d.activeTasks)+1)
+					d.sleepBackoff(ctx, attempt)
 				}
 
 				// FAILOVER: Switch mirror on retry

--- a/internal/engine/concurrent/worker.go
+++ b/internal/engine/concurrent/worker.go
@@ -46,7 +46,7 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 			if attempt > 0 {
 
 				if len(mirrors) == 1 {
-					time.Sleep(time.Duration(1<<attempt) * types.RetryBaseDelay) // Exponential backoff incase of failure
+					d.sleepBackoff(ctx, attempt, len(d.activeTasks)+1)
 				}
 
 				// FAILOVER: Switch mirror on retry
@@ -149,6 +149,7 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 			d.activeMu.Unlock()
 
 			if lastErr == nil {
+				d.clear429()
 				// Check if we stopped early due to stealing
 				stopAt := activeTask.StopAt.Load()
 				current := activeTask.CurrentOffset.Load()
@@ -185,7 +186,7 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 			d.taskRequeueCount[task.Offset] = count + 1
 			d.taskRequeueMu.Unlock()
 
-			maxRequeues := maxRetries * 2
+			maxRequeues := maxRetries
 			if count >= maxRequeues {
 				return fmt.Errorf("task at offset %d failed after %d requeue attempts: %w", task.Offset, count, lastErr)
 			}
@@ -241,6 +242,7 @@ func (d *ConcurrentDownloader) downloadTask(ctx context.Context, rawurl string, 
 
 	// Handle rate limiting explicitly
 	if resp.StatusCode == http.StatusTooManyRequests {
+		d.report429()
 		return fmt.Errorf("rate limited (429)")
 	}
 

--- a/internal/engine/concurrent/worker.go
+++ b/internal/engine/concurrent/worker.go
@@ -41,6 +41,7 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 
 		var lastErr error
 		maxRetries := d.Runtime.GetMaxTaskRetries()
+		var activeTask *ActiveTask
 		for attempt := 0; attempt < maxRetries; attempt++ {
 			if attempt > 0 {
 
@@ -62,7 +63,7 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 			// Register active task with per-task cancellable context
 			taskCtx, taskCancel := context.WithCancel(ctx)
 			now := time.Now()
-			activeTask := &ActiveTask{
+			activeTask = &ActiveTask{
 				Task:        task,
 				StartTime:   now,
 				Cancel:      taskCancel,
@@ -174,7 +175,32 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 
 		if lastErr != nil {
 			utils.Debug("Worker %d: task at offset %d failed after %d retries: %v", id, task.Offset, maxRetries, lastErr)
-			return lastErr
+
+			d.activeMu.Lock()
+			delete(d.activeTasks, id)
+			d.activeMu.Unlock()
+
+			d.taskRequeueMu.Lock()
+			count := d.taskRequeueCount[task.Offset]
+			d.taskRequeueCount[task.Offset] = count + 1
+			d.taskRequeueMu.Unlock()
+
+			maxRequeues := maxRetries * 2
+			if count >= maxRequeues {
+				return fmt.Errorf("task at offset %d failed after %d requeue attempts: %w", task.Offset, count, lastErr)
+			}
+
+			if remaining := activeTask.RemainingTask(); remaining != nil {
+				originalEnd := task.Offset + task.Length
+				if remaining.Offset+remaining.Length > originalEnd {
+					remaining.Length = originalEnd - remaining.Offset
+				}
+				if remaining.Length > 0 {
+					queue.Push(*remaining)
+					utils.Debug("Worker %d: re-queued %d bytes at offset %d (requeue %d/%d)",
+						id, remaining.Length, remaining.Offset, count+1, maxRequeues)
+				}
+			}
 		}
 	}
 }

--- a/internal/engine/concurrent/worker.go
+++ b/internal/engine/concurrent/worker.go
@@ -2,11 +2,11 @@ package concurrent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
-	"strings"
 	"sync/atomic"
 	"time"
 
@@ -97,7 +97,7 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 
 			taskStart := time.Now()
 			lastErr = d.downloadTask(taskCtx, currentURL, file, activeTask, buf, client, totalSize)
-			if lastErr != nil && strings.Contains(lastErr.Error(), "rate limited") && !had429ThisTask {
+			if lastErr != nil && errors.Is(lastErr, ErrRateLimited) && !had429ThisTask {
 				d.report429()
 				had429ThisTask = true
 			}
@@ -164,6 +164,9 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 				if had429ThisTask {
 					d.clear429()
 				}
+				d.taskRequeueMu.Lock()
+				delete(d.taskRequeueCount, task.Offset)
+				d.taskRequeueMu.Unlock()
 				// Check if we stopped early due to stealing
 				stopAt := activeTask.StopAt.Load()
 				current := activeTask.CurrentOffset.Load()
@@ -195,6 +198,12 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 			delete(d.activeTasks, id)
 			d.activeMu.Unlock()
 
+			// The requeue circuit-breaker is keyed on task.Offset. When a chunk
+			// makes partial progress across retries, task.Offset advances (see
+			// the resume-on-retry block above), effectively resetting the count
+			// for the new offset. This is intentional: forward progress means
+			// the chunk is eventually completable, so we allow a fresh budget.
+			// Only zero-progress failures (e.g. pure 429) are strictly capped.
 			d.taskRequeueMu.Lock()
 			count := d.taskRequeueCount[task.Offset]
 			d.taskRequeueCount[task.Offset] = count + 1
@@ -262,7 +271,7 @@ func (d *ConcurrentDownloader) downloadTask(ctx context.Context, rawurl string, 
 
 	// Handle rate limiting explicitly
 	if resp.StatusCode == http.StatusTooManyRequests {
-		return fmt.Errorf("rate limited (429)")
+		return ErrRateLimited
 	}
 
 	// Validate status code

--- a/internal/engine/concurrent/worker.go
+++ b/internal/engine/concurrent/worker.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -42,6 +43,7 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 		var lastErr error
 		maxRetries := d.Runtime.GetMaxTaskRetries()
 		var activeTask *ActiveTask
+		had429ThisTask := false
 		for attempt := 0; attempt < maxRetries; attempt++ {
 			if attempt > 0 {
 
@@ -95,6 +97,10 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 
 			taskStart := time.Now()
 			lastErr = d.downloadTask(taskCtx, currentURL, file, activeTask, buf, client, totalSize)
+			if lastErr != nil && strings.Contains(lastErr.Error(), "rate limited") && !had429ThisTask {
+				d.report429()
+				had429ThisTask = true
+			}
 
 			// CRITICAL: Capture external cancellation state BEFORE calling taskCancel()
 			// If we call taskCancel() first, taskCtx.Err() will always be non-nil
@@ -106,6 +112,9 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 			// Check for PARENT context cancellation (pause/shutdown)
 			// This preserves active task info for pause handler to collect
 			if ctx.Err() != nil {
+				if had429ThisTask {
+					d.clear429()
+				}
 				// DON'T delete from activeTasks - pause handler needs it
 				if d.State != nil {
 					d.State.ActiveWorkers.Add(-1)
@@ -140,6 +149,9 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 				d.activeMu.Unlock()
 				// Clear lastErr so the fallthrough logic doesn't re-queue the original task
 				lastErr = nil
+				if had429ThisTask {
+					d.clear429()
+				}
 				break // Exit retry loop, get next task
 			}
 
@@ -149,7 +161,9 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 			d.activeMu.Unlock()
 
 			if lastErr == nil {
-				d.clear429()
+				if had429ThisTask {
+					d.clear429()
+				}
 				// Check if we stopped early due to stealing
 				stopAt := activeTask.StopAt.Load()
 				current := activeTask.CurrentOffset.Load()
@@ -188,6 +202,9 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 
 			maxRequeues := maxRetries
 			if count >= maxRequeues {
+				if had429ThisTask {
+					d.clear429()
+				}
 				return fmt.Errorf("task at offset %d failed after %d requeue attempts: %w", task.Offset, count, lastErr)
 			}
 
@@ -201,6 +218,9 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 					utils.Debug("Worker %d: re-queued %d bytes at offset %d (requeue %d/%d)",
 						id, remaining.Length, remaining.Offset, count+1, maxRequeues)
 				}
+			}
+			if had429ThisTask {
+				d.clear429()
 			}
 		}
 	}
@@ -242,7 +262,6 @@ func (d *ConcurrentDownloader) downloadTask(ctx context.Context, rawurl string, 
 
 	// Handle rate limiting explicitly
 	if resp.StatusCode == http.StatusTooManyRequests {
-		d.report429()
 		return fmt.Errorf("rate limited (429)")
 	}
 

--- a/internal/engine/types/config.go
+++ b/internal/engine/types/config.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 )
 
@@ -69,6 +70,7 @@ type DownloadConfig struct {
 	SupportsRange      bool
 	RateLimitBps       int64
 	RateLimitSet       bool
+	Global429          *atomic.Int32
 }
 
 // ByteLimiter abstracts byte-based throttling for downloads.


### PR DESCRIPTION
Resolves issue with premature cancellation on worker failure, implements task requeue logic, and adds adaptive 429 exponential backoff.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes premature download cancellation on worker failure by replacing the immediate `cancel()` call with task re-queue logic and a circuit breaker, and wires a pool-level `atomic.Int32` counter into each download for cross-download adaptive 429 backoff.

- `worker.go` gains an outer re-queue loop: exhausted chunks are pushed back to `TaskQueue` (up to `maxRetries` re-queues keyed on `task.Offset`) instead of triggering an immediate abort; the `had429ThisTask` flag keeps `active429Count` balanced across all exit paths.
- `downloader.go` delays `cancel()` until after all workers finish and adds `sleepBackoff`, `report429`, and `clear429` helpers; `executeWorkers` captures orphan chunks in an `atomic.Int64` after `wg.Wait()`.
- `pool.go`/`manager.go`/`types/config.go` plumb a pool-scoped `global429Count` all the way into `ConcurrentDownloader` via `SetShared429Count`, fixing the previously no-op `Global429` field.

<h3>Confidence Score: 3/5</h3>

Do not merge until the deadlock in executeWorkers is resolved; under specific scheduling, a worker stuck in queue.Pop() will permanently hang the download goroutine.

The core logic change — delaying cancel() until after all workers finish — introduces a deadlock: when the re-queue circuit breaker fires for the last task without pushing it back to TaskQueue, any idle worker waiting in the blocking condvar queue.Pop() is stuck forever because queue.Close() is only called after wg.Wait(), which can never return. This affects the primary download path whenever a chunk permanently fails while another worker has gone idle waiting for work.

internal/engine/concurrent/downloader.go (executeWorkers cancel() flow) and internal/engine/concurrent/requeue_test.go (non-deterministic request-counter test)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/engine/concurrent/downloader.go | Refactors executeWorkers to delay cancel() until after all workers finish, enabling re-queue logic; introduces active429Count/shared429Count, sleepBackoff, and report/clear429 helpers. The delayed cancel() creates a deadlock path when the circuit breaker fires while another worker is idle in queue.Pop(). |
| internal/engine/concurrent/worker.go | Adds task re-queue loop with circuit breaker (taskRequeueCount), had429ThisTask flag for balanced report/clear429 calls, and context-aware sleepBackoff. The 429 counter bookkeeping is correct; the acknowledged circuit-breaker bypass via advancing task.Offset is intentional per the code comment. |
| internal/engine/concurrent/requeue_test.go | New test file covering four requeue/429 scenarios; the single-worker test uses a non-deterministic global request counter with concurrent workers, which could produce flaky results under adverse scheduling. SetShared429Count integration path is not exercised. |
| internal/download/pool.go | Adds global429Count atomic field to WorkerPool, wires it into each download's config, and improves the cancel-wait loop to use context.WithTimeout instead of a manual deadline poll. Previously the Global429 pointer was never forwarded to the downloader engine; this PR fixes that. |
| internal/download/manager.go | Forwards cfg.Global429 to the downloader via SetShared429Count when present; small targeted change with no issues found. |
| internal/engine/types/config.go | Adds Global429 *atomic.Int32 field to DownloadConfig to carry the pool-level shared rate-limit counter; straightforward additive change. |
| cmd/root_startup.go | Adds version/commit debug logging at startup; no issues found. |


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/engine/concurrent/worker.go`, line 178-201 ([link](https://github.com/surgedm/surge/blob/741c47fd0565f5a926b19fde1ba7a5e3b3633f81/internal/engine/concurrent/worker.go#L178-L201)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Circuit breaker bypassed when partial progress is made on each retry**

   The `taskRequeueCount` map uses `task.Offset` as its key, but `task` is mutated in-place at lines 180–183 ("Resume-on-retry") to advance the offset whenever partial progress is made. Each time the task is re-queued after partial progress, the new offset is a fresh key with count 0, so `count >= maxRequeues` never fires. A chunk that makes even a single byte of progress before each failure can be re-queued indefinitely, keeping workers spinning until the download context times out.

   The fix is to capture the original offset before the retry loop and use that stable value as the map key: `originalOffset := task.Offset` (before `for attempt := 0 ...`), then use `d.taskRequeueCount[originalOffset]` throughout.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/engine/concurrent/worker.go
   Line: 178-201

   Comment:
   **Circuit breaker bypassed when partial progress is made on each retry**

   The `taskRequeueCount` map uses `task.Offset` as its key, but `task` is mutated in-place at lines 180–183 ("Resume-on-retry") to advance the offset whenever partial progress is made. Each time the task is re-queued after partial progress, the new offset is a fresh key with count 0, so `count >= maxRequeues` never fires. A chunk that makes even a single byte of progress before each failure can be re-queued indefinitely, keeping workers spinning until the download context times out.

   The fix is to capture the original offset before the retry loop and use that stable value as the map key: `originalOffset := task.Offset` (before `for attempt := 0 ...`), then use `d.taskRequeueCount[originalOffset]` throughout.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/engine/concurrent/downloader.go:542-548
**Deadlock when circuit breaker fires with a worker idle in `queue.Pop()`**

`queue.Pop()` is a blocking condvar wait (`cond.Wait()`) that only wakes up when a task is pushed or `queue.Close()` is called. `queue.Close()` is only called here after `wg.Wait()` returns. If Worker A exhausts its re-queue budget and returns an error *without* pushing the task back to the queue, while Worker B is blocked in `queue.Pop()` waiting for work, `wg.Wait()` never returns, `queue.Close()` is never called, and Worker B is permanently stuck. The entire `executeWorkers` call deadlocks until an external context timeout fires.

This regression was introduced by removing the immediate `cancel()` call on worker error. In the old code, `cancel()` caused in-flight `downloadTask` calls to abort promptly via context cancellation, meaning all remaining workers exited through the `ctx.Err()` path before they could block in `queue.Pop()`. Now workers loop back to `queue.Pop()` after processing re-queued tasks, creating a window where they are idle in the condvar while another worker exhausts the circuit breaker and exits without pushing.

The minimal fix is to call `cancel()` when a worker error is received — either directly in the goroutine (restoring the original behavior) or inside the `for range workerErrors` loop before the range exits.


`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix: ensure proper 429 counter reset and..."](https://github.com/surgedm/surge/commit/9eb43db7c05d36be1aa527d92fde506ceb93e745) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39755436)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->