### PR TITLE
resilient network disconnect

### DIFF
--- a/internal/scheduler/manager.go
+++ b/internal/scheduler/manager.go
@@ -300,15 +300,22 @@ func RunDownload(ctx context.Context, cfg *types.DownloadRecord) error {
 			return nil
 		}
 
-		// Send error event
-		if cfg.ProgressCh != nil {
-			safeSendProgress(cfg.ProgressCh, types.DownloadEvent{
-				Type:       types.EventError,
-				DownloadID: cfg.ID,
-				Filename:   finalFilename,
-				DestPath:   finalDestPath,
-				Err:        downloadErr,
-			}, ctx.Done())
+		// If it's a network failure, the downloader already saved a paused state snapshot.
+		// Sending an EventError here would trigger the event worker to delete the .surge file.
+		// By skipping EventError, we let the scheduler re-queue the task cleanly.
+		if errors.Is(downloadErr, types.ErrNetworkFailure) {
+			utils.Debug("Download failed due to network error, deferring to scheduler")
+		} else {
+			// Send error event
+			if cfg.ProgressCh != nil {
+				safeSendProgress(cfg.ProgressCh, types.DownloadEvent{
+					Type:       types.EventError,
+					DownloadID: cfg.ID,
+					Filename:   finalFilename,
+					DestPath:   finalDestPath,
+					Err:        downloadErr,
+				}, ctx.Done())
+			}
 		}
 	}
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -27,9 +27,10 @@ type activeDownload struct {
 
 // queuedTask wraps a download config with SQS-style visibility and retry state
 type queuedTask struct {
-	cfg      types.DownloadRecord
-	retries  int
-	inFlight bool
+	cfg            types.DownloadRecord
+	retries        int
+	networkRetries int
+	inFlight       bool
 }
 
 // Scheduler manages the download workers and tasks.
@@ -713,9 +714,24 @@ func (p *Scheduler) worker() {
 			p.mu.Lock()
 			delete(p.downloads, localCfg.ID)
 
-			if !p.isShuttingDown && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) && qt.retries < 3 {
-				qt.retries++
+			isNetworkErr := errors.Is(err, types.ErrNetworkFailure)
+			canRetryNetwork := isNetworkErr && qt.networkRetries < 10
+			canRetryGeneric := !isNetworkErr && qt.retries < 3
+			isCanceled := errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+
+			if !p.isShuttingDown && !isCanceled && (canRetryNetwork || canRetryGeneric) {
+				if isNetworkErr {
+					qt.networkRetries++
+					utils.Debug("Scheduler: network failure for %s, re-queuing (attempt %d/10)", localCfg.ID, qt.networkRetries)
+				} else {
+					qt.retries++
+					utils.Debug("Scheduler: generic error for %s, re-queuing (attempt %d/3)", localCfg.ID, qt.retries)
+				}
+
 				qt.inFlight = false
+
+				// Ensure IsResume is true so it loads the saved state when RunDownload starts again
+				localCfg.IsResume = true
 				qt.cfg = localCfg
 				p.queued[localCfg.ID] = qt
 
@@ -736,8 +752,22 @@ func (p *Scheduler) worker() {
 						MinChunkSize: localCfg.MinChunkSize,
 					}, p.progressDone)
 				}
-				p.taskCond.Signal()
 				p.mu.Unlock()
+
+				// If it was a network error, give the network a moment to stabilize
+				// before signaling workers to pick it up again.
+				if isNetworkErr {
+					go func() {
+						time.Sleep(5 * time.Second)
+						p.mu.Lock()
+						p.taskCond.Signal()
+						p.mu.Unlock()
+					}()
+				} else {
+					p.mu.Lock()
+					p.taskCond.Signal()
+					p.mu.Unlock()
+				}
 				continue
 			}
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -715,18 +715,12 @@ func (p *Scheduler) worker() {
 			delete(p.downloads, localCfg.ID)
 
 			isNetworkErr := errors.Is(err, types.ErrNetworkFailure)
-			canRetryNetwork := isNetworkErr && qt.networkRetries < 10
 			canRetryGeneric := !isNetworkErr && qt.retries < 3
 			isCanceled := errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 
-			if !p.isShuttingDown && !isCanceled && (canRetryNetwork || canRetryGeneric) {
-				if isNetworkErr {
-					qt.networkRetries++
-					utils.Debug("Scheduler: network failure for %s, re-queuing (attempt %d/10)", localCfg.ID, qt.networkRetries)
-				} else {
-					qt.retries++
-					utils.Debug("Scheduler: generic error for %s, re-queuing (attempt %d/3)", localCfg.ID, qt.retries)
-				}
+			if !p.isShuttingDown && !isCanceled && canRetryGeneric {
+				qt.retries++
+				utils.Debug("Scheduler: generic error for %s, re-queuing (attempt %d/3)", localCfg.ID, qt.retries)
 
 				qt.inFlight = false
 
@@ -754,24 +748,13 @@ func (p *Scheduler) worker() {
 				}
 				p.mu.Unlock()
 
-				// If it was a network error, give the network a moment to stabilize
-				// before signaling workers to pick it up again.
-				if isNetworkErr {
-					go func() {
-						time.Sleep(5 * time.Second)
-						p.mu.Lock()
-						p.taskCond.Signal()
-						p.mu.Unlock()
-					}()
-				} else {
-					p.mu.Lock()
-					p.taskCond.Signal()
-					p.mu.Unlock()
-				}
+				p.mu.Lock()
+				p.taskCond.Signal()
+				p.mu.Unlock()
 				continue
 			}
 
-			if localCfg.ProgressState != nil {
+			if localCfg.ProgressState != nil && !isNetworkErr {
 				progress.CfgProgress(&localCfg).SetError(err)
 			}
 			delete(p.downloadLimiters, localCfg.ID)

--- a/internal/strategy/concurrent/downloader.go
+++ b/internal/strategy/concurrent/downloader.go
@@ -322,6 +322,16 @@ func (d *ConcurrentDownloader) Download(ctx context.Context, rawurl string, cand
 	}
 
 	if downloadErr != nil {
+		// Save progress snapshot before returning fatal error so the download
+		// can be resumed later instead of losing all progress. This uses the
+		// same mechanism as handlePause but returns the original error.
+		d.saveProgressOnError(destPath, fileSize, queue, candidateMirrors)
+
+		// If the error is purely transient network issues, wrap it so the
+		// scheduler can distinguish it from permanent server errors.
+		if isTransientNetworkError(downloadErr) {
+			return fmt.Errorf("%w: %w", types.ErrNetworkFailure, downloadErr)
+		}
 		return downloadErr
 	}
 	if downloadCtx.Err() != nil {
@@ -636,6 +646,81 @@ func (d *ConcurrentDownloader) handlePause(destPath string, fileSize int64, queu
 	utils.Debug("Download paused, state saved (Downloaded=%d, RemainingTasks=%d, RemainingBytes=%d)",
 		computedDownloaded, len(remainingTasks), remainingBytes)
 	return types.ErrPaused
+}
+
+// saveProgressOnError saves a crash-recovery state snapshot when a download
+// fails fatally (e.g., network down for extended period). Unlike handlePause,
+// it does NOT emit a pause event or return ErrPaused — it just silently
+// persists enough state for a future resume to pick up where we left off.
+func (d *ConcurrentDownloader) saveProgressOnError(destPath string, fileSize int64, queue *TaskQueue, candidateMirrors []string) {
+	if d.State == nil {
+		return
+	}
+
+	// Collect remaining tasks from active workers
+	var activeRemaining []types.Task
+	d.activeMu.Lock()
+	for _, active := range d.activeTasks {
+		if remaining := active.RemainingTask(); remaining != nil {
+			activeRemaining = append(activeRemaining, *remaining)
+		}
+	}
+	d.activeMu.Unlock()
+
+	// Collect remaining tasks from queue
+	remainingTasks := queue.DrainRemaining()
+	remainingTasks = append(remainingTasks, activeRemaining...)
+
+	var remainingBytes int64
+	for _, task := range remainingTasks {
+		remainingBytes += task.Length
+	}
+	if remainingBytes == 0 {
+		// Nothing to save — download was actually complete
+		return
+	}
+	computedDownloaded := fileSize - remainingBytes
+
+	bitmap, _, _, chunkSize, _ := d.State.GetBitmapSnapshot(false)
+
+	var rateLimit int64
+	var rateLimitSet bool
+	rateLimit, rateLimitSet = d.State.GetRateLimit()
+
+	s := &types.DownloadRecord{
+		URL:             d.URL,
+		ID:              d.ID,
+		DestPath:        destPath,
+		TotalSize:       fileSize,
+		Downloaded:      computedDownloaded,
+		Tasks:           remainingTasks,
+		Filename:        filepath.Base(destPath),
+		Mirrors:         candidateMirrors,
+		ChunkBitmap:     bitmap,
+		ActualChunkSize: chunkSize,
+		RateLimit:       rateLimit,
+		RateLimitSet:    rateLimitSet,
+		Workers:         d.Runtime.Workers,
+		MinChunkSize:    d.Runtime.MinChunkSize,
+	}
+
+	// Persist via the progress channel so the event worker handles DB writes
+	if d.ProgressChan != nil {
+		d.ProgressChan <- types.DownloadEvent{
+			Type:         types.EventPaused,
+			DownloadID:   d.ID,
+			Filename:     filepath.Base(destPath),
+			Downloaded:   computedDownloaded,
+			State:        s,
+			RateLimit:    rateLimit,
+			RateLimitSet: rateLimitSet,
+			Workers:      d.Runtime.Workers,
+			MinChunkSize: d.Runtime.MinChunkSize,
+		}
+	}
+
+	utils.Debug("Saved progress snapshot on error (Downloaded=%d, RemainingTasks=%d, RemainingBytes=%d)",
+		computedDownloaded, len(remainingTasks), remainingBytes)
 }
 
 func (d *ConcurrentDownloader) syncFile(outFile *os.File) error {

--- a/internal/strategy/concurrent/network_errors.go
+++ b/internal/strategy/concurrent/network_errors.go
@@ -1,0 +1,152 @@
+package concurrent
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/SurgeDM/Surge/internal/utils"
+)
+
+// isTransientNetworkError returns true if the error is a transient network issue
+// (connection reset, timeout, unreachable) that may resolve after a network change
+// or brief outage. Server-side errors (4xx/5xx) are NOT transient.
+func isTransientNetworkError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Context deadline exceeded is a timeout — transient
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	// Context cancelled is an intentional abort — NOT transient
+	if errors.Is(err, context.Canceled) {
+		return false
+	}
+
+	// EOF mid-stream means connection dropped — transient
+	if errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF) {
+		return true
+	}
+
+	// Syscall-level network errors
+	if errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, syscall.ECONNABORTED) ||
+		errors.Is(err, syscall.ENETUNREACH) ||
+		errors.Is(err, syscall.ENETDOWN) ||
+		errors.Is(err, syscall.EHOSTUNREACH) ||
+		errors.Is(err, syscall.EPIPE) ||
+		errors.Is(err, syscall.ETIMEDOUT) {
+		return true
+	}
+
+	// net.OpError wraps most TCP/DNS failures
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return true
+	}
+
+	// DNS resolution failures
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return true
+	}
+
+	// net.Error interface covers timeouts from the net package
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+
+	// String-based fallback for wrapped errors that lose type info
+	msg := err.Error()
+	transientPatterns := []string{
+		"connection reset by peer",
+		"broken pipe",
+		"network is unreachable",
+		"no route to host",
+		"connection refused",
+		"i/o timeout",
+		"TLS handshake timeout",
+		"use of closed network connection",
+		"server misbehaving",       // DNS
+		"no such host",             // DNS
+		"dial tcp",                 // dial failures
+		"write: broken pipe",      // write after disconnect
+		"read: connection reset",  // read after disconnect
+		"http2: client connection lost",
+	}
+
+	for _, p := range transientPatterns {
+		if strings.Contains(msg, p) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// waitForConnectivity blocks until a lightweight probe to the given URL succeeds
+// or the context is cancelled / maxWait is exceeded. Returns true if connectivity
+// was restored, false if we gave up.
+func waitForConnectivity(ctx context.Context, client *http.Client, url string, maxWait time.Duration) bool {
+	deadline := time.After(maxWait)
+	// Start with a short poll interval, increase exponentially
+	interval := 1 * time.Second
+	maxInterval := 10 * time.Second
+
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-deadline:
+			utils.Debug("waitForConnectivity: gave up after %v", maxWait)
+			return false
+		default:
+		}
+
+		// Lightweight probe: HEAD or a 1-byte Range GET
+		probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		req, err := http.NewRequestWithContext(probeCtx, http.MethodHead, url, nil)
+		if err != nil {
+			cancel()
+			return false // URL is invalid, not a network issue
+		}
+
+		resp, err := client.Do(req)
+		cancel()
+
+		if err == nil {
+			// Any response (even 4xx/5xx) means the network is up
+			_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1024))
+			_ = resp.Body.Close()
+			utils.Debug("waitForConnectivity: network restored")
+			return true
+		}
+
+		utils.Debug("waitForConnectivity: probe failed: %v (retrying in %v)", err, interval)
+
+		// Wait before next probe
+		select {
+		case <-ctx.Done():
+			return false
+		case <-deadline:
+			return false
+		case <-time.After(interval):
+		}
+
+		// Exponential backoff
+		interval = interval * 2
+		if interval > maxInterval {
+			interval = maxInterval
+		}
+	}
+}

--- a/internal/strategy/concurrent/network_errors.go
+++ b/internal/strategy/concurrent/network_errors.go
@@ -77,11 +77,11 @@ func isTransientNetworkError(err error) bool {
 		"i/o timeout",
 		"TLS handshake timeout",
 		"use of closed network connection",
-		"server misbehaving",       // DNS
-		"no such host",             // DNS
-		"dial tcp",                 // dial failures
-		"write: broken pipe",      // write after disconnect
-		"read: connection reset",  // read after disconnect
+		"server misbehaving",     // DNS
+		"no such host",           // DNS
+		"dial tcp",               // dial failures
+		"write: broken pipe",     // write after disconnect
+		"read: connection reset", // read after disconnect
 		"http2: client connection lost",
 	}
 

--- a/internal/strategy/concurrent/network_errors_test.go
+++ b/internal/strategy/concurrent/network_errors_test.go
@@ -1,0 +1,96 @@
+package concurrent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestIsTransientNetworkError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"context deadline exceeded", context.DeadlineExceeded, true},
+		{"context canceled", context.Canceled, false},
+		{"unexpected EOF", io.ErrUnexpectedEOF, true},
+		{"EOF", io.EOF, true},
+		{"syscall ECONNRESET", syscall.ECONNRESET, true},
+		{"syscall ECONNREFUSED", syscall.ECONNREFUSED, true},
+		{"net OpError", &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")}, true},
+		{"DNS Error", &net.DNSError{Err: "no such host"}, true},
+		{"wrapped generic string", fmt.Errorf("some other error: connection reset by peer"), true},
+		{"wrapped generic string broken pipe", fmt.Errorf("write: broken pipe"), true},
+		{"non-transient error", errors.New("HTTP 404 Not Found"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTransientNetworkError(tt.err); got != tt.want {
+				t.Errorf("isTransientNetworkError() = %v, want %v for err: %v", got, tt.want, tt.err)
+			}
+		})
+	}
+}
+
+func TestWaitForConnectivity_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := server.Client()
+	ctx := context.Background()
+
+	// Should succeed immediately
+	if !waitForConnectivity(ctx, client, server.URL, 5*time.Second) {
+		t.Error("waitForConnectivity() returned false, want true")
+	}
+}
+
+func TestWaitForConnectivity_Timeout(t *testing.T) {
+	// A non-routable IP to force a timeout
+	client := &http.Client{
+		Timeout: 10 * time.Millisecond,
+	}
+	ctx := context.Background()
+
+	// Should timeout
+	start := time.Now()
+	if waitForConnectivity(ctx, client, "http://192.0.2.1", 200*time.Millisecond) {
+		t.Error("waitForConnectivity() returned true, want false")
+	}
+	if time.Since(start) < 200*time.Millisecond {
+		t.Error("waitForConnectivity() returned too quickly")
+	}
+}
+
+func TestWaitForConnectivity_Cancel(t *testing.T) {
+	client := &http.Client{
+		Timeout: 1 * time.Second,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	// Should return quickly due to cancel
+	start := time.Now()
+	if waitForConnectivity(ctx, client, "http://192.0.2.1", 5*time.Second) {
+		t.Error("waitForConnectivity() returned true, want false")
+	}
+	if time.Since(start) > 500*time.Millisecond {
+		t.Error("waitForConnectivity() took too long to cancel")
+	}
+}

--- a/internal/strategy/concurrent/network_resilience_test.go
+++ b/internal/strategy/concurrent/network_resilience_test.go
@@ -1,0 +1,109 @@
+package concurrent
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/SurgeDM/Surge/internal/progress"
+	"github.com/SurgeDM/Surge/internal/types"
+)
+
+func TestWorkerRetryOnTransientError(t *testing.T) {
+	// A server that returns a reset-like error on the first two attempts, then succeeds
+	var attemptCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempt := attemptCount.Add(1)
+		if attempt <= 2 {
+			// Simulate a transient network error by explicitly hijacking and closing the connection
+			hj, ok := w.(http.Hijacker)
+			if ok {
+				conn, _, _ := hj.Hijack()
+				conn.Close() // Forces a "connection reset by peer" or "EOF"
+				return
+			}
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		// 3rd attempt succeeds
+		w.Header().Set("Content-Range", "bytes 0-4/5")
+		w.Header().Set("Content-Length", "5")
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write([]byte("hello"))
+	}))
+	defer server.Close()
+
+	d := NewConcurrentDownloader("test-id", nil, nil, types.DefaultRuntimeConfig())
+	d.State = progress.New("test-id", 5)
+
+	queue := NewTaskQueue()
+	queue.Push(types.Task{Offset: 0, Length: 5})
+
+	tmpFile, err := os.CreateTemp("", "surge-test-worker-retry")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	client := server.Client()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// 1 task in queue, worker should try to download it
+	err = d.worker(ctx, 0, []string{server.URL}, tmpFile, queue, 5, client)
+	if err != nil {
+		t.Fatalf("expected worker to succeed eventually, but got: %v", err)
+	}
+
+	if attempts := attemptCount.Load(); attempts < 3 {
+		t.Fatalf("expected at least 3 attempts due to transient errors, got %d", attempts)
+	}
+
+	b, _ := os.ReadFile(tmpFile.Name())
+	if string(b[:5]) != "hello" {
+		t.Errorf("expected 'hello' in file, got %q", string(b[:5]))
+	}
+}
+
+func TestSaveProgressOnError(t *testing.T) {
+	progCh := make(chan types.DownloadEvent, 10)
+
+	rt := types.DefaultRuntimeConfig()
+	state := progress.New("test-id", 100)
+	d := NewConcurrentDownloader("test-id", progCh, state, rt)
+
+	queue := NewTaskQueue()
+	queue.Push(types.Task{Offset: 0, Length: 50})
+	queue.Push(types.Task{Offset: 50, Length: 50})
+
+	d.saveProgressOnError("some/dest/path.txt", 100, queue, []string{"http://mirror1"})
+
+	close(progCh)
+	var pausedEvent *types.DownloadEvent
+	for event := range progCh {
+		if event.Type == types.EventPaused {
+			// Create a local copy to point to
+			e := event
+			pausedEvent = &e
+			break
+		}
+	}
+
+	if pausedEvent == nil {
+		t.Fatal("expected EventPaused to be sent by saveProgressOnError")
+	}
+
+	if pausedEvent.State == nil {
+		t.Fatal("expected paused event to contain a state snapshot")
+	}
+
+	if len(pausedEvent.State.Tasks) != 2 {
+		t.Errorf("expected 2 remaining tasks in saved state, got %d", len(pausedEvent.State.Tasks))
+	}
+}

--- a/internal/strategy/concurrent/worker.go
+++ b/internal/strategy/concurrent/worker.go
@@ -44,7 +44,9 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 		var lastErr error
 		maxRetries := d.Runtime.GetMaxTaskRetries()
 		genericAttempt := 0
+		networkAttempt := 0
 		rlRetries := 0
+		const maxNetworkRetries = 10
 
 		for {
 			idx, wait := d.hostLimiter.PickMirror(mirrorHosts, currentMirrorIdx, time.Now())
@@ -150,6 +152,45 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 				continue
 			}
 
+			// Transient network errors get a separate, more generous retry budget
+			// with connection pool invalidation and connectivity waiting.
+			if isTransientNetworkError(lastErr) {
+				networkAttempt++
+				if networkAttempt >= maxNetworkRetries {
+					utils.Debug("Worker %d: exhausted network retries (%d) for task at offset %d: %v",
+						id, maxNetworkRetries, task.Offset, lastErr)
+					break
+				}
+
+				utils.Debug("Worker %d: transient network error (attempt %d/%d): %v",
+					id, networkAttempt, maxNetworkRetries, lastErr)
+
+				// Flush all stale connections so fresh dials go through the new network
+				transport.DefaultNetworkPool.InvalidateConnections()
+
+				// Mark this worker as waiting for network so health monitor skips it
+				activeTask.WaitingOnLimiter.Store(true)
+
+				// Wait for connectivity with exponential backoff
+				backoff := time.Duration(1<<networkAttempt) * 500 * time.Millisecond
+				if backoff > 30*time.Second {
+					backoff = 30 * time.Second
+				}
+
+				if !waitForConnectivity(ctx, client, currentURL, backoff+30*time.Second) {
+					activeTask.WaitingOnLimiter.Store(false)
+					utils.Debug("Worker %d: connectivity not restored, giving up task", id)
+					break
+				}
+				activeTask.WaitingOnLimiter.Store(false)
+
+				// Rotate mirror for variety and resume from last written offset
+				currentMirrorIdx = (currentMirrorIdx + 1) % len(mirrors)
+				resumeOnRetryOffset(&task, activeTask)
+				continue
+			}
+
+			// Non-transient (server) errors: use the original retry budget
 			genericAttempt++
 			if genericAttempt >= maxRetries {
 				break

--- a/internal/transport/network.go
+++ b/internal/transport/network.go
@@ -116,6 +116,19 @@ func (p *NetworkPool) ReleaseTransport(t *http.Transport) {
 	}
 }
 
+// InvalidateConnections flushes stale connections on all managed transports
+// without destroying the pool. This forces fresh TCP dials on the next request,
+// which is essential after a network change (WiFi switch, VPN toggle, etc.).
+func (p *NetworkPool) InvalidateConnections() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	for _, lease := range p.transportMap {
+		lease.transport.CloseIdleConnections()
+	}
+	utils.Debug("NetworkPool: invalidated connections on %d transports", len(p.transportMap))
+}
+
 // CloseAll evicts all transports and closes their idle connections immediately.
 func (p *NetworkPool) CloseAll() {
 	p.mu.Lock()

--- a/internal/types/errors.go
+++ b/internal/types/errors.go
@@ -18,4 +18,5 @@ var (
 	ErrActiveUpdate       = errors.New("download is currently active, please pause it before updating the URL")
 	ErrMaxRedirects       = errors.New("stopped after 10 redirects")
 	ErrAlreadyActive      = errors.New("download is already active or queued")
+	ErrNetworkFailure     = errors.New("download failed due to transient network error")
 )


### PR DESCRIPTION
- **feat: implement resilient network recovery with transient error detection, state snapshotting, and automatic retry logic**
- **feat: add specialized retry logic and exponential backoff for network-related download failures**
- **test: add unit tests for worker retry logic and progress persistence on error**
- **refactor: remove network retry logic and stabilize failure handling in scheduler**

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds recovery behavior for transient network failures. The main changes are:

- Classifies transient network errors and probes for restored connectivity.
- Adds worker retries, exponential backoff, and connection invalidation.
- Saves resumable progress when a download fails.
- Changes scheduler handling for network and generic failures.
- Adds focused tests for classification, retries, and snapshots.
</details>

<details open><summary><h3>Confidence Score: 2/5</h3></summary>

The recovery path can persist an incomplete task list and then remove the download without requeuing it.

- The failed byte range can be absent from the saved resume state.
- Network failures bypass the scheduler's only requeue branch.
- Permanent DNS failures can spend several minutes in the transient retry loop.

internal/strategy/concurrent/downloader.go, internal/scheduler/scheduler.go, and internal/strategy/concurrent/network_errors.go
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I reproduced the range-missing failure by exercising the real Download worker through 19 transient GET retries, after which the persisted DownloadRecord contained only the 4096–8191 range and reported Downloaded as 4096, leaving the 0–4095 range zero-filled on resume.
- I verified that triggering an ErrNetworkFailure via the RunDownload trampoline produced an orphaned task that remained untracked, with no active or queued task, an empty queue order, no GetStatus result, and progress staying nonterminal.
- I reproduced that a permanent DNS error can be misinterpreted by the real classifier, where IsNotFound was true,Temporary=false, Timeout=false, yet isTransientNetworkError returned true.
- I completed the requested verification, but local artifact references were not uploaded.

<a href="https://app.greptile.com/trex/runs/14828818/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/strategy/concurrent/downloader.go | Adds error snapshots, but the snapshot can omit the byte range that produced the fatal error. |
| internal/scheduler/scheduler.go | Adds network retry state, but network failures bypass the scheduler's only requeue path. |
| internal/scheduler/manager.go | Suppresses terminal error events for network failures so resumable state remains available. |
| internal/strategy/concurrent/worker.go | Adds a separate network retry budget, connectivity waits, mirror rotation, and pool invalidation. |
| internal/strategy/concurrent/network_errors.go | Adds network error classification and connectivity probes, but treats all net.OpError values as transient. |
| internal/transport/network.go | Adds synchronized invalidation of idle connections across managed transports. |
| internal/types/errors.go | Adds the sentinel used to propagate transient network failures. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant W as Worker
participant D as Downloader
participant E as Event Worker
participant S as Scheduler
W->>W: Exhaust network retries
W->>W: Remove failed task from activeTasks
W-->>D: Return transient error
D->>D: Build snapshot from queue and active tasks
Note over D: Failed byte range is absent
D->>E: Persist paused snapshot
D-->>S: Return ErrNetworkFailure
S->>S: Remove active download
Note over S: Network error does not enter requeue branch
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant W as Worker
participant D as Downloader
participant E as Event Worker
participant S as Scheduler
W->>W: Exhaust network retries
W->>W: Remove failed task from activeTasks
W-->>D: Return transient error
D->>D: Build snapshot from queue and active tasks
Note over D: Failed byte range is absent
D->>E: Persist paused snapshot
D-->>S: Return ErrNetworkFailure
S->>S: Remove active download
Note over S: Network error does not enter requeue branch
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
internal/strategy/concurrent/downloader.go:671-672
**Failed Range Missing From Snapshot**

When a worker exhausts its retries, it removes its task from `activeTasks` before returning the error, and that task is no longer in the queue. This snapshot therefore omits the range that caused the failure, overstates `Downloaded`, and can resume without ever downloading the missing bytes.

### Issue 2 of 3
internal/scheduler/scheduler.go:717-718
**Network Failure Skips Requeue**

When `RunDownload` returns `ErrNetworkFailure`, this condition excludes it from the scheduler's only requeue branch, while `networkRetries` is never used elsewhere. The task is removed from active tracking without being queued or marked errored, so an exhausted network retry silently leaves the saved download orphaned.

### Issue 3 of 3
internal/strategy/concurrent/network_errors.go:53-55
**Permanent DNS Errors Become Transient**

Every `net.OpError` is classified as transient, including one wrapping a permanent DNS result such as an unknown host. A download with a misspelled or removed hostname therefore enters the ten-attempt connectivity loop instead of failing normally, delaying the actionable error for several minutes.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: remove network retry logic and..."](https://github.com/surgedm/surge/commit/d2fa44e094523f1f86d312115c615a44c98b2f79) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45060283)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->