### PR TITLE
fix: maintain active tasks during worker backoff to prevent phantom progress on pause

### DIFF
--- a/internal/strategy/concurrent/concurrent_test.go
+++ b/internal/strategy/concurrent/concurrent_test.go
@@ -817,3 +817,67 @@ func TestConcurrentDownloader_Download_BootstrapFail_InvalidRange(t *testing.T) 
 		t.Errorf("Expected range error, got: %v", err)
 	}
 }
+
+
+func TestConcurrentDownloader_PauseDuringRetryBackoff(t *testing.T) {
+	tmpDir, cleanup := initTestState(t)
+	defer cleanup()
+
+	fileSize := int64(256 * utils.KiB)
+	server := testutil.NewMockServerT(t,
+		testutil.WithFileSize(fileSize),
+		testutil.WithRangeSupport(true),
+		testutil.WithFailOnNthRequest(1),
+	)
+	defer server.Close()
+
+	destPath := filepath.Join(tmpDir, "pause_backoff_test.bin")
+	state := progress.New("pause-backoff-test", fileSize)
+	runtime := &types.RuntimeConfig{
+		MaxConnectionsPerDownload: 1,
+		MaxTaskRetries:            5,
+		MinChunkSize:              64 * utils.KiB,
+	}
+
+	progressCh := make(chan types.DownloadEvent, 10)
+	downloader := NewConcurrentDownloader("pause-backoff-id", progressCh, state, runtime)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if f, err := os.Create(destPath + ".surge"); err == nil {
+		_ = f.Close()
+	}
+
+	go func() {
+		time.Sleep(150 * time.Millisecond) // Ensure worker hits error and sleeps
+		state.Pause()
+	}()
+
+	err := downloader.Download(ctx, server.URL(), nil, nil, destPath, fileSize)
+	if !errors.Is(err, types.ErrPaused) {
+		t.Fatalf("Expected ErrPaused, got: %v", err)
+	}
+
+	var pausedEvent *types.DownloadEvent
+	close(progressCh)
+	for event := range progressCh {
+		if event.Type == types.EventPaused {
+			pausedEvent = &event
+			break
+		}
+	}
+
+	if pausedEvent == nil {
+		t.Fatalf("Expected EventPaused on progress channel")
+	}
+
+	savedState := pausedEvent.State
+	if savedState == nil {
+		t.Fatalf("Expected state in paused event")
+	}
+
+	if savedState.Downloaded > 0 {
+		t.Errorf("Expected 0 bytes downloaded in saved state, but got %d (progress jump bug!)", savedState.Downloaded)
+	}
+}

--- a/internal/strategy/concurrent/worker.go
+++ b/internal/strategy/concurrent/worker.go
@@ -41,6 +41,24 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 			d.State.ActiveWorkers.Add(1)
 		}
 
+		now := time.Now()
+		activeTask := &ActiveTask{
+			Task:        task,
+			StartTime:   now,
+			WindowStart: now,
+		}
+		if task.SharedMaxOffset != nil {
+			activeTask.SharedMaxOffset = task.SharedMaxOffset
+			activeTask.Hedged.Store(1)
+		}
+		activeTask.CurrentOffset.Store(task.Offset)
+		activeTask.StopAt.Store(task.Offset + task.Length)
+		activeTask.LastActivity.Store(now.UnixNano())
+
+		d.activeMu.Lock()
+		d.activeTasks[id] = activeTask
+		d.activeMu.Unlock()
+
 		var lastErr error
 		maxRetries := d.Runtime.GetMaxTaskRetries()
 		genericAttempt := 0
@@ -50,34 +68,25 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 			idx, wait := d.hostLimiter.PickMirror(mirrorHosts, currentMirrorIdx, time.Now())
 			currentMirrorIdx = idx
 			if wait > 0 {
+				activeTask.WaitingOnLimiter.Store(true)
 				if !interruptibleSleep(ctx, wait) {
+					activeTask.WaitingOnLimiter.Store(false)
 					if d.State != nil {
 						d.State.ActiveWorkers.Add(-1)
 					}
 					return ctx.Err()
 				}
+				activeTask.WaitingOnLimiter.Store(false)
 			}
 			currentURL := mirrors[currentMirrorIdx]
 
 			taskCtx, taskCancel := context.WithCancel(ctx)
 			now := time.Now()
-			activeTask := &ActiveTask{
-				Task:        task,
-				StartTime:   now,
-				Cancel:      taskCancel,
-				WindowStart: now,
-			}
-			if task.SharedMaxOffset != nil {
-				activeTask.SharedMaxOffset = task.SharedMaxOffset
-				activeTask.Hedged.Store(1)
-			}
-			activeTask.CurrentOffset.Store(task.Offset)
-			activeTask.StopAt.Store(task.Offset + task.Length)
+			activeTask.Cancel = taskCancel
+			activeTask.StartTime = now
+			activeTask.WindowStart = now
+			activeTask.WindowBytes.Store(0)
 			activeTask.LastActivity.Store(now.UnixNano())
-
-			d.activeMu.Lock()
-			d.activeTasks[id] = activeTask
-			d.activeMu.Unlock()
 
 			if d.State != nil {
 				utils.Debug("Worker %d: Setting range %d-%d to Downloading", id, task.Offset, task.Offset+task.Length)
@@ -116,16 +125,9 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 							id, remaining.Length, remaining.Offset)
 					}
 				}
-				d.activeMu.Lock()
-				delete(d.activeTasks, id)
-				d.activeMu.Unlock()
 				lastErr = nil
 				break
 			}
-
-			d.activeMu.Lock()
-			delete(d.activeTasks, id)
-			d.activeMu.Unlock()
 
 			if lastErr == nil {
 				d.hostLimiter.RecordSuccess(mirrorHosts[currentMirrorIdx])
@@ -157,10 +159,16 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 			d.ReportMirrorError(mirrors[currentMirrorIdx])
 			currentMirrorIdx = (currentMirrorIdx + 1) % len(mirrors)
 			if len(mirrors) == 1 {
+				activeTask.WaitingOnLimiter.Store(true)
 				interruptibleSleep(ctx, time.Duration(1<<genericAttempt)*types.RetryBaseDelay)
+				activeTask.WaitingOnLimiter.Store(false)
 			}
 			resumeOnRetryOffset(&task, activeTask)
 		}
+
+		d.activeMu.Lock()
+		delete(d.activeTasks, id)
+		d.activeMu.Unlock()
 
 		if d.State != nil {
 			d.State.ActiveWorkers.Add(-1)
@@ -557,5 +565,6 @@ func resumeOnRetryOffset(task *types.Task, activeTask *ActiveTask) {
 		oldStart := task.Offset
 		task.Offset = current
 		task.Length = oldStart + task.Length - current
+		activeTask.Task = *task
 	}
 }


### PR DESCRIPTION
## Description
Fixes an issue where pausing a download while workers were sleeping between retries (e.g., exponential backoff) would result in a phantom progress jump to ~95%.

### Root Cause
Workers were temporarily removing their `ActiveTask` from the tracked `d.activeTasks` map during retry delays. If the download was paused exactly during this sleep window, the `handlePause` routine wouldn't see these orphaned tasks in `activeTasks` or the queue, effectively treating them as 100% completed. This caused the saved state to skip these chunks, leading to corrupted files (bad shasum) upon resume.

### Fix
- Updated the worker loop to initialize `ActiveTask` once per popped task and safely maintain it in `d.activeTasks` throughout the entire retry cycle.
- Updated `resumeOnRetryOffset` to sync the modified offsets back into `activeTask.Task`.
- By keeping the task tracked, `handlePause` will correctly extract the exact remaining bytes, properly save the session state, and prevent corrupted resumes.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Keeps each worker’s `ActiveTask` in `activeTasks` for the full retry/backoff cycle so pause can still see in-flight ranges, and syncs `activeTask.Task` after offset resume on retry.
- Create `ActiveTask` once per popped task and register it before the retry loop; remove it only after the task finishes.
- Set `WaitingOnLimiter` around host-limiter and single-mirror backoff sleeps.
- On retry, `resumeOnRetryOffset` also copies the updated range into `activeTask.Task`.
- Adds `TestConcurrentDownloader_PauseDuringRetryBackoff` expecting paused saved `Downloaded == 0` when pause hits during retry sleep.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the ActiveTask lifetime change correctly preserves remaining ranges for pause without introducing a new failure path in the reviewed code.

Pause/resume remaining work is driven by CurrentOffset/StopAt while the task stays registered through backoff; early exits on cancel leave entries for handlePause, and successful paths delete after the task loop.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the TestConcurrentDownloader\_PauseDuringRetryBackoff test with race detection and verbose output; the runtime proof shows the test passed with exit code 0.

<a href="https://app.greptile.com/trex/runs/16361340/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/strategy/concurrent/worker.go | Holds ActiveTask across retries/backoff and cleans it up after the task loop so pause accounting no longer drops in-flight ranges. |
| internal/strategy/concurrent/concurrent_test.go | Regression test pauses during forced first-request failure backoff and asserts no phantom downloaded bytes in the paused state. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant W as Worker
  participant AT as activeTasks
  participant HP as handlePause
  W->>AT: insert ActiveTask (before retries)
  loop retry/backoff
    W->>W: downloadTask / interruptibleSleep
    Note over AT: task remains visible
  end
  W->>AT: delete after task done
  Note over HP: after workers exit
  HP->>AT: RemainingTask() per entry
  HP->>HP: save remaining + computed Downloaded
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test: add regression test for pause duri..."](https://github.com/surgedm/surge/commit/2948d4a3b70efc2b79a8af2403e1842ae3885ef4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48250942)</sub>

<!-- /greptile_comment -->