### PR TITLE
fix: resolve crash loop for legacy service manager installations

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1,10 +1,7 @@
 package cmd
 
 import (
-	"os/exec"
-
 	"github.com/SurgeDM/Surge/internal/types"
-
 	"bytes"
 	"encoding/json"
 	"fmt"
@@ -730,20 +727,9 @@ func TestServerStartCmd_FailsIfSystemServiceRunning(t *testing.T) {
 	checkSystemServiceRunning = func() bool { return true }
 	t.Cleanup(func() { checkSystemServiceRunning = origCheck })
 
-	// Write a mock PID file to simulate a live process holding the service
-	// We spawn a dummy background process to get a valid PID that isn't our own,
-	// working around os.Getppid() returning 0 on Wine/Windows.
-	dummyCmd := exec.Command(os.Args[0], "-test.run=TestDummyWait")
-	dummyCmd.Env = append(os.Environ(), "RUN_DUMMY_WAIT=1")
-	if err := dummyCmd.Start(); err != nil {
-		t.Fatalf("failed to start dummy process: %v", err)
-	}
-	t.Cleanup(func() { _ = dummyCmd.Process.Kill() })
-
-	pidFile := filepath.Join(config.GetSystemRuntimeDir(), "pid")
-	if err := os.WriteFile(pidFile, []byte(fmt.Sprintf("%d", dummyCmd.Process.Pid)), 0644); err != nil {
-		t.Fatalf("failed to write pid file: %v", err)
-	}
+	origTerminalCheck := checkIsTerminal
+	checkIsTerminal = func() bool { return true }
+	t.Cleanup(func() { checkIsTerminal = origTerminalCheck })
 
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
@@ -1564,13 +1550,4 @@ func TestResolveServerToken_FlagOverridesEnv(t *testing.T) {
 	if got != "flag-token-xyz" {
 		t.Fatalf("resolveServerToken() = %q, want %q", got, "flag-token-xyz")
 	}
-}
-
-// TestDummyWait is a helper test that just blocks. It's used by other tests
-// to spawn a child process that stays alive.
-func TestDummyWait(t *testing.T) {
-	if os.Getenv("RUN_DUMMY_WAIT") != "1" {
-		t.Skip("Skipping dummy wait test")
-	}
-	time.Sleep(1 * time.Hour)
 }

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os/exec"
+
 	"github.com/SurgeDM/Surge/internal/types"
 
 	"bytes"
@@ -727,6 +729,21 @@ func TestServerStartCmd_FailsIfSystemServiceRunning(t *testing.T) {
 	origCheck := checkSystemServiceRunning
 	checkSystemServiceRunning = func() bool { return true }
 	t.Cleanup(func() { checkSystemServiceRunning = origCheck })
+
+	// Write a mock PID file to simulate a live process holding the service
+	// We spawn a dummy background process to get a valid PID that isn't our own,
+	// working around os.Getppid() returning 0 on Wine/Windows.
+	dummyCmd := exec.Command(os.Args[0], "-test.run=TestDummyWait")
+	dummyCmd.Env = append(os.Environ(), "RUN_DUMMY_WAIT=1")
+	if err := dummyCmd.Start(); err != nil {
+		t.Fatalf("failed to start dummy process: %v", err)
+	}
+	t.Cleanup(func() { _ = dummyCmd.Process.Kill() })
+
+	pidFile := filepath.Join(config.GetSystemRuntimeDir(), "pid")
+	if err := os.WriteFile(pidFile, []byte(fmt.Sprintf("%d", dummyCmd.Process.Pid)), 0644); err != nil {
+		t.Fatalf("failed to write pid file: %v", err)
+	}
 
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
@@ -1547,4 +1564,13 @@ func TestResolveServerToken_FlagOverridesEnv(t *testing.T) {
 	if got != "flag-token-xyz" {
 		t.Fatalf("resolveServerToken() = %q, want %q", got, "flag-token-xyz")
 	}
+}
+
+// TestDummyWait is a helper test that just blocks. It's used by other tests
+// to spawn a child process that stays alive.
+func TestDummyWait(t *testing.T) {
+	if os.Getenv("RUN_DUMMY_WAIT") != "1" {
+		t.Skip("Skipping dummy wait test")
+	}
+	time.Sleep(1 * time.Hour)
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/utils"
 	"github.com/spf13/cobra"
 )
@@ -34,8 +35,33 @@ var serverStartCmd = &cobra.Command{
 		if isSystemServiceFlag {
 			activeServerMode = "service"
 		}
+
 		if checkSystemServiceRunning() && !isSystemServiceFlag {
-			return fmt.Errorf("system service is already running. Use 'surge connect' to interact with it, or stop the service first")
+			// Backward compatibility for older systemd/runit service files that used `surge server start`
+			// instead of `surge service __run`. In these cases, the service manager thinks the service
+			// is starting/running because we ARE the service.
+			// We verify if another instance is actually alive by checking the PID file.
+			sysPid := readPIDFile(config.GetSystemRuntimeDir())
+			isAlive := false
+			if sysPid > 0 && sysPid != os.Getpid() {
+				if p, err := os.FindProcess(sysPid); err == nil {
+					// Sending signal 0 checks if the process exists
+					if err := p.Signal(syscall.Signal(0)); err == nil {
+						isAlive = true
+					}
+				}
+			}
+
+			// Also check environment variables that strongly suggest we are the service manager
+			isServiceEnv := os.Getenv("INVOCATION_ID") != "" // systemd
+
+			if isAlive && !isServiceEnv {
+				return fmt.Errorf("system service is already running. Use 'surge connect' to interact with it, or stop the service first")
+			}
+
+			// We are likely being started by the service manager via legacy args, so act as the system service
+			isSystemServiceFlag = true
+			activeServerMode = "service"
 		}
 
 		// Attempt to acquire lock before any global state initialization

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -13,7 +13,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/utils"
 	"github.com/spf13/cobra"
 )
@@ -41,23 +40,8 @@ var serverStartCmd = &cobra.Command{
 			// Backward compatibility for older systemd/runit service files that used `surge server start`
 			// instead of `surge service __run`. In these cases, the service manager thinks the service
 			// is starting/running because we ARE the service.
-			// We verify if another instance is actually alive by checking the PID file.
-			sysPid := readPIDFile(config.GetSystemRuntimeDir())
-			isAlive := false
-			if sysPid > 0 && sysPid != os.Getpid() {
-				if p, err := os.FindProcess(sysPid); err == nil {
-					if runtime.GOOS == "windows" {
-						isAlive = true
-					} else if err := p.Signal(syscall.Signal(0)); err == nil {
-						isAlive = true
-					}
-				}
-			}
-
-			// Also check environment variables that strongly suggest we are the service manager
-			isServiceEnv := os.Getenv("INVOCATION_ID") != "" // systemd
-
-			if isAlive && !isServiceEnv {
+			// We differentiate between an interactive user and a service manager by checking for a terminal.
+			if checkIsTerminal() {
 				return fmt.Errorf("system service is already running. Use 'surge connect' to interact with it, or stop the service first")
 			}
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"runtime"
 
 	"os"
 	"os/signal"
@@ -45,8 +46,9 @@ var serverStartCmd = &cobra.Command{
 			isAlive := false
 			if sysPid > 0 && sysPid != os.Getpid() {
 				if p, err := os.FindProcess(sysPid); err == nil {
-					// Sending signal 0 checks if the process exists
-					if err := p.Signal(syscall.Signal(0)); err == nil {
+					if runtime.GOOS == "windows" {
+						isAlive = true
+					} else if err := p.Signal(syscall.Signal(0)); err == nil {
 						isAlive = true
 					}
 				}
@@ -150,11 +152,13 @@ var serverStatusCmd = &cobra.Command{
 			return
 		}
 
-		// Sending signal 0 to check existence
-		err = process.Signal(syscall.Signal(0))
-		if err != nil {
-			fmt.Printf("Surge server is NOT running (Process %d dead).\n", pid)
-			return
+		if runtime.GOOS != "windows" {
+			// Sending signal 0 to check existence
+			err = process.Signal(syscall.Signal(0))
+			if err != nil {
+				fmt.Printf("Surge server is NOT running (Process %d dead).\n", pid)
+				return
+			}
 		}
 
 		port := readActivePort()

--- a/cmd/test_env_test.go
+++ b/cmd/test_env_test.go
@@ -22,8 +22,6 @@ func setupXDGEnvIsolation(t *testing.T) string {
 	oldCacheHome := xdg.CacheHome
 	oldRuntimeDir := xdg.RuntimeDir
 
-	t.Setenv("INVOCATION_ID", "")
-
 	xdg.ConfigHome = tempDir
 	xdg.DataHome = tempDir
 	xdg.StateHome = tempDir

--- a/cmd/test_env_test.go
+++ b/cmd/test_env_test.go
@@ -22,6 +22,8 @@ func setupXDGEnvIsolation(t *testing.T) string {
 	oldCacheHome := xdg.CacheHome
 	oldRuntimeDir := xdg.RuntimeDir
 
+	t.Setenv("INVOCATION_ID", "")
+
 	xdg.ConfigHome = tempDir
 	xdg.DataHome = tempDir
 	xdg.StateHome = tempDir

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -16,6 +16,7 @@ import (
 	"github.com/SurgeDM/Surge/internal/store"
 	"github.com/SurgeDM/Surge/internal/types"
 	"github.com/SurgeDM/Surge/internal/utils"
+	"github.com/charmbracelet/x/term"
 )
 
 type activeConnectionDetails struct {
@@ -467,8 +468,5 @@ func resolveIDFromCandidates(partialID string, candidates []string) (string, err
 }
 
 var checkIsTerminal = func() bool {
-	if fi, err := os.Stdout.Stat(); err == nil {
-		return (fi.Mode() & os.ModeCharDevice) != 0
-	}
-	return false
+	return term.IsTerminal(os.Stdout.Fd())
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -465,3 +465,10 @@ func resolveIDFromCandidates(partialID string, candidates []string) (string, err
 
 	return partialID, nil // No match, use as-is (will fail with "not found" later)
 }
+
+var checkIsTerminal = func() bool {
+	if fi, err := os.Stdout.Stat(); err == nil {
+		return (fi.Mode() & os.ModeCharDevice) != 0
+	}
+	return false
+}

--- a/internal/strategy/concurrent/concurrent_test.go
+++ b/internal/strategy/concurrent/concurrent_test.go
@@ -496,7 +496,7 @@ func TestConcurrentDownloader_RetryOnFailure(t *testing.T) {
 	state := progress.New("retry-test", fileSize)
 	runtime := &types.RuntimeConfig{
 		MaxConnectionsPerDownload: 2,
-		MaxTaskRetries:            5, 
+		MaxTaskRetries:            5,
 		MinChunkSize:              64 * utils.KiB,
 	}
 

--- a/internal/utils/http_test.go
+++ b/internal/utils/http_test.go
@@ -17,31 +17,31 @@ func TestSameSite(t *testing.T) {
 		{"exact same domain", "example.com", "example.com", true},
 		{"exact same IP", "127.0.0.1", "127.0.0.1", true},
 		{"exact same IPv6", "[::1]", "[::1]", true},
-		
+
 		// Subdomains on standard TLDs
 		{"standard TLD subdomains", "a.example.com", "b.example.com", true},
 		{"deep subdomains", "x.y.z.example.com", "example.com", true},
 		{"easynews subdomains", "members.easynews.com", "iad-dl-08.easynews.com", true},
-		
+
 		// Complex TLDs (eTLD+1)
 		{"complex TLD subdomains", "a.example.co.uk", "b.example.co.uk", true},
 		{"different sites on complex TLD", "example.co.uk", "other.co.uk", false},
 		{"github.io subdomains (private TLD)", "user1.github.io", "user2.github.io", false},
 		{"github.io same site", "user1.github.io", "sub.user1.github.io", true},
-		
+
 		// Cross-site cases
 		{"filmyzilla cross-site domains", "1.filmyzilla.vin", "cdn-02-nl-zilla.filmyzdl.com", false},
 		{"different domains", "example.com", "other.com", false},
 		{"different TLDs", "example.com", "example.org", false},
 		{"IP vs localhost", "127.0.0.1", "localhost", false},
 		{"different IPs", "192.168.1.1", "192.168.1.2", false},
-		
+
 		// Port handling
 		{"with same ports", "example.com:8080", "sub.example.com:8080", true},
 		{"with different ports", "example.com:80", "sub.example.com:443", true},
 		{"IP with port", "127.0.0.1:8080", "127.0.0.1:9090", true},
 		{"one with port, one without", "example.com", "sub.example.com:8080", true},
-		
+
 		// Malformed or empty
 		{"empty strings", "", "", true},
 		{"one empty string", "example.com", "", false},
@@ -144,11 +144,11 @@ func TestCopyRedirectHeaders(t *testing.T) {
 		},
 		// Edge cases
 		{
-			name:   "nil request headers safe check",
-			dstURL: "https://b.example.com",
-			srcURL: "https://a.example.com",
-			srcHeaders: nil, // shouldn't panic
-			initialDstHdr: http.Header{},
+			name:           "nil request headers safe check",
+			dstURL:         "https://b.example.com",
+			srcURL:         "https://a.example.com",
+			srcHeaders:     nil, // shouldn't panic
+			initialDstHdr:  http.Header{},
 			expectedDstHdr: http.Header{},
 		},
 		{
@@ -201,11 +201,11 @@ func TestCopyRedirectHeaders(t *testing.T) {
 func TestCopyRedirectHeaders_NilRequests(t *testing.T) {
 	// Should not panic
 	CopyRedirectHeaders(nil, nil)
-	
+
 	req := &http.Request{URL: mustParseURL(t, "https://example.com")}
 	CopyRedirectHeaders(req, nil)
 	CopyRedirectHeaders(nil, req)
-	
+
 	reqNoURL := &http.Request{}
 	CopyRedirectHeaders(req, reqNoURL)
 	CopyRedirectHeaders(reqNoURL, req)


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Relaxes the “system service already running” guard for non-interactive legacy `surge server start` invocations and hardens terminal detection.
- When the OS service is reported running and `--is-system-service` is absent, interactive (TTY) starts still error; non-TTY starts force service mode and continue.
- Adds injectable `checkIsTerminal` via charmbracelet `term.IsTerminal` on stdout.
- Skips signal-0 process liveness on Windows in `server status`.
- Test tweak so the system-service-running start failure path mocks a TTY; minor whitespace-only test cleanups.
</details>

<details open><summary><h3>Confidence Score: 2/5</h3></summary>

Not safe to merge until the non-TTY service-guard path stops allowing a second daemon when the system service is already running (stale or missing system PID still bypasses a real exclusivity check).

Interactive starts are blocked when the service is up, but a non-TTY `surge server start` still upgrades itself to service mode and proceeds; locking stays on the user runtime dir and listen scanning still begins at 1700, so a competing process can bind nearby and fight the real unit for default port and runtime files. The older runit/OpenRC crash-loop from requiring INVOCATION_ID is no longer present under the terminal-based guard.

**Files Needing Attention:** cmd/server.go (and lock/runtime resolution in cmd/lock.go, cmd/root_http_server.go)
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Checked the pre-fix legacy service start runtime capture log and confirmed exit code 0.
- Validated the PR-head runtime capture log and confirmed it covers both terminal states with exit code 0.
- Cataloged the focused harness source files included for reproducibility.

<a href="https://app.greptile.com/trex/runs/16388320/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| cmd/server.go | Non-TTY legacy path forces service mode when the system service is reported running, but does not align lock/runtime/port binding with a real system daemon, leaving the prior dual-daemon race open. |
| cmd/utils.go | Adds checkIsTerminal using term.IsTerminal(os.Stdout.Fd()) for the service-guard branch and tests. |
| cmd/cmd_test.go | Mocks checkIsTerminal true so the interactive system-service-running failure path still asserts the hard error. |
| internal/strategy/concurrent/concurrent_test.go | Whitespace-only formatting in a test literal. |
| internal/utils/http_test.go | Whitespace/alignment-only test formatting. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix: use x/term for robust terminal dete..."](https://github.com/surgedm/surge/commit/e7a6e8978232dbea56211da5246abd29c4337f97) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48179950)</sub>

<!-- /greptile_comment -->