### PR TITLE
Fix `surge service` add CLI support for system token retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ surge service install
 surge service start
 surge service stop
 surge service status
+surge service token
 
 # Uninstall the service
 surge service uninstall
@@ -140,7 +141,11 @@ This means the server is accessible via `localhost` (127.0.0.1) as well as your 
 The API is token-protected. Generate/read your token by running:
 
 ```bash
+# Get the standard token
 surge token
+
+# Get the token if Surge is installed as a system service
+surge service token
 ```
 
 Alternatively, you can find it in the TUI under **Settings > Extension**.
@@ -238,7 +243,7 @@ We would love to see you benchmark Surge on your system!
 The Surge extension intercepts browser downloads and sends them straight to your terminal. It communicates with the Surge client on port **1700** by default.
 
 > [!IMPORTANT]
-> An **Auth Token** is required to connect the extension to your Surge server. This can be obtained from the TUI under **Settings > Extension** or by running `surge token`.
+> An **Auth Token** is required to connect the extension to your Surge server. This can be obtained from the TUI under **Settings > Extension**, or by running `surge token` (or `surge service token` if installed as a system service).
 
 ### Chrome / Edge / Brave
 

--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -1060,16 +1060,12 @@ func TestProcessDownloads_RemoteAndLocal(t *testing.T) {
 func setupIsolatedCmdState(t *testing.T) {
 	t.Helper()
 	origSettings := globalSettings
-	origGetService := GetService
-
-	// Mock GetService to avoid interacting with real OS service manager
-	GetService = func() (service.Service, error) {
-		return &mockService{status: service.StatusStopped}, nil
-	}
+	origCheck := checkSystemServiceRunning
+	checkSystemServiceRunning = func() bool { return false }
 
 	t.Cleanup(func() {
 		globalSettings = origSettings
-		GetService = origGetService
+		checkSystemServiceRunning = origCheck
 		resetGlobalShutdownCoordinatorForTest(nil)
 	})
 

--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -1060,8 +1060,16 @@ func TestProcessDownloads_RemoteAndLocal(t *testing.T) {
 func setupIsolatedCmdState(t *testing.T) {
 	t.Helper()
 	origSettings := globalSettings
+	origGetService := GetService
+
+	// Mock GetService to avoid interacting with real OS service manager
+	GetService = func() (service.Service, error) {
+		return &mockService{status: service.StatusStopped}, nil
+	}
+
 	t.Cleanup(func() {
 		globalSettings = origSettings
+		GetService = origGetService
 		resetGlobalShutdownCoordinatorForTest(nil)
 	})
 

--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -57,6 +57,10 @@ func TestResolveDownloadID_Remote(t *testing.T) {
 	saveActivePort(port)
 	defer removeActivePort()
 
+	origToken := globalToken
+	globalToken = "test-token"
+	t.Cleanup(func() { globalToken = origToken })
+
 	// 3. Test resolveDownloadID
 	partial := "aabbcc"
 	full, err := resolveDownloadID(partial)
@@ -169,6 +173,10 @@ func TestResolveDownloadID_LocalModeFallsBackToDBWhenRemoteListFails(t *testing.
 	_, _ = fmt.Sscanf(portStr, "%d", &port)
 	saveActivePort(port)
 	t.Cleanup(removeActivePort)
+
+	origToken := globalToken
+	globalToken = "test-token"
+	t.Cleanup(func() { globalToken = origToken })
 
 	full, err := resolveDownloadID("99aabb")
 	if err != nil {
@@ -670,6 +678,10 @@ func TestActionCommandsRunE_ReturnAmbiguousIDErrors(t *testing.T) {
 			_, _ = fmt.Sscanf(portStr, "%d", &port)
 			saveActivePort(port)
 			t.Cleanup(removeActivePort)
+
+			origToken := globalToken
+			globalToken = "test-token"
+			t.Cleanup(func() { globalToken = origToken })
 
 			entries := []types.DownloadRecord{
 				{ID: "deadbeef-1234-5678-90ab-cdef12345678", Filename: "first.bin"},

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -316,9 +316,12 @@ func TestResolveTokenForConnectTarget_IPv6LoopbackUsesLocalToken(t *testing.T) {
 
 	origToken := globalToken
 	globalToken = ""
+	origCheck := checkSystemServiceRunning
+	checkSystemServiceRunning = func() bool { return false }
 	t.Setenv("SURGE_TOKEN", "")
 	t.Cleanup(func() {
 		globalToken = origToken
+		checkSystemServiceRunning = origCheck
 	})
 
 	target, err := parseConnectTarget("[::1]:1700", false)
@@ -352,8 +355,11 @@ func TestResolveTokenForConnectTarget_UsesActiveTokenForMatchingLocalPort(t *tes
 
 	origToken := globalToken
 	globalToken = ""
+	origCheck := checkSystemServiceRunning
+	checkSystemServiceRunning = func() bool { return false }
 	t.Cleanup(func() {
 		globalToken = origToken
+		checkSystemServiceRunning = origCheck
 	})
 	if err := writeTokenToFile(filepath.Join(config.GetStateDir(), "token"), "connect-token"); err != nil {
 		t.Fatalf("write token failed: %v", err)

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -689,6 +689,52 @@ func TestRootCmd_InvalidURL(t *testing.T) {
 	}
 }
 
+func TestRootCmd_FailsIfSystemServiceRunning(t *testing.T) {
+	setupIsolatedCmdState(t)
+
+	// Simulate system service running
+	origCheck := checkSystemServiceRunning
+	checkSystemServiceRunning = func() bool { return true }
+	t.Cleanup(func() { checkSystemServiceRunning = origCheck })
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"https://example.com/test"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when system service is running, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "system service is already running") {
+		t.Errorf("expected error to mention system service, got %v", err)
+	}
+}
+
+func TestServerStartCmd_FailsIfSystemServiceRunning(t *testing.T) {
+	setupIsolatedCmdState(t)
+
+	// Simulate system service running
+	origCheck := checkSystemServiceRunning
+	checkSystemServiceRunning = func() bool { return true }
+	t.Cleanup(func() { checkSystemServiceRunning = origCheck })
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"server", "start"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when system service is running, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "system service is already running") {
+		t.Errorf("expected error to mention system service, got %v", err)
+	}
+}
+
 func TestRootCmd_Version(t *testing.T) {
 	if rootCmd.Version == "" {
 		t.Error("rootCmd.Version should not be empty")

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -105,17 +105,18 @@ func TestFindAvailablePort_AllPortsOccupied(t *testing.T) {
 // =============================================================================
 
 func TestSaveAndRemoveActivePort(t *testing.T) {
-	// Setup temp dir
 	tmpDir := t.TempDir()
 	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
-	t.Setenv("SURGE_SYSTEM_RUNTIME_DIR", tmpDir)
-	t.Setenv("SURGE_SYSTEM_STATE_DIR", tmpDir)
-	t.Setenv("XDG_CONFIG_HOME", tmpDir) // For EnsureDirs to work happily
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 	t.Setenv("APPDATA", tmpDir)
-	// Ensure config dirs exist
+	t.Setenv("XDG_STATE_HOME", tmpDir)
+
 	if err := config.EnsureDirs(); err != nil {
 		t.Fatalf("Failed to ensure dirs: %v", err)
 	}
+
+	t.Setenv("SURGE_SYSTEM_RUNTIME_DIR", config.GetRuntimeDir())
+	t.Setenv("SURGE_SYSTEM_STATE_DIR", config.GetStateDir())
 
 	// Save port
 	testPort := 12345
@@ -337,22 +338,23 @@ func TestResolveTokenForConnectTarget_IPv6LoopbackUsesLocalToken(t *testing.T) {
 func TestResolveTokenForConnectTarget_UsesActiveTokenForMatchingLocalPort(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
-	t.Setenv("SURGE_SYSTEM_RUNTIME_DIR", tmpDir)
-	t.Setenv("SURGE_SYSTEM_STATE_DIR", tmpDir)
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 	t.Setenv("APPDATA", tmpDir)
 	t.Setenv("XDG_STATE_HOME", tmpDir)
 	t.Setenv("SURGE_TOKEN", "")
+
+	if err := config.EnsureDirs(); err != nil {
+		t.Fatalf("Failed to ensure dirs: %v", err)
+	}
+
+	t.Setenv("SURGE_SYSTEM_RUNTIME_DIR", config.GetRuntimeDir())
+	t.Setenv("SURGE_SYSTEM_STATE_DIR", config.GetStateDir())
 
 	origToken := globalToken
 	globalToken = ""
 	t.Cleanup(func() {
 		globalToken = origToken
 	})
-
-	if err := config.EnsureDirs(); err != nil {
-		t.Fatalf("Failed to ensure dirs: %v", err)
-	}
 	if err := writeTokenToFile(filepath.Join(config.GetStateDir(), "token"), "connect-token"); err != nil {
 		t.Fatalf("write token failed: %v", err)
 	}
@@ -1316,16 +1318,18 @@ func TestCorsMiddleware_AllMethods(t *testing.T) {
 // =============================================================================
 
 func TestPortFileLifecycle(t *testing.T) {
-	// Setup temp dir
 	tmpDir := t.TempDir()
 	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
-	t.Setenv("SURGE_SYSTEM_RUNTIME_DIR", tmpDir)
-	t.Setenv("SURGE_SYSTEM_STATE_DIR", tmpDir)
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("APPDATA", tmpDir)
+	t.Setenv("XDG_STATE_HOME", tmpDir)
 
 	if err := config.EnsureDirs(); err != nil {
 		t.Fatalf("Failed to ensure dirs: %v", err)
 	}
+
+	t.Setenv("SURGE_SYSTEM_RUNTIME_DIR", config.GetRuntimeDir())
+	t.Setenv("SURGE_SYSTEM_STATE_DIR", config.GetStateDir())
 
 	// Clean up first
 	removeActivePort()

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -108,6 +108,8 @@ func TestSaveAndRemoveActivePort(t *testing.T) {
 	// Setup temp dir
 	tmpDir := t.TempDir()
 	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
+	t.Setenv("SURGE_SYSTEM_RUNTIME_DIR", tmpDir)
+	t.Setenv("SURGE_SYSTEM_STATE_DIR", tmpDir)
 	t.Setenv("XDG_CONFIG_HOME", tmpDir) // For EnsureDirs to work happily
 	t.Setenv("APPDATA", tmpDir)
 	// Ensure config dirs exist
@@ -208,6 +210,8 @@ func TestCorsMiddleware_PassesThrough(t *testing.T) {
 func TestConnectCmd_AutoDetectsLocalServer(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
+	t.Setenv("SURGE_SYSTEM_RUNTIME_DIR", tmpDir)
+	t.Setenv("SURGE_SYSTEM_STATE_DIR", tmpDir)
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 	t.Setenv("APPDATA", tmpDir)
 	if err := config.EnsureDirs(); err != nil {
@@ -238,6 +242,8 @@ func TestConnectCmd_AutoDetectsLocalServer(t *testing.T) {
 func TestConnectCmd_NoServerRunning(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
+	t.Setenv("SURGE_SYSTEM_RUNTIME_DIR", tmpDir)
+	t.Setenv("SURGE_SYSTEM_STATE_DIR", tmpDir)
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 	t.Setenv("APPDATA", tmpDir)
 	if err := config.EnsureDirs(); err != nil {
@@ -299,6 +305,8 @@ func TestParseConnectTarget_BaseURL(t *testing.T) {
 func TestResolveTokenForConnectTarget_IPv6LoopbackUsesLocalToken(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
+	t.Setenv("SURGE_SYSTEM_RUNTIME_DIR", tmpDir)
+	t.Setenv("SURGE_SYSTEM_STATE_DIR", tmpDir)
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 	t.Setenv("APPDATA", tmpDir)
 	if err := config.EnsureDirs(); err != nil {
@@ -329,6 +337,8 @@ func TestResolveTokenForConnectTarget_IPv6LoopbackUsesLocalToken(t *testing.T) {
 func TestResolveTokenForConnectTarget_UsesActiveTokenForMatchingLocalPort(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
+	t.Setenv("SURGE_SYSTEM_RUNTIME_DIR", tmpDir)
+	t.Setenv("SURGE_SYSTEM_STATE_DIR", tmpDir)
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 	t.Setenv("APPDATA", tmpDir)
 	t.Setenv("XDG_STATE_HOME", tmpDir)
@@ -739,6 +749,8 @@ func TestReadRootRunOptions_TracksExplicitPort(t *testing.T) {
 func TestMaybeStartRootHTTPServer_NoServerSkipsPortFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
+	t.Setenv("SURGE_SYSTEM_RUNTIME_DIR", tmpDir)
+	t.Setenv("SURGE_SYSTEM_STATE_DIR", tmpDir)
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 	t.Setenv("APPDATA", tmpDir)
 	if err := config.EnsureDirs(); err != nil {
@@ -1261,6 +1273,8 @@ func TestPortFileLifecycle(t *testing.T) {
 	// Setup temp dir
 	tmpDir := t.TempDir()
 	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
+	t.Setenv("SURGE_SYSTEM_RUNTIME_DIR", tmpDir)
+	t.Setenv("SURGE_SYSTEM_STATE_DIR", tmpDir)
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 
 	if err := config.EnsureDirs(); err != nil {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1027,6 +1027,9 @@ func TestStartHTTPServer_HealthEndpoint(t *testing.T) {
 	if int(result["port"].(float64)) != port {
 		t.Errorf("Expected port %d, got %v", port, result["port"])
 	}
+	if result["mode"] != "local" && result["mode"] != "service" {
+		t.Errorf("Expected mode 'local' or 'service', got %v", result["mode"])
+	}
 }
 
 func TestStartHTTPServer_HasCORSHeaders(t *testing.T) {

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -146,6 +146,10 @@ func resolveTokenForConnectTarget(target connectTarget) (string, error) {
 			return tok, nil
 		}
 
+		if !isElevated() && checkSystemServiceRunning() {
+			return "", fmt.Errorf("system service is running but its token could not be read. Try connecting with elevated privileges")
+		}
+
 		if tok, err := readTokenFromFile(secondChoice); err == nil && tok != "" {
 			return tok, nil
 		}

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -6,10 +6,12 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/service"
 	"github.com/SurgeDM/Surge/internal/tui"
 	"github.com/spf13/cobra"
@@ -121,24 +123,25 @@ func resolveTokenForConnectTarget(target connectTarget) (string, error) {
 	if isLocalHost(serverHost) {
 		_, serverPort := parseRemoteServerAddress(target.BaseURL)
 		if details, ok := getActiveConnectionDetails(); ok && details.port == serverPort {
+			// Port file matched — use the token associated with that runtime dir
+			// (already handles both user and system runtime dirs).
 			return resolveLocalTokenForDetails(details), nil
 		}
-		// Active connection details didn't match (or no port file). Try reading
-		// both the user and system token files so connecting to a root-owned
-		// daemon works without --token.
-		if tok := resolveLocalToken(); tok != "" {
+
+		// No matching port file. Probe token files in order of specificity:
+		//   1. System state dir — for daemons running as root/SYSTEM (issue #530)
+		//   2. User state dir   — for user-level daemons without a port file
+		//   3. Generate         — last resort (creates a new user-level token)
+		if tok, err := readSystemServiceToken(); err == nil && tok != "" {
 			return tok, nil
 		}
-		// Last resort: try the system state dir directly (daemon may be running
-		// as root even if the port file isn't under a root-owned runtime dir).
-		if tok, err := readSystemServiceToken(); err == nil && tok != "" {
+		if tok, err := readTokenFromFile(filepath.Join(config.GetStateDir(), "token")); err == nil && tok != "" {
 			return tok, nil
 		}
 		return ensureAuthToken(), nil
 	}
 	return "", fmt.Errorf("remote target %q requires authentication: use --token or set SURGE_TOKEN", target.BaseURL)
 }
-
 
 func parseConnectTarget(target string, allowInsecureHTTP bool) (connectTarget, error) {
 	target = strings.TrimSpace(target)

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -129,13 +129,15 @@ func resolveTokenForConnectTarget(target connectTarget) (string, error) {
 		}
 
 		// No matching port file. Probe token files in order of specificity:
-		//   1. User state dir   — for user-level daemons without a port file
-		//   2. System state dir — for daemons running as root/SYSTEM (issue #530)
+		//   1. System state dir — for daemons running as root/SYSTEM (issue #530).
+		//      Tried first: a stale user-level token would cause 401 against the
+		//      system service, whereas the system token is the intentional deployment.
+		//   2. User state dir   — for user-level daemons without a port file
 		//   3. Generate         — last resort (creates a new user-level token)
-		if tok, err := readTokenFromFile(filepath.Join(config.GetStateDir(), "token")); err == nil && tok != "" {
+		if tok, err := readSystemServiceToken(); err == nil && tok != "" {
 			return tok, nil
 		}
-		if tok, err := readSystemServiceToken(); err == nil && tok != "" {
+		if tok, err := readTokenFromFile(filepath.Join(config.GetStateDir(), "token")); err == nil && tok != "" {
 			return tok, nil
 		}
 		return ensureAuthToken(), nil

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -129,13 +129,13 @@ func resolveTokenForConnectTarget(target connectTarget) (string, error) {
 		}
 
 		// No matching port file. Probe token files in order of specificity:
-		//   1. System state dir — for daemons running as root/SYSTEM (issue #530)
-		//   2. User state dir   — for user-level daemons without a port file
+		//   1. User state dir   — for user-level daemons without a port file
+		//   2. System state dir — for daemons running as root/SYSTEM (issue #530)
 		//   3. Generate         — last resort (creates a new user-level token)
-		if tok, err := readSystemServiceToken(); err == nil && tok != "" {
+		if tok, err := readTokenFromFile(filepath.Join(config.GetStateDir(), "token")); err == nil && tok != "" {
 			return tok, nil
 		}
-		if tok, err := readTokenFromFile(filepath.Join(config.GetStateDir(), "token")); err == nil && tok != "" {
+		if tok, err := readSystemServiceToken(); err == nil && tok != "" {
 			return tok, nil
 		}
 		return ensureAuthToken(), nil

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -123,10 +123,22 @@ func resolveTokenForConnectTarget(target connectTarget) (string, error) {
 		if details, ok := getActiveConnectionDetails(); ok && details.port == serverPort {
 			return resolveLocalTokenForDetails(details), nil
 		}
+		// Active connection details didn't match (or no port file). Try reading
+		// both the user and system token files so connecting to a root-owned
+		// daemon works without --token.
+		if tok := resolveLocalToken(); tok != "" {
+			return tok, nil
+		}
+		// Last resort: try the system state dir directly (daemon may be running
+		// as root even if the port file isn't under a root-owned runtime dir).
+		if tok, err := readSystemServiceToken(); err == nil && tok != "" {
+			return tok, nil
+		}
 		return ensureAuthToken(), nil
 	}
 	return "", fmt.Errorf("remote target %q requires authentication: use --token or set SURGE_TOKEN", target.BaseURL)
 }
+
 
 func parseConnectTarget(target string, allowInsecureHTTP bool) (connectTarget, error) {
 	target = strings.TrimSpace(target)

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -128,15 +128,25 @@ func resolveTokenForConnectTarget(target connectTarget) (string, error) {
 			return resolveLocalTokenForDetails(details), nil
 		}
 
-		// No matching port file. Prefer the system service token over a potentially
-		// stale user-level token to avoid 401s against the system daemon.
-		systemTokenFile := filepath.Join(config.GetSystemStateDir(), "token")
-		if tok, err := readTokenFromFile(systemTokenFile); err == nil && tok != "" {
+		// No matching port file. Prioritize the privilege level of the daemon we are most likely talking to.
+		var firstChoice, secondChoice string
+		if !isElevated() && checkSystemServiceRunning() {
+			firstChoice = filepath.Join(config.GetSystemStateDir(), "token")
+			secondChoice = filepath.Join(config.GetStateDir(), "token")
+		} else {
+			firstChoice = resolveTokenPath()
+			if isElevated() {
+				secondChoice = filepath.Join(config.GetStateDir(), "token")
+			} else {
+				secondChoice = filepath.Join(config.GetSystemStateDir(), "token")
+			}
+		}
+
+		if tok, err := readTokenFromFile(firstChoice); err == nil && tok != "" {
 			return tok, nil
 		}
 
-		userTokenFile := filepath.Join(config.GetStateDir(), "token")
-		if tok, err := readTokenFromFile(userTokenFile); err == nil && tok != "" {
+		if tok, err := readTokenFromFile(secondChoice); err == nil && tok != "" {
 			return tok, nil
 		}
 

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -128,21 +128,15 @@ func resolveTokenForConnectTarget(target connectTarget) (string, error) {
 			return resolveLocalTokenForDetails(details), nil
 		}
 
-		// No matching port file. Probe token files prioritizing the privilege
-		// level of this client process, since it is most likely trying to talk
-		// to its corresponding daemon.
-		myTokenFile := resolveTokenPath()
-		if tok, err := readTokenFromFile(myTokenFile); err == nil && tok != "" {
+		// No matching port file. Prefer the system service token over a potentially
+		// stale user-level token to avoid 401s against the system daemon.
+		systemTokenFile := filepath.Join(config.GetSystemStateDir(), "token")
+		if tok, err := readTokenFromFile(systemTokenFile); err == nil && tok != "" {
 			return tok, nil
 		}
 
-		var fallbackTokenFile string
-		if isElevated() {
-			fallbackTokenFile = filepath.Join(config.GetStateDir(), "token")
-		} else {
-			fallbackTokenFile = filepath.Join(config.GetSystemStateDir(), "token")
-		}
-		if tok, err := readTokenFromFile(fallbackTokenFile); err == nil && tok != "" {
+		userTokenFile := filepath.Join(config.GetStateDir(), "token")
+		if tok, err := readTokenFromFile(userTokenFile); err == nil && tok != "" {
 			return tok, nil
 		}
 

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -125,7 +125,7 @@ func resolveTokenForConnectTarget(target connectTarget) (string, error) {
 		if details, ok := getActiveConnectionDetails(); ok && details.port == serverPort {
 			// Port file matched — use the token associated with that runtime dir
 			// (already handles both user and system runtime dirs).
-			return resolveLocalTokenForDetails(details), nil
+			return resolveLocalTokenForDetails(details)
 		}
 
 		// No matching port file. Prioritize the privilege level of the daemon we are most likely talking to.

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -128,18 +128,24 @@ func resolveTokenForConnectTarget(target connectTarget) (string, error) {
 			return resolveLocalTokenForDetails(details), nil
 		}
 
-		// No matching port file. Probe token files in order of specificity:
-		//   1. System state dir — for daemons running as root/SYSTEM (issue #530).
-		//      Tried first: a stale user-level token would cause 401 against the
-		//      system service, whereas the system token is the intentional deployment.
-		//   2. User state dir   — for user-level daemons without a port file
-		//   3. Generate         — last resort (creates a new user-level token)
-		if tok, err := readSystemServiceToken(); err == nil && tok != "" {
+		// No matching port file. Probe token files prioritizing the privilege
+		// level of this client process, since it is most likely trying to talk
+		// to its corresponding daemon.
+		myTokenFile := resolveTokenPath()
+		if tok, err := readTokenFromFile(myTokenFile); err == nil && tok != "" {
 			return tok, nil
 		}
-		if tok, err := readTokenFromFile(filepath.Join(config.GetStateDir(), "token")); err == nil && tok != "" {
+
+		var fallbackTokenFile string
+		if isElevated() {
+			fallbackTokenFile = filepath.Join(config.GetStateDir(), "token")
+		} else {
+			fallbackTokenFile = filepath.Join(config.GetSystemStateDir(), "token")
+		}
+		if tok, err := readTokenFromFile(fallbackTokenFile); err == nil && tok != "" {
 			return tok, nil
 		}
+
 		return ensureAuthToken(), nil
 	}
 	return "", fmt.Errorf("remote target %q requires authentication: use --token or set SURGE_TOKEN", target.BaseURL)

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -123,9 +123,12 @@ func resolveTokenForConnectTarget(target connectTarget) (string, error) {
 	if isLocalHost(serverHost) {
 		_, serverPort := parseRemoteServerAddress(target.BaseURL)
 		if details, ok := getActiveConnectionDetails(); ok && details.port == serverPort {
-			// Port file matched — use the token associated with that runtime dir
-			// (already handles both user and system runtime dirs).
-			return resolveLocalTokenForDetails(details)
+			// Port file matched — use the token associated with that runtime dir,
+			// unless the system service is running and we matched a stale user
+			// port file (which would send the wrong token → 401).
+			if isElevated() || !checkSystemServiceRunning() || details.runtimeDir == config.GetSystemRuntimeDir() {
+				return resolveLocalTokenForDetails(details)
+			}
 		}
 
 		// No matching port file. Prioritize the privilege level of the daemon we are most likely talking to.

--- a/cmd/elevated_unix.go
+++ b/cmd/elevated_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package cmd
+
+import "os"
+
+// isElevated reports whether the current process is running with root
+// privileges. Used to select the correct token file path: root processes
+// (system service daemons) use GetSystemStateDir, others use GetStateDir.
+func isElevated() bool {
+	return os.Getuid() == 0
+}

--- a/cmd/http_api.go
+++ b/cmd/http_api.go
@@ -33,6 +33,7 @@ func registerHTTPRoutes(mux *http.ServeMux, port int, defaultOutputDir string, s
 		writeJSONResponse(w, http.StatusOK, map[string]interface{}{
 			"status": "ok",
 			"port":   port,
+			"mode":   activeServerMode,
 		})
 	})
 

--- a/cmd/http_handler_test.go
+++ b/cmd/http_handler_test.go
@@ -248,6 +248,9 @@ func TestHandleDownload_PathResolution(t *testing.T) {
 			}
 		})
 	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(filepath.Join(mustGetwd(t), "relative"))
+	})
 }
 
 func TestShouldFallbackUnmappedWindowsPath(t *testing.T) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -489,7 +489,7 @@ var rootCmd = &cobra.Command{
 			return nil
 		}
 
-		if isSystemServiceRunning() {
+		if checkSystemServiceRunning() {
 			return fmt.Errorf("system service is already running. Use 'surge connect' to interact with it, or stop the service first")
 		}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -489,6 +489,10 @@ var rootCmd = &cobra.Command{
 			return nil
 		}
 
+		if isSystemServiceRunning() {
+			return fmt.Errorf("system service is already running. Use 'surge connect' to interact with it, or stop the service first")
+		}
+
 		if len(args) > 0 {
 			var validFound bool
 			for _, arg := range args {

--- a/cmd/root_headless.go
+++ b/cmd/root_headless.go
@@ -23,26 +23,34 @@ func StartHeadlessConsumer(ctx context.Context, service service.DownloadService)
 		}
 		defer cleanup()
 
-		for msg := range stream {
-			switch msg.Type {
-			case types.EventStarted:
-				fmt.Printf("Started: %s [%s]\n", msg.Filename, truncateID(msg.DownloadID))
-			case types.EventComplete:
-				atomic.AddInt32(&activeDownloads, -1)
-				fmt.Printf("Completed: %s [%s] (in %s)\n", msg.Filename, truncateID(msg.DownloadID), msg.Elapsed)
-			case types.EventError:
-				atomic.AddInt32(&activeDownloads, -1)
-				fmt.Printf("Error: %s [%s]: %v\n", msg.Filename, truncateID(msg.DownloadID), msg.Err)
-			case types.EventQueued:
-				fmt.Printf("Queued: %s [%s]\n", msg.Filename, truncateID(msg.DownloadID))
-			case types.EventPaused:
-				fmt.Printf("Paused: %s [%s]\n", msg.Filename, truncateID(msg.DownloadID))
-			case types.EventResumed:
-				fmt.Printf("Resumed: %s [%s]\n", msg.Filename, truncateID(msg.DownloadID))
-			case types.EventRemoved:
-				fmt.Printf("Removed: %s [%s]\n", msg.Filename, truncateID(msg.DownloadID))
-			case types.EventProgress, types.EventRequest, types.EventBatchRequest, types.EventBatchProgress, types.EventSystem:
-				// Streaming/internal events are intentionally not logged to stdout.
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case msg, ok := <-stream:
+				if !ok {
+					return
+				}
+				switch msg.Type {
+				case types.EventStarted:
+					fmt.Printf("Started: %s [%s]\n", msg.Filename, truncateID(msg.DownloadID))
+				case types.EventComplete:
+					atomic.AddInt32(&activeDownloads, -1)
+					fmt.Printf("Completed: %s [%s] (in %s)\n", msg.Filename, truncateID(msg.DownloadID), msg.Elapsed)
+				case types.EventError:
+					atomic.AddInt32(&activeDownloads, -1)
+					fmt.Printf("Error: %s [%s]: %v\n", msg.Filename, truncateID(msg.DownloadID), msg.Err)
+				case types.EventQueued:
+					fmt.Printf("Queued: %s [%s]\n", msg.Filename, truncateID(msg.DownloadID))
+				case types.EventPaused:
+					fmt.Printf("Paused: %s [%s]\n", msg.Filename, truncateID(msg.DownloadID))
+				case types.EventResumed:
+					fmt.Printf("Resumed: %s [%s]\n", msg.Filename, truncateID(msg.DownloadID))
+				case types.EventRemoved:
+					fmt.Printf("Removed: %s [%s]\n", msg.Filename, truncateID(msg.DownloadID))
+				case types.EventProgress, types.EventRequest, types.EventBatchRequest, types.EventBatchProgress, types.EventSystem:
+					// Streaming/internal events are intentionally not logged to stdout.
+				}
 			}
 		}
 	}()

--- a/cmd/root_http_server.go
+++ b/cmd/root_http_server.go
@@ -16,6 +16,17 @@ import (
 	"github.com/google/uuid"
 )
 
+// resolveTokenPath returns the path of the auth-token file that this
+// process should use.  When the process is running as root/SYSTEM the
+// token lives in the system state directory so that the daemon and the
+// interactive user look in the same place.
+func resolveTokenPath() string {
+	if isElevated() {
+		return filepath.Join(config.GetSystemStateDir(), "token")
+	}
+	return filepath.Join(config.GetStateDir(), "token")
+}
+
 const serverBindHost = "0.0.0.0"
 
 // findAvailablePort tries ports starting from 'start' until one is available
@@ -146,24 +157,46 @@ func authMiddleware(token string, next http.Handler) http.Handler {
 }
 
 func ensureAuthToken() string {
-	stateTokenFile := filepath.Join(config.GetStateDir(), "token")
-	if token, err := readTokenFromFile(stateTokenFile); err == nil {
+	tokenFile := resolveTokenPath()
+	if token, err := readTokenFromFile(tokenFile); err == nil {
 		return token
 	}
 
 	token := uuid.New().String()
-	if err := writeTokenToFile(stateTokenFile, token); err != nil {
-		utils.Debug("Failed to write token file in state dir: %v", err)
+	if err := writeTokenToFile(tokenFile, token); err != nil {
+		utils.Debug("Failed to write token file in %s: %v", tokenFile, err)
 	}
 	return token
 }
 
 func persistAuthToken(token string) {
-	stateTokenFile := filepath.Join(config.GetStateDir(), "token")
-
-	if err := writeTokenToFile(stateTokenFile, token); err != nil {
-		utils.Debug("Failed to write token file in state dir: %v", err)
+	tokenFile := resolveTokenPath()
+	if err := writeTokenToFile(tokenFile, token); err != nil {
+		utils.Debug("Failed to write token file in %s: %v", tokenFile, err)
 	}
+}
+
+// ensureSystemToken reads (or generates) the token used by the system service
+// and returns it.  This is always in GetSystemStateDir regardless of the
+// current user — callers that need the system token use this directly.
+func ensureSystemToken() (string, error) {
+	tokenFile := filepath.Join(config.GetSystemStateDir(), "token")
+	if token, err := readTokenFromFile(tokenFile); err == nil {
+		return token, nil
+	}
+	token := uuid.New().String()
+	if err := writeTokenToFile(tokenFile, token); err != nil {
+		return "", fmt.Errorf("failed to write system token to %s: %w", tokenFile, err)
+	}
+	return token, nil
+}
+
+// readSystemServiceToken reads the token from the system state directory
+// without generating one.  Returns an error if the file doesn't exist or
+// isn't readable (the caller may need elevated privileges).
+func readSystemServiceToken() (string, error) {
+	tokenFile := filepath.Join(config.GetSystemStateDir(), "token")
+	return readTokenFromFile(tokenFile)
 }
 
 func readTokenFromFile(path string) (string, error) {

--- a/cmd/root_http_server.go
+++ b/cmd/root_http_server.go
@@ -171,6 +171,7 @@ func authMiddleware(token string, next http.Handler) http.Handler {
 func ensureAuthToken() string {
 	tokenFile := resolveTokenPath()
 	if token, err := readTokenFromFile(tokenFile); err == nil {
+		mirrorTokenToRuntime(token)
 		return token
 	}
 
@@ -178,6 +179,7 @@ func ensureAuthToken() string {
 	if err := writeTokenToFile(tokenFile, token); err != nil {
 		utils.Debug("Failed to write token file in %s: %v", tokenFile, err)
 	}
+	mirrorTokenToRuntime(token)
 	return token
 }
 
@@ -186,6 +188,7 @@ func persistAuthToken(token string) {
 	if err := writeTokenToFile(tokenFile, token); err != nil {
 		utils.Debug("Failed to write token file in %s: %v", tokenFile, err)
 	}
+	mirrorTokenToRuntime(token)
 }
 
 // ensureSystemToken reads (or generates) the token used by the system service
@@ -194,12 +197,14 @@ func persistAuthToken(token string) {
 func ensureSystemToken() (string, error) {
 	tokenFile := filepath.Join(config.GetSystemStateDir(), "token")
 	if token, err := readTokenFromFile(tokenFile); err == nil {
+		mirrorTokenToRuntime(token)
 		return token, nil
 	}
 	token := uuid.New().String()
 	if err := writeTokenToFile(tokenFile, token); err != nil {
 		return "", fmt.Errorf("failed to write system token to %s: %w", tokenFile, err)
 	}
+	mirrorTokenToRuntime(token)
 	return token, nil
 }
 
@@ -228,4 +233,15 @@ func writeTokenToFile(path string, token string) error {
 		return err
 	}
 	return os.WriteFile(path, []byte(token), 0o600)
+}
+
+// mirrorTokenToRuntime writes a 0644 copy of the token to the runtime dir
+// so that local CLI clients can auto-discover and connect without needing sudo.
+func mirrorTokenToRuntime(token string) {
+	runtimeDir := resolveRuntimeDir()
+	if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+		return
+	}
+	runtimeTokenFile := filepath.Join(runtimeDir, "token")
+	_ = os.WriteFile(runtimeTokenFile, []byte(token), 0o644)
 }

--- a/cmd/root_http_server.go
+++ b/cmd/root_http_server.go
@@ -27,6 +27,17 @@ func resolveTokenPath() string {
 	return filepath.Join(config.GetStateDir(), "token")
 }
 
+// resolveRuntimeDir returns the runtime directory this process should use for
+// port/PID files.  Mirrors resolveTokenPath: elevated processes (system service
+// daemons) write to GetSystemRuntimeDir() so that non-elevated clients running
+// getActiveConnectionDetails() can discover them via the system candidate.
+func resolveRuntimeDir() string {
+	if isElevated() {
+		return config.GetSystemRuntimeDir()
+	}
+	return config.GetRuntimeDir()
+}
+
 const serverBindHost = "0.0.0.0"
 
 // findAvailablePort tries ports starting from 'start' until one is available
@@ -59,12 +70,13 @@ func bindServerListener(portFlag int) (int, net.Listener, error) {
 
 // saveActivePort writes the active port for local CLI and extension discovery.
 func saveActivePort(port int) {
-	if err := os.MkdirAll(config.GetRuntimeDir(), 0o755); err != nil {
+	runtimeDir := resolveRuntimeDir()
+	if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
 		utils.Debug("Error creating runtime directory for port file: %v", err)
 		return
 	}
 
-	portFile := filepath.Join(config.GetRuntimeDir(), "port")
+	portFile := filepath.Join(runtimeDir, "port")
 	if err := os.WriteFile(portFile, []byte(fmt.Sprintf("%d", port)), 0o644); err != nil {
 		utils.Debug("Error writing port file: %v", err)
 	}
@@ -73,7 +85,7 @@ func saveActivePort(port int) {
 
 // removeActivePort cleans up the port file on exit
 func removeActivePort() {
-	portFile := filepath.Join(config.GetRuntimeDir(), "port")
+	portFile := filepath.Join(resolveRuntimeDir(), "port")
 	if err := os.Remove(portFile); err != nil && !os.IsNotExist(err) {
 		utils.Debug("Error removing port file: %v", err)
 	}

--- a/cmd/root_http_server.go
+++ b/cmd/root_http_server.go
@@ -94,7 +94,7 @@ func removeActivePort() {
 var (
 	globalHTTPServer   *http.Server
 	globalHTTPServerMu sync.Mutex
-	activeServerMode   = "tui"
+	activeServerMode   = "local"
 )
 
 // startHTTPServer starts the HTTP server using an existing listener

--- a/cmd/root_http_server.go
+++ b/cmd/root_http_server.go
@@ -94,6 +94,7 @@ func removeActivePort() {
 var (
 	globalHTTPServer   *http.Server
 	globalHTTPServerMu sync.Mutex
+	activeServerMode   = "tui"
 )
 
 // startHTTPServer starts the HTTP server using an existing listener

--- a/cmd/root_http_server_windows.go
+++ b/cmd/root_http_server_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package cmd
+
+import "golang.org/x/sys/windows"
+
+// isElevated reports whether the current process has administrator
+// privileges on Windows by inspecting the process token elevation level.
+func isElevated() bool {
+	return windows.GetCurrentProcessToken().IsElevated()
+}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -32,7 +32,7 @@ var serverStartCmd = &cobra.Command{
 	Use:   "start [url]...",
 	Short: "Start the Surge server in headless mode",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if isSystemServiceRunning() && !isSystemServiceFlag {
+		if checkSystemServiceRunning() && !isSystemServiceFlag {
 			return fmt.Errorf("system service is already running. Use 'surge connect' to interact with it, or stop the service first")
 		}
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -206,7 +206,7 @@ func startServerLogic(cmd *cobra.Command, args []string, portFlag int, batchFile
 	fmt.Printf("Serving on %s:%d\n", host, port)
 	fmt.Println("Press Ctrl+C to exit.")
 
-	StartHeadlessConsumer(cmd.Context(), GlobalService)
+	StartHeadlessConsumer(cmd.Root().Context(), GlobalService)
 
 	// Auto-resume paused downloads (unless --no-resume)
 	if !noResume {
@@ -240,7 +240,7 @@ func startServerLogic(cmd *cobra.Command, args []string, portFlag int, batchFile
 		case sig := <-sigChan:
 			fmt.Printf("\nReceived %s. Shutting down...\n", sig)
 			_ = executeGlobalShutdown(fmt.Sprintf("server signal: %s", sig))
-		case <-cmd.Context().Done():
+		case <-cmd.Root().Context().Done():
 			fmt.Printf("\nService stop requested. Shutting down...\n")
 			_ = executeGlobalShutdown("server: service context cancelled")
 		case <-exitWhenDoneCh:
@@ -258,7 +258,7 @@ func startServerLogic(cmd *cobra.Command, args []string, portFlag int, batchFile
 	case sig := <-sigChan:
 		fmt.Printf("\nReceived %s. Shutting down...\n", sig)
 		_ = executeGlobalShutdown(fmt.Sprintf("server signal: %s", sig))
-	case <-cmd.Context().Done():
+	case <-cmd.Root().Context().Done():
 		fmt.Printf("\nService stop requested. Shutting down...\n")
 		_ = executeGlobalShutdown("server: service context cancelled")
 	}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -12,7 +12,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/utils"
 	"github.com/spf13/cobra"
 )
@@ -153,25 +152,25 @@ func init() {
 
 func savePID() {
 	pid := os.Getpid()
-	if err := os.MkdirAll(config.GetRuntimeDir(), 0o755); err != nil {
+	if err := os.MkdirAll(resolveRuntimeDir(), 0o755); err != nil {
 		utils.Debug("Error creating runtime directory for PID file: %v", err)
 		return
 	}
-	pidFile := filepath.Join(config.GetRuntimeDir(), "pid")
+	pidFile := filepath.Join(resolveRuntimeDir(), "pid")
 	if err := os.WriteFile(pidFile, []byte(fmt.Sprintf("%d", pid)), 0o644); err != nil {
 		utils.Debug("Error writing PID file: %v", err)
 	}
 }
 
 func removePID() {
-	pidFile := filepath.Join(config.GetRuntimeDir(), "pid")
+	pidFile := filepath.Join(resolveRuntimeDir(), "pid")
 	if err := os.Remove(pidFile); err != nil && !os.IsNotExist(err) {
 		utils.Debug("Error removing PID file: %v", err)
 	}
 }
 
 func readPID() int {
-	pidFile := filepath.Join(config.GetRuntimeDir(), "pid")
+	pidFile := filepath.Join(resolveRuntimeDir(), "pid")
 	data, err := os.ReadFile(pidFile)
 	if err != nil {
 		return 0

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -31,6 +31,7 @@ var serverStartCmd = &cobra.Command{
 	Use:   "start [url]...",
 	Short: "Start the Surge server in headless mode",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		activeServerMode = "service"
 		if checkSystemServiceRunning() && !isSystemServiceFlag {
 			return fmt.Errorf("system service is already running. Use 'surge connect' to interact with it, or stop the service first")
 		}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -147,7 +147,7 @@ func init() {
 	serverCmd.PersistentFlags().String("token", "", "Auth token for API clients (or set SURGE_TOKEN)")
 
 	serverStartCmd.Flags().BoolVar(&isSystemServiceFlag, "is-system-service", false, "Internal flag for service manager")
-	serverStartCmd.Flags().MarkHidden("is-system-service")
+	_ = serverStartCmd.Flags().MarkHidden("is-system-service")
 }
 
 func savePID() {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -31,7 +31,9 @@ var serverStartCmd = &cobra.Command{
 	Use:   "start [url]...",
 	Short: "Start the Surge server in headless mode",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		activeServerMode = "service"
+		if isSystemServiceFlag {
+			activeServerMode = "service"
+		}
 		if checkSystemServiceRunning() && !isSystemServiceFlag {
 			return fmt.Errorf("system service is already running. Use 'surge connect' to interact with it, or stop the service first")
 		}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -26,10 +26,16 @@ var serverCmd = &cobra.Command{
 	},
 }
 
+var isSystemServiceFlag bool
+
 var serverStartCmd = &cobra.Command{
 	Use:   "start [url]...",
 	Short: "Start the Surge server in headless mode",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if isSystemServiceRunning() && !isSystemServiceFlag {
+			return fmt.Errorf("system service is already running. Use 'surge connect' to interact with it, or stop the service first")
+		}
+
 		// Attempt to acquire lock before any global state initialization
 		isMaster, err := AcquireLock()
 		if err != nil {
@@ -140,6 +146,9 @@ func init() {
 	serverCmd.PersistentFlags().Bool("exit-when-done", false, "Exit when all downloads complete")
 	serverCmd.PersistentFlags().Bool("no-resume", false, "Do not auto-resume paused downloads on startup")
 	serverCmd.PersistentFlags().String("token", "", "Auth token for API clients (or set SURGE_TOKEN)")
+
+	serverStartCmd.Flags().BoolVar(&isSystemServiceFlag, "is-system-service", false, "Internal flag for service manager")
+	serverStartCmd.Flags().MarkHidden("is-system-service")
 }
 
 func savePID() {

--- a/cmd/service_kardianos.go
+++ b/cmd/service_kardianos.go
@@ -95,8 +95,30 @@ func runAction(action func(service.Service) error, successMsg string) func(*cobr
 var serviceInstallCmd = &cobra.Command{
 	Use:   "install",
 	Short: "Install Surge as a system service",
-	RunE:  runAction(func(s service.Service) error { return s.Install() }, "Service installed successfully"),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		s, err := GetService()
+		if err != nil {
+			return err
+		}
+		if err := s.Install(); err != nil {
+			return err
+		}
+		// Pre-generate the service token in the system state directory so
+		// that `surge token` / `surge connect` can discover it without users
+		// having to use --token manually.
+		token, tokenErr := ensureSystemToken()
+		fmt.Println("Service installed successfully")
+		if tokenErr == nil {
+			fmt.Printf("Service auth token: %s\n", token)
+			fmt.Println("Use 'surge service token' to print this token again.")
+		} else {
+			fmt.Printf("Warning: could not persist service token: %v\n", tokenErr)
+			fmt.Println("Run 'sudo surge service token' after starting the service to retrieve it.")
+		}
+		return nil
+	},
 }
+
 
 var serviceUninstallCmd = &cobra.Command{
 	Use:   "uninstall",
@@ -145,6 +167,31 @@ var serviceCmd = &cobra.Command{
 	Short: "Manage Surge as a system service",
 }
 
+// serviceTokenCmd prints the auth token used by the system service daemon.
+var serviceTokenCmd = &cobra.Command{
+	Use:   "token",
+	Short: "Print the auth token used by the system service daemon",
+	Long: `Print the auth token that the Surge system service uses.
+
+The system service (installed with 'surge service install') stores its token
+separately from the interactive-user token. Use this command to retrieve it
+when connecting via 'surge connect' or setting up the browser extension.
+
+Note: reading the system token file may require elevated privileges (sudo).`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		token, err := readSystemServiceToken()
+		if err != nil {
+			var hint string
+			if !isElevated() {
+				hint = " (try running with sudo/administrator privileges)"
+			}
+			return fmt.Errorf("could not read system service token%s: %w", hint, err)
+		}
+		fmt.Println(token)
+		return nil
+	},
+}
+
 // __run is the entry point the installer writes into ExecStart
 var serviceRunCmd = &cobra.Command{
 	Use:    "__run",
@@ -159,5 +206,7 @@ func init() {
 	serviceCmd.AddCommand(serviceStartCmd)
 	serviceCmd.AddCommand(serviceStopCmd)
 	serviceCmd.AddCommand(serviceStatusCmd)
+	serviceCmd.AddCommand(serviceTokenCmd)
 	serviceCmd.AddCommand(serviceRunCmd)
 }
+

--- a/cmd/service_kardianos.go
+++ b/cmd/service_kardianos.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/kardianos/service"
 	"github.com/spf13/cobra"
 )
@@ -154,7 +155,15 @@ var serviceStatusCmd = &cobra.Command{
 		}
 		switch status {
 		case service.StatusRunning:
-			fmt.Println("Service is running")
+			pid := readPIDFile(config.GetSystemRuntimeDir())
+			port := readPortFile(config.GetSystemRuntimeDir())
+			if pid > 0 && port > 0 {
+				fmt.Printf("Service is running (PID: %d, Port: %d)\n", pid, port)
+			} else if pid > 0 {
+				fmt.Printf("Service is running (PID: %d)\n", pid)
+			} else {
+				fmt.Println("Service is running")
+			}
 		case service.StatusStopped:
 			fmt.Println("Service is stopped")
 		default:

--- a/cmd/service_kardianos.go
+++ b/cmd/service_kardianos.go
@@ -71,7 +71,9 @@ func (p *program) Stop(s service.Service) error {
 	}
 }
 
-func GetService() (service.Service, error) {
+// GetService is a var so tests can swap in a mock without touching the OS
+// service manager.
+var GetService = func() (service.Service, error) {
 	prg := &program{}
 	return service.New(prg, serviceConfig)
 }
@@ -118,7 +120,6 @@ var serviceInstallCmd = &cobra.Command{
 		return nil
 	},
 }
-
 
 var serviceUninstallCmd = &cobra.Command{
 	Use:   "uninstall",
@@ -209,4 +210,3 @@ func init() {
 	serviceCmd.AddCommand(serviceTokenCmd)
 	serviceCmd.AddCommand(serviceRunCmd)
 }
-

--- a/cmd/service_kardianos.go
+++ b/cmd/service_kardianos.go
@@ -72,7 +72,8 @@ func (p *program) Stop(s service.Service) error {
 }
 
 // GetService is a var so tests can swap in a mock without touching the OS
-// service manager.
+// service manager.  Tests that reassign this must NOT use t.Parallel()
+// because the variable is package-scoped.
 var GetService = func() (service.Service, error) {
 	prg := &program{}
 	return service.New(prg, serviceConfig)

--- a/cmd/service_kardianos.go
+++ b/cmd/service_kardianos.go
@@ -171,6 +171,8 @@ var serviceStatusCmd = &cobra.Command{
 				fmt.Printf("Service is running (PID: %d, Port: %d)\n", pid, port)
 			} else if pid > 0 {
 				fmt.Printf("Service is running (PID: %d)\n", pid)
+			} else if port > 0 {
+				fmt.Printf("Service is running (Port: %d)\n", port)
 			} else {
 				fmt.Println("Service is running")
 			}

--- a/cmd/service_kardianos.go
+++ b/cmd/service_kardianos.go
@@ -41,7 +41,7 @@ func (p *program) Start(s service.Service) error {
 		// permanently overrides rootCmd's args for the rest of the process
 		// lifetime, which is fine: the process is owned by the service
 		// manager from here until shutdown.
-		rootCmd.SetArgs([]string{"server", "start"})
+		rootCmd.SetArgs([]string{"server", "start", "--is-system-service"})
 		if err := rootCmd.ExecuteContext(ctx); err != nil {
 			fmt.Fprintf(os.Stderr, "Service error: %v\n", err)
 			p.errCh <- err
@@ -143,6 +143,16 @@ var serviceStopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "Stop the Surge system service",
 	RunE:  runAction(func(s service.Service) error { return s.Stop() }, "Service stopped successfully"),
+}
+
+// isSystemServiceRunning checks if the Kardianos service is currently running.
+func isSystemServiceRunning() bool {
+	s, err := GetService()
+	if err != nil {
+		return false
+	}
+	status, err := s.Status()
+	return err == nil && status == service.StatusRunning
 }
 
 var serviceStatusCmd = &cobra.Command{

--- a/cmd/service_kardianos_test.go
+++ b/cmd/service_kardianos_test.go
@@ -3,7 +3,9 @@
 package cmd
 
 import (
+	"fmt"
 	"net"
+	"runtime"
 	"testing"
 	"time"
 
@@ -47,11 +49,16 @@ func waitStop(t *testing.T, p *program, s service.Service) {
 	case err := <-stopErr:
 		assert.NoError(t, err)
 	case <-time.After(5 * time.Second):
+		buf := make([]byte, 1<<20)
+		n := runtime.Stack(buf, true)
+		fmt.Printf("GOROUTINE DUMP:\n%s\n", buf[:n])
 		t.Fatal("p.Stop timed out")
 	}
 }
 
 func TestProgramLifecycle(t *testing.T) {
+	setupIsolatedCmdState(t)
+
 	ln, err := net.Listen("tcp", "0.0.0.0:0")
 	if err != nil {
 		t.Skipf("Skipping test because tcp listener cannot bind (e.g. Windows dual-stack provider issue): %v", err)
@@ -105,6 +112,8 @@ func TestToggleServiceFunc(t *testing.T) {
 }
 
 func TestProgramContextCancellation(t *testing.T) {
+	setupIsolatedCmdState(t)
+
 	ln, err := net.Listen("tcp", "0.0.0.0:0")
 	if err != nil {
 		t.Skipf("Skipping test because tcp listener cannot bind (e.g. Windows dual-stack provider issue): %v", err)

--- a/cmd/service_termux.go
+++ b/cmd/service_termux.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -191,6 +192,13 @@ var serviceStatusCmd = &cobra.Command{
 
 		out, _ := sv("status", svServiceName())
 		fmt.Println(out)
+
+		if strings.HasPrefix(out, "run:") {
+			port := readPortFile(config.GetSystemRuntimeDir())
+			if port > 0 {
+				fmt.Printf("Service port: %d\n", port)
+			}
+		}
 		return nil
 	},
 }

--- a/cmd/service_termux.go
+++ b/cmd/service_termux.go
@@ -51,7 +51,7 @@ func termuxServiceRunScript() string {
 	if exe == "" {
 		exe = "surge"
 	}
-	return "#!/" + defaultPrefix() + "/bin/sh\nexec " + exe + " server start\n"
+	return "#!/" + defaultPrefix() + "/bin/sh\nexec " + exe + " server start --is-system-service\n"
 }
 
 // sv runs an sv command and returns its output.
@@ -84,6 +84,22 @@ func isTermuxServicesAvailable() bool {
 		return false
 	}
 	return true
+}
+
+// isSystemServiceRunning checks if the Termux service is currently running.
+func isSystemServiceRunning() bool {
+	if !isTermuxServicesAvailable() {
+		return false
+	}
+	svcDir := termuxServiceDir()
+	if _, err := os.Stat(svcDir); os.IsNotExist(err) {
+		return false
+	}
+	out, err := sv("status", svServiceName())
+	if err != nil {
+		return false
+	}
+	return strings.HasPrefix(out, "run:")
 }
 
 // writeRunScript writes a service run script with executable permissions.

--- a/cmd/service_token_test.go
+++ b/cmd/service_token_test.go
@@ -457,6 +457,30 @@ func TestResolveTokenForConnectTarget_SystemTokenBeatsStaleUserToken(t *testing.
 		"system token must win over stale user token in the no-port-file fallback path")
 }
 
+func TestResolveTokenForConnectTarget_SystemTokenUnreadable(t *testing.T) {
+	if isElevated() {
+		t.Skip("skipping: elevated — system and user token paths are the same")
+	}
+
+	isolateTokenEnv(t)
+	require.NoError(t, config.EnsureDirs())
+
+	// Write a stale user token, but DO NOT write a system token (simulating unreadable/missing)
+	const staleUserToken = "stale-old-user-token"
+	writeUserToken(t, staleUserToken)
+
+	origCheck := checkSystemServiceRunning
+	checkSystemServiceRunning = func() bool { return true }
+	t.Cleanup(func() { checkSystemServiceRunning = origCheck })
+
+	target, err := parseConnectTarget("127.0.0.1:1700", false)
+	require.NoError(t, err)
+
+	_, err = resolveTokenForConnectTarget(target)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "system service is running but its token could not be read")
+}
+
 // ---------------------------------------------------------------------------
 // Subcommand registration
 // ---------------------------------------------------------------------------

--- a/cmd/service_token_test.go
+++ b/cmd/service_token_test.go
@@ -1,0 +1,404 @@
+//go:build !android
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/SurgeDM/Surge/internal/config"
+	"github.com/kardianos/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// isolateTokenEnv sets up a fully isolated XDG + system-state environment
+// and returns a struct with both dirs. All env vars that affect token file
+// paths are reset automatically via t.Cleanup.
+type tokenEnvDirs struct {
+	userState   string
+	systemState string
+}
+
+func isolateTokenEnv(t *testing.T) tokenEnvDirs {
+	t.Helper()
+	userDir := t.TempDir()
+	sysDir := t.TempDir()
+
+	t.Setenv("XDG_CONFIG_HOME", userDir)
+	t.Setenv("XDG_STATE_HOME", userDir)
+	t.Setenv("XDG_RUNTIME_DIR", userDir)
+	t.Setenv("XDG_DATA_HOME", userDir)
+	t.Setenv("HOME", userDir)
+	t.Setenv("APPDATA", userDir)
+	t.Setenv("USERPROFILE", userDir)
+	t.Setenv("SystemRoot", userDir)
+	// The key override: redirect GetSystemStateDir() to our temp dir.
+	t.Setenv("SURGE_SYSTEM_STATE_DIR", sysDir)
+	// Suppress token overrides so file-path logic is exercised.
+	t.Setenv("SURGE_TOKEN", "")
+
+	origToken := globalToken
+	globalToken = ""
+	t.Cleanup(func() { globalToken = origToken })
+
+	return tokenEnvDirs{userState: userDir, systemState: sysDir}
+}
+
+func writeUserToken(t *testing.T, token string) {
+	t.Helper()
+	tokenFile := filepath.Join(config.GetStateDir(), "token")
+	require.NoError(t, writeTokenToFile(tokenFile, token))
+}
+
+func writeSystemTokenTo(t *testing.T, sysDir, token string) {
+	t.Helper()
+	tokenFile := filepath.Join(sysDir, "token")
+	require.NoError(t, writeTokenToFile(tokenFile, token))
+}
+
+// ---------------------------------------------------------------------------
+// resolveTokenPath
+// ---------------------------------------------------------------------------
+
+// resolveTokenPath must return the user state dir path when NOT elevated.
+func TestResolveTokenPath_UserMode(t *testing.T) {
+	if isElevated() {
+		t.Skip("skipping: test process is running as root; cannot test non-elevated path")
+	}
+	dirs := isolateTokenEnv(t)
+	require.NoError(t, config.EnsureDirs())
+
+	got := resolveTokenPath()
+	// On non-elevated processes the token lives in the user state dir.
+	assert.Equal(t, filepath.Join(config.GetStateDir(), "token"), got,
+		"non-elevated resolveTokenPath should point to user state dir")
+	_ = dirs
+}
+
+// When elevated, resolveTokenPath must return the system state dir path.
+func TestResolveTokenPath_ElevatedMode(t *testing.T) {
+	if !isElevated() {
+		t.Skip("skipping: test process is not root; cannot test elevated path")
+	}
+	dirs := isolateTokenEnv(t)
+
+	got := resolveTokenPath()
+	assert.Equal(t, filepath.Join(dirs.systemState, "token"), got,
+		"elevated resolveTokenPath should point to system state dir")
+}
+
+// ---------------------------------------------------------------------------
+// ensureAuthToken / persistAuthToken  (user-mode)
+// ---------------------------------------------------------------------------
+
+func TestEnsureAuthToken_CreatesTokenFile(t *testing.T) {
+	if isElevated() {
+		t.Skip("skipping: test process is running as root")
+	}
+	isolateTokenEnv(t)
+	require.NoError(t, config.EnsureDirs())
+
+	token := ensureAuthToken()
+	require.NotEmpty(t, token)
+
+	// Token must be persisted so the next call returns the same value.
+	token2 := ensureAuthToken()
+	assert.Equal(t, token, token2, "ensureAuthToken should be idempotent")
+}
+
+func TestEnsureAuthToken_ReadsExistingToken(t *testing.T) {
+	if isElevated() {
+		t.Skip("skipping: test process is running as root")
+	}
+	isolateTokenEnv(t)
+	require.NoError(t, config.EnsureDirs())
+
+	const want = "preset-token-value"
+	writeUserToken(t, want)
+
+	got := ensureAuthToken()
+	assert.Equal(t, want, got)
+}
+
+func TestPersistAuthToken_WritesToCorrectStateDir(t *testing.T) {
+	if isElevated() {
+		t.Skip("skipping: test process is running as root")
+	}
+	dirs := isolateTokenEnv(t)
+	require.NoError(t, config.EnsureDirs())
+
+	const want = "persist-test-token"
+	persistAuthToken(want)
+
+	tokenFile := filepath.Join(dirs.userState, "surge", "token") // GetStateDir() = userDir/surge
+	data, err := os.ReadFile(tokenFile)
+	require.NoError(t, err, "token file should exist in user state dir after persistAuthToken")
+	assert.Equal(t, want, strings.TrimSpace(string(data)))
+}
+
+// ---------------------------------------------------------------------------
+// ensureSystemToken / readSystemServiceToken
+// ---------------------------------------------------------------------------
+
+func TestEnsureSystemToken_CreatesAndReturnsToken(t *testing.T) {
+	dirs := isolateTokenEnv(t)
+
+	token, err := ensureSystemToken()
+	require.NoError(t, err)
+	assert.NotEmpty(t, token)
+
+	// Idempotent.
+	token2, err := ensureSystemToken()
+	require.NoError(t, err)
+	assert.Equal(t, token, token2, "ensureSystemToken must return the same token on repeated calls")
+
+	// Token actually on disk at the system state dir.
+	data, err := os.ReadFile(filepath.Join(dirs.systemState, "token"))
+	require.NoError(t, err)
+	assert.Equal(t, token, strings.TrimSpace(string(data)))
+}
+
+func TestReadSystemServiceToken_ReadsExistingToken(t *testing.T) {
+	dirs := isolateTokenEnv(t)
+
+	const want = "known-system-token"
+	writeSystemTokenTo(t, dirs.systemState, want)
+
+	got, err := readSystemServiceToken()
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestReadSystemServiceToken_ErrorWhenMissing(t *testing.T) {
+	isolateTokenEnv(t)
+	// System state dir exists (created by isolateTokenEnv via t.TempDir) but
+	// has no token file.
+	_, err := readSystemServiceToken()
+	assert.Error(t, err, "readSystemServiceToken should error when no token file exists")
+}
+
+// ---------------------------------------------------------------------------
+// resolveTokenForConnectTarget — system-token fallback (issue #530)
+// ---------------------------------------------------------------------------
+
+// When no user token / active port match exists but a system token file does,
+// resolveTokenForConnectTarget should return the system token for localhost.
+func TestResolveTokenForConnectTarget_FallsBackToSystemToken(t *testing.T) {
+	if isElevated() {
+		t.Skip("skipping: elevated — system and user token paths are the same")
+	}
+
+	dirs := isolateTokenEnv(t)
+	require.NoError(t, config.EnsureDirs())
+
+	const sysToken = "system-daemon-token-530"
+	writeSystemTokenTo(t, dirs.systemState, sysToken)
+	// Ensure no user token file exists.
+	_ = os.Remove(filepath.Join(config.GetStateDir(), "token"))
+
+	target, err := parseConnectTarget("127.0.0.1:1700", false)
+	require.NoError(t, err)
+
+	got, err := resolveTokenForConnectTarget(target)
+	require.NoError(t, err)
+	assert.Equal(t, sysToken, got,
+		"resolveTokenForConnectTarget should fall back to the system token for localhost when no user token matches")
+}
+
+// User token in active connection details beats system token.
+func TestResolveTokenForConnectTarget_UserTokenTakesPrecedence(t *testing.T) {
+	if isElevated() {
+		t.Skip("skipping: elevated — system and user token paths are the same")
+	}
+
+	dirs := isolateTokenEnv(t)
+	require.NoError(t, config.EnsureDirs())
+
+	const userToken = "user-level-token"
+	const sysToken = "system-level-token"
+
+	writeUserToken(t, userToken)
+	writeSystemTokenTo(t, dirs.systemState, sysToken)
+
+	saveActivePort(2001)
+	t.Cleanup(removeActivePort)
+
+	target, err := parseConnectTarget("127.0.0.1:2001", false)
+	require.NoError(t, err)
+
+	got, err := resolveTokenForConnectTarget(target)
+	require.NoError(t, err)
+	assert.Equal(t, userToken, got,
+		"active-connection user token should take precedence over system token")
+}
+
+// Explicit --token flag always wins.
+func TestResolveTokenForConnectTarget_ExplicitFlagWins(t *testing.T) {
+	dirs := isolateTokenEnv(t)
+	writeSystemTokenTo(t, dirs.systemState, "system-token")
+	require.NoError(t, config.EnsureDirs())
+	writeUserToken(t, "user-token")
+
+	origToken := globalToken
+	globalToken = "explicit-flag-token"
+	t.Cleanup(func() { globalToken = origToken })
+
+	target, err := parseConnectTarget("127.0.0.1:1700", false)
+	require.NoError(t, err)
+
+	got, err := resolveTokenForConnectTarget(target)
+	require.NoError(t, err)
+	assert.Equal(t, "explicit-flag-token", got, "--token flag must win over all file-based tokens")
+}
+
+// ---------------------------------------------------------------------------
+// surge service token subcommand
+// ---------------------------------------------------------------------------
+
+func TestServiceTokenCmd_PrintsSystemToken(t *testing.T) {
+	dirs := isolateTokenEnv(t)
+
+	const want = "service-cmd-test-token"
+	writeSystemTokenTo(t, dirs.systemState, want)
+
+	out := captureStdout(t, func() {
+		err := serviceTokenCmd.RunE(serviceTokenCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Equal(t, want, strings.TrimSpace(out))
+}
+
+func TestServiceTokenCmd_ErrorWhenNoTokenFile(t *testing.T) {
+	isolateTokenEnv(t)
+	// systemState dir exists (t.TempDir) but has no token file.
+	err := serviceTokenCmd.RunE(serviceTokenCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not read system service token")
+}
+
+func TestServiceTokenCmd_NonRootHintInError(t *testing.T) {
+	if isElevated() {
+		t.Skip("skipping: elevated process — hint text branch not exercised")
+	}
+	isolateTokenEnv(t)
+	err := serviceTokenCmd.RunE(serviceTokenCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sudo",
+		"error message should hint at using sudo for non-root users")
+}
+
+// ---------------------------------------------------------------------------
+// surge service install — token generation side-effect
+// ---------------------------------------------------------------------------
+
+type mockInstallSvc struct {
+	service.Service
+	installCalled bool
+}
+
+func (m *mockInstallSvc) Install() error {
+	m.installCalled = true
+	return nil
+}
+
+func TestServiceInstallCmd_GeneratesAndPrintsToken(t *testing.T) {
+	dirs := isolateTokenEnv(t)
+
+	mock := &mockInstallSvc{}
+	origGetService := GetService
+	GetService = func() (service.Service, error) { return mock, nil }
+	t.Cleanup(func() { GetService = origGetService })
+
+	out := captureStdout(t, func() {
+		err := serviceInstallCmd.RunE(serviceInstallCmd, nil)
+		require.NoError(t, err)
+	})
+
+	assert.True(t, mock.installCalled, "Install() should be called")
+	assert.Contains(t, out, "Service installed successfully")
+	assert.Contains(t, out, "Service auth token:")
+
+	// The printed token must match what was actually persisted.
+	data, err := os.ReadFile(filepath.Join(dirs.systemState, "token"))
+	require.NoError(t, err)
+	persistedToken := strings.TrimSpace(string(data))
+	assert.Contains(t, out, persistedToken,
+		"printed token must match the token written to the system state dir")
+}
+
+func TestServiceInstallCmd_IdempotentToken(t *testing.T) {
+	dirs := isolateTokenEnv(t)
+
+	// Pre-write a token — install should print this existing token, not generate a new one.
+	const preExisting = "pre-existing-service-token"
+	writeSystemTokenTo(t, dirs.systemState, preExisting)
+
+	mock := &mockInstallSvc{}
+	origGetService := GetService
+	GetService = func() (service.Service, error) { return mock, nil }
+	t.Cleanup(func() { GetService = origGetService })
+
+	out := captureStdout(t, func() {
+		err := serviceInstallCmd.RunE(serviceInstallCmd, nil)
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, out, preExisting,
+		"install should preserve and print the pre-existing system token")
+}
+
+// ---------------------------------------------------------------------------
+// surge token command
+// ---------------------------------------------------------------------------
+
+func TestTokenCmd_PrintsActiveServerToken(t *testing.T) {
+	if isElevated() {
+		t.Skip("skipping: test process is running as root")
+	}
+
+	isolateTokenEnv(t)
+	require.NoError(t, config.EnsureDirs())
+
+	const want = "active-server-token"
+	writeUserToken(t, want)
+
+	out := captureStdout(t, func() {
+		tokenCmd.Run(tokenCmd, nil)
+	})
+	assert.Equal(t, want, strings.TrimSpace(out))
+}
+
+// ---------------------------------------------------------------------------
+// Subcommand registration
+// ---------------------------------------------------------------------------
+
+func TestServiceCmd_HasTokenSubcommand(t *testing.T) {
+	found := false
+	for _, cmd := range serviceCmd.Commands() {
+		if cmd.Name() == "token" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "serviceCmd should register a 'token' subcommand")
+}
+
+func TestServiceCmd_HasExpectedSubcommands(t *testing.T) {
+	want := []string{"install", "uninstall", "start", "stop", "status", "token"}
+	names := make(map[string]bool)
+	for _, cmd := range serviceCmd.Commands() {
+		if !cmd.Hidden {
+			names[cmd.Name()] = true
+		}
+	}
+	for _, sub := range want {
+		assert.True(t, names[sub], "serviceCmd should have subcommand %q", sub)
+	}
+}

--- a/cmd/service_token_test.go
+++ b/cmd/service_token_test.go
@@ -376,6 +376,56 @@ func TestTokenCmd_PrintsActiveServerToken(t *testing.T) {
 	assert.Equal(t, want, strings.TrimSpace(out))
 }
 
+// surge token must ignore SURGE_TOKEN / --token overrides and report the actual
+// daemon token on disk. Scripts that pipe `surge token` into a config file must
+// get the real token, not whatever env var happens to be set.
+func TestTokenCmd_IgnoresSURGE_TOKEN_Override(t *testing.T) {
+	if isElevated() {
+		t.Skip("skipping: test process is running as root")
+	}
+
+	isolateTokenEnv(t)
+	require.NoError(t, config.EnsureDirs())
+
+	const daemonToken = "daemon-persisted-token"
+	writeUserToken(t, daemonToken)
+
+	// Set the override — surge token must NOT echo this back.
+	t.Setenv("SURGE_TOKEN", "override-should-not-appear")
+
+	out := captureStdout(t, func() {
+		tokenCmd.Run(tokenCmd, nil)
+	})
+	assert.Equal(t, daemonToken, strings.TrimSpace(out),
+		"surge token must print the daemon's persisted token, not the SURGE_TOKEN override")
+}
+
+// When no port file matches, surge connect must prefer the system service token
+// over a stale user-level token to avoid 401s against the system daemon.
+func TestResolveTokenForConnectTarget_SystemTokenBeatsStaleUserToken(t *testing.T) {
+	if isElevated() {
+		t.Skip("skipping: elevated — system and user token paths are the same")
+	}
+
+	dirs := isolateTokenEnv(t)
+	require.NoError(t, config.EnsureDirs())
+
+	const sysToken = "system-service-token"
+	const staleUserToken = "stale-old-user-token"
+
+	// Both tokens exist on disk; no port file matches target port.
+	writeSystemTokenTo(t, dirs.systemState, sysToken)
+	writeUserToken(t, staleUserToken)
+
+	target, err := parseConnectTarget("127.0.0.1:1700", false)
+	require.NoError(t, err)
+
+	got, err := resolveTokenForConnectTarget(target)
+	require.NoError(t, err)
+	assert.Equal(t, sysToken, got,
+		"system token must win over stale user token in the no-port-file fallback path")
+}
+
 // ---------------------------------------------------------------------------
 // Subcommand registration
 // ---------------------------------------------------------------------------

--- a/cmd/service_token_test.go
+++ b/cmd/service_token_test.go
@@ -418,6 +418,11 @@ func TestTokenCmd_ErrorsIfSystemServiceRunningButUnreadable(t *testing.T) {
 	isolateTokenEnv(t)
 	require.NoError(t, config.EnsureDirs())
 
+	// Simulate a stale user daemon leaving a token and port file behind
+	writeUserToken(t, "stale-user-token")
+	portFile := filepath.Join(config.GetRuntimeDir(), "port")
+	require.NoError(t, os.WriteFile(portFile, []byte("1700"), 0644))
+
 	origCheck := checkSystemServiceRunning
 	checkSystemServiceRunning = func() bool { return true }
 	t.Cleanup(func() { checkSystemServiceRunning = origCheck })

--- a/cmd/service_token_test.go
+++ b/cmd/service_token_test.go
@@ -372,7 +372,8 @@ func TestTokenCmd_PrintsActiveServerToken(t *testing.T) {
 	writeUserToken(t, want)
 
 	out := captureStdout(t, func() {
-		tokenCmd.Run(tokenCmd, nil)
+		err := tokenCmd.RunE(tokenCmd, nil)
+		require.NoError(t, err)
 	})
 	assert.Equal(t, want, strings.TrimSpace(out))
 }
@@ -395,7 +396,8 @@ func TestTokenCmd_IgnoresSURGE_TOKEN_Override(t *testing.T) {
 	t.Setenv("SURGE_TOKEN", "override-should-not-appear")
 
 	out := captureStdout(t, func() {
-		tokenCmd.Run(tokenCmd, nil)
+		err := tokenCmd.RunE(tokenCmd, nil)
+		require.NoError(t, err)
 	})
 	assert.Equal(t, daemonToken, strings.TrimSpace(out),
 		"surge token must print the daemon's persisted token, not the SURGE_TOKEN override")
@@ -417,6 +419,10 @@ func TestResolveTokenForConnectTarget_SystemTokenBeatsStaleUserToken(t *testing.
 	// Both tokens exist on disk; no port file matches target port.
 	writeSystemTokenTo(t, dirs.systemState, sysToken)
 	writeUserToken(t, staleUserToken)
+
+	origCheck := checkSystemServiceRunning
+	checkSystemServiceRunning = func() bool { return true }
+	t.Cleanup(func() { checkSystemServiceRunning = origCheck })
 
 	target, err := parseConnectTarget("127.0.0.1:1700", false)
 	require.NoError(t, err)

--- a/cmd/service_token_test.go
+++ b/cmd/service_token_test.go
@@ -1,5 +1,7 @@
 //go:build !android
 
+// Tests in this file mutate package-level variables (globalToken, GetService)
+// and redirect os.Stdout via captureStdout.  They must NOT use t.Parallel().
 package cmd
 
 import (
@@ -72,14 +74,13 @@ func TestResolveTokenPath_UserMode(t *testing.T) {
 	if isElevated() {
 		t.Skip("skipping: test process is running as root; cannot test non-elevated path")
 	}
-	dirs := isolateTokenEnv(t)
+	isolateTokenEnv(t)
 	require.NoError(t, config.EnsureDirs())
 
 	got := resolveTokenPath()
 	// On non-elevated processes the token lives in the user state dir.
 	assert.Equal(t, filepath.Join(config.GetStateDir(), "token"), got,
 		"non-elevated resolveTokenPath should point to user state dir")
-	_ = dirs
 }
 
 // When elevated, resolveTokenPath must return the system state dir path.

--- a/cmd/service_token_test.go
+++ b/cmd/service_token_test.go
@@ -49,7 +49,14 @@ func isolateTokenEnv(t *testing.T) tokenEnvDirs {
 
 	origToken := globalToken
 	globalToken = ""
-	t.Cleanup(func() { globalToken = origToken })
+	
+	origCheck := checkSystemServiceRunning
+	checkSystemServiceRunning = func() bool { return false }
+
+	t.Cleanup(func() { 
+		globalToken = origToken 
+		checkSystemServiceRunning = origCheck
+	})
 
 	return tokenEnvDirs{userState: userDir, systemState: sysDir}
 }
@@ -401,6 +408,23 @@ func TestTokenCmd_IgnoresSURGE_TOKEN_Override(t *testing.T) {
 	})
 	assert.Equal(t, daemonToken, strings.TrimSpace(out),
 		"surge token must print the daemon's persisted token, not the SURGE_TOKEN override")
+}
+
+func TestTokenCmd_ErrorsIfSystemServiceRunningButUnreadable(t *testing.T) {
+	if isElevated() {
+		t.Skip("skipping: test process is running as root")
+	}
+
+	isolateTokenEnv(t)
+	require.NoError(t, config.EnsureDirs())
+
+	origCheck := checkSystemServiceRunning
+	checkSystemServiceRunning = func() bool { return true }
+	t.Cleanup(func() { checkSystemServiceRunning = origCheck })
+
+	err := tokenCmd.RunE(tokenCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "system service is running but its token could not be read")
 }
 
 // When no port file matches, surge connect must prefer the system service token

--- a/cmd/service_token_test.go
+++ b/cmd/service_token_test.go
@@ -486,6 +486,42 @@ func TestResolveTokenForConnectTarget_SystemTokenUnreadable(t *testing.T) {
 	assert.Contains(t, err.Error(), "system service is running but its token could not be read")
 }
 
+func TestResolveTokenForConnectTarget_SystemTokenBeatsStaleUserPort(t *testing.T) {
+	if isElevated() {
+		t.Skip("skipping: elevated — system and user token paths are the same")
+	}
+
+	dirs := isolateTokenEnv(t)
+	require.NoError(t, config.EnsureDirs())
+
+	const sysToken = "system-service-token"
+	const staleUserToken = "stale-old-user-token"
+
+	// Both tokens exist on disk. The system token is written to the system dir, the user token to the user dir.
+	writeSystemTokenTo(t, dirs.systemState, sysToken)
+	writeUserToken(t, staleUserToken)
+
+	// Simulate an active system service on port 1700 and a stale user port file ALSO claiming 1700.
+	sysPortFile := filepath.Join(config.GetSystemRuntimeDir(), "port")
+	require.NoError(t, os.MkdirAll(config.GetSystemRuntimeDir(), 0755))
+	require.NoError(t, os.WriteFile(sysPortFile, []byte("1700"), 0644))
+
+	portFile := filepath.Join(config.GetRuntimeDir(), "port")
+	require.NoError(t, os.WriteFile(portFile, []byte("1700"), 0644))
+
+	origCheck := checkSystemServiceRunning
+	checkSystemServiceRunning = func() bool { return true }
+	t.Cleanup(func() { checkSystemServiceRunning = origCheck })
+
+	target, err := parseConnectTarget("127.0.0.1:1700", false)
+	require.NoError(t, err)
+
+	got, err := resolveTokenForConnectTarget(target)
+	require.NoError(t, err)
+	assert.Equal(t, sysToken, got,
+		"system token must win over stale user port when system service is running")
+}
+
 func TestResolveTokenForConnectTarget_PortMatchesButTokenUnreadable(t *testing.T) {
 	if isElevated() {
 		t.Skip("skipping: elevated — system and user token paths are the same")

--- a/cmd/service_token_test.go
+++ b/cmd/service_token_test.go
@@ -43,6 +43,7 @@ func isolateTokenEnv(t *testing.T) tokenEnvDirs {
 	t.Setenv("SystemRoot", userDir)
 	// The key override: redirect GetSystemStateDir() to our temp dir.
 	t.Setenv("SURGE_SYSTEM_STATE_DIR", sysDir)
+	t.Setenv("SURGE_SYSTEM_RUNTIME_DIR", sysDir)
 	// Suppress token overrides so file-path logic is exercised.
 	t.Setenv("SURGE_TOKEN", "")
 

--- a/cmd/service_token_test.go
+++ b/cmd/service_token_test.go
@@ -49,12 +49,12 @@ func isolateTokenEnv(t *testing.T) tokenEnvDirs {
 
 	origToken := globalToken
 	globalToken = ""
-	
+
 	origCheck := checkSystemServiceRunning
 	checkSystemServiceRunning = func() bool { return false }
 
-	t.Cleanup(func() { 
-		globalToken = origToken 
+	t.Cleanup(func() {
+		globalToken = origToken
 		checkSystemServiceRunning = origCheck
 	})
 
@@ -484,6 +484,30 @@ func TestResolveTokenForConnectTarget_SystemTokenUnreadable(t *testing.T) {
 	_, err = resolveTokenForConnectTarget(target)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "system service is running but its token could not be read")
+}
+
+func TestResolveTokenForConnectTarget_PortMatchesButTokenUnreadable(t *testing.T) {
+	if isElevated() {
+		t.Skip("skipping: elevated — system and user token paths are the same")
+	}
+
+	isolateTokenEnv(t)
+	require.NoError(t, config.EnsureDirs())
+
+	// Save active port
+	saveActivePort(1700)
+	t.Cleanup(removeActivePort)
+
+	// Ensure no token files exist
+	_ = os.Remove(filepath.Join(config.GetStateDir(), "token"))
+
+	target, err := parseConnectTarget("127.0.0.1:1700", false)
+	require.NoError(t, err)
+
+	_, err = resolveTokenForConnectTarget(target)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "local server is running on port 1700")
+	assert.Contains(t, err.Error(), "token could not be read")
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/test_env_test.go
+++ b/cmd/test_env_test.go
@@ -50,6 +50,8 @@ func setupXDGEnvIsolation(t *testing.T) string {
 	t.Setenv("XDG_CACHE_HOME", tempDir)
 	t.Setenv("XDG_RUNTIME_DIR", tempDir)
 	t.Setenv("HOME", tempDir)
+	t.Setenv("SURGE_SYSTEM_RUNTIME_DIR", tempDir)
+	t.Setenv("SURGE_SYSTEM_STATE_DIR", tempDir)
 
 	return tempDir
 }

--- a/cmd/token.go
+++ b/cmd/token.go
@@ -15,6 +15,10 @@ When a local server is detected, the token it is using is printed.
 When the system service is running (started with 'surge service start'), use
 'surge service token' to read its dedicated token.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if !isElevated() && checkSystemServiceRunning() {
+			return fmt.Errorf("system service is running but its token could not be read. Try running 'sudo surge token' or 'surge service token' with elevated privileges")
+		}
+
 		// Read the persisted token directly — intentionally bypasses --token /
 		// SURGE_TOKEN so that `surge token` always reports what the local daemon
 		// is actually using, not an override that could mislead scripts.
@@ -25,10 +29,6 @@ When the system service is running (started with 'surge service start'), use
 
 		if isElevated() {
 			return fmt.Errorf("no active local server found. To get the system service token, use 'surge service token'")
-		}
-
-		if checkSystemServiceRunning() {
-			return fmt.Errorf("system service is running but its token could not be read. Try running 'sudo surge token' or 'surge service token' with elevated privileges")
 		}
 
 		token := ensureAuthToken()

--- a/cmd/token.go
+++ b/cmd/token.go
@@ -14,17 +14,22 @@ var tokenCmd = &cobra.Command{
 When a local server is detected, the token it is using is printed.
 When the system service is running (started with 'surge service start'), use
 'surge service token' to read its dedicated token.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		// Read the persisted token directly — intentionally bypasses --token /
 		// SURGE_TOKEN so that `surge token` always reports what the local daemon
 		// is actually using, not an override that could mislead scripts.
 		if details, ok := getActiveConnectionDetails(); ok && details.token != "" {
 			fmt.Println(details.token)
-			return
+			return nil
+		}
+
+		if isElevated() {
+			return fmt.Errorf("no active local server found. To get the system service token, use 'surge service token'")
 		}
 
 		token := ensureAuthToken()
 		fmt.Println(token)
+		return nil
 	},
 }
 

--- a/cmd/token.go
+++ b/cmd/token.go
@@ -9,8 +9,13 @@ import (
 var tokenCmd = &cobra.Command{
 	Use:   "token",
 	Short: "Print the auth token used by the Surge daemon",
+	Long: `Print the auth token for the currently running Surge server.
+
+When a local server is detected, the token it is using is printed.
+When the system service is running (started with 'surge service start'), use
+'surge service token' to read its dedicated token.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		token := ensureAuthToken()
+		token := resolveLocalToken()
 		fmt.Println(token)
 	},
 }

--- a/cmd/token.go
+++ b/cmd/token.go
@@ -15,7 +15,10 @@ When a local server is detected, the token it is using is printed.
 When the system service is running (started with 'surge service start'), use
 'surge service token' to read its dedicated token.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		token := resolveLocalToken()
+		// Read the persisted token directly — intentionally bypasses --token /
+		// SURGE_TOKEN so that `surge token` always reports what the local daemon
+		// is actually using, not an override that could mislead scripts.
+		token := ensureAuthToken()
 		fmt.Println(token)
 	},
 }

--- a/cmd/token.go
+++ b/cmd/token.go
@@ -27,6 +27,10 @@ When the system service is running (started with 'surge service start'), use
 			return fmt.Errorf("no active local server found. To get the system service token, use 'surge service token'")
 		}
 
+		if checkSystemServiceRunning() {
+			return fmt.Errorf("system service is running but its token could not be read. Try running 'sudo surge token' or 'surge service token' with elevated privileges")
+		}
+
 		token := ensureAuthToken()
 		fmt.Println(token)
 		return nil

--- a/cmd/token.go
+++ b/cmd/token.go
@@ -18,6 +18,11 @@ When the system service is running (started with 'surge service start'), use
 		// Read the persisted token directly — intentionally bypasses --token /
 		// SURGE_TOKEN so that `surge token` always reports what the local daemon
 		// is actually using, not an override that could mislead scripts.
+		if details, ok := getActiveConnectionDetails(); ok && details.token != "" {
+			fmt.Println(details.token)
+			return
+		}
+
 		token := ensureAuthToken()
 		fmt.Println(token)
 	},

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -77,7 +77,10 @@ func getActiveConnectionDetails() (activeConnectionDetails, bool) {
 			continue
 		}
 		candidate.port = port
-		candidate.token = readStateToken(candidate.stateDir)
+		candidate.token = readStateToken(candidate.runtimeDir)
+		if candidate.token == "" {
+			candidate.token = readStateToken(candidate.stateDir)
+		}
 		return candidate, true
 	}
 	return activeConnectionDetails{}, false

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -36,6 +36,17 @@ func readPortFile(runtimeDir string) int {
 	return port
 }
 
+func readPIDFile(runtimeDir string) int {
+	pidFile := filepath.Join(runtimeDir, "pid")
+	data, err := os.ReadFile(pidFile)
+	if err != nil {
+		return 0
+	}
+	var pid int
+	_, _ = fmt.Sscanf(string(data), "%d", &pid)
+	return pid
+}
+
 func readStateToken(stateDir string) string {
 	token, err := readTokenFromFile(filepath.Join(stateDir, "token"))
 	if err != nil {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -36,6 +36,8 @@ func readPortFile(runtimeDir string) int {
 	return port
 }
 
+var checkSystemServiceRunning = isSystemServiceRunning
+
 func readPIDFile(runtimeDir string) int {
 	pidFile := filepath.Join(runtimeDir, "pid")
 	data, err := os.ReadFile(pidFile)

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -58,16 +58,18 @@ func readStateToken(stateDir string) string {
 }
 
 func activeConnectionCandidates() []activeConnectionDetails {
-	return []activeConnectionDetails{
-		{
-			runtimeDir: config.GetRuntimeDir(),
-			stateDir:   config.GetStateDir(),
-		},
-		{
-			runtimeDir: config.GetSystemRuntimeDir(),
-			stateDir:   config.GetSystemStateDir(),
-		},
+	userCand := activeConnectionDetails{
+		runtimeDir: config.GetRuntimeDir(),
+		stateDir:   config.GetStateDir(),
 	}
+	sysCand := activeConnectionDetails{
+		runtimeDir: config.GetSystemRuntimeDir(),
+		stateDir:   config.GetSystemStateDir(),
+	}
+	if checkSystemServiceRunning() {
+		return []activeConnectionDetails{sysCand, userCand}
+	}
+	return []activeConnectionDetails{userCand, sysCand}
 }
 
 func getActiveConnectionDetails() (activeConnectionDetails, bool) {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -158,20 +158,24 @@ func ValidateAndNormalizeURL(rawURL string) (string, error) {
 }
 
 func resolveLocalToken() string {
-	return resolveLocalTokenForDetails(activeConnectionDetails{})
+	token, _ := resolveLocalTokenForDetails(activeConnectionDetails{})
+	return token
 }
 
-func resolveLocalTokenForDetails(details activeConnectionDetails) string {
+func resolveLocalTokenForDetails(details activeConnectionDetails) (string, error) {
 	if token := strings.TrimSpace(globalToken); token != "" {
-		return token
+		return token, nil
 	}
 	if token := strings.TrimSpace(os.Getenv("SURGE_TOKEN")); token != "" {
-		return token
+		return token, nil
 	}
 	if token := strings.TrimSpace(details.token); token != "" {
-		return token
+		return token, nil
 	}
-	return ensureAuthToken()
+	if details.port != 0 {
+		return "", fmt.Errorf("local server is running on port %d but its token could not be read. Try connecting with elevated privileges", details.port)
+	}
+	return ensureAuthToken(), nil
 }
 
 // resolveHostTarget returns the target host, prioritizing the --host flag over the SURGE_HOST environment variable.
@@ -204,7 +208,11 @@ func resolveAPIConnection(requireServer bool) (string, string, error) {
 	if target == "" {
 		details, ok := getActiveConnectionDetails()
 		if ok {
-			return fmt.Sprintf("http://127.0.0.1:%d", details.port), resolveLocalTokenForDetails(details), nil
+			token, err := resolveLocalTokenForDetails(details)
+			if err != nil {
+				return "", "", err
+			}
+			return fmt.Sprintf("http://127.0.0.1:%d", details.port), token, nil
 		}
 		if !requireServer {
 			return "", "", nil

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -146,6 +146,9 @@ func TestResolveAPIConnection_PairsLocalPortAndTokenFromSameState(t *testing.T) 
 	if err := config.EnsureDirs(); err != nil {
 		t.Fatalf("config.EnsureDirs() failed: %v", err)
 	}
+
+	t.Setenv("SURGE_SYSTEM_RUNTIME_DIR", config.GetRuntimeDir())
+	t.Setenv("SURGE_SYSTEM_STATE_DIR", config.GetStateDir())
 	if err := writeTokenToFile(filepath.Join(config.GetStateDir(), "token"), "paired-token"); err != nil {
 		t.Fatalf("write token failed: %v", err)
 	}

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -18,7 +18,7 @@ Surge provides a robust Command Line Interface for automation and scripting. For
 | `surge rm <id>`             | Removes a download by ID/prefix.                                                       | `--clean`, `--purge`                                                                                | Alias: `kill`.                                                          |
 | `surge config [path] [val]` | Get, set, or reset Surge configuration options via the CLI.                            | None                                                                                                | See [SETTINGS.md](SETTINGS.md) for available settings. Run without args to list all. |
 | `surge token`               | Prints current API auth token. (Also visible in TUI > Settings > Extension)            | None                                                                                                | Useful for remote clients.                                              |
-| `surge service <cmd>`       | Manages Surge as a system service (daemon).                                            | `install`, `uninstall`, `start`, `stop`, `status`                                                   | Cross-platform (Linux/Windows/macOS). See [Service Management](#service-management). |
+| `surge service <cmd>`       | Manages Surge as a system service (daemon).                                            | `install`, `uninstall`, `start`, `stop`, `status`, `token`                                      | Cross-platform (Linux/Windows/macOS). See [Service Management](#service-management). |
 | `surge bug-report`          | Opens a pre-filled GitHub bug report. Prompts for target (Core/Extension) and optional system/log details. | None                                                                                                | Prints a manual URL fallback if browser open fails.                     |
 
 ## Service Management
@@ -30,6 +30,7 @@ The `service` command allows you to manage Surge as a background daemon that sta
 - `surge service start`: Starts the background service.
 - `surge service stop`: Stops the background service.
 - `surge service status`: Checks if the service is installed and running.
+- `surge service token`: Prints the auth token used by the system service daemon.
 
 **Note**: On most systems, these commands require administrative privileges (e.g., `sudo surge service install`).
 

--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -691,26 +691,31 @@ function handleMessage(message: Record<string, any>): Promise<unknown> | unknown
 
         const candidates = buildPortScanCandidates(DEFAULT_PORT, MAX_PORT_SCAN, [url], baseHost);
         let sawUnauthorized = false;
+        let sawService = false;
         for (let index = 0; index < candidates.length; index += PORT_SCAN_BATCH_SIZE) {
           const batch = candidates.slice(index, index + PORT_SCAN_BATCH_SIZE);
           const results = await Promise.all(batch.map(async (candidate) => {
             try {
               const r1 = await fetch(`${candidate}/health`, { signal: AbortSignal.timeout(300) });
-              if (!r1.ok) return { candidate, ok: false, status: 0 };
+              if (!r1.ok) return { candidate, ok: false, status: 0, mode: '' };
+              const hData = await r1.json().catch(() => ({}));
               const r2 = await fetch(`${candidate}/list`, {
                 headers: { Authorization: `Bearer ${token}` },
                 signal: AbortSignal.timeout(1000),
               });
-              return { candidate, ok: r2.ok, status: r2.status };
-            } catch { return { candidate, ok: false, status: 0 }; }
+              return { candidate, ok: r2.ok, status: r2.status, mode: hData.mode };
+            } catch { return { candidate, ok: false, status: 0, mode: '' }; }
           }));
 
           for (const result of results) {
-            if (result.status === 401) sawUnauthorized = true;
+            if (result.status === 401) {
+              sawUnauthorized = true;
+              if (result.mode === 'service') sawService = true;
+            }
             if (result.ok) return { ok: true, url: result.candidate };
           }
         }
-        return { ok: false, error: sawUnauthorized ? 'invalid_token' : 'no_server' };
+        return { ok: false, error: sawUnauthorized ? (sawService ? 'invalid_token_service' : 'invalid_token') : 'no_server' };
       })();
 
     case 'validateAuth':

--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -1003,4 +1003,5 @@ export const __test__ = {
   },
   handleDownloadCreated,
   reresolveActiveServerUrl,
+  handleMessage,
 };

--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -712,7 +712,7 @@ function handleMessage(message: Record<string, any>): Promise<unknown> | unknown
               sawUnauthorized = true;
               if (result.mode === 'service') sawService = true;
             }
-            if (result.ok) return { ok: true, url: result.candidate };
+            if (result.ok) return { ok: true, url: result.candidate, mode: result.mode };
           }
         }
         return { ok: false, error: sawUnauthorized ? (sawService ? 'invalid_token_service' : 'invalid_token') : 'no_server' };

--- a/extension/entrypoints/popup/components/SettingsView.tsx
+++ b/extension/entrypoints/popup/components/SettingsView.tsx
@@ -65,9 +65,13 @@ export default function SettingsView() {
     showServerStatus('Connecting...', 0); // Keep showing until done
     
     try {
-      const res = await browser.runtime.sendMessage({ type: 'testConnection', url, token }).catch(() => null) as { ok?: boolean; url?: string; error?: string } | null;
+      const res = await browser.runtime.sendMessage({ type: 'testConnection', url, token }).catch(() => null) as { ok?: boolean; url?: string; error?: string; mode?: string } | null;
       if (res?.ok) {
         setConnectionValid(true);
+        if (!newProfileName().trim()) {
+          if (res.mode === 'service') setNewProfileName('Surge System Service');
+          else if (res.mode === 'local') setNewProfileName('Surge Local');
+        }
         showServerStatus('Connected');
       } else if (res?.error === 'invalid_token_service') {
         showServerStatus('Invalid System Service Token');

--- a/extension/entrypoints/popup/components/SettingsView.tsx
+++ b/extension/entrypoints/popup/components/SettingsView.tsx
@@ -69,6 +69,8 @@ export default function SettingsView() {
       if (res?.ok) {
         setConnectionValid(true);
         showServerStatus('Connected');
+      } else if (res?.error === 'invalid_token_service') {
+        showServerStatus('Invalid System Service Token');
       } else if (res?.error === 'invalid_token') {
         showServerStatus('Invalid Token');
       } else {

--- a/extension/test/background.test.ts
+++ b/extension/test/background.test.ts
@@ -202,4 +202,24 @@ describe('testConnection message handler', () => {
 
     expect(result).toEqual({ ok: false, error: 'invalid_token_service' });
   });
+
+  it('returns mode on successful connection', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === 'http://127.0.0.1:1700/health') {
+        return new Response(JSON.stringify({ mode: 'local' }), { status: 200 });
+      }
+      if (url === 'http://127.0.0.1:1700/list') {
+        return new Response('[]', { status: 200 });
+      }
+      throw new Error('connection refused');
+    }));
+
+    const result = await __test__.handleMessage({
+      type: 'testConnection',
+      url: 'http://127.0.0.1:1700',
+      token: 'good-token'
+    });
+
+    expect(result).toEqual({ ok: true, url: 'http://127.0.0.1:1700', mode: 'local' });
+  });
 });

--- a/extension/test/background.test.ts
+++ b/extension/test/background.test.ts
@@ -161,3 +161,45 @@ describe('background auth persistence', () => {
     });
   });
 });
+
+describe('testConnection message handler', () => {
+  it('reports invalid_token when server mode is local and token is wrong', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === 'http://127.0.0.1:1700/health') {
+        return new Response(JSON.stringify({ mode: 'local' }), { status: 200 });
+      }
+      if (url === 'http://127.0.0.1:1700/list') {
+        return new Response('Unauthorized', { status: 401 });
+      }
+      throw new Error('connection refused');
+    }));
+
+    const result = await __test__.handleMessage({
+      type: 'testConnection',
+      url: 'http://127.0.0.1:1700',
+      token: 'bad-token'
+    });
+
+    expect(result).toEqual({ ok: false, error: 'invalid_token' });
+  });
+
+  it('reports invalid_token_service when server mode is service and token is wrong', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === 'http://127.0.0.1:1700/health') {
+        return new Response(JSON.stringify({ mode: 'service' }), { status: 200 });
+      }
+      if (url === 'http://127.0.0.1:1700/list') {
+        return new Response('Unauthorized', { status: 401 });
+      }
+      throw new Error('connection refused');
+    }));
+
+    const result = await __test__.handleMessage({
+      type: 'testConnection',
+      url: 'http://127.0.0.1:1700',
+      token: 'bad-token'
+    });
+
+    expect(result).toEqual({ ok: false, error: 'invalid_token_service' });
+  });
+});

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -60,6 +60,14 @@ func GetSystemSurgeDir() string {
 }
 
 func GetSystemStateDir() string {
+	// Allow tests (and advanced deployments) to override the system state dir
+	// without needing root access.  The env var must be an absolute path.
+	if override := strings.TrimSpace(os.Getenv("SURGE_SYSTEM_STATE_DIR")); override != "" {
+		if filepath.IsAbs(override) {
+			return override
+		}
+	}
+
 	if runtime.GOOS == "windows" {
 		return GetSystemSurgeDir()
 	}

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -80,6 +80,19 @@ func GetSystemStateDir() string {
 }
 
 func GetSystemRuntimeDir() string {
+	// Allow tests (and advanced deployments) to override without root access.
+	if override := strings.TrimSpace(os.Getenv("SURGE_SYSTEM_RUNTIME_DIR")); override != "" {
+		if filepath.IsAbs(override) {
+			return override
+		}
+	}
+	// On Linux, system services write runtime files (port, PID) to /run/<name>
+	// which is world-readable (0755) by convention — the FHS standard location
+	// used by nginx, postgresql, etc.  This allows non-root users to auto-detect
+	// a system-service Surge daemon without needing read access to /root.
+	if runtime.GOOS == "linux" {
+		return filepath.Join(string(filepath.Separator), "run", "surge")
+	}
 	return filepath.Join(GetSystemStateDir(), "runtime")
 }
 

--- a/internal/lint/leak_test.go
+++ b/internal/lint/leak_test.go
@@ -157,7 +157,7 @@ func TestGlobalGoleakEnforcement(t *testing.T) {
 					if entry.Name() == "main_test.go" {
 						hasMainTestFile = true
 					}
-					
+
 					content, readErr := os.ReadFile(filepath.Join(path, entry.Name()))
 					if readErr == nil {
 						contentStr := string(content)

--- a/internal/tui/update_modals.go
+++ b/internal/tui/update_modals.go
@@ -237,15 +237,15 @@ func (m RootModel) updateBatchConfirm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 		added := 0
 		skipped := 0
 		var batchCmds []tea.Cmd
-		
+
 		pathChanged := path != m.batchFilePath
-		
+
 		for _, request := range m.pendingBatchRequests {
 			requestPath := path
 			if !pathChanged && request.Path != "" {
 				requestPath = request.Path
 			}
-			
+
 			isDefaultPath := m.isDefaultDownloadPath(requestPath)
 			if requestPath == "" {
 				isDefaultPath = true


### PR DESCRIPTION
Closes #530 
Closes #350

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds system-service token support for Surge. The main changes are:

- Adds `surge service token` for reading the service daemon token.
- Separates user and system token/runtime paths.
- Updates localhost token resolution for user and service daemons.
- Reports server mode through the health endpoint for extension setup.
- Adds tests and docs for the service-token flows.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

No blocking issues found in the changed code.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The service token validation suite was executed and confirmed to complete with EXIT\_CODE: 0, with all five targeted tests passing, as shown by the general-contract-validation-proof.

<a href="https://app.greptile.com/trex/runs/14826779/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| cmd/connect.go | Updates localhost token lookup to prefer the token for the daemon that is expected to own the target port. |
| cmd/token.go | Changes `surge token` to print the active local daemon token and avoid token override values. |
| cmd/root_http_server.go | Adds user/system token path selection and mirrors daemon tokens into runtime discovery paths. |
| cmd/service_kardianos.go | Adds service-token retrieval and starts managed services with service-mode CLI wiring. |
| extension/entrypoints/background.ts | Uses health-mode data to distinguish local and service token validation results. |

</details>

<sub>Reviews (13): Last reviewed commit: ["fix: prevent 401 errors by verifying sys..."](https://github.com/surgedm/surge/commit/91fafc76a4213d280f08003e75d05f5935f1ef97) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44104240)</sub>

<!-- /greptile_comment -->