### PR TITLE
fix: broken fallback to single downloader

### DIFF
--- a/cmd/root_startup.go
+++ b/cmd/root_startup.go
@@ -50,6 +50,7 @@ func initializeGlobalState() error {
 
 	// Config logging
 	utils.ConfigureDebug(logsDir)
+	utils.Debug("Surge %s (commit %s)", Version, Commit)
 
 	// Clean up old logs (keeping retention-1 because a new log will be created immediately after)
 	retention := config.Resolve[int](getSettings().General.LogRetentionCount)

--- a/internal/download/manager.go
+++ b/internal/download/manager.go
@@ -238,6 +238,11 @@ func RunDownload(ctx context.Context, cfg *types.DownloadConfig) error {
 		if d.TotalSize > 0 {
 			effectiveTotalSize = d.TotalSize
 		}
+		if downloadErr != nil {
+			utils.Debug("Single-threaded download failed: %v", downloadErr)
+		} else {
+			utils.Debug("Single-threaded download completed: %d bytes", effectiveTotalSize)
+		}
 	}
 
 	// Only send completion if NO error AND not paused

--- a/internal/download/pool.go
+++ b/internal/download/pool.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/SurgeDM/Surge/internal/engine"
+	"github.com/SurgeDM/Surge/internal/engine/events"
 	"github.com/SurgeDM/Surge/internal/engine/types"
 	"github.com/SurgeDM/Surge/internal/utils"
 )
@@ -622,7 +623,33 @@ func (p *WorkerPool) worker() {
 
 		if isPaused {
 			utils.Debug("WorkerPool: Download %s paused cleanly", localCfg.ID)
-			// If paused, we keep it in downloads map for potential resume via ExtractPausedConfig
+			// The concurrent downloader sends DownloadPausedMsg itself via handlePause()
+			// (which causes RunDownload to return nil). When a single-threaded download is
+			// paused, RunDownload returns a non-nil error, and the pool must fill the gap.
+			if err != nil && localCfg.ProgressCh != nil {
+				var downloaded int64
+				var rateLimit int64
+				var rateLimitSet bool
+				var workers int
+				var minChunkSize int64
+				if localCfg.State != nil {
+					downloaded = localCfg.State.Downloaded.Load()
+				}
+				if localCfg.Runtime != nil {
+					workers = localCfg.Runtime.Workers
+					minChunkSize = localCfg.Runtime.MinChunkSize
+				}
+				rateLimit, rateLimitSet = localCfg.RateLimitBps, localCfg.RateLimitSet
+				safeSendProgress(localCfg.ProgressCh, events.DownloadPausedMsg{
+					DownloadID:   localCfg.ID,
+					Filename:     localCfg.Filename,
+					Downloaded:   downloaded,
+					RateLimit:    rateLimit,
+					RateLimitSet: rateLimitSet,
+					Workers:      workers,
+					MinChunkSize: minChunkSize,
+				})
+			}
 		} else if err != nil {
 			if localCfg.State != nil {
 				localCfg.State.SetError(err)

--- a/internal/engine/single/downloader.go
+++ b/internal/engine/single/downloader.go
@@ -92,38 +92,73 @@ func (d *SingleDownloader) Download(ctx context.Context, rawurl, destPath string
 		d.State.SetCancelFunc(cancel)
 	}
 
-	req, err := http.NewRequestWithContext(dlCtx, http.MethodGet, rawurl, nil)
-	if err != nil {
-		return err
+	buildRequest := func() (*http.Request, error) {
+		req, err := http.NewRequestWithContext(dlCtx, http.MethodGet, rawurl, nil)
+		if err != nil {
+			return nil, err
+		}
+		for key, val := range d.Headers {
+			if strings.EqualFold(key, "Range") {
+				continue
+			}
+			req.Header.Set(key, val)
+		}
+		req.Header.Set("User-Agent", d.Runtime.GetUserAgent())
+		return req, nil
 	}
 
-	for key, val := range d.Headers {
-		// Never forward a caller-supplied Range header. This downloader fetches
-		// the whole file in one connection, so a range-capable server would
-		// reply 206 and the strict 200 check below would abort a valid download.
-		// The worker, probe and redirect paths strip Range for the same reason.
-		if strings.EqualFold(key, "Range") {
+	var resp *http.Response
+	const maxRlRetries = types.RateLimitMaxRetries
+	rlRetries := 0
+
+	for {
+		req, err := buildRequest()
+		if err != nil {
+			return err
+		}
+
+		resp, err = client.Do(req)
+		if err != nil {
+			utils.Debug("Single downloader: GET %s failed: %v", rawurl, err)
+			return err
+		}
+
+		if resp.StatusCode == http.StatusOK {
+			break
+		}
+
+		if resp.StatusCode == http.StatusTooManyRequests ||
+			(resp.StatusCode == http.StatusServiceUnavailable && resp.Header.Get("Retry-After") != "") {
+			_ = resp.Body.Close()
+			rlRetries++
+			if rlRetries > maxRlRetries {
+				utils.Debug("Single downloader: rate limited after %d retries for %s", maxRlRetries, rawurl)
+				return fmt.Errorf("rate limited after %d retries: %d", maxRlRetries, resp.StatusCode)
+			}
+
+			ra, _ := engine.ParseRetryAfter(resp.Header.Get("Retry-After"), time.Now())
+			if ra <= 0 {
+				ra = 5 * time.Second
+			}
+			utils.Debug("Single downloader: rate limited (%d), waiting %v (retry %d/%d)", resp.StatusCode, ra, rlRetries, maxRlRetries)
+			select {
+			case <-dlCtx.Done():
+				return dlCtx.Err()
+			case <-time.After(ra):
+			}
 			continue
 		}
-		req.Header.Set(key, val)
-	}
-	req.Header.Set("User-Agent", d.Runtime.GetUserAgent())
 
-	resp, err := client.Do(req)
-	if err != nil {
-		utils.Debug("Single downloader: GET %s failed: %v", rawurl, err)
-		return err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			utils.Debug("Error closing response body: %v", err)
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK {
+		_ = resp.Body.Close()
 		utils.Debug("Single downloader: unexpected status %d for %s", resp.StatusCode, rawurl)
 		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
+
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			utils.Debug("Error closing response body: %v", cerr)
+		}
+	}()
 
 	if fileSize <= 0 && resp.ContentLength > 0 {
 		fileSize = resp.ContentLength

--- a/internal/engine/single/downloader.go
+++ b/internal/engine/single/downloader.go
@@ -86,7 +86,13 @@ func (d *SingleDownloader) Download(ctx context.Context, rawurl, destPath string
 		defer d.State.ActiveWorkers.Store(0)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawurl, nil)
+	dlCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	if d.State != nil {
+		d.State.SetCancelFunc(cancel)
+	}
+
+	req, err := http.NewRequestWithContext(dlCtx, http.MethodGet, rawurl, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/engine/single/downloader.go
+++ b/internal/engine/single/downloader.go
@@ -83,6 +83,7 @@ func (d *SingleDownloader) Download(ctx context.Context, rawurl, destPath string
 		d.State.SetURL(rawurl)
 		d.State.SetDestPath(destPath)
 		d.State.ActiveWorkers.Store(1)
+		defer d.State.ActiveWorkers.Store(0)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawurl, nil)

--- a/internal/engine/single/downloader.go
+++ b/internal/engine/single/downloader.go
@@ -105,6 +105,7 @@ func (d *SingleDownloader) Download(ctx context.Context, rawurl, destPath string
 
 	resp, err := client.Do(req)
 	if err != nil {
+		utils.Debug("Single downloader: GET %s failed: %v", rawurl, err)
 		return err
 	}
 	defer func() {
@@ -114,6 +115,7 @@ func (d *SingleDownloader) Download(ctx context.Context, rawurl, destPath string
 	}()
 
 	if resp.StatusCode != http.StatusOK {
+		utils.Debug("Single downloader: unexpected status %d for %s", resp.StatusCode, rawurl)
 		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 
@@ -168,6 +170,7 @@ func (d *SingleDownloader) Download(ctx context.Context, rawurl, destPath string
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return ctxErr
 		}
+		utils.Debug("Single downloader: copy error for %s: %v", rawurl, err)
 		return fmt.Errorf("copy error: %w", err)
 	}
 

--- a/internal/engine/single/downloader.go
+++ b/internal/engine/single/downloader.go
@@ -231,6 +231,7 @@ type progressReader struct {
 	batchInterval time.Duration
 	written       int64
 	pending       int64
+	pendingStart  int64
 	lastFlush     time.Time
 	readChecks    uint8
 }
@@ -256,6 +257,9 @@ func (w *progressReader) Read(p []byte) (int, error) {
 
 	written := int64(n)
 	w.written += written
+	if w.pending == 0 {
+		w.pendingStart = w.written - written
+	}
 	w.pending += written
 	if w.pending >= w.batchSize {
 		w.flushWithTime(time.Now())
@@ -293,6 +297,9 @@ func (w *progressReader) flushWithTime(now time.Time) {
 		return
 	}
 
+	if w.pending > 0 {
+		w.state.UpdateChunkStatus(w.pendingStart, w.pending, types.ChunkCompleted)
+	}
 	w.state.Downloaded.Store(w.written)
 	w.state.VerifiedProgress.Store(w.written)
 	w.pending = 0

--- a/internal/engine/single/downloader.go
+++ b/internal/engine/single/downloader.go
@@ -82,6 +82,7 @@ func (d *SingleDownloader) Download(ctx context.Context, rawurl, destPath string
 	if d.State != nil {
 		d.State.SetURL(rawurl)
 		d.State.SetDestPath(destPath)
+		d.State.ActiveWorkers.Store(1)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawurl, nil)

--- a/internal/engine/single/downloader_test.go
+++ b/internal/engine/single/downloader_test.go
@@ -382,8 +382,8 @@ func TestSingleDownloader_Download_Success(t *testing.T) {
 	if state.Downloaded.Load() != fileSize {
 		t.Errorf("Downloaded %d != fileSize %d", state.Downloaded.Load(), fileSize)
 	}
-	if state.ActiveWorkers.Load() != 1 {
-		t.Errorf("ActiveWorkers = %d, want 1 (single-threaded should report 1 connection)", state.ActiveWorkers.Load())
+	if state.ActiveWorkers.Load() != 0 {
+		t.Errorf("ActiveWorkers = %d, want 0 (should clear after download completes)", state.ActiveWorkers.Load())
 	}
 }
 
@@ -526,8 +526,8 @@ func TestSingleDownloader_Download_ProgressTracking(t *testing.T) {
 	if state.VerifiedProgress.Load() != fileSize {
 		t.Errorf("Verified progress %d != file size %d", state.VerifiedProgress.Load(), fileSize)
 	}
-	if state.ActiveWorkers.Load() != 1 {
-		t.Errorf("ActiveWorkers = %d, want 1 (single-threaded should report 1 connection)", state.ActiveWorkers.Load())
+	if state.ActiveWorkers.Load() != 0 {
+		t.Errorf("ActiveWorkers = %d, want 0 (should clear after download completes)", state.ActiveWorkers.Load())
 	}
 }
 

--- a/internal/engine/single/downloader_test.go
+++ b/internal/engine/single/downloader_test.go
@@ -382,6 +382,9 @@ func TestSingleDownloader_Download_Success(t *testing.T) {
 	if state.Downloaded.Load() != fileSize {
 		t.Errorf("Downloaded %d != fileSize %d", state.Downloaded.Load(), fileSize)
 	}
+	if state.ActiveWorkers.Load() != 1 {
+		t.Errorf("ActiveWorkers = %d, want 1 (single-threaded should report 1 connection)", state.ActiveWorkers.Load())
+	}
 }
 
 func TestSingleDownloader_StripsCallerRangeHeader(t *testing.T) {
@@ -522,6 +525,9 @@ func TestSingleDownloader_Download_ProgressTracking(t *testing.T) {
 	}
 	if state.VerifiedProgress.Load() != fileSize {
 		t.Errorf("Verified progress %d != file size %d", state.VerifiedProgress.Load(), fileSize)
+	}
+	if state.ActiveWorkers.Load() != 1 {
+		t.Errorf("ActiveWorkers = %d, want 1 (single-threaded should report 1 connection)", state.ActiveWorkers.Load())
 	}
 }
 

--- a/internal/engine/types/progress.go
+++ b/internal/engine/types/progress.go
@@ -247,6 +247,7 @@ func (ps *ProgressState) SessionReset() {
 	ps.SessionStartBytes = 0
 	ps.StartTime = time.Now()
 	ps.SavedElapsed = 0
+	ps.ActiveWorkers.Store(0)
 	ps.Done.Store(false)
 	ps.Paused.Store(false)
 	ps.Pausing.Store(false)

--- a/internal/engine/types/progress.go
+++ b/internal/engine/types/progress.go
@@ -436,7 +436,6 @@ func (ps *ProgressState) UpdateChunkStatus(offset, length int64, status ChunkSta
 	ps.mu.Lock()
 
 	if ps.ActualChunkSize == 0 || len(ps.ChunkBitmap) == 0 {
-		utils.Debug("UpdateChunkStatus skipped: ActualChunkSize=%d, BitmapLen=%d", ps.ActualChunkSize, len(ps.ChunkBitmap))
 		ps.mu.Unlock()
 		return
 	}

--- a/internal/engine/types/progress_test.go
+++ b/internal/engine/types/progress_test.go
@@ -313,6 +313,7 @@ func TestProgressState_SessionReset(t *testing.T) {
 	ps.SessionStartBytes = 100
 	ps.SavedElapsed = 10 * time.Second
 	ps.Done.Store(true)
+	ps.ActiveWorkers.Store(8)
 	ps.InitBitmap(1000, 100)
 
 	// Simulate some activity
@@ -334,6 +335,9 @@ func TestProgressState_SessionReset(t *testing.T) {
 	}
 	if ps.Done.Load() {
 		t.Error("Done should be false after reset")
+	}
+	if ps.ActiveWorkers.Load() != 0 {
+		t.Errorf("ActiveWorkers = %d, want 0", ps.ActiveWorkers.Load())
 	}
 
 	// Verify bitmap was cleared


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two related gaps in the single-threaded download path: `DownloadPausedMsg` was never emitted when a single-threaded download was paused (the pool now sends it when `isPaused && err != nil`), and `ActiveWorkers` was never set or cleared, leaving progress state inconsistent. It also adds rate-limit retry logic (429/503 Retry-After) to the single downloader and wires `UpdateChunkStatus` into `progressReader` so the chunk bitmap is populated during single-threaded transfers.

- **Pool pause fix** (`pool.go`): The discriminating condition `isPaused && err != nil` correctly identifies single-threaded paused downloads (which return a non-nil error) vs. concurrent ones (which send the message themselves and return nil).
- **Single downloader enhancements** (`single/downloader.go`): Introduces a child context (`dlCtx`) for pause/cancel, deferred `ActiveWorkers` lifecycle management, 429/503 retry-after loop, and chunk-bitmap updates via `progressReader.flushWithTime`.
- **State cleanup** (`types/progress.go`): `SessionReset` now zeroes `ActiveWorkers`; the noisy `UpdateChunkStatus` skipped debug log is removed since single-threaded downloads call it with no bitmap.

<h3>Confidence Score: 5/5</h3>

The core bug fixes are correct and well-scoped; the two findings are minor quality concerns that do not affect correctness of the main fix.

The pause-message fix and ActiveWorkers lifecycle management are correct. The throttledReader context mismatch only causes marginal pause-response delay under rate limiting, and the missing retry tests do not affect current runtime behavior.

internal/engine/single/downloader.go — the rate-limit retry loop and the throttledReader context are the areas worth a second look

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/download/pool.go | Adds DownloadPausedMsg emission for single-threaded paused downloads; the discriminating condition (isPaused && err != nil) correctly distinguishes single-threaded (returns non-nil error on pause) from concurrent (returns nil, sends message itself) |
| internal/engine/single/downloader.go | Adds ActiveWorkers lifecycle, a child context for cancellation, rate-limit retry loop, and UpdateChunkStatus calls to progressReader; throttledReader still uses parent ctx instead of dlCtx, and the retry loop has no test coverage |
| internal/engine/types/progress.go | SessionReset now zeroes ActiveWorkers and removes a noisy debug log from UpdateChunkStatus |
| internal/engine/single/downloader_test.go | Adds ActiveWorkers post-completion assertions; does not cover the new rate-limit retry code path |
| internal/engine/types/progress_test.go | Extends SessionReset test to verify ActiveWorkers is zeroed; straightforward and correct |
| internal/download/manager.go | Adds debug logging around single-threaded download outcome; minimal, correct change |
| cmd/root_startup.go | Logs version and commit at startup for easier debugging; safe one-liner addition |

<sub>Reviews (4): Last reviewed commit: ["feat: single downloader Retry-After"](https://github.com/surgedm/surge/commit/10ce64f8d65b745b3df92c5b7d26354744cd9988) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40050417)</sub>

**Context used:**

- Rule used - What: All code changes must include tests for edge... ([source](https://app.greptile.com/surge-org-3/-/custom-context?memory=2b22782d-3452-4d55-b059-e631b2540ce8))

<!-- /greptile_comment -->