### PR TITLE
feat(shutdown): added functionality to shutdown surge when all downloads are done

### DIFF
--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -38,6 +38,7 @@ type GeneralSettings struct {
 	DefaultDownloadDir           *Setting `json:"default_download_dir"`
 	WarnOnDuplicate              *Setting `json:"warn_on_duplicate"`
 	DownloadCompleteNotification *Setting `json:"download_complete_notification"`
+	AutoShutdownAfterDownloads   *Setting `json:"auto_shutdown_after_downloads"`
 	AllowRemoteOpenActions       *Setting `json:"allow_remote_open_actions"`
 	AutoResume                   *Setting `json:"auto_resume"`
 	AutoStart                    *Setting `json:"auto_start"`
@@ -254,6 +255,7 @@ func (s *Settings) initializeCategoriesList() {
 				s.General.DefaultDownloadDir,
 				s.General.WarnOnDuplicate,
 				s.General.DownloadCompleteNotification,
+				s.General.AutoShutdownAfterDownloads,
 				s.General.AllowRemoteOpenActions,
 				s.General.AutoResume,
 				s.General.AutoStart,
@@ -547,6 +549,14 @@ func DefaultSettings() *Settings {
 				Type:         TypeBool,
 				DefaultValue: true,
 				Value:        true,
+			},
+			AutoShutdownAfterDownloads: &Setting{
+				Key:          "auto_shutdown_after_downloads",
+				Label:        "Auto Shutdown",
+				Description:  "Shut down the computer after all downloads finish. Active, queued, and paused downloads block shutdown.",
+				Type:         TypeBool,
+				DefaultValue: false,
+				Value:        false,
 			},
 			AllowRemoteOpenActions: &Setting{
 				Key:          "allow_remote_open_actions",

--- a/internal/power/power.go
+++ b/internal/power/power.go
@@ -10,9 +10,3 @@ type Controller interface {
 	Shutdown(ctx context.Context) error
 	AcquireInhibitor(reason string) (ReleaseFunc, error)
 }
-
-type noopController struct{}
-
-func (noopController) AcquireInhibitor(string) (ReleaseFunc, error) {
-	return func() error { return nil }, nil
-}

--- a/internal/power/power.go
+++ b/internal/power/power.go
@@ -1,0 +1,18 @@
+package power
+
+import "context"
+
+// ReleaseFunc releases a previously acquired power-management inhibitor.
+type ReleaseFunc func() error
+
+// Controller owns OS power operations.
+type Controller interface {
+	Shutdown(ctx context.Context) error
+	AcquireInhibitor(reason string) (ReleaseFunc, error)
+}
+
+type noopController struct{}
+
+func (noopController) AcquireInhibitor(string) (ReleaseFunc, error) {
+	return func() error { return nil }, nil
+}

--- a/internal/power/power_darwin.go
+++ b/internal/power/power_darwin.go
@@ -1,0 +1,39 @@
+//go:build darwin
+
+package power
+
+import (
+	"context"
+	"os/exec"
+)
+
+type osController struct{}
+
+func NewController() Controller {
+	return osController{}
+}
+
+func (osController) Shutdown(ctx context.Context) error {
+	if err := exec.CommandContext(ctx, "osascript", "-e", `tell application "System Events" to shut down`).Run(); err == nil {
+		return nil
+	}
+	return exec.CommandContext(ctx, "shutdown", "-h", "now").Run()
+}
+
+func (osController) AcquireInhibitor(reason string) (ReleaseFunc, error) {
+	cmd := exec.Command("caffeinate", "-dimsu")
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	return func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		if err := cmd.Process.Kill(); err != nil {
+			return err
+		}
+		_, _ = cmd.Process.Wait()
+		return nil
+	}, nil
+}

--- a/internal/power/power_linux.go
+++ b/internal/power/power_linux.go
@@ -1,0 +1,54 @@
+//go:build linux
+
+package power
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+)
+
+type osController struct{}
+
+func NewController() Controller {
+	return osController{}
+}
+
+func (osController) Shutdown(ctx context.Context) error {
+	if err := exec.CommandContext(ctx, "systemctl", "poweroff").Run(); err == nil {
+		return nil
+	}
+	return exec.CommandContext(ctx, "shutdown", "-h", "now").Run()
+}
+
+func (osController) AcquireInhibitor(reason string) (ReleaseFunc, error) {
+	if _, err := exec.LookPath("systemd-inhibit"); err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return func() error { return nil }, nil
+		}
+		return nil, err
+	}
+
+	cmd := exec.Command(
+		"systemd-inhibit",
+		"--what=sleep:shutdown",
+		"--mode=block",
+		"--why="+reason,
+		"sleep",
+		"infinity",
+	)
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	return func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		if err := cmd.Process.Kill(); err != nil {
+			return err
+		}
+		_, _ = cmd.Process.Wait()
+		return nil
+	}, nil
+}

--- a/internal/power/power_other.go
+++ b/internal/power/power_other.go
@@ -1,0 +1,20 @@
+//go:build !windows && !linux && !darwin
+
+package power
+
+import (
+	"context"
+	"errors"
+)
+
+type osController struct {
+	noopController
+}
+
+func NewController() Controller {
+	return osController{}
+}
+
+func (osController) Shutdown(context.Context) error {
+	return errors.New("shutdown is not supported on this platform")
+}

--- a/internal/power/power_windows.go
+++ b/internal/power/power_windows.go
@@ -1,0 +1,45 @@
+//go:build windows
+
+package power
+
+import (
+	"context"
+	"os/exec"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	esContinuous     = 0x80000000
+	esSystemRequired = 0x00000001
+)
+
+type osController struct{}
+
+func NewController() Controller {
+	return osController{}
+}
+
+func (osController) Shutdown(ctx context.Context) error {
+	return exec.CommandContext(ctx, "shutdown", "/s", "/t", "0").Run()
+}
+
+func (osController) AcquireInhibitor(string) (ReleaseFunc, error) {
+	kernel32 := windows.NewLazySystemDLL("kernel32.dll")
+	proc := kernel32.NewProc("SetThreadExecutionState")
+	ret, _, err := proc.Call(uintptr(esContinuous | esSystemRequired))
+	if ret == 0 {
+		if err != syscall.Errno(0) {
+			return nil, err
+		}
+		return nil, syscall.EINVAL
+	}
+	return func() error {
+		ret, _, err := proc.Call(uintptr(esContinuous))
+		if ret == 0 && err != syscall.Errno(0) {
+			return err
+		}
+		return nil
+	}, nil
+}

--- a/internal/power/power_windows.go
+++ b/internal/power/power_windows.go
@@ -5,6 +5,8 @@ package power
 import (
 	"context"
 	"os/exec"
+	"runtime"
+	"sync"
 	"syscall"
 
 	"golang.org/x/sys/windows"
@@ -28,18 +30,48 @@ func (osController) Shutdown(ctx context.Context) error {
 func (osController) AcquireInhibitor(string) (ReleaseFunc, error) {
 	kernel32 := windows.NewLazySystemDLL("kernel32.dll")
 	proc := kernel32.NewProc("SetThreadExecutionState")
-	ret, _, err := proc.Call(uintptr(esContinuous | esSystemRequired))
-	if ret == 0 {
-		if err != syscall.Errno(0) {
-			return nil, err
-		}
-		return nil, syscall.EINVAL
-	}
-	return func() error {
-		ret, _, err := proc.Call(uintptr(esContinuous))
-		if ret == 0 && err != syscall.Errno(0) {
-			return err
+
+	setExecutionState := func(state uintptr) error {
+		ret, _, err := proc.Call(state)
+		if ret == 0 {
+			if err != syscall.Errno(0) {
+				return err
+			}
+			return syscall.EINVAL
 		}
 		return nil
+	}
+
+	readyCh := make(chan error, 1)
+	releaseCh := make(chan struct{})
+	doneCh := make(chan struct{})
+	var releaseOnce sync.Once
+	var releaseErr error
+
+	go func() {
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+		defer close(doneCh)
+
+		if err := setExecutionState(uintptr(esContinuous | esSystemRequired)); err != nil {
+			readyCh <- err
+			return
+		}
+		readyCh <- nil
+
+		<-releaseCh
+		releaseErr = setExecutionState(uintptr(esContinuous))
+	}()
+
+	if err := <-readyCh; err != nil {
+		return nil, err
+	}
+
+	return func() error {
+		releaseOnce.Do(func() {
+			close(releaseCh)
+		})
+		<-doneCh
+		return releaseErr
 	}, nil
 }

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -19,6 +19,8 @@ type autoShutdownResultMsg struct {
 
 type autoShutdownCheckMsg struct{}
 
+type autoShutdownRetryMsg struct{}
+
 type enqueueSuccessMsg struct {
 	tempID   string
 	id       string

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -13,6 +13,12 @@ type shutdownCompleteMsg struct {
 	err error
 }
 
+type autoShutdownResultMsg struct {
+	err error
+}
+
+type autoShutdownCheckMsg struct{}
+
 type enqueueSuccessMsg struct {
 	tempID   string
 	id       string

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -242,6 +242,7 @@ type RootModel struct {
 
 	autoShutdownArmed     bool
 	autoShutdownTriggered bool
+	autoShutdownRetrying  bool
 	powerController       power.Controller
 	powerInhibitorRelease power.ReleaseFunc
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -23,6 +23,7 @@ import (
 	"charm.land/lipgloss/v2"
 
 	"github.com/SurgeDM/Surge/internal/config"
+	"github.com/SurgeDM/Surge/internal/power"
 	"github.com/SurgeDM/Surge/internal/service"
 	"github.com/SurgeDM/Surge/internal/tui/colors"
 	"github.com/SurgeDM/Surge/internal/tui/components"
@@ -238,6 +239,11 @@ type RootModel struct {
 	cancelEnqueue    context.CancelFunc
 	shuttingDown     bool
 	RestartRequested bool // Flag to signal process re-exec after TUI shutdown
+
+	autoShutdownArmed     bool
+	autoShutdownTriggered bool
+	powerController       power.Controller
+	powerInhibitorRelease power.ReleaseFunc
 
 	ToggleServiceFunc func(bool) error
 
@@ -501,6 +507,7 @@ func InitialRootModel(serverPort int, currentVersion string, service service.Dow
 		InitialDarkBackground: initialDarkBackground,
 		enqueueCtx:            enqueueCtx,
 		cancelEnqueue:         cancelEnqueue,
+		powerController:       power.NewController(),
 		spinner:               s,
 	}
 
@@ -574,6 +581,12 @@ func (m RootModel) Init() tea.Cmd {
 		warnings := m.StartupConfigWarnings
 		cmds = append(cmds, func() tea.Msg {
 			return startupConfigWarningMsg(warnings)
+		})
+	}
+
+	if m.isAutoShutdownEnabled() {
+		cmds = append(cmds, func() tea.Msg {
+			return autoShutdownCheckMsg{}
 		})
 	}
 

--- a/internal/tui/power.go
+++ b/internal/tui/power.go
@@ -120,6 +120,7 @@ func (m *RootModel) applyAutoShutdownSettingChange() {
 
 func (m RootModel) handleAutoShutdownResult(err error) RootModel {
 	if err != nil {
+		m.autoShutdownTriggered = false
 		m.addLogEntry(LogStyleError.Render(fmt.Sprintf("\u2716 Auto-shutdown failed: %v", err)))
 	}
 	return m

--- a/internal/tui/power.go
+++ b/internal/tui/power.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"fmt"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/SurgeDM/Surge/internal/config"
@@ -10,7 +11,10 @@ import (
 	"github.com/SurgeDM/Surge/internal/utils"
 )
 
-const autoShutdownReason = "Surge is waiting for downloads to finish before shutting down."
+const (
+	autoShutdownReason     = "Surge is waiting for downloads to finish before shutting down."
+	autoShutdownRetryDelay = 30 * time.Second
+)
 
 func (m RootModel) isAutoShutdownEnabled() bool {
 	return m.Settings != nil && config.Resolve[bool](m.Settings.General.AutoShutdownAfterDownloads)
@@ -49,11 +53,12 @@ func (m RootModel) refreshAutoShutdown() (RootModel, tea.Cmd) {
 	if !m.isAutoShutdownEnabled() {
 		m.autoShutdownArmed = false
 		m.autoShutdownTriggered = false
+		m.autoShutdownRetrying = false
 		m.releasePowerInhibitor()
 		return m, nil
 	}
 
-	if m.autoShutdownTriggered {
+	if m.autoShutdownTriggered || m.autoShutdownRetrying {
 		return m, nil
 	}
 
@@ -96,11 +101,12 @@ func (m *RootModel) applyAutoShutdownSettingChange() {
 	if !m.isAutoShutdownEnabled() {
 		m.autoShutdownArmed = false
 		m.autoShutdownTriggered = false
+		m.autoShutdownRetrying = false
 		m.releasePowerInhibitor()
 		return
 	}
 
-	if m.autoShutdownTriggered || m.autoShutdownArmed || !m.hasPendingDownloads() {
+	if m.autoShutdownTriggered || m.autoShutdownRetrying || m.autoShutdownArmed || !m.hasPendingDownloads() {
 		return
 	}
 
@@ -118,10 +124,19 @@ func (m *RootModel) applyAutoShutdownSettingChange() {
 	m.addLogEntry(LogStyleStarted.Render("\u23fb Auto-shutdown armed"))
 }
 
-func (m RootModel) handleAutoShutdownResult(err error) RootModel {
+func (m RootModel) handleAutoShutdownResult(err error) (RootModel, tea.Cmd) {
 	if err != nil {
 		m.autoShutdownTriggered = false
+		m.autoShutdownRetrying = true
 		m.addLogEntry(LogStyleError.Render(fmt.Sprintf("\u2716 Auto-shutdown failed: %v", err)))
+		return m, tea.Tick(autoShutdownRetryDelay, func(time.Time) tea.Msg {
+			return autoShutdownRetryMsg{}
+		})
 	}
-	return m
+	return m, nil
+}
+
+func (m RootModel) handleAutoShutdownRetry() (RootModel, tea.Cmd) {
+	m.autoShutdownRetrying = false
+	return m.refreshAutoShutdown()
 }

--- a/internal/tui/power.go
+++ b/internal/tui/power.go
@@ -1,0 +1,126 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/SurgeDM/Surge/internal/config"
+	"github.com/SurgeDM/Surge/internal/power"
+	"github.com/SurgeDM/Surge/internal/utils"
+)
+
+const autoShutdownReason = "Surge is waiting for downloads to finish before shutting down."
+
+func (m RootModel) isAutoShutdownEnabled() bool {
+	return m.Settings != nil && config.Resolve[bool](m.Settings.General.AutoShutdownAfterDownloads)
+}
+
+func (m RootModel) hasPendingDownloads() bool {
+	for _, d := range m.downloads {
+		if d == nil {
+			continue
+		}
+		if d.done || d.err != nil {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func (m *RootModel) ensurePowerController() {
+	if m.powerController == nil {
+		m.powerController = power.NewController()
+	}
+}
+
+func (m *RootModel) releasePowerInhibitor() {
+	if m.powerInhibitorRelease == nil {
+		return
+	}
+	if err := m.powerInhibitorRelease(); err != nil {
+		utils.Debug("Auto-shutdown: failed to release power inhibitor: %v", err)
+	}
+	m.powerInhibitorRelease = nil
+}
+
+func (m RootModel) refreshAutoShutdown() (RootModel, tea.Cmd) {
+	if !m.isAutoShutdownEnabled() {
+		m.autoShutdownArmed = false
+		m.autoShutdownTriggered = false
+		m.releasePowerInhibitor()
+		return m, nil
+	}
+
+	if m.autoShutdownTriggered {
+		return m, nil
+	}
+
+	pending := m.hasPendingDownloads()
+	if !m.autoShutdownArmed {
+		if !pending {
+			return m, nil
+		}
+		m.autoShutdownArmed = true
+		m.ensurePowerController()
+		if m.powerInhibitorRelease == nil {
+			release, err := m.powerController.AcquireInhibitor(autoShutdownReason)
+			if err != nil {
+				m.addLogEntry(LogStyleError.Render("\u26a0 Auto-shutdown enabled, but sleep prevention failed: " + err.Error()))
+				utils.Debug("Auto-shutdown: acquire inhibitor failed: %v", err)
+			} else {
+				m.powerInhibitorRelease = release
+			}
+		}
+		m.addLogEntry(LogStyleStarted.Render("\u23fb Auto-shutdown armed"))
+		return m, nil
+	}
+
+	if pending {
+		return m, nil
+	}
+
+	m.autoShutdownTriggered = true
+	m.releasePowerInhibitor()
+	m.ensurePowerController()
+	m.addLogEntry(LogStyleStarted.Render("\u23fb All downloads finished; shutting down computer"))
+
+	controller := m.powerController
+	return m, func() tea.Msg {
+		return autoShutdownResultMsg{err: controller.Shutdown(context.Background())}
+	}
+}
+
+func (m *RootModel) applyAutoShutdownSettingChange() {
+	if !m.isAutoShutdownEnabled() {
+		m.autoShutdownArmed = false
+		m.autoShutdownTriggered = false
+		m.releasePowerInhibitor()
+		return
+	}
+
+	if m.autoShutdownTriggered || m.autoShutdownArmed || !m.hasPendingDownloads() {
+		return
+	}
+
+	m.autoShutdownArmed = true
+	m.ensurePowerController()
+	if m.powerInhibitorRelease == nil {
+		release, err := m.powerController.AcquireInhibitor(autoShutdownReason)
+		if err != nil {
+			m.addLogEntry(LogStyleError.Render("\u26a0 Auto-shutdown enabled, but sleep prevention failed: " + err.Error()))
+			utils.Debug("Auto-shutdown: acquire inhibitor failed: %v", err)
+		} else {
+			m.powerInhibitorRelease = release
+		}
+	}
+	m.addLogEntry(LogStyleStarted.Render("\u23fb Auto-shutdown armed"))
+}
+
+func (m RootModel) handleAutoShutdownResult(err error) RootModel {
+	if err != nil {
+		m.addLogEntry(LogStyleError.Render(fmt.Sprintf("\u2716 Auto-shutdown failed: %v", err)))
+	}
+	return m
+}

--- a/internal/tui/power.go
+++ b/internal/tui/power.go
@@ -49,6 +49,20 @@ func (m *RootModel) releasePowerInhibitor() {
 	m.powerInhibitorRelease = nil
 }
 
+func (m *RootModel) acquirePowerInhibitor() {
+	m.ensurePowerController()
+	if m.powerInhibitorRelease != nil {
+		return
+	}
+	release, err := m.powerController.AcquireInhibitor(autoShutdownReason)
+	if err != nil {
+		m.addLogEntry(LogStyleError.Render("\u26a0 Auto-shutdown enabled, but sleep prevention failed: " + err.Error()))
+		utils.Debug("Auto-shutdown: acquire inhibitor failed: %v", err)
+		return
+	}
+	m.powerInhibitorRelease = release
+}
+
 func (m RootModel) refreshAutoShutdown() (RootModel, tea.Cmd) {
 	if !m.isAutoShutdownEnabled() {
 		m.autoShutdownArmed = false
@@ -68,16 +82,7 @@ func (m RootModel) refreshAutoShutdown() (RootModel, tea.Cmd) {
 			return m, nil
 		}
 		m.autoShutdownArmed = true
-		m.ensurePowerController()
-		if m.powerInhibitorRelease == nil {
-			release, err := m.powerController.AcquireInhibitor(autoShutdownReason)
-			if err != nil {
-				m.addLogEntry(LogStyleError.Render("\u26a0 Auto-shutdown enabled, but sleep prevention failed: " + err.Error()))
-				utils.Debug("Auto-shutdown: acquire inhibitor failed: %v", err)
-			} else {
-				m.powerInhibitorRelease = release
-			}
-		}
+		m.acquirePowerInhibitor()
 		m.addLogEntry(LogStyleStarted.Render("\u23fb Auto-shutdown armed"))
 		return m, nil
 	}
@@ -111,16 +116,7 @@ func (m *RootModel) applyAutoShutdownSettingChange() {
 	}
 
 	m.autoShutdownArmed = true
-	m.ensurePowerController()
-	if m.powerInhibitorRelease == nil {
-		release, err := m.powerController.AcquireInhibitor(autoShutdownReason)
-		if err != nil {
-			m.addLogEntry(LogStyleError.Render("\u26a0 Auto-shutdown enabled, but sleep prevention failed: " + err.Error()))
-			utils.Debug("Auto-shutdown: acquire inhibitor failed: %v", err)
-		} else {
-			m.powerInhibitorRelease = release
-		}
-	}
+	m.acquirePowerInhibitor()
 	m.addLogEntry(LogStyleStarted.Render("\u23fb Auto-shutdown armed"))
 }
 
@@ -128,6 +124,7 @@ func (m RootModel) handleAutoShutdownResult(err error) (RootModel, tea.Cmd) {
 	if err != nil {
 		m.autoShutdownTriggered = false
 		m.autoShutdownRetrying = true
+		m.acquirePowerInhibitor()
 		m.addLogEntry(LogStyleError.Render(fmt.Sprintf("\u2716 Auto-shutdown failed: %v", err)))
 		return m, tea.Tick(autoShutdownRetryDelay, func(time.Time) tea.Msg {
 			return autoShutdownRetryMsg{}

--- a/internal/tui/power_test.go
+++ b/internal/tui/power_test.go
@@ -1,0 +1,140 @@
+package tui
+
+import (
+	"context"
+	"testing"
+
+	"charm.land/bubbles/v2/viewport"
+	"github.com/SurgeDM/Surge/internal/config"
+	"github.com/SurgeDM/Surge/internal/power"
+	"github.com/SurgeDM/Surge/internal/types"
+)
+
+type fakePowerController struct {
+	shutdowns int
+	inhibits  int
+	releases  int
+}
+
+func (f *fakePowerController) Shutdown(context.Context) error {
+	f.shutdowns++
+	return nil
+}
+
+func (f *fakePowerController) AcquireInhibitor(string) (power.ReleaseFunc, error) {
+	f.inhibits++
+	return func() error {
+		f.releases++
+		return nil
+	}, nil
+}
+
+func newAutoShutdownTestModel(power *fakePowerController, downloads ...*DownloadModel) RootModel {
+	settings := config.DefaultSettings()
+	settings.General.AutoShutdownAfterDownloads.Value = true
+	return RootModel{
+		Settings:        settings,
+		downloads:       downloads,
+		list:            NewDownloadList(80, 20),
+		logViewport:     viewport.New(viewport.WithWidth(40), viewport.WithHeight(5)),
+		powerController: power,
+	}
+}
+
+func TestAutoShutdown_TriggersWhenLastDownloadCompletes(t *testing.T) {
+	power := &fakePowerController{}
+	dm := NewDownloadModel("id-1", "https://example.com/file.bin", "file.bin", 100)
+	dm.started = true
+	m := newAutoShutdownTestModel(power, dm)
+
+	m.applyAutoShutdownSettingChange()
+	if !m.autoShutdownArmed {
+		t.Fatal("expected auto-shutdown to arm when pending download exists")
+	}
+	if power.inhibits != 1 {
+		t.Fatalf("inhibits = %d, want 1", power.inhibits)
+	}
+
+	updated, cmd := m.Update(types.DownloadEvent{
+		Type:       types.EventComplete,
+		DownloadID: "id-1",
+		Filename:   "file.bin",
+		Total:      100,
+	})
+	m2 := updated.(RootModel)
+	if !m2.autoShutdownTriggered {
+		t.Fatal("expected auto-shutdown to be marked triggered")
+	}
+	if power.releases != 1 {
+		t.Fatalf("releases = %d, want 1", power.releases)
+	}
+	if cmd == nil {
+		t.Fatal("expected shutdown command")
+	}
+	executeCmds(cmd)
+	if power.shutdowns != 1 {
+		t.Fatalf("shutdowns = %d, want 1", power.shutdowns)
+	}
+
+	updated, cmd = m2.Update(types.DownloadEvent{
+		Type:       types.EventComplete,
+		DownloadID: "id-1",
+		Filename:   "file.bin",
+		Total:      100,
+	})
+	_ = updated
+	executeCmds(cmd)
+	if power.shutdowns != 1 {
+		t.Fatalf("shutdowns after duplicate event = %d, want 1", power.shutdowns)
+	}
+}
+
+func TestAutoShutdown_PausedDownloadBlocksShutdown(t *testing.T) {
+	power := &fakePowerController{}
+	active := NewDownloadModel("id-active", "https://example.com/active.bin", "active.bin", 100)
+	active.started = true
+	paused := NewDownloadModel("id-paused", "https://example.com/paused.bin", "paused.bin", 100)
+	paused.paused = true
+	m := newAutoShutdownTestModel(power, active, paused)
+	m.applyAutoShutdownSettingChange()
+
+	updated, cmd := m.Update(types.DownloadEvent{
+		Type:       types.EventComplete,
+		DownloadID: "id-active",
+		Filename:   "active.bin",
+		Total:      100,
+	})
+	m2 := updated.(RootModel)
+
+	if m2.autoShutdownTriggered {
+		t.Fatal("expected paused download to block shutdown")
+	}
+	executeCmds(cmd)
+	if power.shutdowns != 0 {
+		t.Fatalf("shutdowns = %d, want 0", power.shutdowns)
+	}
+}
+
+func TestAutoShutdown_DisablingSettingReleasesInhibitor(t *testing.T) {
+	power := &fakePowerController{}
+	dm := NewDownloadModel("id-1", "https://example.com/file.bin", "file.bin", 100)
+	m := newAutoShutdownTestModel(power, dm)
+	m.applyAutoShutdownSettingChange()
+
+	if power.inhibits != 1 {
+		t.Fatalf("inhibits = %d, want 1", power.inhibits)
+	}
+
+	if err := m.setSettingValue("General", "auto_shutdown_after_downloads", "false"); err != nil {
+		t.Fatalf("setSettingValue failed: %v", err)
+	}
+	if m.autoShutdownArmed {
+		t.Fatal("expected auto-shutdown to disarm")
+	}
+	if power.releases != 1 {
+		t.Fatalf("releases = %d, want 1", power.releases)
+	}
+	if config.Resolve[bool](m.Settings.General.AutoShutdownAfterDownloads) {
+		t.Fatal("expected setting to be false")
+	}
+}

--- a/internal/tui/power_test.go
+++ b/internal/tui/power_test.go
@@ -167,7 +167,31 @@ func TestAutoShutdown_DeleteLastPendingDownloadReconciles(t *testing.T) {
 	}
 }
 
-func TestAutoShutdown_ShutdownFailureClearsTriggeredLatch(t *testing.T) {
+func TestAutoShutdown_ShutdownFailureSchedulesRetryWithBackoff(t *testing.T) {
+	errShutdown := errors.New("shutdown failed")
+	power := &fakePowerController{shutdownErr: errShutdown}
+	m := newAutoShutdownTestModel(power)
+	m.autoShutdownArmed = true
+	m.autoShutdownTriggered = true
+
+	updated, cmd := m.Update(autoShutdownResultMsg{err: errShutdown})
+	m2 := updated.(RootModel)
+
+	if m2.autoShutdownTriggered {
+		t.Fatal("expected failed shutdown to clear triggered latch")
+	}
+	if !m2.autoShutdownRetrying {
+		t.Fatal("expected failed shutdown to schedule retry")
+	}
+	if !m2.autoShutdownArmed {
+		t.Fatal("expected failed shutdown to keep auto-shutdown armed")
+	}
+	if cmd == nil {
+		t.Fatal("expected retry timer command")
+	}
+}
+
+func TestAutoShutdown_ShutdownFailureDoesNotRetryBeforeScheduledMessage(t *testing.T) {
 	errShutdown := errors.New("shutdown failed")
 	power := &fakePowerController{shutdownErr: errShutdown}
 	m := newAutoShutdownTestModel(power)
@@ -177,10 +201,30 @@ func TestAutoShutdown_ShutdownFailureClearsTriggeredLatch(t *testing.T) {
 	updated, _ := m.Update(autoShutdownResultMsg{err: errShutdown})
 	m2 := updated.(RootModel)
 
-	if m2.autoShutdownTriggered {
-		t.Fatal("expected failed shutdown to clear triggered latch")
+	updated, cmd := m2.Update(types.DownloadEvent{
+		Type:       types.EventComplete,
+		DownloadID: "already-done",
+		Filename:   "done.bin",
+		Total:      1,
+	})
+	m3 := updated.(RootModel)
+	executeCmds(cmd)
+
+	if !m3.autoShutdownRetrying {
+		t.Fatal("expected retry to remain scheduled")
 	}
-	if !m2.autoShutdownArmed {
-		t.Fatal("expected failed shutdown to keep auto-shutdown armed")
+	if power.shutdowns != 0 {
+		t.Fatalf("shutdowns before retry message = %d, want 0", power.shutdowns)
+	}
+
+	power.shutdownErr = nil
+	updated, cmd = m3.Update(autoShutdownRetryMsg{})
+	m4 := updated.(RootModel)
+	if !m4.autoShutdownTriggered {
+		t.Fatal("expected retry message to trigger shutdown")
+	}
+	executeCmds(cmd)
+	if power.shutdowns != 1 {
+		t.Fatalf("shutdowns after retry message = %d, want 1", power.shutdowns)
 	}
 }

--- a/internal/tui/power_test.go
+++ b/internal/tui/power_test.go
@@ -2,23 +2,26 @@ package tui
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"charm.land/bubbles/v2/viewport"
+	tea "charm.land/bubbletea/v2"
 	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/power"
 	"github.com/SurgeDM/Surge/internal/types"
 )
 
 type fakePowerController struct {
-	shutdowns int
-	inhibits  int
-	releases  int
+	shutdowns   int
+	inhibits    int
+	releases    int
+	shutdownErr error
 }
 
 func (f *fakePowerController) Shutdown(context.Context) error {
 	f.shutdowns++
-	return nil
+	return f.shutdownErr
 }
 
 func (f *fakePowerController) AcquireInhibitor(string) (power.ReleaseFunc, error) {
@@ -136,5 +139,48 @@ func TestAutoShutdown_DisablingSettingReleasesInhibitor(t *testing.T) {
 	}
 	if config.Resolve[bool](m.Settings.General.AutoShutdownAfterDownloads) {
 		t.Fatal("expected setting to be false")
+	}
+}
+
+func TestAutoShutdown_DeleteLastPendingDownloadReconciles(t *testing.T) {
+	power := &fakePowerController{}
+	dm := NewDownloadModel("id-1", "https://example.com/file.bin", "file.bin", 100)
+	m := newAutoShutdownTestModel(power, dm)
+	m.Service = &mockService{}
+	m.keys = config.DefaultKeyMap()
+	m.applyAutoShutdownSettingChange()
+	m.UpdateListItems()
+	m.list.Select(0)
+
+	updated, cmd := m.Update(tea.KeyPressMsg{Code: 'x', Text: "x"})
+	m2 := updated.(RootModel)
+
+	if len(m2.downloads) != 0 {
+		t.Fatalf("expected delete to remove download, got %d", len(m2.downloads))
+	}
+	if !m2.autoShutdownTriggered {
+		t.Fatal("expected delete of last pending download to trigger auto-shutdown")
+	}
+	executeCmds(cmd)
+	if power.shutdowns != 1 {
+		t.Fatalf("shutdowns = %d, want 1", power.shutdowns)
+	}
+}
+
+func TestAutoShutdown_ShutdownFailureClearsTriggeredLatch(t *testing.T) {
+	errShutdown := errors.New("shutdown failed")
+	power := &fakePowerController{shutdownErr: errShutdown}
+	m := newAutoShutdownTestModel(power)
+	m.autoShutdownArmed = true
+	m.autoShutdownTriggered = true
+
+	updated, _ := m.Update(autoShutdownResultMsg{err: errShutdown})
+	m2 := updated.(RootModel)
+
+	if m2.autoShutdownTriggered {
+		t.Fatal("expected failed shutdown to clear triggered latch")
+	}
+	if !m2.autoShutdownArmed {
+		t.Fatal("expected failed shutdown to keep auto-shutdown armed")
 	}
 }

--- a/internal/tui/power_test.go
+++ b/internal/tui/power_test.go
@@ -186,6 +186,12 @@ func TestAutoShutdown_ShutdownFailureSchedulesRetryWithBackoff(t *testing.T) {
 	if !m2.autoShutdownArmed {
 		t.Fatal("expected failed shutdown to keep auto-shutdown armed")
 	}
+	if power.inhibits != 1 {
+		t.Fatalf("inhibits during retry backoff = %d, want 1", power.inhibits)
+	}
+	if m2.powerInhibitorRelease == nil {
+		t.Fatal("expected failed shutdown to hold power inhibitor during retry backoff")
+	}
 	if cmd == nil {
 		t.Fatal("expected retry timer command")
 	}

--- a/internal/tui/update_dashboard.go
+++ b/internal/tui/update_dashboard.go
@@ -164,7 +164,8 @@ func (m RootModel) updateDashboard(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 				m.removeDownloadByID(targetID)
 			}
 			m.UpdateListItems()
-			return m, nil
+			m, autoCmd := m.refreshAutoShutdown()
+			return m, autoCmd
 		}
 	}
 

--- a/internal/tui/update_events.go
+++ b/internal/tui/update_events.go
@@ -40,7 +40,10 @@ func (m RootModel) updateEvents(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.refreshAutoShutdown()
 
 	case autoShutdownResultMsg:
-		return m.handleAutoShutdownResult(msg.err), nil
+		return m.handleAutoShutdownResult(msg.err)
+
+	case autoShutdownRetryMsg:
+		return m.handleAutoShutdownRetry()
 
 	case spinner.TickMsg:
 		var cmd tea.Cmd

--- a/internal/tui/update_events.go
+++ b/internal/tui/update_events.go
@@ -26,10 +26,22 @@ func stateProgress(state interface{}) *engineprogress.DownloadProgress {
 
 func (m RootModel) updateEvents(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if ev, ok := msg.(types.DownloadEvent); ok {
-		return m.handleDownloadEvent(ev)
+		model, cmd := m.handleDownloadEvent(ev)
+		root, ok := model.(RootModel)
+		if !ok {
+			return model, cmd
+		}
+		root, autoCmd := root.refreshAutoShutdown()
+		return root, tea.Batch(cmd, autoCmd)
 	}
 
 	switch msg := msg.(type) {
+	case autoShutdownCheckMsg:
+		return m.refreshAutoShutdown()
+
+	case autoShutdownResultMsg:
+		return m.handleAutoShutdownResult(msg.err), nil
+
 	case spinner.TickMsg:
 		var cmd tea.Cmd
 		m.spinner, cmd = m.spinner.Update(msg)
@@ -90,7 +102,8 @@ func (m RootModel) updateEvents(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		m.UpdateListItems()
-		return m, nil
+		m, autoCmd := m.refreshAutoShutdown()
+		return m, autoCmd
 
 	case enqueueErrorMsg:
 		if msg.tempID != "" {
@@ -114,7 +127,8 @@ func (m RootModel) updateEvents(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.UpdateListItems()
 		}
 		m.addLogEntry(LogStyleError.Render("\u2716 Failed to enqueue download: " + msg.err.Error()))
-		return m, nil
+		m, autoCmd := m.refreshAutoShutdown()
+		return m, autoCmd
 
 	case startupConfigWarningMsg:
 		for _, w := range msg {

--- a/internal/tui/update_modals.go
+++ b/internal/tui/update_modals.go
@@ -193,6 +193,7 @@ func (m RootModel) updateQuitConfirm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		if m.cancelEnqueue != nil {
 			m.cancelEnqueue()
 		}
+		m.releasePowerInhibitor()
 		m.shuttingDown = true
 		return m, shutdownCmd(m.Service)
 	}
@@ -237,15 +238,15 @@ func (m RootModel) updateBatchConfirm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 		added := 0
 		skipped := 0
 		var batchCmds []tea.Cmd
-		
+
 		pathChanged := path != m.batchFilePath
-		
+
 		for _, request := range m.pendingBatchRequests {
 			requestPath := path
 			if !pathChanged && request.Path != "" {
 				requestPath = request.Path
 			}
-			
+
 			isDefaultPath := m.isDefaultDownloadPath(requestPath)
 			if requestPath == "" {
 				isDefaultPath = true
@@ -531,6 +532,7 @@ func (m RootModel) updateRestartConfirm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd
 		if m.cancelEnqueue != nil {
 			m.cancelEnqueue()
 		}
+		m.releasePowerInhibitor()
 		m.shuttingDown = true
 		m.RestartRequested = true
 		return m, shutdownCmd(m.Service)

--- a/internal/tui/update_modals.go
+++ b/internal/tui/update_modals.go
@@ -640,7 +640,8 @@ func (m RootModel) updatePurgeConfirm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 			m.addLogEntry(LogStyleStarted.Render("\u2714 Purged download"))
 		}
 
-		return m, nil
+		m, autoCmd := m.refreshAutoShutdown()
+		return m, autoCmd
 	}
 
 	cancelPurge := func() (tea.Model, tea.Cmd) {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -403,6 +403,13 @@ func (m RootModel) View() tea.View {
 		limitChunk = lipgloss.JoinHorizontal(lipgloss.Center, limitGlyph, " ", lipgloss.NewStyle().Foreground(colors.Gray()).Render("\u221E"))
 	}
 
+	// Auto-shutdown indicator
+	powerColor := colors.Gray()
+	if m.isAutoShutdownEnabled() {
+		powerColor = colors.Orange()
+	}
+	powerChunk := lipgloss.NewStyle().Foreground(powerColor).Render("\u23fb")
+
 	// Version indicator
 	versionBlue := colors.ThemeColor("#005cc5", "#58a6ff")
 	versionChunk := lipgloss.NewStyle().Foreground(versionBlue).Render(fmt.Sprintf("v%s", m.CurrentVersion))
@@ -411,6 +418,8 @@ func (m RootModel) View() tea.View {
 		speedChunk,
 		dimSep,
 		limitChunk,
+		dimSep,
+		powerChunk,
 		dimSep,
 		versionChunk,
 	))

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -408,7 +408,11 @@ func (m RootModel) View() tea.View {
 	if m.isAutoShutdownEnabled() {
 		powerColor = colors.Orange()
 	}
-	powerChunk := lipgloss.NewStyle().Foreground(powerColor).Render("\u23fb")
+	powerChunk := lipgloss.NewStyle().
+		Foreground(powerColor).
+		Width(3).
+		Align(lipgloss.Center).
+		Render("\u23fb")
 
 	// Version indicator
 	versionBlue := colors.ThemeColor("#005cc5", "#58a6ff")

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -722,6 +722,9 @@ func (m *RootModel) setSettingValue(category, key, value string) error {
 		return err
 	}
 	setting.Value = parsedVal
+	if key == "auto_shutdown_after_downloads" {
+		m.applyAutoShutdownSettingChange()
+	}
 	return nil
 }
 
@@ -957,6 +960,9 @@ func (m *RootModel) resetSettingToDefault(category, key string, defaults *config
 	defaultSetting := defaults.FindSetting(category, key)
 	if setting != nil && defaultSetting != nil {
 		setting.Value = defaultSetting.Value
+	}
+	if key == "auto_shutdown_after_downloads" {
+		m.applyAutoShutdownSettingChange()
 	}
 	return nil
 }

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -630,7 +630,7 @@ func TestFooter_GlyphsAlwaysPresent(t *testing.T) {
 	m.height = 35
 
 	last := footerLine(m)
-	for _, glyph := range []string{"\u2B07", "\u26A1"} {
+	for _, glyph := range []string{"\u2B07", "\u26A1", "\u23fb"} {
 		if !strings.Contains(last, glyph) {
 			t.Errorf("footer missing glyph %q, got: %q", glyph, last)
 		}
@@ -739,7 +739,7 @@ func TestFooter_HidesHelpAtNarrowWidth(t *testing.T) {
 
 	last := footerLine(m)
 	// Speed/limit/version glyphs must still appear
-	for _, glyph := range []string{"\u2B07", "\u26A1"} {
+	for _, glyph := range []string{"\u2B07", "\u26A1", "\u23fb"} {
 		if !strings.Contains(last, glyph) {
 			t.Errorf("narrow footer missing glyph %q, got: %q", glyph, last)
 		}


### PR DESCRIPTION
…ads are done

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds automatic system shutdown after all downloads finish. The main changes are:

- A configurable auto-shutdown setting and TUI status indicator.
- Cross-platform shutdown and sleep-inhibitor controllers.
- Download-state reconciliation for completion, deletion, purge, and enqueue events.
- Delayed shutdown retries with sleep prevention during backoff.
- Tests for completion, paused downloads, deletion, settings, and retries.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

The Windows inhibitor now releases execution state on the thread that acquired it. Download removal paths now refresh auto-shutdown state. Failed shutdowns retain sleep prevention and retry after a delay.

No blocking issues remain in the changed paths.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The baseline focused test run for TestAutoShutdown completed successfully (exit code 0).
- The race-enabled test run for TestAutoShutdown completed successfully (exit code 0).
- A separate captured command enumerated the fake Shutdown/AcquireInhibitor seam with counter assertions and all six tests executed.

<a href="https://app.greptile.com/trex/runs/14537922/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/power/power_windows.go | Keeps Windows execution-state acquisition and release on the same locked OS thread. |
| internal/tui/power.go | Manages auto-shutdown arming, inhibition, shutdown execution, and delayed retries. |
| internal/tui/update_events.go | Reconciles auto-shutdown after download events and handles shutdown retry messages. |
| internal/tui/update_dashboard.go | Reconciles auto-shutdown after downloads are removed from the dashboard. |
| internal/tui/update_modals.go | Releases the power inhibitor on quit or restart and reconciles purge actions. |
| internal/tui/power_test.go | Tests shutdown triggering, blocking states, setting changes, deletion, and retry behavior. |

</details>

<sub>Reviews (5): Last reviewed commit: ["tui: keep power inhibitor during auto-sh..."](https://github.com/surgedm/surge/commit/0882b85825bda0236fff6f0c062b44b2e7e58847) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44232503)</sub>

<!-- /greptile_comment -->