### PR TITLE
ci: fix docker build race condition with release

### DIFF
--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -52,6 +52,25 @@ jobs:
           fi
           echo "version=$SURGE_VERSION" >> $GITHUB_OUTPUT
 
+      - name: Wait for Release Assets
+        run: |
+          VERSION="${{ steps.surge-version.outputs.version }}"
+          echo "Waiting for release assets for version v$VERSION to be published..."
+          MAX_RETRIES=60
+          RETRY_INTERVAL=20
+          
+          for ((i=1; i<=MAX_RETRIES; i++)); do
+            if curl -s -f -I "https://github.com/SurgeDM/Surge/releases/download/v${VERSION}/surge_${VERSION}_linux_amd64.tar.gz" > /dev/null; then
+              echo "Release assets are available!"
+              exit 0
+            fi
+            echo "Attempt $i/$MAX_RETRIES: Release not ready yet, waiting ${RETRY_INTERVAL}s..."
+            sleep $RETRY_INTERVAL
+          done
+          
+          echo "Timeout waiting for release assets after $((MAX_RETRIES * RETRY_INTERVAL / 60)) minutes."
+          exit 1
+
       - name: Decide latest tag behavior
         id: latest-tag
         run: |

--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -56,11 +56,14 @@ jobs:
         run: |
           VERSION="${{ steps.surge-version.outputs.version }}"
           echo "Waiting for release assets for version v$VERSION to be published..."
-          MAX_RETRIES=60
+          MAX_RETRIES=180
           RETRY_INTERVAL=20
           
+          AMD64_URL="https://github.com/SurgeDM/Surge/releases/download/v${VERSION}/surge_${VERSION}_linux_amd64.tar.gz"
+          ARM64_URL="https://github.com/SurgeDM/Surge/releases/download/v${VERSION}/surge_${VERSION}_linux_arm64.tar.gz"
+          
           for ((i=1; i<=MAX_RETRIES; i++)); do
-            if curl -s -f -I "https://github.com/SurgeDM/Surge/releases/download/v${VERSION}/surge_${VERSION}_linux_amd64.tar.gz" > /dev/null; then
+            if curl -s -f -I "$AMD64_URL" > /dev/null && curl -s -f -I "$ARM64_URL" > /dev/null; then
               echo "Release assets are available!"
               exit 0
             fi


### PR DESCRIPTION
Wait for release assets to be ready before building docker image to fix exit code 22 error.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a pre-build wait so Docker image builds only start after GitHub release assets exist.
- New "Wait for Release Assets" step polls both `linux_amd64` and `linux_arm64` tarball URLs with HEAD requests.
- Retries up to 180 times every 20s (~60 minutes) before failing the job.
- Intended to fix curl exit code 22 when the multi-arch Dockerfile downloads binaries before GoReleaser finishes uploading.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This PR appears safe to merge; prior wait-step gaps are addressed and no blocking failure remains.

Both architectures are required before the build proceeds, and the wait window is long enough that no blocking failure remains from the earlier race/timeout issues.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the release assets gate harness to establish the baseline behavior for the gate, confirming the amd64 HEAD request exits with code 0.
- Ran the first gate attempt; the harness shows it requests both assets and retries because arm64 returns 22.
- Ran the second gate attempt; both assets return 0 and the gate exits successfully.
- Ran the timeout scenario; after two attempts the gate exits with code 1 because arm64 never becomes ready.

<a href="https://app.greptile.com/trex/runs/16363657/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/build-push-images.yml | Wait step now gates on both amd64 and arm64 assets with a ~60-minute timeout before the multi-arch Docker build. |

</details>

<sub>Reviews (2): Last reviewed commit: ["ci: wait for both amd64 and arm64 assets..."](https://github.com/surgedm/surge/commit/c132369db41dc95e30a8e7724b82f4e63628ab7c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48254774)</sub>

<!-- /greptile_comment -->