### PR TITLE
ci: add go fmt workflow and apply formatting

### DIFF
--- a/.github/workflows/go-fmt.yml
+++ b/.github/workflows/go-fmt.yml
@@ -1,0 +1,34 @@
+name: Go Fmt
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**.go'
+  pull_request:
+    paths:
+      - '**.go'
+
+permissions:
+  contents: write
+
+jobs:
+  go-fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+          
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.0'
+
+      - name: Run go fmt
+        run: go fmt ./...
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "style: run go fmt"

--- a/internal/strategy/concurrent/concurrent_test.go
+++ b/internal/strategy/concurrent/concurrent_test.go
@@ -496,7 +496,7 @@ func TestConcurrentDownloader_RetryOnFailure(t *testing.T) {
 	state := progress.New("retry-test", fileSize)
 	runtime := &types.RuntimeConfig{
 		MaxConnectionsPerDownload: 2,
-		MaxTaskRetries:            5, 
+		MaxTaskRetries:            5,
 		MinChunkSize:              64 * utils.KiB,
 	}
 
@@ -817,7 +817,6 @@ func TestConcurrentDownloader_Download_BootstrapFail_InvalidRange(t *testing.T) 
 		t.Errorf("Expected range error, got: %v", err)
 	}
 }
-
 
 func TestConcurrentDownloader_PauseDuringRetryBackoff(t *testing.T) {
 	tmpDir, cleanup := initTestState(t)

--- a/internal/strategy/concurrent/downloader.go
+++ b/internal/strategy/concurrent/downloader.go
@@ -592,7 +592,7 @@ func (d *ConcurrentDownloader) saveStateSnapshot(destPath string, fileSize int64
 		remainingTasks = append(remainingTasks, task)
 		remainingBytes += task.Length
 	}
-	
+
 	if remainingBytes == 0 {
 		utils.Debug("Download state save requested at completion boundary; finalizing as completed")
 		d.State.Resume()
@@ -633,7 +633,7 @@ func (d *ConcurrentDownloader) saveStateSnapshot(destPath string, fileSize int64
 		Workers:         d.Runtime.Workers,
 		MinChunkSize:    d.Runtime.MinChunkSize,
 	}
-	
+
 	if emitPauseEvent {
 		if d.ProgressChan != nil {
 			d.ProgressChan <- types.DownloadEvent{

--- a/internal/strategy/concurrent/downloader_helpers_test.go
+++ b/internal/strategy/concurrent/downloader_helpers_test.go
@@ -282,25 +282,25 @@ func TestSaveStateSnapshot_HedgeOrderingAndResume(t *testing.T) {
 	destPath := filepath.Join(tmpDir, "hedge.bin")
 	state := progress.New("test-id", fileSize)
 	downloader := &ConcurrentDownloader{
-		ID:      "test-id",
-		State:   state,
-		Runtime: &types.RuntimeConfig{},
-		URL:     "http://example.com/hedge.bin",
+		ID:          "test-id",
+		State:       state,
+		Runtime:     &types.RuntimeConfig{},
+		URL:         "http://example.com/hedge.bin",
 		activeTasks: make(map[int]*ActiveTask),
 	}
-	
+
 	if err := store.AddToMasterList(types.DownloadRecord{
-		ID:         "test-id",
-		URL:        "http://example.com/hedge.bin",
-		DestPath:   destPath,
-		Status:     "downloading",
-		TotalSize:  fileSize,
+		ID:        "test-id",
+		URL:       "http://example.com/hedge.bin",
+		DestPath:  destPath,
+		Status:    "downloading",
+		TotalSize: fileSize,
 	}); err != nil {
 		t.Fatal(err)
 	}
 
 	queue := NewTaskQueue()
-	
+
 	// Create a shared offset pointer
 	sharedOffset := &atomic.Int64{}
 	sharedOffset.Store(500)
@@ -318,7 +318,7 @@ func TestSaveStateSnapshot_HedgeOrderingAndResume(t *testing.T) {
 	}
 	active.CurrentOffset.Store(600)
 	active.StopAt.Store(1000)
-	
+
 	downloader.activeTasks[0] = active
 
 	// Run saveStateSnapshot directly (false to not emit EventPaused, just write to store)

--- a/internal/strategy/concurrent/task.go
+++ b/internal/strategy/concurrent/task.go
@@ -54,9 +54,9 @@ func (at *ActiveTask) RemainingTask() *types.Task {
 	if current >= stopAt {
 		return nil
 	}
-	
+
 	return &types.Task{
-		Offset: current, 
+		Offset: current,
 		Length: stopAt - current,
 	}
 }

--- a/internal/utils/http_test.go
+++ b/internal/utils/http_test.go
@@ -17,31 +17,31 @@ func TestSameSite(t *testing.T) {
 		{"exact same domain", "example.com", "example.com", true},
 		{"exact same IP", "127.0.0.1", "127.0.0.1", true},
 		{"exact same IPv6", "[::1]", "[::1]", true},
-		
+
 		// Subdomains on standard TLDs
 		{"standard TLD subdomains", "a.example.com", "b.example.com", true},
 		{"deep subdomains", "x.y.z.example.com", "example.com", true},
 		{"easynews subdomains", "members.easynews.com", "iad-dl-08.easynews.com", true},
-		
+
 		// Complex TLDs (eTLD+1)
 		{"complex TLD subdomains", "a.example.co.uk", "b.example.co.uk", true},
 		{"different sites on complex TLD", "example.co.uk", "other.co.uk", false},
 		{"github.io subdomains (private TLD)", "user1.github.io", "user2.github.io", false},
 		{"github.io same site", "user1.github.io", "sub.user1.github.io", true},
-		
+
 		// Cross-site cases
 		{"filmyzilla cross-site domains", "1.filmyzilla.vin", "cdn-02-nl-zilla.filmyzdl.com", false},
 		{"different domains", "example.com", "other.com", false},
 		{"different TLDs", "example.com", "example.org", false},
 		{"IP vs localhost", "127.0.0.1", "localhost", false},
 		{"different IPs", "192.168.1.1", "192.168.1.2", false},
-		
+
 		// Port handling
 		{"with same ports", "example.com:8080", "sub.example.com:8080", true},
 		{"with different ports", "example.com:80", "sub.example.com:443", true},
 		{"IP with port", "127.0.0.1:8080", "127.0.0.1:9090", true},
 		{"one with port, one without", "example.com", "sub.example.com:8080", true},
-		
+
 		// Malformed or empty
 		{"empty strings", "", "", true},
 		{"one empty string", "example.com", "", false},
@@ -144,11 +144,11 @@ func TestCopyRedirectHeaders(t *testing.T) {
 		},
 		// Edge cases
 		{
-			name:   "nil request headers safe check",
-			dstURL: "https://b.example.com",
-			srcURL: "https://a.example.com",
-			srcHeaders: nil, // shouldn't panic
-			initialDstHdr: http.Header{},
+			name:           "nil request headers safe check",
+			dstURL:         "https://b.example.com",
+			srcURL:         "https://a.example.com",
+			srcHeaders:     nil, // shouldn't panic
+			initialDstHdr:  http.Header{},
 			expectedDstHdr: http.Header{},
 		},
 		{
@@ -201,11 +201,11 @@ func TestCopyRedirectHeaders(t *testing.T) {
 func TestCopyRedirectHeaders_NilRequests(t *testing.T) {
 	// Should not panic
 	CopyRedirectHeaders(nil, nil)
-	
+
 	req := &http.Request{URL: mustParseURL(t, "https://example.com")}
 	CopyRedirectHeaders(req, nil)
 	CopyRedirectHeaders(nil, req)
-	
+
 	reqNoURL := &http.Request{}
 	CopyRedirectHeaders(req, reqNoURL)
 	CopyRedirectHeaders(reqNoURL, req)


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to automatically run `go fmt` on Go source files and commits any changes. It also includes formatting fixes applied to the codebase.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a GitHub Actions workflow that runs `go fmt ./...` and auto-commits formatting fixes, and applies whitespace-only gofmt cleanups under `internal/strategy/concurrent/`.

- New `.github/workflows/go-fmt.yml` on `push` to `main` and `pull_request` when `**.go` changes, with `contents: write` and `stefanzweifel/git-auto-commit-action@v5`.
- Formatting-only edits in concurrent downloader/task/test files (blank lines and struct field alignment).
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Not safe to merge as-is until the Go Fmt workflow’s pull_request auto-commit path is fixed for forks (or replaced with a check-only fmt gate).

The Go source edits are pure formatting, but the new workflow will fail or mis-handle external PRs when it tries to push fmt commits with a read-only fork token and base-repo checkout, and the write job still uses mutable action tags.

**Files Needing Attention:** .github/workflows/go-fmt.yml
</details>

<details open><summary><h3>Security Review</h3></summary>

No proven exploitable vulnerability in this PR. Residual hardening concern: the write-capable fmt job references actions by mutable tags (`@v4`/`@v5`), so a compromised tag could abuse the job token to push commits; pin actions to full SHAs if keeping auto-commit.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The executable harness validated the fork PR auto-commit workflow, including the pull\_request trigger, base-repository head-ref checkout, go fmt command, and auto-commit configuration.
- The simulated fork PR run produced a formatting commit on the contributor-named branch in the base repository.
- The read-only permission simulation rejected the push with a 403 error and exit code 1, leaving the remote tip unchanged.
- Artifacts capturing the repro harness and the verbose trace of the formatting commit and rejected push were preserved for review.

<a href="https://app.greptile.com/trex/runs/16389085/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/go-fmt.yml | New auto-fmt workflow with write + auto-commit; fork PRs and mutable action pins are the main risks. |
| internal/strategy/concurrent/downloader.go | Whitespace-only gofmt cleanup; no behavioral change. |
| internal/strategy/concurrent/task.go | Whitespace-only gofmt cleanup in RemainingTask. |
| internal/strategy/concurrent/concurrent_test.go | Removes an extra blank line only. |
| internal/strategy/concurrent/downloader_helpers_test.go | gofmt field alignment and blank-line cleanup in tests. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
A[push main or PR with *.go] --> B[checkout ref head_ref or ref_name]
B --> C[setup-go 1.25.0]
C --> D[go fmt ./...]
D --> E[git-auto-commit-action]
E -->|same-repo branch + write token| F[push style commit]
E -->|fork PR read-only token| G[push fails / check red]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/go-fmt.yml:9-34
**Fork PR auto-commit fails**

When a pull_request from a fork touches `**.go` files, this job checks out the base repository with `ref: ${{ github.head_ref || github.ref_name }}` (no `repository` override) and then runs `git-auto-commit-action` under `permissions: contents: write`. GitHub still issues a read-only `GITHUB_TOKEN` for fork `pull_request` runs, so the push step fails with a permission error and the Go Fmt check goes red without updating the contributor branch. Prefer a check-only `gofmt -l` gate on PRs, or restrict auto-commit to same-repo branches with an explicit non-fork guard.

### Issue 2
.github/workflows/go-fmt.yml:20-34
**Mutable tags with write access**

This job grants `contents: write` and runs `actions/checkout@v4`, `actions/setup-go@v5`, and `stefanzweifel/git-auto-commit-action@v5` by mutable tags. A retargeted tag can execute arbitrary code with the job token and push commits. Pin each `uses:` line to a full commit SHA while keeping write access for auto-commit.

**How this was verified:** Traced the write-capable job token through checkout, setup-go, and git-auto-commit steps that all resolve actions by mutable version tags.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into go-fmt"](https://github.com/surgedm/surge/commit/56be0b8343d3e3d5e8e11a17987ba4015c9b5fac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48306473)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->