### PR TITLE
feat: add dependabot configuration for extension

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,8 @@ updates:
   - package-ecosystem: "gomod" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/extension"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds daily Dependabot monitoring for the browser extension while also changing Go module checks from weekly to daily.
- Configures the npm ecosystem for `/extension`.
- Schedules extension dependency checks daily.
- Increases the existing root Go module update cadence to daily.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, though the unrelated Go dependency schedule change should be removed or justified to keep the change focused.

The extension entry matches the repository's standalone npm project, while the existing Go ecosystem is independently changed from weekly to daily without being required for extension monitoring.

.github/dependabot.yml
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Before state showed the parent configuration exiting 1 due to a missing /extension npm, establishing the baseline for the contract validation.
- After the change, the head configuration exited 0 and both manifests were parsed and confirmed.
- The assertion harness was preserved to reproduce the validation scenario for future tests.

<a href="https://app.greptile.com/trex/runs/15666552/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/dependabot.yml | Correctly targets the extension's npm project, but also includes an unrelated change to the existing Go update cadence. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/dependabot.yml:11
**Unrelated Go cadence change**

Changing the existing Go dependency schedule from weekly to daily is independent of adding npm monitoring for the extension, expanding update and CI activity beyond the stated feature without a supporting reason.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add dependabot configuration for e..."](https://github.com/surgedm/surge/commit/3241899a831b967e0bb15bf090138a7d03e57328) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46842239)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - What: Flag commits that bundle unnecessary changes... ([source](https://app.greptile.com/surge-org-3/-/custom-context?memory=74a28159-60fc-4201-a661-331594ebaf90))

<!-- /greptile_comment -->