### PR TITLE
feat(transport): share TLS client session cache across NetworkPool transports

### DIFF
--- a/internal/transport/network.go
+++ b/internal/transport/network.go
@@ -41,6 +41,11 @@ var DefaultNetworkPool = &NetworkPool{
 	transportMap: make(map[*http.Transport]*transportLease),
 }
 
+// sharedClientSessionCache is a process-lifetime LRU TLS session cache shared by
+// all NetworkPool transports so new dials can resume across Transport rebuilds
+// and poolKeys. Capacity 256 is host:port keyed. Do not clear on CloseAll.
+var sharedClientSessionCache = tls.NewLRUClientSessionCache(256)
+
 // AcquireTransport returns a shared transport for the given configuration.
 func (p *NetworkPool) AcquireTransport(proxyURL, customDNS string, maxConns int) *http.Transport {
 	p.mu.Lock()
@@ -173,5 +178,8 @@ func (p *NetworkPool) createNewTransport(proxyURL, customDNS string, maxConns in
 		DisableCompression: true,
 		ForceAttemptHTTP2:  false,
 		TLSNextProto:       make(map[string]func(string, *tls.Conn) http.RoundTripper),
+		TLSClientConfig: &tls.Config{
+			ClientSessionCache: sharedClientSessionCache,
+		},
 	}
 }

--- a/internal/transport/network_test.go
+++ b/internal/transport/network_test.go
@@ -10,6 +10,83 @@ import (
 	"github.com/SurgeDM/Surge/internal/types"
 )
 
+func TestNetworkPool_ClientSessionCache_SharedAcrossPoolKeys(t *testing.T) {
+	pool := &NetworkPool{}
+
+	t1 := pool.AcquireTransport("http://proxy1", "", 0)
+	t2 := pool.AcquireTransport("http://proxy2", "", 0)
+	defer pool.ReleaseTransport(t1)
+	defer pool.ReleaseTransport(t2)
+
+	if t1 == t2 {
+		t.Fatal("expected distinct transports for different poolKeys")
+	}
+	if t1.TLSClientConfig == nil || t2.TLSClientConfig == nil {
+		t.Fatal("expected non-nil TLSClientConfig on both transports")
+	}
+	if t1.TLSClientConfig == t2.TLSClientConfig {
+		t.Fatal("expected distinct *tls.Config instances per transport")
+	}
+	if t1.TLSClientConfig.ClientSessionCache == nil {
+		t.Fatal("expected non-nil ClientSessionCache")
+	}
+	if t1.TLSClientConfig.ClientSessionCache != t2.TLSClientConfig.ClientSessionCache {
+		t.Fatal("expected shared ClientSessionCache pointer across poolKeys")
+	}
+	if t1.TLSClientConfig.ClientSessionCache != sharedClientSessionCache {
+		t.Fatal("expected ClientSessionCache to be package sharedClientSessionCache")
+	}
+}
+
+func TestNetworkPool_CloseAll_PreservesClientSessionCache(t *testing.T) {
+	pool := &NetworkPool{}
+
+	tr := pool.AcquireTransport("", "", 0)
+	if tr.TLSClientConfig == nil || tr.TLSClientConfig.ClientSessionCache == nil {
+		t.Fatal("expected wired ClientSessionCache before CloseAll")
+	}
+	cache := tr.TLSClientConfig.ClientSessionCache
+	pool.ReleaseTransport(tr)
+
+	pool.CloseAll()
+
+	tr2 := pool.AcquireTransport("", "", 0)
+	defer pool.ReleaseTransport(tr2)
+
+	if tr2.TLSClientConfig == nil {
+		t.Fatal("expected non-nil TLSClientConfig after CloseAll re-Acquire")
+	}
+	if tr2.TLSClientConfig.ClientSessionCache != cache {
+		t.Fatal("expected ClientSessionCache to survive CloseAll")
+	}
+	if tr2.TLSClientConfig.ClientSessionCache != sharedClientSessionCache {
+		t.Fatal("expected surviving cache to remain package sharedClientSessionCache")
+	}
+	assertHTTP2Disabled(t, tr2)
+}
+
+func TestNetworkPool_ClientSessionCache_HTTP2Disabled(t *testing.T) {
+	pool := &NetworkPool{}
+	tr := pool.AcquireTransport("", "", 0)
+	defer pool.ReleaseTransport(tr)
+	assertHTTP2Disabled(t, tr)
+}
+
+func assertHTTP2Disabled(t *testing.T, tr *http.Transport) {
+	t.Helper()
+	if tr.ForceAttemptHTTP2 {
+		t.Error("expected ForceAttemptHTTP2 == false")
+	}
+	if tr.TLSNextProto == nil {
+		t.Error("expected non-nil TLSNextProto map")
+	} else if len(tr.TLSNextProto) != 0 {
+		t.Errorf("expected empty TLSNextProto, got len=%d", len(tr.TLSNextProto))
+	}
+	if tr.DialContext == nil {
+		t.Error("expected custom DialContext")
+	}
+}
+
 func TestNetworkPool_Reuse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
Hey there,

The current `http.Transport` idle pool does a great job reusing connections and reducing overhead, but it looks like we might be missing a shared TLS `ClientSessionCache`.

Because of this, we aren't truly maximizing the handshake savings during scenarios like pause/resume, user network switching, or when workers are forced to dial a fresh connection (e.g., after CDN disconnects or during dynamic scale-ups).

So, let's introduce a package-level `tls.ClientSessionCache` (I went with an LRU of 256) and wire it directly into the `TLSClientConfig` for new transports! By doing this, anytime the engine actually needs to establish a new connection to the same host, we can consistently save a full 1-RTT on the TLS handshake overhead.

I've put together a small patch to enable this. Let's see how much we can smooth out those reconnection bumps! Let me know your thoughts on this approach.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enables TLS session resumption across transports created by NetworkPool.
- Adds a process-wide, concurrency-safe LRU client-session cache with 256 entries.
- Assigns each transport a distinct TLS configuration backed by the shared cache.
- Adds tests covering cross-pool-key sharing, preservation across CloseAll, and continued HTTP/2 disablement.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

The shared standard-library TLS session cache is safe for concurrent use, remains scoped by TLS server identity, and rejected or stale sessions transparently fall back to a full handshake.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I reviewed the general-contract-validation-proof to identify how the before and after states compare for transports and TLS resume.
- I verified that after the PR the transports are distinct, there is no TCP reuse, and server\_tls\_did\_resume is \[false true\], confirming the intended post-change behavior.
- I confirmed that CloseAll closed the idle connection without discarding the process-wide TLS session cache.
- I linked and reviewed the uploaded artifacts (the Go source and three log artifacts) to support reviewer inspection of the proof.

<a href="https://app.greptile.com/trex/runs/16001125/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/transport/network.go | Adds a package-level TLS client-session cache and wires it into newly created transports without changing certificate validation or TLS-version defaults. |
| internal/transport/network_test.go | Verifies cache sharing and lifecycle behavior while preserving the transport's existing HTTP/2 configuration. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
participant P as NetworkPool
participant T1 as Transport A
participant C as Shared TLS Session Cache
participant T2 as Transport B
P->>T1: Create transport
T1->>C: Store session for host
P->>T2: Create transport for another pool key
T2->>C: Retrieve session for host
T2-->>T2: Attempt resumed TLS handshake
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(transport): share TLS client sessio..."](https://github.com/surgedm/surge/commit/6b6a2ccc1c520c676baf9dafb62633d068506af8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47539464)</sub>

<!-- /greptile_comment -->