### PR TITLE
fix: align Dockerfile download paths with actual release asset names

### DIFF
--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -59,11 +59,11 @@ jobs:
           MAX_RETRIES=180
           RETRY_INTERVAL=20
           
-          AMD64_URL="https://github.com/SurgeDM/Surge/releases/download/v${VERSION}/surge_${VERSION}_linux_amd64.tar.gz"
-          ARM64_URL="https://github.com/SurgeDM/Surge/releases/download/v${VERSION}/surge_${VERSION}_linux_arm64.tar.gz"
+          AMD64_URL="https://github.com/SurgeDM/Surge/releases/download/v${VERSION}/Surge_${VERSION}_linux_amd64.tar.gz"
+          ARM64_URL="https://github.com/SurgeDM/Surge/releases/download/v${VERSION}/Surge_${VERSION}_linux_arm64.tar.gz"
           
           for ((i=1; i<=MAX_RETRIES; i++)); do
-            if curl -s -f -I "$AMD64_URL" > /dev/null && curl -s -f -I "$ARM64_URL" > /dev/null; then
+            if curl -s -f -I -L "$AMD64_URL" > /dev/null && curl -s -f -I -L "$ARM64_URL" > /dev/null; then
               echo "Release assets are available!"
               exit 0
             fi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,7 @@ RUN if [ "${TARGETOS:-linux}" != "linux" ]; then \
     fi && \
     echo "Downloading surge v${SURGE_VERSION} for ${TARGETOS:-linux}/${SURGE_ARCH}" && \
     curl -fsSL -o /tmp/surge.tar.gz \
-      "https://github.com/SurgeDM/Surge/releases/download/v${SURGE_VERSION}/surge_${SURGE_VERSION}_linux_${SURGE_ARCH}.tar.gz" && \
+      "https://github.com/SurgeDM/Surge/releases/download/v${SURGE_VERSION}/Surge_${SURGE_VERSION}_linux_${SURGE_ARCH}.tar.gz" && \
     mkdir -p /tmp/surge-extract /out && \
     tar -xzf /tmp/surge.tar.gz -C /tmp/surge-extract && \
     install -m 0755 /tmp/surge-extract/surge /out/surge


### PR DESCRIPTION
Fixes #569

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes Docker image build download URLs and the release-asset wait check to match GoReleaser’s actual asset names (`Surge_${VERSION}_linux_*.tar.gz` instead of lowercase `surge_`), and adds `-L` so the availability HEAD checks follow GitHub CDN redirects.

- Updates `docker/Dockerfile` release asset URL prefix from `surge_` to `Surge_`
- Aligns wait-for-release AMD64/ARM64 URLs the same way in `build-push-images.yml`
- Adds `curl -L` on the release-asset availability HEAD checks
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This PR appears safe to merge; it corrects release asset URL casing and redirect following with no remaining blocking defects.

GoReleaser’s name_template and observed release assets use Surge_ prefixes, the Dockerfile already downloads with -L, and no other lowercase surge_ asset URLs remain in the repo.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The initial HEAD probes to the release asset URLs showed HTTP 302 Found, demonstrating that headers alone did not establish final asset availability.
- We corrected the URLs to be case-sensitive and enabled -L to follow redirects, then re-ran the asset fetch for both amd64 and arm64.
- The final fetch returned HTTP 200 OK for both architectures, with the amd64 download transferring 6,222,209 bytes.
- Verification of the downloaded tarball contents with tar -tzf completed successfully, listing LICENSE, README.md, and surge.

<a href="https://app.greptile.com/trex/runs/16387542/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docker/Dockerfile | Updates the downloader stage release URL prefix from surge_ to Surge_ to match GoReleaser ProjectName-based archive names. |
| .github/workflows/build-push-images.yml | Aligns wait-for-release asset URLs with Surge_ naming and adds curl -L so HEAD checks follow redirects before the multi-arch image build. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: align Dockerfile download paths wit..."](https://github.com/surgedm/surge/commit/570e2f766e5ec2a49be8f3c72aaa8892bc072f39) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48303892)</sub>

<!-- /greptile_comment -->