### PR TITLE
Add confirmation popup for removing downloads

### DIFF
--- a/internal/tui/delete_resilience_test.go
+++ b/internal/tui/delete_resilience_test.go
@@ -55,11 +55,12 @@ func TestUpdateDashboard_DeleteResilience(t *testing.T) {
 	// This test validates the TUI's defensive layer independently of the service
 	// implementation. Even though Service.Delete currently returns nil for missing
 	// IDs, the TUI should still gracefully handle ErrNotFound if it occurs.
-	dm := &DownloadModel{ID: "ghost-id", Filename: "ghost.zip"}
+	dm := &DownloadModel{ID: "ghost-id", Filename: "ghost.zip", done: true}
 	svc := &mockService{deleteErr: types.ErrNotFound}
 
 	m := RootModel{
 		state:     DashboardState,
+		activeTab: TabDone,
 		downloads: []*DownloadModel{dm},
 		Service:   svc,
 		keys:      config.DefaultKeyMap(),
@@ -82,11 +83,12 @@ func TestUpdateDashboard_DeleteResilience(t *testing.T) {
 }
 
 func TestUpdateDashboard_DeleteSuccess(t *testing.T) {
-	dm := &DownloadModel{ID: "real-id", Filename: "real.zip"}
+	dm := &DownloadModel{ID: "real-id", Filename: "real.zip", done: true}
 	svc := &mockService{deleteErr: nil}
 
 	m := RootModel{
 		state:     DashboardState,
+		activeTab: TabDone,
 		downloads: []*DownloadModel{dm},
 		Service:   svc,
 		keys:      config.DefaultKeyMap(),
@@ -105,11 +107,12 @@ func TestUpdateDashboard_DeleteSuccess(t *testing.T) {
 }
 
 func TestUpdateDashboard_DeleteOtherError(t *testing.T) {
-	dm := &DownloadModel{ID: "error-id", Filename: "error.zip"}
+	dm := &DownloadModel{ID: "error-id", Filename: "error.zip", done: true}
 	svc := &mockService{deleteErr: errors.New("some other error")}
 
 	m := RootModel{
 		state:     DashboardState,
+		activeTab: TabDone,
 		downloads: []*DownloadModel{dm},
 		Service:   svc,
 		keys:      config.DefaultKeyMap(),
@@ -124,5 +127,118 @@ func TestUpdateDashboard_DeleteOtherError(t *testing.T) {
 
 	if len(m2.downloads) != 1 {
 		t.Errorf("Expected download to REMAIN on non-not-found error, but %d entries remain", len(m2.downloads))
+	}
+}
+
+func TestUpdateDashboard_DeletePausedDownloadPromptsConfirmation(t *testing.T) {
+	dm := &DownloadModel{ID: "paused-id", Filename: "paused.zip", paused: true}
+	svc := &mockService{}
+
+	m := RootModel{
+		state:     DashboardState,
+		downloads: []*DownloadModel{dm},
+		Service:   svc,
+		keys:      config.DefaultKeyMap(),
+		list:      NewDownloadList(80, 20),
+	}
+	m.UpdateListItems()
+	m.list.Select(0)
+
+	updated, _ := m.updateDashboard(tea.KeyPressMsg{Code: 'x', Text: "x"})
+	m2 := updated.(RootModel)
+
+	if m2.state != RemoveConfirmState {
+		t.Fatalf("expected remove confirmation state, got %v", m2.state)
+	}
+	if m2.removeTargetID != "paused-id" {
+		t.Fatalf("removeTargetID = %q, want paused-id", m2.removeTargetID)
+	}
+	if svc.deletedID != "" {
+		t.Fatalf("expected delete not to run before confirmation, got %q", svc.deletedID)
+	}
+	if len(m2.downloads) != 1 {
+		t.Fatalf("expected download to remain before confirmation, got %d", len(m2.downloads))
+	}
+}
+
+func TestUpdateDashboard_DeleteActiveDownloadPromptsConfirmation(t *testing.T) {
+	dm := &DownloadModel{ID: "active-id", Filename: "active.zip", started: true, Speed: 1024}
+	svc := &mockService{}
+
+	m := RootModel{
+		state:     DashboardState,
+		activeTab: TabActive,
+		downloads: []*DownloadModel{dm},
+		Service:   svc,
+		keys:      config.DefaultKeyMap(),
+		list:      NewDownloadList(80, 20),
+	}
+	m.UpdateListItems()
+	m.list.Select(0)
+
+	updated, _ := m.updateDashboard(tea.KeyPressMsg{Code: 'x', Text: "x"})
+	m2 := updated.(RootModel)
+
+	if m2.state != RemoveConfirmState {
+		t.Fatalf("expected remove confirmation state, got %v", m2.state)
+	}
+	if svc.deletedID != "" {
+		t.Fatalf("expected delete not to run before confirmation, got %q", svc.deletedID)
+	}
+}
+
+func TestRemoveConfirm_CancelKeepsDownload(t *testing.T) {
+	dm := &DownloadModel{ID: "paused-id", Filename: "paused.zip", paused: true}
+	svc := &mockService{}
+
+	m := RootModel{
+		state:          RemoveConfirmState,
+		removeTargetID: "paused-id",
+		downloads:      []*DownloadModel{dm},
+		Service:        svc,
+		keys:           config.DefaultKeyMap(),
+		list:           NewDownloadList(80, 20),
+	}
+	m.UpdateListItems()
+
+	updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	m2 := updated.(RootModel)
+
+	if m2.state != DashboardState {
+		t.Fatalf("expected dashboard state after cancel, got %v", m2.state)
+	}
+	if len(m2.downloads) != 1 {
+		t.Fatalf("expected download to remain after cancel, got %d", len(m2.downloads))
+	}
+	if svc.deletedID != "" {
+		t.Fatalf("expected delete not to run after cancel, got %q", svc.deletedID)
+	}
+}
+
+func TestRemoveConfirm_ConfirmDeletesDownload(t *testing.T) {
+	dm := &DownloadModel{ID: "paused-id", Filename: "paused.zip", paused: true}
+	svc := &mockService{}
+
+	m := RootModel{
+		state:          RemoveConfirmState,
+		removeTargetID: "paused-id",
+		downloads:      []*DownloadModel{dm},
+		Service:        svc,
+		keys:           config.DefaultKeyMap(),
+		list:           NewDownloadList(80, 20),
+	}
+	m.UpdateListItems()
+
+	updated, _ := m.Update(tea.KeyPressMsg{Code: 'y', Text: "y"})
+	m2 := updated.(RootModel)
+
+	if m2.state != DashboardState {
+		t.Fatalf("expected dashboard state after confirm, got %v", m2.state)
+	}
+	if len(m2.downloads) != 0 {
+		t.Fatalf("expected download to be removed after confirm, got %d", len(m2.downloads))
+	}
+	if svc.deletedID != "paused-id" {
+		t.Fatalf("expected Service.Delete paused-id, got %q", svc.deletedID)
 	}
 }

--- a/internal/tui/delete_resilience_test.go
+++ b/internal/tui/delete_resilience_test.go
@@ -187,6 +187,89 @@ func TestUpdateDashboard_DeleteActiveDownloadPromptsConfirmation(t *testing.T) {
 	}
 }
 
+func TestUpdateDashboard_DeleteErroredDownloadPromptsConfirmation(t *testing.T) {
+	dm := &DownloadModel{ID: "error-id", Filename: "partial.zip", done: true, err: errors.New("network failed")}
+	svc := &mockService{}
+
+	m := RootModel{
+		state:     DashboardState,
+		activeTab: TabDone,
+		downloads: []*DownloadModel{dm},
+		Service:   svc,
+		keys:      config.DefaultKeyMap(),
+		list:      NewDownloadList(80, 20),
+	}
+	m.UpdateListItems()
+	m.list.Select(0)
+
+	updated, _ := m.updateDashboard(tea.KeyPressMsg{Code: 'x', Text: "x"})
+	m2 := updated.(RootModel)
+
+	if m2.state != RemoveConfirmState {
+		t.Fatalf("expected remove confirmation state, got %v", m2.state)
+	}
+	if m2.removeTargetID != "error-id" {
+		t.Fatalf("removeTargetID = %q, want error-id", m2.removeTargetID)
+	}
+	if svc.deletedID != "" {
+		t.Fatalf("expected delete not to run before confirmation, got %q", svc.deletedID)
+	}
+}
+
+func TestRemoveConfirm_QueuesIncomingSingleRequest(t *testing.T) {
+	m := RootModel{
+		state:          RemoveConfirmState,
+		removeTargetID: "paused-id",
+		Settings:       config.DefaultSettings(),
+		keys:           config.DefaultKeyMap(),
+		list:           NewDownloadList(80, 20),
+	}
+
+	updated, _ := m.handleDownloadEvent(types.DownloadEvent{
+		Type:     types.EventRequest,
+		URL:      "https://example.com/new.zip",
+		Filename: "new.zip",
+		Path:     "/tmp/downloads",
+	})
+	m2 := updated.(RootModel)
+
+	if m2.state != RemoveConfirmState {
+		t.Fatalf("expected remove confirmation state to remain, got %v", m2.state)
+	}
+	if m2.removeTargetID != "paused-id" {
+		t.Fatalf("removeTargetID = %q, want paused-id", m2.removeTargetID)
+	}
+	if len(m2.pendingRequestQueue) != 1 || m2.pendingRequestQueue[0].URL != "https://example.com/new.zip" {
+		t.Fatalf("expected incoming request queued, got %#v", m2.pendingRequestQueue)
+	}
+}
+
+func TestRemoveConfirm_QueuesIncomingBatchRequest(t *testing.T) {
+	m := RootModel{
+		state:          RemoveConfirmState,
+		removeTargetID: "paused-id",
+		Settings:       config.DefaultSettings(),
+		keys:           config.DefaultKeyMap(),
+		list:           NewDownloadList(80, 20),
+	}
+
+	updated, _ := m.handleDownloadEvent(types.DownloadEvent{
+		Type: types.EventBatchRequest,
+		Path: "/tmp/downloads",
+		BatchEvents: []types.DownloadEvent{
+			{Type: types.EventRequest, URL: "https://example.com/one.zip"},
+		},
+	})
+	m2 := updated.(RootModel)
+
+	if m2.state != RemoveConfirmState {
+		t.Fatalf("expected remove confirmation state to remain, got %v", m2.state)
+	}
+	if len(m2.pendingBatchRequestQueue) != 1 {
+		t.Fatalf("expected incoming batch request queued, got %d", len(m2.pendingBatchRequestQueue))
+	}
+}
+
 func TestRemoveConfirm_CancelKeepsDownload(t *testing.T) {
 	dm := &DownloadModel{ID: "paused-id", Filename: "paused.zip", paused: true}
 	svc := &mockService{}

--- a/internal/tui/delete_resilience_test.go
+++ b/internal/tui/delete_resilience_test.go
@@ -270,6 +270,89 @@ func TestRemoveConfirm_QueuesIncomingBatchRequest(t *testing.T) {
 	}
 }
 
+func TestRemoveConfirm_CancelShowsNextQueuedRequest(t *testing.T) {
+	settings := config.DefaultSettings()
+	settings.Extension.ExtensionPrompt.Value = true
+	dm := &DownloadModel{ID: "paused-id", Filename: "paused.zip", paused: true}
+
+	m := RootModel{
+		state:          RemoveConfirmState,
+		removeTargetID: "paused-id",
+		downloads:      []*DownloadModel{dm},
+		Settings:       settings,
+		keys:           config.DefaultKeyMap(),
+		inputs:         newInputModels(),
+		list:           NewDownloadList(80, 20),
+		pendingRequestQueue: []types.DownloadEvent{
+			{Type: types.EventRequest, URL: "https://example.com/new.zip", Filename: "new.zip", Path: "/tmp/downloads"},
+		},
+	}
+
+	updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	m2 := updated.(RootModel)
+
+	if m2.state != ExtensionConfirmationState {
+		t.Fatalf("expected queued request to open extension confirmation, got %v", m2.state)
+	}
+	if m2.removeTargetID != "" {
+		t.Fatalf("expected removeTargetID cleared, got %q", m2.removeTargetID)
+	}
+	if len(m2.pendingRequestQueue) != 0 {
+		t.Fatalf("expected queued request consumed, got %d", len(m2.pendingRequestQueue))
+	}
+	if m2.pendingURL != "https://example.com/new.zip" {
+		t.Fatalf("pendingURL = %q, want queued request URL", m2.pendingURL)
+	}
+	if len(m2.downloads) != 1 {
+		t.Fatalf("expected cancelled remove to keep download, got %d", len(m2.downloads))
+	}
+}
+
+func TestRemoveConfirm_ConfirmShowsNextQueuedBatchRequest(t *testing.T) {
+	dm := &DownloadModel{ID: "paused-id", Filename: "paused.zip", paused: true}
+	svc := &mockService{}
+
+	m := RootModel{
+		state:          RemoveConfirmState,
+		removeTargetID: "paused-id",
+		downloads:      []*DownloadModel{dm},
+		Service:        svc,
+		Settings:       config.DefaultSettings(),
+		keys:           config.DefaultKeyMap(),
+		inputs:         newInputModels(),
+		list:           NewDownloadList(80, 20),
+		pendingBatchRequestQueue: []types.DownloadEvent{
+			{
+				Type: types.EventBatchRequest,
+				Path: "/tmp/downloads",
+				BatchEvents: []types.DownloadEvent{
+					{Type: types.EventRequest, URL: "https://example.com/one.zip"},
+				},
+			},
+		},
+	}
+	m.UpdateListItems()
+
+	updated, _ := m.Update(tea.KeyPressMsg{Code: 'y', Text: "y"})
+	m2 := updated.(RootModel)
+
+	if m2.state != BatchConfirmState {
+		t.Fatalf("expected queued batch to open batch confirmation, got %v", m2.state)
+	}
+	if svc.deletedID != "paused-id" {
+		t.Fatalf("expected Service.Delete paused-id, got %q", svc.deletedID)
+	}
+	if len(m2.downloads) != 0 {
+		t.Fatalf("expected confirmed remove to delete download, got %d", len(m2.downloads))
+	}
+	if len(m2.pendingBatchRequestQueue) != 0 {
+		t.Fatalf("expected queued batch consumed, got %d", len(m2.pendingBatchRequestQueue))
+	}
+	if len(m2.pendingBatchRequests) != 1 || m2.pendingBatchRequests[0].URL != "https://example.com/one.zip" {
+		t.Fatalf("expected pending batch request loaded, got %#v", m2.pendingBatchRequests)
+	}
+}
+
 func TestRemoveConfirm_CancelKeepsDownload(t *testing.T) {
 	dm := &DownloadModel{ID: "paused-id", Filename: "paused.zip", paused: true}
 	svc := &mockService{}

--- a/internal/tui/download_requests.go
+++ b/internal/tui/download_requests.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (m RootModel) handleDownloadRequestMsg(msg types.DownloadEvent, queueIfBusy bool) (tea.Model, tea.Cmd) {
-	if queueIfBusy && (m.state == ExtensionConfirmationState || m.state == DuplicateWarningState || m.state == BatchConfirmState) {
+	if queueIfBusy && m.isRequestConfirmationBusy() {
 		m.pendingRequestQueue = append(m.pendingRequestQueue, msg)
 		return m, nil
 	}
@@ -63,7 +63,7 @@ func (m RootModel) handleDownloadRequestMsg(msg types.DownloadEvent, queueIfBusy
 }
 
 func (m RootModel) handleBatchDownloadRequestMsg(msg types.DownloadEvent, queueIfBusy bool) (tea.Model, tea.Cmd) {
-	if queueIfBusy && (m.state == ExtensionConfirmationState || m.state == DuplicateWarningState || m.state == BatchConfirmState) {
+	if queueIfBusy && m.isRequestConfirmationBusy() {
 		m.pendingBatchRequestQueue = append(m.pendingBatchRequestQueue, msg)
 		return m, nil
 	}
@@ -77,6 +77,13 @@ func (m RootModel) handleBatchDownloadRequestMsg(msg types.DownloadEvent, queueI
 	m.inputs[2].SetValue(m.batchFilePath)
 	m.state = BatchConfirmState
 	return m, nil
+}
+
+func (m RootModel) isRequestConfirmationBusy() bool {
+	return m.state == ExtensionConfirmationState ||
+		m.state == DuplicateWarningState ||
+		m.state == BatchConfirmState ||
+		m.state == RemoveConfirmState
 }
 
 func (m RootModel) showNextPendingRequest() (tea.Model, tea.Cmd) {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -66,6 +66,7 @@ const (
 	CategoryResetConfirmState
 	SpeedLimitsState
 	PurgeConfirmState
+	RemoveConfirmState
 )
 
 type FilePickerOrigin int
@@ -118,15 +119,16 @@ type DownloadModel struct {
 }
 
 type RootModel struct {
-	downloads     []*DownloadModel
-	width         int
-	height        int
-	state         UIState
-	activeTab     int // 0=Queued, 1=Active, 2=Done
-	pinnedTab     int // -1=None, 0=Queued, 1=Active, 2=Done
-	inputs        []textinput.Model
-	focusedInput  int
-	purgeTargetID string
+	downloads      []*DownloadModel
+	width          int
+	height         int
+	state          UIState
+	activeTab      int // 0=Queued, 1=Active, 2=Done
+	pinnedTab      int // -1=None, 0=Queued, 1=Active, 2=Done
+	inputs         []textinput.Model
+	focusedInput   int
+	purgeTargetID  string
+	removeTargetID string
 	// Service Interface
 	// Core
 	Service      service.DownloadService

--- a/internal/tui/power_test.go
+++ b/internal/tui/power_test.go
@@ -152,9 +152,18 @@ func TestAutoShutdown_DeleteLastPendingDownloadReconciles(t *testing.T) {
 	m.UpdateListItems()
 	m.list.Select(0)
 
-	updated, cmd := m.Update(tea.KeyPressMsg{Code: 'x', Text: "x"})
+	updated, _ := m.Update(tea.KeyPressMsg{Code: 'x', Text: "x"})
 	m2 := updated.(RootModel)
 
+	if m2.state != RemoveConfirmState {
+		t.Fatalf("expected remove confirmation state, got %v", m2.state)
+	}
+	if len(m2.downloads) != 1 {
+		t.Fatalf("expected download to remain before confirmation, got %d", len(m2.downloads))
+	}
+
+	updated, cmd := m2.Update(tea.KeyPressMsg{Code: 'y', Text: "y"})
+	m2 = updated.(RootModel)
 	if len(m2.downloads) != 0 {
 		t.Fatalf("expected delete to remove download, got %d", len(m2.downloads))
 	}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -276,6 +276,9 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case PurgeConfirmState:
 			return m.updatePurgeConfirm(msg)
 
+		case RemoveConfirmState:
+			return m.updateRemoveConfirm(msg)
+
 		default:
 			return m, nil
 		}

--- a/internal/tui/update_dashboard.go
+++ b/internal/tui/update_dashboard.go
@@ -1,8 +1,6 @@
 package tui
 
 import (
-	"errors"
-
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/list"
 	tea "charm.land/bubbletea/v2"
@@ -145,27 +143,13 @@ func (m RootModel) updateDashboard(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		if m.list.FilterState() == list.Filtering {
 			// Fall through
 		} else if d := m.GetSelectedDownload(); d != nil {
-			if m.Service == nil {
-				m.addLogEntry(LogStyleError.Render("\u2716 Service unavailable"))
+			if !d.done {
+				m.removeTargetID = d.ID
+				m.quitConfirmFocused = 1 // default focus on "Cancel"
+				m.state = RemoveConfirmState
 				return m, nil
 			}
-			targetID := d.ID
-
-			// Call Service Delete
-			if err := m.Service.Delete(targetID); err != nil {
-				// If the download is not found, it's already gone from the engine/DB.
-				// We still remove it from our local list to avoid it being "stuck".
-				if errors.Is(err, types.ErrNotFound) {
-					m.removeDownloadByID(targetID)
-				} else {
-					m.addLogEntry(LogStyleError.Render("\u2716 Delete failed: " + err.Error()))
-				}
-			} else {
-				m.removeDownloadByID(targetID)
-			}
-			m.UpdateListItems()
-			m, autoCmd := m.refreshAutoShutdown()
-			return m, autoCmd
+			return m.deleteDownload(d.ID)
 		}
 	}
 

--- a/internal/tui/update_dashboard.go
+++ b/internal/tui/update_dashboard.go
@@ -143,7 +143,7 @@ func (m RootModel) updateDashboard(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		if m.list.FilterState() == list.Filtering {
 			// Fall through
 		} else if d := m.GetSelectedDownload(); d != nil {
-			if !d.done {
+			if !d.done || d.err != nil {
 				m.removeTargetID = d.ID
 				m.quitConfirmFocused = 1 // default focus on "Cancel"
 				m.state = RemoveConfirmState

--- a/internal/tui/update_modals.go
+++ b/internal/tui/update_modals.go
@@ -665,3 +665,61 @@ func (m RootModel) updatePurgeConfirm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 
 	return m, nil
 }
+
+func (m RootModel) updateRemoveConfirm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	confirmRemove := func() (tea.Model, tea.Cmd) {
+		targetID := m.removeTargetID
+		m.removeTargetID = ""
+		m.quitConfirmFocused = 0
+		m.state = DashboardState
+		return m.deleteDownload(targetID)
+	}
+
+	cancelRemove := func() (tea.Model, tea.Cmd) {
+		m.removeTargetID = ""
+		m.quitConfirmFocused = 0
+		m.state = DashboardState
+		return m, nil
+	}
+
+	m, decision, handled := m.handleYesNoSelection(msg)
+	if !handled {
+		return m, nil
+	}
+
+	switch decision {
+	case yesNoYes:
+		return confirmRemove()
+	case yesNoNo, yesNoCancel:
+		return cancelRemove()
+	}
+
+	return m, nil
+}
+
+func (m RootModel) deleteDownload(targetID string) (tea.Model, tea.Cmd) {
+	if targetID == "" {
+		return m, nil
+	}
+
+	if m.Service == nil {
+		m.addLogEntry(LogStyleError.Render("\u2716 Service unavailable"))
+		return m, nil
+	}
+
+	if err := m.Service.Delete(targetID); err != nil {
+		// If the download is not found, it's already gone from the engine/DB.
+		// We still remove it from our local list to avoid it being "stuck".
+		if errors.Is(err, types.ErrNotFound) {
+			m.removeDownloadByID(targetID)
+		} else {
+			m.addLogEntry(LogStyleError.Render("\u2716 Delete failed: " + err.Error()))
+		}
+	} else {
+		m.removeDownloadByID(targetID)
+	}
+
+	m.UpdateListItems()
+	m, autoCmd := m.refreshAutoShutdown()
+	return m, autoCmd
+}

--- a/internal/tui/update_modals.go
+++ b/internal/tui/update_modals.go
@@ -672,14 +672,20 @@ func (m RootModel) updateRemoveConfirm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd)
 		m.removeTargetID = ""
 		m.quitConfirmFocused = 0
 		m.state = DashboardState
-		return m.deleteDownload(targetID)
+		model, deleteCmd := m.deleteDownload(targetID)
+		root, ok := model.(RootModel)
+		if !ok {
+			return model, deleteCmd
+		}
+		nextModel, nextCmd := root.showNextPendingRequest()
+		return nextModel, tea.Batch(deleteCmd, nextCmd)
 	}
 
 	cancelRemove := func() (tea.Model, tea.Cmd) {
 		m.removeTargetID = ""
 		m.quitConfirmFocused = 0
 		m.state = DashboardState
-		return m, nil
+		return m.showNextPendingRequest()
 	}
 
 	m, decision, handled := m.handleYesNoSelection(msg)

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -314,6 +314,10 @@ func (m RootModel) View() tea.View {
 		return m.wrapView(m.renderModalWithOverlay(m.viewPurgeConfirm()))
 	}
 
+	if m.state == RemoveConfirmState {
+		return m.wrapView(m.renderModalWithOverlay(m.viewRemoveConfirm()))
+	}
+
 	if m.state == UpdateAvailableState && m.UpdateInfo != nil {
 		modal := components.ConfirmationModal{
 			Title:       "\u2b06 Update Available",
@@ -921,6 +925,42 @@ func (m RootModel) viewPurgeConfirm() string {
 		Keys:             m.keys.QuitConfirm, // QuitConfirm works as a general yes/no
 		Help:             m.help,
 		BorderColor:      colors.Red(),
+		ShowYesNoButtons: true,
+		YesNoFocused:     m.quitConfirmFocused,
+		YesLabel:         "Yes",
+		NoLabel:          "No",
+	}
+
+	w, h := GetDynamicModalDimensions(m.width, m.height, 46, 8, 60, 12)
+	modal.Width = w
+	modal.Height = h
+
+	return modal.RenderWithBtopBox(renderBtopBox, PaneTitleStyle)
+}
+
+func (m RootModel) viewRemoveConfirm() string {
+	filename := ""
+	if d := m.FindDownloadByID(m.removeTargetID); d != nil {
+		filename = d.Filename
+		if filename == "" || filename == "Queued" {
+			filename = d.URL
+		}
+	}
+
+	if filename == "" {
+		filename = "this download"
+	} else if len(filename) > 30 {
+		filename = filename[:27] + "..."
+	}
+
+	modal := components.ConfirmationModal{
+		Title:            "Remove Download",
+		Message:          "Remove this download?",
+		Detail:           fmt.Sprintf("File: %s\nThis paused or active download may lose progress data.", filename),
+		Keys:             m.keys.QuitConfirm, // QuitConfirm works as a general yes/no
+		Help:             m.help,
+		BorderColor:      colors.Orange(),
+		ButtonColor:      colors.Orange(),
 		ShowYesNoButtons: true,
 		YesNoFocused:     m.quitConfirmFocused,
 		YesLabel:         "Yes",

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -914,8 +914,8 @@ func (m RootModel) viewPurgeConfirm() string {
 
 	if filename == "" {
 		filename = "this download"
-	} else if len(filename) > 30 {
-		filename = filename[:27] + "..."
+	} else {
+		filename = utils.Truncate(filename, 30)
 	}
 
 	modal := components.ConfirmationModal{
@@ -949,8 +949,8 @@ func (m RootModel) viewRemoveConfirm() string {
 
 	if filename == "" {
 		filename = "this download"
-	} else if len(filename) > 30 {
-		filename = filename[:27] + "..."
+	} else {
+		filename = utils.Truncate(filename, 30)
 	}
 
 	modal := components.ConfirmationModal{

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -221,6 +221,28 @@ func TestView_QuitConfirmTinyTerminalDoesNotPanic(t *testing.T) {
 	_ = m.View()
 }
 
+func TestView_RemoveConfirmTruncatesUTF8FilenameSafely(t *testing.T) {
+	m := InitialRootModel(1701, "test-version", nil, orchestrator.NewLifecycleManager(nil, nil, nil), nil, false)
+	m.state = RemoveConfirmState
+	m.removeTargetID = "id-1"
+	m.width = 120
+	m.height = 35
+	m.downloads = []*DownloadModel{
+		{ID: "id-1", Filename: "日本語日本語日本語日本語日本語日本語.zip", paused: true},
+	}
+
+	plain := ansiEscapeRE.ReplaceAllString(m.View().Content, "")
+	if strings.Contains(plain, "\uFFFD") {
+		t.Fatalf("expected UTF-8 filename truncation without replacement characters, got:\n%s", plain)
+	}
+	if !strings.Contains(plain, "File: 日本語") {
+		t.Fatalf("expected filename prefix in remove confirmation, got:\n%s", plain)
+	}
+	if !strings.Contains(plain, "\u2026") {
+		t.Fatalf("expected truncated filename ellipsis, got:\n%s", plain)
+	}
+}
+
 func TestView_SettingsTinyTerminalDoesNotPanic(t *testing.T) {
 	m := InitialRootModel(1701, "test-version", nil, orchestrator.NewLifecycleManager(nil, nil, nil), nil, false)
 	m.state = SettingsState


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds confirmation before removing downloads from the TUI. The main changes are:

- Confirmation for active, paused, and errored downloads.
- Queuing of incoming requests while confirmation is open.
- Unicode-safe filename truncation in confirmation modals.
- Tests for removal, request queuing, and auto-shutdown behavior.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

No blocking issues found in the changed code.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Pressed x on the paused download to initiate removal; the UI moved to RemoveConfirmState with downloads=1 and service\_deleted cleared, and the file detail with Yes/No controls became visible.
- Pressed Escape to cancel the removal, returning to DashboardState with downloads=1 and service\_deleted cleared.
- Reopened the paused download and confirmed deletion with y, resulting in DashboardState with downloads=0 and service\_deleted=paused-review-id.
- Captured visual and log artifacts showing the baseline paused state, the removal modal, and the validation logs for the flow.

<a href="https://app.greptile.com/trex/runs/15260436/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/tui/update_dashboard.go | Routes unfinished and errored downloads through removal confirmation. |
| internal/tui/update_modals.go | Handles removal confirmation and resumes queued requests on both exit paths. |
| internal/tui/download_requests.go | Keeps incoming requests queued while removal confirmation is active. |
| internal/tui/view.go | Renders the removal modal with Unicode-safe filename truncation. |
| internal/tui/delete_resilience_test.go | Covers removal confirmation and queued-request integration paths. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;popup-cancel-paused-or-act..."](https://github.com/surgedm/surge/commit/6499305f0e67cedae9fcb3274f31ad0da3161438) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44532019)</sub>

<!-- /greptile_comment -->