### PR TITLE
Fix footer separator character in view.go

### DIFF
--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -375,7 +375,7 @@ func (m RootModel) View() tea.View {
 	helpText := lipgloss.NewStyle().PaddingLeft(2).Render(m.help.View(m.keys.Dashboard))
 
 	// --- Right-side footer: speed ｜ limit ｜ version ---
-	dimSep := lipgloss.NewStyle().Foreground(colors.Gray()).Render(" \uff5c ")
+	dimSep := lipgloss.NewStyle().Foreground(colors.Gray()).Render(" \u2502 ")
 
 	// Global speed indicator
 	speedBps := m.calcTotalSpeedBps()

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -374,7 +374,7 @@ func (m RootModel) View() tea.View {
 	// Footer - keybindings on left, speed/limit/version on bottom-right
 	helpText := lipgloss.NewStyle().PaddingLeft(2).Render(m.help.View(m.keys.Dashboard))
 
-	// --- Right-side footer: speed ｜ limit ｜ version ---
+	// --- Right-side footer: speed │ limit │ version ---
 	dimSep := lipgloss.NewStyle().Foreground(colors.Gray()).Render(" \u2502 ")
 
 	// Global speed indicator


### PR DESCRIPTION
Replace `U+FF5C` (`｜`) with `U+2502` (`│`).

`U+FF5C` (**FULLWIDTH VERTICAL LINE**) is intended primarily for East Asian typography and is absent from many common programming/terminal fonts (e.g. Roboto Mono, Noto Sans Symbols, Noto Sans Symbols 2, Nerd Fonts Symbols, and Noto Color Emoji), resulting in missing-glyph placeholders.

`U+2502` (**BOX DRAWINGS LIGHT VERTICAL**) has near-universal support in terminal monospace fonts while preserving the intended appearance.

For reference:
- `U+2502` (BOX DRAWINGS LIGHT VERTICAL): https://www.compart.com/en/unicode/U+2502

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the `U+FF5C` (FULLWIDTH VERTICAL LINE) footer separator with `U+2502` (BOX DRAWINGS LIGHT VERTICAL) in `view.go`, fixing a missing-glyph issue in common terminal monospace fonts. Both the comment and the rendered escape sequence are updated consistently.

- Swaps `\uff5c` for `\u2502` in the `dimSep` render call so the separator displays correctly across Roboto Mono, Nerd Fonts, and similar terminal fonts.
- Updates the inline comment to reflect the new character, keeping documentation in sync with the code.

<h3>Confidence Score: 5/5</h3>

This is a safe, minimal typography fix touching a single constant in the footer renderer with no logic changes.

The change swaps one Unicode escape for another in a cosmetic separator string and its corresponding comment. Both the comment and the rendered value are updated consistently, and there is no risk of behavioral regression.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/tui/view.go | Replaces U+FF5C (FULLWIDTH VERTICAL LINE) with U+2502 (BOX DRAWINGS LIGHT VERTICAL) in both the comment and the rendered separator string — a safe, focused typography fix. |

<sub>Reviews (2): Last reviewed commit: ["Update internal/tui/view.go"](https://github.com/surgedm/surge/commit/8250655bf91c7a4a28f127846ded88043b986c6f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41916653)</sub>

<!-- /greptile_comment -->