### PR TITLE
fix: emit EventError once after all retries; skip retries for 4xx errors

### DIFF
--- a/internal/orchestrator/events.go
+++ b/internal/orchestrator/events.go
@@ -313,19 +313,10 @@ func (mgr *LifecycleManager) StartEventWorker(ch <-chan types.DownloadEvent) {
 
 		case types.EventError:
 			existing, _ := store.GetDownload(m.DownloadID)
-			destPath := m.DestPath
 			if existing != nil {
 				existing.Status = "error"
 				if err := store.AddToMasterList(*existing); err != nil {
 					utils.Debug("Lifecycle: Failed to persist error state: %v", err)
-				}
-				if existing.DestPath != "" {
-					destPath = existing.DestPath
-				}
-			}
-			if destPath != "" {
-				if err := RemoveIncompleteFile(destPath); err != nil {
-					utils.Debug("Lifecycle: Failed to remove incomplete file after error: %v", err)
 				}
 			}
 			if settings := mgr.GetSettings(); settings != nil && config.Resolve[bool](settings.General.DownloadCompleteNotification) {

--- a/internal/scheduler/manager.go
+++ b/internal/scheduler/manager.go
@@ -221,9 +221,15 @@ func RunDownload(ctx context.Context, cfg *types.DownloadRecord) error {
 			effectiveTotalSize = d.TotalSize
 		}
 
+		var downloaded int64
+		if progState != nil {
+			downloaded = progState.Bytes.Downloaded.Load()
+		}
+
 		// Determine if we should attempt a fallback to single-threaded mode.
-		// We fallback if concurrent failed, but it wasn't a clean pause or external cancellation.
-		if downloadErr != nil && !errors.Is(downloadErr, types.ErrPaused) && !errors.Is(downloadErr, context.Canceled) && !errors.Is(downloadErr, context.DeadlineExceeded) {
+		// We fallback if concurrent failed, but it wasn't a clean pause or external cancellation,
+		// AND we haven't made any progress yet (to avoid discarding progress).
+		if downloadErr != nil && !errors.Is(downloadErr, types.ErrPaused) && !errors.Is(downloadErr, context.Canceled) && !errors.Is(downloadErr, context.DeadlineExceeded) && downloaded == 0 {
 			utils.Debug("Concurrent download failed: %v - falling back to single-threaded", downloadErr)
 			useConcurrent = false // Trigger sequential block below
 

--- a/internal/scheduler/manager.go
+++ b/internal/scheduler/manager.go
@@ -299,17 +299,7 @@ func RunDownload(ctx context.Context, cfg *types.DownloadRecord) error {
 			utils.Debug("Download canceled cleanly")
 			return nil
 		}
-
-		// Send error event
-		if cfg.ProgressCh != nil {
-			safeSendProgress(cfg.ProgressCh, types.DownloadEvent{
-				Type:       types.EventError,
-				DownloadID: cfg.ID,
-				Filename:   finalFilename,
-				DestPath:   finalDestPath,
-				Err:        downloadErr,
-			}, ctx.Done())
-		}
+		// EventError is emitted by the scheduler's worker() after all retries are exhausted.
 	}
 
 	return downloadErr

--- a/internal/scheduler/manager_test.go
+++ b/internal/scheduler/manager_test.go
@@ -642,3 +642,37 @@ func BenchmarkUniqueFilePath_WithConflict(b *testing.B) {
 		uniqueFilePath(path)
 	}
 }
+
+func TestRunDownload_DoesNotEmitEventErrorOnFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	server := testutil.NewHTTPServerT(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	progressCh := make(chan types.DownloadEvent, 16)
+	cfg := types.DownloadRecord{
+		URL:           server.URL,
+		OutputPath:    tmpDir,
+		Filename:      "fail.bin",
+		ID:            "no-event-error-test",
+		ProgressCh:    progressCh,
+		ProgressState: progress.New("no-event-error-test", 0),
+		Runtime:       &types.RuntimeConfig{},
+		TotalSize:     0,
+		SupportsRange: false,
+	}
+
+	err := RunDownload(context.Background(), &cfg)
+	if err == nil {
+		t.Fatal("Expected RunDownload to return an error, got nil")
+	}
+
+	// Drain the channel and check if EventError was emitted
+	close(progressCh)
+	for msg := range progressCh {
+		if msg.Type == types.EventError {
+			t.Fatalf("RunDownload should not emit EventError, but it did: %+v", msg)
+		}
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -715,14 +715,13 @@ func (p *Scheduler) worker() {
 
 			if !p.isShuttingDown && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) && !types.IsPermanentHTTPError(err) && qt.retries < 10 {
 				qt.retries++
-				qt.inFlight = false
+				qt.inFlight = true // Keep in-flight while sending progress outside lock
 				qt.cfg = localCfg
 				p.queued[localCfg.ID] = qt
 
 				p.removeQueueOrderLocked(localCfg.ID)
 				p.queueOrder = append(p.queueOrder, localCfg.ID)
 
-				p.taskCond.Signal()
 				p.mu.Unlock()
 
 				if localCfg.ProgressCh != nil {
@@ -739,8 +738,24 @@ func (p *Scheduler) worker() {
 						MinChunkSize: localCfg.MinChunkSize,
 					}, p.progressDone)
 				}
+
+				p.mu.Lock()
+				if _, ok := p.queued[localCfg.ID]; ok {
+					qt.inFlight = false
+					p.queued[localCfg.ID] = qt
+				} else {
+					// GracefulShutdown or Cancel removed it while we were unlocked.
+					// Since we were in-flight, they didn't decrement wg, so we must.
+					p.wg.Done()
+				}
+				p.taskCond.Signal()
+				p.mu.Unlock()
 				// ponytail: naive backoff blocks worker thread, but naturally limits retry storms
-				time.Sleep(time.Second * time.Duration(qt.retries))
+				select {
+				case <-time.After(time.Second * time.Duration(qt.retries)):
+				case <-p.progressDone:
+					// Wake up early if shutting down
+				}
 				continue
 			}
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -681,6 +681,7 @@ func (p *Scheduler) worker() {
 
 		if isPaused {
 			utils.Debug("Scheduler: Download %s paused cleanly", localCfg.ID)
+			p.wg.Done() // Signal worker completion before potentially blocking on progress channel
 			// The concurrent downloader sends DownloadPausedMsg itself via handlePause()
 			// (which causes RunDownload to return nil). When a single-threaded download is
 			// paused, RunDownload returns a non-nil error, and the pool must fill the gap.
@@ -775,6 +776,7 @@ func (p *Scheduler) worker() {
 			}
 			delete(p.downloadLimiters, localCfg.ID)
 			p.mu.Unlock()
+			p.wg.Done() // Signal worker completion before potentially blocking on progress channel
 
 			// Send outside the lock: safeSendProgress may block on a full
 			// channel and must not hold p.mu while doing so.
@@ -793,9 +795,9 @@ func (p *Scheduler) worker() {
 			delete(p.downloads, localCfg.ID)
 			delete(p.downloadLimiters, localCfg.ID)
 			p.mu.Unlock()
+			p.wg.Done()
 		}
 		// If paused, we keep it in downloads map for potential resume
-		p.wg.Done()
 	}
 }
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -713,7 +713,7 @@ func (p *Scheduler) worker() {
 			p.mu.Lock()
 			delete(p.downloads, localCfg.ID)
 
-			if !p.isShuttingDown && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) && qt.retries < 3 {
+			if !p.isShuttingDown && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) && !types.IsPermanentHTTPError(err) && qt.retries < 3 {
 				qt.retries++
 				qt.inFlight = false
 				qt.cfg = localCfg
@@ -739,6 +739,24 @@ func (p *Scheduler) worker() {
 				p.taskCond.Signal()
 				p.mu.Unlock()
 				continue
+			}
+
+			// All retries exhausted (or error is permanent/canceled): emit a single EventError.
+			if localCfg.ProgressCh != nil {
+				var finalDestPath string
+				if localCfg.ProgressState != nil {
+					finalDestPath = progress.CfgProgress(&localCfg).GetDestPath()
+				}
+				if finalDestPath == "" {
+					finalDestPath = resolveDestPath(&localCfg)
+				}
+				safeSendProgress(localCfg.ProgressCh, types.DownloadEvent{
+					Type:       types.EventError,
+					DownloadID: localCfg.ID,
+					Filename:   localCfg.Filename,
+					DestPath:   finalDestPath,
+					Err:        err,
+				}, p.progressDone)
 			}
 
 			if localCfg.ProgressState != nil {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -741,22 +741,31 @@ func (p *Scheduler) worker() {
 				continue
 			}
 
-			// All retries exhausted (or error is permanent/canceled): emit a single EventError.
+			// All retries exhausted (or error is permanent/canceled): collect event
+			// metadata under the lock, then send outside it so a full progress
+			// channel cannot block the scheduler mutex.
+			var errEvent *types.DownloadEvent
 			if localCfg.ProgressCh != nil {
 				var finalDestPath string
+				var finalFilename string
 				if localCfg.ProgressState != nil {
-					finalDestPath = progress.CfgProgress(&localCfg).GetDestPath()
+					p := progress.CfgProgress(&localCfg)
+					finalDestPath = p.GetDestPath()
+					finalFilename = p.GetFilename()
 				}
 				if finalDestPath == "" {
 					finalDestPath = resolveDestPath(&localCfg)
 				}
-				safeSendProgress(localCfg.ProgressCh, types.DownloadEvent{
+				if finalFilename == "" {
+					finalFilename = localCfg.Filename
+				}
+				errEvent = &types.DownloadEvent{
 					Type:       types.EventError,
 					DownloadID: localCfg.ID,
-					Filename:   localCfg.Filename,
+					Filename:   finalFilename,
 					DestPath:   finalDestPath,
 					Err:        err,
-				}, p.progressDone)
+				}
 			}
 
 			if localCfg.ProgressState != nil {
@@ -764,6 +773,12 @@ func (p *Scheduler) worker() {
 			}
 			delete(p.downloadLimiters, localCfg.ID)
 			p.mu.Unlock()
+
+			// Send outside the lock: safeSendProgress may block on a full
+			// channel and must not hold p.mu while doing so.
+			if errEvent != nil {
+				safeSendProgress(localCfg.ProgressCh, *errEvent, p.progressDone)
+			}
 		} else {
 			// Only mark as done if not paused
 			if localCfg.ProgressState != nil {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -713,14 +713,14 @@ func (p *Scheduler) worker() {
 			p.mu.Lock()
 			delete(p.downloads, localCfg.ID)
 
-			if !p.isShuttingDown && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) && !types.IsPermanentHTTPError(err) && qt.retries < 3 {
+			if !p.isShuttingDown && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) && !types.IsPermanentHTTPError(err) && qt.retries < 10 {
 				qt.retries++
 				qt.inFlight = false
 				qt.cfg = localCfg
 				p.queued[localCfg.ID] = qt
 
 				p.removeQueueOrderLocked(localCfg.ID)
-				p.queueOrder = append([]string{localCfg.ID}, p.queueOrder...)
+				p.queueOrder = append(p.queueOrder, localCfg.ID)
 
 				if localCfg.ProgressCh != nil {
 					safeSendProgress(localCfg.ProgressCh, types.DownloadEvent{
@@ -738,6 +738,8 @@ func (p *Scheduler) worker() {
 				}
 				p.taskCond.Signal()
 				p.mu.Unlock()
+				// ponytail: naive backoff blocks worker thread, but naturally limits retry storms
+				time.Sleep(time.Second * time.Duration(qt.retries))
 				continue
 			}
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -722,6 +722,9 @@ func (p *Scheduler) worker() {
 				p.removeQueueOrderLocked(localCfg.ID)
 				p.queueOrder = append(p.queueOrder, localCfg.ID)
 
+				p.taskCond.Signal()
+				p.mu.Unlock()
+
 				if localCfg.ProgressCh != nil {
 					safeSendProgress(localCfg.ProgressCh, types.DownloadEvent{
 						Type:         types.EventQueued,
@@ -736,8 +739,6 @@ func (p *Scheduler) worker() {
 						MinChunkSize: localCfg.MinChunkSize,
 					}, p.progressDone)
 				}
-				p.taskCond.Signal()
-				p.mu.Unlock()
 				// ponytail: naive backoff blocks worker thread, but naturally limits retry storms
 				time.Sleep(time.Second * time.Duration(qt.retries))
 				continue

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -681,7 +681,6 @@ func (p *Scheduler) worker() {
 
 		if isPaused {
 			utils.Debug("Scheduler: Download %s paused cleanly", localCfg.ID)
-			p.wg.Done() // Signal worker completion before potentially blocking on progress channel
 			// The concurrent downloader sends DownloadPausedMsg itself via handlePause()
 			// (which causes RunDownload to return nil). When a single-threaded download is
 			// paused, RunDownload returns a non-nil error, and the pool must fill the gap.
@@ -776,7 +775,6 @@ func (p *Scheduler) worker() {
 			}
 			delete(p.downloadLimiters, localCfg.ID)
 			p.mu.Unlock()
-			p.wg.Done() // Signal worker completion before potentially blocking on progress channel
 
 			// Send outside the lock: safeSendProgress may block on a full
 			// channel and must not hold p.mu while doing so.
@@ -795,9 +793,9 @@ func (p *Scheduler) worker() {
 			delete(p.downloads, localCfg.ID)
 			delete(p.downloadLimiters, localCfg.ID)
 			p.mu.Unlock()
-			p.wg.Done()
 		}
 		// If paused, we keep it in downloads map for potential resume
+		p.wg.Done()
 	}
 }
 
@@ -959,10 +957,12 @@ func (p *Scheduler) GracefulShutdown() {
 			<-ticker.C
 		}
 
-		p.wg.Wait() // Blocks until all workers call Done()
-
 		// Signal that progressCh must no longer be sent to, so that
 		// safeSendProgress calls in workers can abort if the channel is full.
+		// This must happen before wg.Wait() to break deadlocks where a worker
+		// is blocked on a full channel and preventing wg from completing.
 		close(p.progressDone)
+
+		p.wg.Wait() // Blocks until all workers call Done()
 	})
 }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sync"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/SurgeDM/Surge/internal/progress"
+	"github.com/SurgeDM/Surge/internal/testutil"
 	"github.com/SurgeDM/Surge/internal/transport"
 	"github.com/SurgeDM/Surge/internal/types"
 )
@@ -1030,5 +1032,56 @@ func TestScheduler_GracefulShutdown_WorkerSkipsQueuedAfterShutdown(t *testing.T)
 	pool.mu.RUnlock()
 	if stillQueued {
 		t.Error("expected queued map to be cleared after GracefulShutdown")
+	}
+}
+
+func TestWorker_SkipsRetriesOnPermanentError(t *testing.T) {
+	ch := make(chan types.DownloadEvent, 100)
+	pool := New(ch, 1)
+
+	// A server that returns a 403 Forbidden, which should trigger ErrPermanentHTTP
+	server := testutil.NewHTTPServerT(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	id := "test-permanent-error"
+	pool.Add(types.DownloadRecord{
+		ID:            id,
+		URL:           server.URL,
+		ProgressState: progress.New(id, 0),
+		Runtime:       &types.RuntimeConfig{},
+	})
+
+	// Since max retries is 3, if it were to retry, it would take multiple attempts.
+	// But because 403 is a permanent error, it should fail immediately and emit exactly ONE EventError.
+	timeout := time.After(3 * time.Second)
+	errorCount := 0
+
+	for {
+		select {
+		case msg := <-ch:
+			if msg.Type == types.EventError {
+				errorCount++
+				if !types.IsPermanentHTTPError(msg.Err) {
+					t.Errorf("expected error to be permanent HTTP error, got: %v", msg.Err)
+				}
+			}
+		case <-timeout:
+			t.Fatal("timed out waiting for worker to finish")
+		}
+
+		pool.mu.RLock()
+		_, inActive := pool.downloads[id]
+		_, inQueue := pool.queued[id]
+		pool.mu.RUnlock()
+
+		if !inActive && !inQueue && errorCount > 0 {
+			break // Worker finished processing the download
+		}
+	}
+
+	if errorCount != 1 {
+		t.Errorf("expected exactly 1 EventError for permanent failure, got %d", errorCount)
 	}
 }

--- a/internal/service/local_service_test.go
+++ b/internal/service/local_service_test.go
@@ -53,9 +53,26 @@ func setupTestService(t *testing.T) (*LocalDownloadService, *httptest.Server, st
 }
 
 func TestLocalDownloadService_AddWithID_UsesProvidedID(t *testing.T) {
-	svc, ts, tmpDir := setupTestService(t)
-	defer ts.Close()
+	svc, globalTs, tmpDir := setupTestService(t)
+	defer globalTs.Close()
 	t.Cleanup(func() { _ = svc.Shutdown() })
+
+	blockCh := make(chan struct{})
+	defer close(blockCh)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "1024")
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		if r.Header.Get("Range") != "bytes=0-0" {
+			select {
+			case <-blockCh:
+			case <-r.Context().Done():
+			}
+		}
+	}))
+	defer ts.Close()
 
 	customID := "test-id-123"
 	id, err := svc.AddWithID(ts.URL, tmpDir, "test.txt", nil, nil, customID, false, 1, 0)

--- a/internal/strategy/concurrent/downloader.go
+++ b/internal/strategy/concurrent/downloader.go
@@ -675,6 +675,9 @@ func (d *ConcurrentDownloader) bootstrapMetadata(ctx context.Context, client *ht
 	}()
 
 	if resp.StatusCode != http.StatusPartialContent {
+		if types.IsPermanentHTTPStatus(resp.StatusCode) {
+			return 0, fmt.Errorf("concurrent bootstrap requires 206 response, got %d: %w", resp.StatusCode, types.ErrPermanentHTTP)
+		}
 		return 0, fmt.Errorf("concurrent bootstrap requires 206 response, got %d", resp.StatusCode)
 	}
 

--- a/internal/strategy/single/downloader.go
+++ b/internal/strategy/single/downloader.go
@@ -158,6 +158,9 @@ func (d *SingleDownloader) Download(ctx context.Context, rawurl, destPath string
 
 		_ = resp.Body.Close()
 		utils.Debug("Single downloader: unexpected status %d for %s", resp.StatusCode, rawurl)
+		if types.IsPermanentHTTPStatus(resp.StatusCode) {
+			return fmt.Errorf("unexpected status code: %d: %w", resp.StatusCode, types.ErrPermanentHTTP)
+		}
 		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 

--- a/internal/types/errors.go
+++ b/internal/types/errors.go
@@ -1,6 +1,9 @@
 package types
 
-import "errors"
+import (
+	"errors"
+	"net/http"
+)
 
 // Common errors
 var (
@@ -18,4 +21,23 @@ var (
 	ErrActiveUpdate       = errors.New("download is currently active, please pause it before updating the URL")
 	ErrMaxRedirects       = errors.New("stopped after 10 redirects")
 	ErrAlreadyActive      = errors.New("download is already active or queued")
+
+	// ErrPermanentHTTP indicates the server returned a 4xx status (other than 429)
+	// that makes retrying pointless (e.g. 403 Forbidden, 404 Not Found, 401 Unauthorized).
+	ErrPermanentHTTP = errors.New("permanent HTTP error")
 )
+
+// IsPermanentHTTPError reports whether err is a permanent HTTP error that
+// should not be retried by the scheduler.
+func IsPermanentHTTPError(err error) bool {
+	return errors.Is(err, ErrPermanentHTTP)
+}
+
+// IsPermanentHTTPStatus reports whether the given HTTP status code represents
+// a permanent failure that should not be retried.
+// 429 Too Many Requests is explicitly excluded because it is transient.
+func IsPermanentHTTPStatus(code int) bool {
+	return code >= http.StatusBadRequest &&
+		code < http.StatusInternalServerError &&
+		code != http.StatusTooManyRequests
+}

--- a/internal/types/errors_test.go
+++ b/internal/types/errors_test.go
@@ -1,0 +1,47 @@
+package types
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+)
+
+func TestIsPermanentHTTPError(t *testing.T) {
+	if !IsPermanentHTTPError(ErrPermanentHTTP) {
+		t.Errorf("Expected IsPermanentHTTPError(ErrPermanentHTTP) to be true")
+	}
+
+	wrappedErr := errors.Join(errors.New("some error"), ErrPermanentHTTP)
+	if !IsPermanentHTTPError(wrappedErr) {
+		t.Errorf("Expected IsPermanentHTTPError to be true for wrapped ErrPermanentHTTP")
+	}
+
+	if IsPermanentHTTPError(errors.New("other error")) {
+		t.Errorf("Expected IsPermanentHTTPError to be false for other errors")
+	}
+}
+
+func TestIsPermanentHTTPStatus(t *testing.T) {
+	tests := []struct {
+		status   int
+		expected bool
+	}{
+		{http.StatusOK, false},
+		{http.StatusMovedPermanently, false},
+		{http.StatusBadRequest, true},           // 400
+		{http.StatusUnauthorized, true},         // 401
+		{http.StatusForbidden, true},            // 403
+		{http.StatusNotFound, true},             // 404
+		{http.StatusTooManyRequests, false},     // 429 is explicitly transient
+		{http.StatusInternalServerError, false}, // 500
+		{http.StatusServiceUnavailable, false},  // 503
+	}
+
+	for _, tt := range tests {
+		t.Run(http.StatusText(tt.status), func(t *testing.T) {
+			if got := IsPermanentHTTPStatus(tt.status); got != tt.expected {
+				t.Errorf("IsPermanentHTTPStatus(%d) = %v, want %v", tt.status, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR revises download failure handling and scheduler shutdown behavior.
- Emits the final error event from the scheduler only after retries are exhausted.
- Treats most HTTP 4xx responses as permanent failures while retaining retries for 429 responses.
- Preserves incomplete downloads and concurrent-download progress for later resumption.
- Moves potentially blocking progress sends outside the scheduler mutex and closes the shutdown signal before waiting for workers.
- Adds coverage for permanent HTTP errors and single error-event emission.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no blocking failures remaining.

The scheduler-lock, shutdown, and stale-filename error-event failures are addressed without an eligible distinct regression.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the targeted Go tests for internal/types and internal/scheduler with a focused run of Test(IsPermanentHTTP|Worker\_SkipsRetriesOnPermanentError|RunDownload\_DoesNotEmitEventErrorOnFailure), using -count=1 -v and a GOCACHE path.
- Verified the current run reports that internal/types passes HTTP status handling for permanent (400, 401, 403, 404) and retryable (429, 5xx) cases, and that internal/scheduler passes both lifecycle tests.
- Compared the current results with the pre-change runtime, which showed RunDownload emitting an EventError and four EventErrors for a permanent 403 failure, and observed that the current implementation completes with a single terminal scheduler-owned EventError.

<a href="https://app.greptile.com/trex/runs/15659688/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/scheduler/scheduler.go | Reworks retry classification, queue accounting, error-event emission, backoff, and shutdown ordering without leaving an eligible blocking failure. |
| internal/scheduler/manager.go | Removes per-attempt error emission and avoids discarding partial progress during concurrent-to-single fallback. |
| internal/orchestrator/events.go | Preserves incomplete download files when processing terminal error events. |
| internal/strategy/concurrent/downloader.go | Marks qualifying 4xx bootstrap responses as permanent HTTP failures. |
| internal/strategy/single/downloader.go | Marks qualifying 4xx download responses as permanent HTTP failures. |
| internal/types/errors.go | Introduces permanent HTTP error classification, excluding rate-limited responses. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
participant W as Scheduler worker
participant D as Downloader
participant P as Progress channel
participant S as Graceful shutdown
W->>D: RunDownload
D-->>W: Return error
alt retryable and attempts remain
    W->>W: Requeue task as in-flight
    W->>P: Emit queued event outside mutex
    W->>W: Clear in-flight state and back off
else permanent or retries exhausted
    W->>P: Emit one error event outside mutex
    W->>W: Complete task accounting
end
S->>P: Close progressDone
S->>W: Wait for completion
```
</details>

<sub>Reviews (5): Last reviewed commit: ["fix: keep tasks in-flight during retry p..."](https://github.com/surgedm/surge/commit/b402003276e5c80ff817af5e3197b3296d5a3fc1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46791590)</sub>

<!-- /greptile_comment -->