### PR TITLE
Change black color value in light theme

### DIFF
--- a/themes/catppuccin.toml
+++ b/themes/catppuccin.toml
@@ -37,7 +37,7 @@ foreground = "#4c4f69"
 accent = "#8839ef"
 
 [colors.light.normal]
-black = "#e6e9ef"
+black = "#ccd0da"
 red = "#d20f39"
 green = "#40a02b"
 yellow = "#df8e1d"


### PR DESCRIPTION
Repalced `#e6e9ef` (Mantle) with `#ccd0da` (Surface 0) . Fixes invisible text.
Before:
<img width="1920" height="1080" alt="before" src="https://github.com/user-attachments/assets/15fb2c4c-199e-4c62-91cf-29f287908d3f" />

After:
<img width="1920" height="1080" alt="after" src="https://github.com/user-attachments/assets/5ce45229-d93e-4423-98e1-2832b0dccb4e" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes invisible text in the Catppuccin Latte (light) theme by replacing the `black` color in `[colors.light.normal]` with a more contrasting value. The previous Mantle color (`#e6e9ef`) was too close in luminosity to the Base background (`#eff1f5`), making any text rendered with ANSI color 0 nearly invisible.

- **Fix**: Changes `[colors.light.normal] black` from `#e6e9ef` (Mantle) to `#ccd0da` (Surface 0), a legitimate step darker in the Catppuccin Latte palette, restoring legible contrast.
- **Scope**: Change is confined to one value in `themes/catppuccin.toml` with no side effects on the dark (Frappe) theme or the bright-color section of the light theme.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a one-value color correction in a theme file with no logic or runtime impact.

The change is a straightforward swap of one hex color for a slightly darker one from the same palette. The before/after screenshots in the PR description confirm the fix works as intended, and the value #ccd0da (Surface 0) is the canonical Catppuccin Latte color appropriate for this slot.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| themes/catppuccin.toml | Single color value change: replaces the nearly-invisible Mantle (#e6e9ef) with Surface 0 (#ccd0da) for the light theme's normal black, improving contrast against the Base background (#eff1f5). |

<sub>Reviews (1): Last reviewed commit: ["Change black color value in light theme"](https://github.com/surgedm/surge/commit/83ce439f56cb702e061f4fde77184657e50a9075) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41921333)</sub>

<!-- /greptile_comment -->