### PR TITLE
Update black color value in surge.toml

### DIFF
--- a/themes/surge.toml
+++ b/themes/surge.toml
@@ -33,7 +33,7 @@ foreground = "#1a1a1a"
 accent = "#d10074"
 
 [colors.light.normal]
-black = "#d0d0d0"
+black = "#c6c6c6"
 red = "#d32f2f"
 green = "#2e7d32"
 yellow = "#f57c00"


### PR DESCRIPTION
Darkened black color in [colors.light.normal] by 5% for better contrast and visibility.

- Old value: `#d0d0d0`
- New value: `#c6c6c6`

Before:
<img width="1904" height="1064" alt="before" src="https://github.com/user-attachments/assets/1fa53405-8d0b-4cbb-abcd-99825170ac17" />

After:
<img width="1904" height="1064" alt="after" src="https://github.com/user-attachments/assets/f0efd495-5713-4a95-b19c-c0410c5c9a87" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR darkens the `black` color value in the `[colors.light.normal]` section of `themes/surge.toml` from `#d0d0d0` to `#c6c6c6`, reducing lightness by approximately 5% to improve contrast and readability in the light theme.

- Single-line config change in `themes/surge.toml` — no logic or behavioral impact beyond the visual color adjustment.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single color value tweak in a theme config file with no downstream logic impact.

The change is limited to one hex color value in a TOML theme file. It cannot introduce regressions in logic, performance, or security — the only effect is the visual appearance of the `black` terminal color in the light theme.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| themes/surge.toml | Single color value update: `black` in `[colors.light.normal]` changed from `#d0d0d0` to `#c6c6c6` for improved contrast in the light theme. |

<sub>Reviews (1): Last reviewed commit: ["Update black color value in surge.toml"](https://github.com/surgedm/surge/commit/9a1779147bf4d72f257c73ead090f04bd5797d05) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41923041)</sub>

<!-- /greptile_comment -->