### PR TITLE
ci: automate dependabot minor/patch updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,24 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      
+      - name: Enable auto-merge for Dependabot PRs
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Sets up auto-merge for dependabot PRs targeting minor and patch versions. Note: you still need to enable Allow auto-merge in the repository settings for this to work.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a GitHub Actions workflow that:
- Runs for Dependabot-authored pull requests.
- Reads Dependabot update metadata.
- Attempts to enable merge-commit auto-merge for minor and patch updates.
</details>

<details open><summary><h3>Confidence Score: 2/5</h3></summary>

This PR should not merge until the workflow uses an event or trusted follow-up design that can actually enable auto-merge for Dependabot pull requests.

Dependabot-triggered pull-request runs receive a read-only token, while the workflow's core command requires pull-request write access, so eligible updates will fail instead of being enrolled in auto-merge; the mutable privileged action reference also warrants hardening.

**Files Needing Attention:** .github/workflows/dependabot-auto-merge.yml
</details>

<details open><summary><h3>Security Review</h3></summary>

The workflow passes a write-capable token to an action referenced by a mutable major-version tag; pin the action to an immutable commit SHA.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- - T-Rex ran the requested verification, but its local artifact references were not uploaded.
- - T-Rex collected and attached validation artifacts for the dependabot-auto-merge scenario, including the before-state log, after-state log, GitHub context log, and the gate-validation harness.
- - The after-state evidence shows YAML parse passes and the configured command was invoked for patch/minor while major updates were skipped.
- - The GitHub context log records the credentials/context blocker that prevented progress, clarifying the blocking condition.
- - The generated gate-validation Ruby harness was produced to enable executable validation.

<a href="https://app.greptile.com/trex/runs/15841609/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/dependabot-auto-merge.yml | Adds Dependabot auto-merge automation, but the selected event supplies insufficient privileges for its merge command and the privileged action is not immutably pinned. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.github/workflows/dependabot-auto-merge.yml:2
**Dependabot token blocks auto-merge**

When Dependabot opens a minor or patch update, this `pull_request` workflow invokes `gh pr merge` with a read-only event token, causing the command to fail with insufficient permissions and leaving auto-merge disabled.

### Issue 2 of 2
.github/workflows/dependabot-auto-merge.yml:15
**Mutable action receives write token**

The mutable `dependabot/fetch-metadata@v2` reference receives a token with content and pull-request write permissions, so a compromised or repointed tag can modify repository content or pull requests. Pin the action to a reviewed full commit SHA.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: add dependabot auto-merge workflow"](https://github.com/surgedm/surge/commit/3c943a2cf04ec36b3ec95f96297e2ebbbcfa3c4f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47188216)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->