### PR TITLE
fix: sporadic 'context cancelled' errors when adding downloads via HTTP API

### DIFF
--- a/cmd/http_handler_test.go
+++ b/cmd/http_handler_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -596,5 +597,88 @@ func TestHandleDownload_PublishError_RecordsPreflightError(t *testing.T) {
 	}
 	if !found {
 		t.Fatal("expected errored download entry in master list after publish failure via HTTP API")
+	}
+}
+
+// TestHandleDownload_DoesNotUseCancelledHTTPRequestContext verifies that the
+// enqueue path uses the application-level enqueue context instead of the HTTP
+// request context. When the HTTP client disconnects or the handler returns
+// before the probe finishes, r.Context() is cancelled — but the download
+// should still be enqueued successfully.
+func TestHandleDownload_DoesNotUseCancelledHTTPRequestContext(t *testing.T) {
+	setupIsolatedCmdState(t)
+
+	progressCh := make(chan types.DownloadEvent, 10)
+	GlobalProgressCh = progressCh
+	if GlobalPool != nil {
+		GlobalPool.GracefulShutdown()
+	}
+	tmpPool := scheduler.New(progressCh, 1)
+	t.Cleanup(func() {
+		if tmpPool != nil {
+			tmpPool.GracefulShutdown()
+		}
+	})
+	GlobalPool = tmpPool
+
+	origLifecycle := GlobalLifecycle
+	origService := GlobalService
+	t.Cleanup(func() {
+		GlobalLifecycle = origLifecycle
+		GlobalService = origService
+		GlobalPool = nil
+		GlobalProgressCh = nil
+	})
+
+	probeServer := testutil.NewHTTPServerT(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Range", "bytes 0-0/7")
+		w.Header().Set("Content-Length", "1")
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write([]byte("x"))
+	}))
+	defer probeServer.Close()
+
+	tempDir := t.TempDir()
+
+	eventBus := orchestrator.NewEventBus()
+	t.Cleanup(func() { eventBus.Shutdown() })
+	getAll := func() []types.DownloadRecord { return GlobalPool.GetAll() }
+	tmpLifecycle := orchestrator.NewLifecycleManager(GlobalPool, eventBus, nil, buildActiveDownloadChecker(getAll))
+	t.Cleanup(func() { tmpLifecycle.Shutdown() })
+	GlobalLifecycle = tmpLifecycle
+	svc := service.NewLocalDownloadService(GlobalLifecycle)
+	GlobalService = svc
+	t.Cleanup(func() {
+		_ = svc.Shutdown()
+	})
+
+	body := fmt.Sprintf(`{
+		"url": %q,
+		"filename": "ctx-test.bin",
+		"path": %q,
+		"skip_approval": true
+	}`, probeServer.URL, tempDir)
+
+	// Create an HTTP request with an already-cancelled context to simulate
+	// a client that disconnects before the probe finishes.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+	req := httptest.NewRequest(http.MethodPost, "/download", bytes.NewBufferString(body)).WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	handleDownload(rec, req, "", svc)
+
+	// Before the fix, this would return 500 with "context canceled".
+	// After the fix, the download should be queued successfully because
+	// enqueueDownloadRequest uses currentEnqueueContext() instead of r.Context().
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 (download queued despite cancelled HTTP context), got %d: %s", rec.Code, rec.Body.String())
+	}
+	configs := GlobalPool.GetAll()
+	if len(configs) != 1 {
+		t.Fatalf("expected 1 download queued, got %d", len(configs))
+	}
+	if configs[0].Filename != "ctx-test.bin" {
+		t.Fatalf("filename = %q, want %q", configs[0].Filename, "ctx-test.bin")
 	}
 }

--- a/cmd/root_downloads.go
+++ b/cmd/root_downloads.go
@@ -417,10 +417,16 @@ func enqueueDownloadRequest(r *http.Request, service service.DownloadService, re
 			Workers:            req.Workers,
 			MinChunkSize:       req.MinChunkSize,
 		}
+		// Use the application-level enqueue context instead of r.Context().
+		// The HTTP request context is cancelled when the handler returns or
+		// the client disconnects, which races against the server probe that
+		// can take several seconds — causing sporadic "context cancelled"
+		// failures on otherwise valid downloads.
+		ctx := currentEnqueueContext()
 		if reqID != "" {
-			return lifecycle.EnqueueWithID(r.Context(), dlReq, reqID)
+			return lifecycle.EnqueueWithID(ctx, dlReq, reqID)
 		}
-		return lifecycle.Enqueue(r.Context(), dlReq)
+		return lifecycle.Enqueue(ctx, dlReq)
 	}
 
 	if reqID != "" {


### PR DESCRIPTION
## Problem

Downloads added via the HTTP API (browser extension) randomly fail with:

```
Error adding: Link enqueue aborted: context cancelled
```

There is no rhyme or reason — retrying the exact same download immediately succeeds.

## Root Cause

`enqueueDownloadRequest()` in `cmd/root_downloads.go` was passing `r.Context()` (the HTTP request context) to `lifecycle.Enqueue()`. 

The `Enqueue` function performs a **server probe** (HEAD request to check file size, range support, filename) which can take several seconds. The HTTP request context `r.Context()` gets cancelled when:
- The HTTP handler returns
- The browser extension client disconnects or times out

This creates a race: if the probe takes longer than the HTTP connection stays alive, the context is cancelled mid-probe, aborting the enqueue.

From the debug log:
- **First attempt (20:58:49)**: Probe starts, takes ~5s, fails with `context canceled`  
- **Second attempt (20:59:09)**: Same URL, probe completes in ~1s, succeeds

## Fix

Replaced `r.Context()` with `currentEnqueueContext()` — the application-level context that only cancels on shutdown. This matches what the TUI path (`processDownloads`) and CLI path already use correctly.

## Testing

Added `TestHandleDownload_DoesNotUseCancelledHTTPRequestContext` which creates an HTTP request with a pre-cancelled context and verifies the download still enqueues successfully. All existing tests pass.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes sporadic HTTP API enqueue failures by decoupling probe/enqueue from the HTTP request context.
- `enqueueDownloadRequest` now passes `currentEnqueueContext()` into `lifecycle.Enqueue` / `EnqueueWithID` instead of `r.Context()`, matching CLI/TUI paths so client disconnect or handler return no longer aborts the server probe.
- Adds `TestHandleDownload_DoesNotUseCancelledHTTPRequestContext` covering a pre-cancelled request context that still queues successfully.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This change appears safe to merge; the context change matches existing CLI/TUI enqueue lifetime and is covered by a focused regression test.

Enqueue uses the shared application cancel-on-shutdown context with a 30s probe timeout derived from it, avoiding request-context races without introducing a new failure mode on the changed path.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused test TestHandleDownload\_DoesNotUseCancelledHTTPRequestContext against the real cmd package and verified it passed.
- Validated the narrow-suite regression evidence and confirmed the regression remains passing alongside the existing HTTP download handler coverage.

<a href="https://app.greptile.com/trex/runs/16228429/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| cmd/root_downloads.go | Switches HTTP enqueue to the process-level enqueue context so probe work is not cancelled by request lifetime. |
| cmd/http_handler_test.go | Adds a regression test that enqueues successfully with an already-cancelled HTTP request context. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Ext as Browser extension
  participant API as handleDownload
  participant Enq as enqueueDownloadRequest
  participant Life as Lifecycle.Enqueue
  participant Probe as ProbeServer

  Ext->>API: POST /download
  API->>Enq: enqueueDownloadRequest
  Note over Enq: ctx = currentEnqueueContext()<br/>(not r.Context())
  Enq->>Life: Enqueue(ctx, dlReq)
  Life->>Probe: probe (up to ~30s)
  Note over Ext,API: Client disconnect would cancel r.Context()<br/>but app enqueue ctx stays live
  Probe-->>Life: size/range/filename
  Life-->>Enq: id, filename
  Enq-->>API: ok
  API-->>Ext: 200 queued (if still connected)
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use application-level context for H..."](https://github.com/surgedm/surge/commit/baf2903fbed2e222a25b7ef44ac56c8543aa7db9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47997112)</sub>

<!-- /greptile_comment -->