### PR TITLE
fix: ignore hidden and build directories in unicode lint test

### DIFF
--- a/internal/lint/unicode_lint_test.go
+++ b/internal/lint/unicode_lint_test.go
@@ -29,9 +29,8 @@ import (
 func TestNoRawUnicodeInStringLiterals(t *testing.T) {
 	root := projectRoot(t)
 
-	// Directories to skip entirely.
+	// Directories to skip entirely (in addition to those starting with . or _)
 	skipDirs := map[string]bool{
-		".git":     true,
 		"vendor":   true,
 		"testdata": true,
 	}
@@ -50,7 +49,8 @@ func TestNoRawUnicodeInStringLiterals(t *testing.T) {
 			return err
 		}
 		if d.IsDir() {
-			if skipDirs[d.Name()] {
+			name := d.Name()
+			if skipDirs[name] || strings.HasPrefix(name, ".") || strings.HasPrefix(name, "_") {
 				return filepath.SkipDir
 			}
 			return nil

--- a/internal/lint/unicode_lint_test.go
+++ b/internal/lint/unicode_lint_test.go
@@ -49,6 +49,11 @@ func TestNoRawUnicodeInStringLiterals(t *testing.T) {
 			return err
 		}
 		if d.IsDir() {
+			// Never skip the walk root: packaging trees often live under
+			// names like _build-surge-xbps that contain go.mod.
+			if path == root {
+				return nil
+			}
 			name := d.Name()
 			if skipDirs[name] || strings.HasPrefix(name, ".") || strings.HasPrefix(name, "_") {
 				return filepath.SkipDir


### PR DESCRIPTION
Fixes #557

This PR updates the `TestNoRawUnicodeInStringLiterals` lint rule to explicitly ignore directories starting with `.` or `_`. This prevents the test from incorrectly scanning third-party dependencies downloaded by packaging tools (like Void Linux's xbps-src which creates `_build-surge-xbps`) during package builds.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the unicode string-literal lint walk to skip hidden and underscore-prefixed directories while still scanning the module root.
- Removes hard-coded `.git` from `skipDirs` in favor of a general `.` / `_` name prefix skip for non-root directories.
- Explicitly does not skip the walk root so packaging workdirs like `_build-surge-xbps` that hold `go.mod` still have their tree scanned.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; the walk-root skip issue is fixed and no blocking failure remains.

The walk root is returned without SkipDir before prefix checks, so module roots named like `_build-surge-xbps` are still traversed and production `.go` files are linted as intended.

**Files Needing Attention:** No files need further attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a general contract validation to compare the behavior of ordinary-descendant/raw\_unicode\_fixture.go before and after changes.
- Confirmed that the before state produced the expected raw-Unicode violation.
- Confirmed that the after state with fixtures beneath dot- and underscore-prefixed descendants produced no violations.
- Used a reusable fixture and the executed harness to ensure traceability of the validation.
- Collected and linked the supporting artifacts (logs and scripts) as evidence for review.

<a href="https://app.greptile.com/trex/runs/16357116/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/lint/unicode_lint_test.go | WalkDir now skips `.`/`_`-prefixed child dirs and vendor/testdata, but never skips the project root, addressing the prior packaging false-pass. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: prevent accidental skipping of the ..."](https://github.com/surgedm/surge/commit/d13d934ef81c788f87d1f056a643b7687211a7f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48242322)</sub>

<!-- /greptile_comment -->