### PR TITLE
fix: deduplicate hedged tasks during pause to prevent progress rollback

### DIFF
--- a/internal/strategy/concurrent/downloader.go
+++ b/internal/strategy/concurrent/downloader.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/SurgeDM/Surge/internal/progress"
@@ -312,6 +313,10 @@ func (d *ConcurrentDownloader) Download(ctx context.Context, rawurl string, cand
 	}
 
 	if downloadErr != nil {
+		// Save state so that retries (like rate limit backoffs) resume from the correct progress
+		if d.State != nil && !errors.Is(downloadErr, context.Canceled) {
+			_ = d.saveStateSnapshot(destPath, fileSize, queue, candidateMirrors, false)
+		}
 		return downloadErr
 	}
 	if downloadCtx.Err() != nil {
@@ -550,27 +555,46 @@ func (d *ConcurrentDownloader) executeWorkers(ctx context.Context, cancel contex
 }
 
 func (d *ConcurrentDownloader) handlePause(destPath string, fileSize int64, queue *TaskQueue, candidateMirrors []string) error {
+	return d.saveStateSnapshot(destPath, fileSize, queue, candidateMirrors, true)
+}
+
+func (d *ConcurrentDownloader) saveStateSnapshot(destPath string, fileSize int64, queue *TaskQueue, candidateMirrors []string, emitPauseEvent bool) error {
 	// 1. Collect active tasks as remaining work FIRST
 	var activeRemaining []types.Task
 	d.activeMu.Lock()
 	for _, active := range d.activeTasks {
 		if remaining := active.RemainingTask(); remaining != nil {
+			// Temporarily attach SharedMaxOffset for deduplication (cleared later)
+			if active.SharedMaxOffset != nil {
+				remaining.SharedMaxOffset = active.SharedMaxOffset
+			}
 			activeRemaining = append(activeRemaining, *remaining)
 		}
 	}
 	d.activeMu.Unlock()
 
 	// 2. Collect remaining tasks from queue
-	remainingTasks := queue.DrainRemaining()
-	remainingTasks = append(remainingTasks, activeRemaining...)
+	allTasks := append([]types.Task(nil), activeRemaining...)
+	allTasks = append(allTasks, queue.DrainRemaining()...)
 
-	// Calculate Downloaded from remaining tasks (ensures consistency)
+	var remainingTasks []types.Task
 	var remainingBytes int64
-	for _, task := range remainingTasks {
+	seenHedged := make(map[*atomic.Int64]bool)
+
+	for _, task := range allTasks {
+		if task.SharedMaxOffset != nil {
+			if seenHedged[task.SharedMaxOffset] {
+				continue
+			}
+			seenHedged[task.SharedMaxOffset] = true
+			task.SharedMaxOffset = nil // Clear it so hot resume doesn't pin ranges as hedged
+		}
+		remainingTasks = append(remainingTasks, task)
 		remainingBytes += task.Length
 	}
+	
 	if remainingBytes == 0 {
-		utils.Debug("Download pause requested at completion boundary; finalizing as completed")
+		utils.Debug("Download state save requested at completion boundary; finalizing as completed")
 		d.State.Resume()
 		_, _ = d.State.FinalizeSession(fileSize)
 		return nil
@@ -609,23 +633,34 @@ func (d *ConcurrentDownloader) handlePause(destPath string, fileSize int64, queu
 		Workers:         d.Runtime.Workers,
 		MinChunkSize:    d.Runtime.MinChunkSize,
 	}
-	if d.ProgressChan != nil {
-		d.ProgressChan <- types.DownloadEvent{
-			Type:         types.EventPaused,
-			DownloadID:   d.ID,
-			Filename:     filepath.Base(destPath),
-			Downloaded:   computedDownloaded,
-			State:        s,
-			RateLimit:    rateLimit,
-			RateLimitSet: rateLimitSet,
-			Workers:      d.Runtime.Workers,
-			MinChunkSize: d.Runtime.MinChunkSize,
+	
+	if emitPauseEvent {
+		if d.ProgressChan != nil {
+			d.ProgressChan <- types.DownloadEvent{
+				Type:         types.EventPaused,
+				DownloadID:   d.ID,
+				Filename:     filepath.Base(destPath),
+				Downloaded:   computedDownloaded,
+				State:        s,
+				RateLimit:    rateLimit,
+				RateLimitSet: rateLimitSet,
+				Workers:      d.Runtime.Workers,
+				MinChunkSize: d.Runtime.MinChunkSize,
+			}
 		}
+		utils.Debug("Download paused, state saved (Downloaded=%d, RemainingTasks=%d, RemainingBytes=%d)",
+			computedDownloaded, len(remainingTasks), remainingBytes)
+		return types.ErrPaused
 	}
 
-	utils.Debug("Download paused, state saved (Downloaded=%d, RemainingTasks=%d, RemainingBytes=%d)",
-		computedDownloaded, len(remainingTasks), remainingBytes)
-	return types.ErrPaused
+	// Direct save on error/retry paths
+	saveErr := store.SaveStateWithOptions(d.URL, destPath, s, store.SaveStateOptions{SkipFileHash: true})
+	if saveErr != nil {
+		utils.Debug("Failed to save state snapshot: %v", saveErr)
+	} else {
+		utils.Debug("Saved progress state snapshot (Downloaded=%d, RemainingTasks=%d)", s.Downloaded, len(s.Tasks))
+	}
+	return nil
 }
 
 func (d *ConcurrentDownloader) syncFile(outFile *os.File) error {

--- a/internal/strategy/concurrent/downloader_helpers_test.go
+++ b/internal/strategy/concurrent/downloader_helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 
 	"github.com/SurgeDM/Surge/internal/progress"
@@ -269,5 +270,85 @@ func TestHandlePause_CompletionFinalization(t *testing.T) {
 
 	if progState.IsPaused() {
 		t.Error("Should have resumed state for completion")
+	}
+}
+
+func TestSaveStateSnapshot_HedgeOrderingAndResume(t *testing.T) {
+	tmpDir := testutil.SetupStateDB(t)
+	cleanup := func() {}
+	defer cleanup()
+
+	fileSize := int64(1000)
+	destPath := filepath.Join(tmpDir, "hedge.bin")
+	state := progress.New("test-id", fileSize)
+	downloader := &ConcurrentDownloader{
+		ID:      "test-id",
+		State:   state,
+		Runtime: &types.RuntimeConfig{},
+		URL:     "http://example.com/hedge.bin",
+		activeTasks: make(map[int]*ActiveTask),
+	}
+	
+	if err := store.AddToMasterList(types.DownloadRecord{
+		ID:         "test-id",
+		URL:        "http://example.com/hedge.bin",
+		DestPath:   destPath,
+		Status:     "downloading",
+		TotalSize:  fileSize,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	queue := NewTaskQueue()
+	
+	// Create a shared offset pointer
+	sharedOffset := &atomic.Int64{}
+	sharedOffset.Store(500)
+
+	// Simulate a queued hedge task that was created when the offset was 500
+	queue.Push(types.Task{
+		Offset:          500,
+		Length:          500, // 1000 - 500
+		SharedMaxOffset: sharedOffset,
+	})
+
+	// Simulate an active worker that has advanced to 600
+	active := &ActiveTask{
+		SharedMaxOffset: sharedOffset,
+	}
+	active.CurrentOffset.Store(600)
+	active.StopAt.Store(1000)
+	
+	downloader.activeTasks[0] = active
+
+	// Run saveStateSnapshot directly (false to not emit EventPaused, just write to store)
+	err := downloader.saveStateSnapshot(destPath, fileSize, queue, nil, false)
+	if err != nil {
+		t.Fatalf("saveStateSnapshot failed: %v", err)
+	}
+
+	// Load the saved state to verify
+	saved, err := store.LoadState(downloader.URL, destPath)
+	if err != nil {
+		t.Fatalf("failed to load saved state: %v", err)
+	}
+
+	if len(saved.Tasks) != 1 {
+		t.Fatalf("Expected exactly 1 deduplicated task, got %d", len(saved.Tasks))
+	}
+
+	task := saved.Tasks[0]
+	// If active worker won deduplication, Length should be 400 (1000-600).
+	// If queued task won, Length would be 500.
+	if task.Length != 400 {
+		t.Errorf("Expected remaining length 400 (active task won), got %d (queued task won?)", task.Length)
+	}
+	if task.Offset != 600 {
+		t.Errorf("Expected remaining offset 600, got %d", task.Offset)
+	}
+
+	// Verify SharedMaxOffset is cleared to prevent hot-resume pinning
+	if task.SharedMaxOffset != nil {
+		t.Errorf("Expected SharedMaxOffset to be cleared, but it was not nil")
 	}
 }

--- a/internal/strategy/concurrent/task.go
+++ b/internal/strategy/concurrent/task.go
@@ -36,24 +36,39 @@ type ActiveTask struct {
 	WaitingOnLimiter atomic.Bool
 }
 
-// RemainingBytes returns the number of bytes left for this task
-func (at *ActiveTask) RemainingBytes() int64 {
+// currentOffset returns the effective offset, using the shared max if it is larger
+func (at *ActiveTask) currentOffset() int64 {
 	current := at.CurrentOffset.Load()
+	if at.SharedMaxOffset != nil {
+		if shared := at.SharedMaxOffset.Load(); shared > current {
+			current = shared
+		}
+	}
+	return current
+}
+
+// RemainingTask returns a Task representing the remaining work, or nil if complete
+func (at *ActiveTask) RemainingTask() *types.Task {
+	current := at.currentOffset()
+	stopAt := at.StopAt.Load()
+	if current >= stopAt {
+		return nil
+	}
+	
+	return &types.Task{
+		Offset: current, 
+		Length: stopAt - current,
+	}
+}
+
+// RemainingBytes returns the number of bytes left in the current task
+func (at *ActiveTask) RemainingBytes() int64 {
+	current := at.currentOffset()
 	stopAt := at.StopAt.Load()
 	if current >= stopAt {
 		return 0
 	}
 	return stopAt - current
-}
-
-// RemainingTask returns a Task representing the remaining work, or nil if complete
-func (at *ActiveTask) RemainingTask() *types.Task {
-	current := at.CurrentOffset.Load()
-	stopAt := at.StopAt.Load()
-	if current >= stopAt {
-		return nil
-	}
-	return &types.Task{Offset: current, Length: stopAt - current}
 }
 
 // GetSpeed returns the current EMA-smoothed speed, decaying if stalled


### PR DESCRIPTION
Fixes a bug where hedged workers were double-counted during pause, causing progress to artificially roll back upon resume.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes hedged-task double-counting on pause so progress no longer rolls back on resume.
- Prefer active RemainingTask results over queued hedges, dedupe by SharedMaxOffset, and clear that pointer before save/resume.
- Share effective-offset logic via currentOffset() for RemainingTask and RemainingBytes.
- Snapshot progress on non-cancel download errors for retry continuity; add hedge ordering/resume coverage.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This PR appears safe to merge; hedge pause/resume handling is addressed and no blocking failures remain.

Active-first SharedMaxOffset deduplication, cleared hedge pointers before save/resume, shared remaining-offset logic, and hedge snapshot coverage leave no blocking failure on the changed path.

**Files Needing Attention:** No files need additional attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Before the validation, the run exited with code 1 and two tasks: offset 500, length 500, shared false; and offset 600, length 400, shared true.
- After the validation, the run exited with code 0 and a single task: offset 600, length 400, shared true (SharedMaxOffset == nil).
- All three focused -race tests passed.
- Artifacts were captured to support review: logs of the test runs and the Go source used for the contract validation.

<a href="https://app.greptile.com/trex/runs/16367452/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/strategy/concurrent/downloader.go | Pause/snapshot now keeps fresher active hedge remainders, clears SharedMaxOffset for resume, and can persist state on error retries. |
| internal/strategy/concurrent/task.go | RemainingTask/RemainingBytes both use shared max offset through currentOffset(). |
| internal/strategy/concurrent/downloader_helpers_test.go | Adds hedge pause ordering and SharedMaxOffset-cleared resume assertions. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: deduplicate hedged tasks during pau..."](https://github.com/surgedm/surge/commit/fa11d77163de34286e6b6c162cf0adc4516c7ff7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48260629)</sub>

<!-- /greptile_comment -->