### PR TITLE
fix/phantom progress on 403

### DIFF
--- a/internal/strategy/concurrent/concurrent_test.go
+++ b/internal/strategy/concurrent/concurrent_test.go
@@ -818,7 +818,6 @@ func TestConcurrentDownloader_Download_BootstrapFail_InvalidRange(t *testing.T) 
 	}
 }
 
-
 func TestConcurrentDownloader_PauseDuringRetryBackoff(t *testing.T) {
 	tmpDir, cleanup := initTestState(t)
 	defer cleanup()

--- a/internal/strategy/concurrent/downloader.go
+++ b/internal/strategy/concurrent/downloader.go
@@ -564,10 +564,6 @@ func (d *ConcurrentDownloader) saveStateSnapshot(destPath string, fileSize int64
 	d.activeMu.Lock()
 	for _, active := range d.activeTasks {
 		if remaining := active.RemainingTask(); remaining != nil {
-			// Temporarily attach SharedMaxOffset for deduplication (cleared later)
-			if active.SharedMaxOffset != nil {
-				remaining.SharedMaxOffset = active.SharedMaxOffset
-			}
 			activeRemaining = append(activeRemaining, *remaining)
 		}
 	}

--- a/internal/strategy/concurrent/downloader.go
+++ b/internal/strategy/concurrent/downloader.go
@@ -592,7 +592,7 @@ func (d *ConcurrentDownloader) saveStateSnapshot(destPath string, fileSize int64
 		remainingTasks = append(remainingTasks, task)
 		remainingBytes += task.Length
 	}
-	
+
 	if remainingBytes == 0 {
 		utils.Debug("Download state save requested at completion boundary; finalizing as completed")
 		d.State.Resume()
@@ -633,7 +633,7 @@ func (d *ConcurrentDownloader) saveStateSnapshot(destPath string, fileSize int64
 		Workers:         d.Runtime.Workers,
 		MinChunkSize:    d.Runtime.MinChunkSize,
 	}
-	
+
 	if emitPauseEvent {
 		if d.ProgressChan != nil {
 			d.ProgressChan <- types.DownloadEvent{

--- a/internal/strategy/concurrent/downloader_helpers_test.go
+++ b/internal/strategy/concurrent/downloader_helpers_test.go
@@ -282,25 +282,25 @@ func TestSaveStateSnapshot_HedgeOrderingAndResume(t *testing.T) {
 	destPath := filepath.Join(tmpDir, "hedge.bin")
 	state := progress.New("test-id", fileSize)
 	downloader := &ConcurrentDownloader{
-		ID:      "test-id",
-		State:   state,
-		Runtime: &types.RuntimeConfig{},
-		URL:     "http://example.com/hedge.bin",
+		ID:          "test-id",
+		State:       state,
+		Runtime:     &types.RuntimeConfig{},
+		URL:         "http://example.com/hedge.bin",
 		activeTasks: make(map[int]*ActiveTask),
 	}
-	
+
 	if err := store.AddToMasterList(types.DownloadRecord{
-		ID:         "test-id",
-		URL:        "http://example.com/hedge.bin",
-		DestPath:   destPath,
-		Status:     "downloading",
-		TotalSize:  fileSize,
+		ID:        "test-id",
+		URL:       "http://example.com/hedge.bin",
+		DestPath:  destPath,
+		Status:    "downloading",
+		TotalSize: fileSize,
 	}); err != nil {
 		t.Fatal(err)
 	}
 
 	queue := NewTaskQueue()
-	
+
 	// Create a shared offset pointer
 	sharedOffset := &atomic.Int64{}
 	sharedOffset.Store(500)
@@ -318,7 +318,7 @@ func TestSaveStateSnapshot_HedgeOrderingAndResume(t *testing.T) {
 	}
 	active.CurrentOffset.Store(600)
 	active.StopAt.Store(1000)
-	
+
 	downloader.activeTasks[0] = active
 
 	// Run saveStateSnapshot directly (false to not emit EventPaused, just write to store)

--- a/internal/strategy/concurrent/task.go
+++ b/internal/strategy/concurrent/task.go
@@ -37,10 +37,10 @@ type ActiveTask struct {
 }
 
 // currentOffset returns the effective offset, using the shared max if it is larger
-func (at *ActiveTask) currentOffset() int64 {
+func (at *ActiveTask) currentOffset(sharedMax *atomic.Int64) int64 {
 	current := at.CurrentOffset.Load()
-	if at.SharedMaxOffset != nil {
-		if shared := at.SharedMaxOffset.Load(); shared > current {
+	if sharedMax != nil {
+		if shared := sharedMax.Load(); shared > current {
 			current = shared
 		}
 	}
@@ -49,15 +49,15 @@ func (at *ActiveTask) currentOffset() int64 {
 
 // RemainingTask returns a Task representing the remaining work, or nil if complete
 func (at *ActiveTask) RemainingTask() *types.Task {
-	current := at.currentOffset()
+	at.SharedMaxOffsetMu.RLock()
+	sharedMax := at.SharedMaxOffset
+	at.SharedMaxOffsetMu.RUnlock()
+
+	current := at.currentOffset(sharedMax)
 	stopAt := at.StopAt.Load()
 	if current >= stopAt {
 		return nil
 	}
-
-	at.SharedMaxOffsetMu.RLock()
-	sharedMax := at.SharedMaxOffset
-	at.SharedMaxOffsetMu.RUnlock()
 
 	return &types.Task{
 		Offset:          current,
@@ -68,7 +68,11 @@ func (at *ActiveTask) RemainingTask() *types.Task {
 
 // RemainingBytes returns the number of bytes left in the current task
 func (at *ActiveTask) RemainingBytes() int64 {
-	current := at.currentOffset()
+	at.SharedMaxOffsetMu.RLock()
+	sharedMax := at.SharedMaxOffset
+	at.SharedMaxOffsetMu.RUnlock()
+
+	current := at.currentOffset(sharedMax)
 	stopAt := at.StopAt.Load()
 	if current >= stopAt {
 		return 0

--- a/internal/strategy/concurrent/task.go
+++ b/internal/strategy/concurrent/task.go
@@ -54,9 +54,9 @@ func (at *ActiveTask) RemainingTask() *types.Task {
 	if current >= stopAt {
 		return nil
 	}
-	
+
 	return &types.Task{
-		Offset: current, 
+		Offset: current,
 		Length: stopAt - current,
 	}
 }

--- a/internal/strategy/concurrent/task.go
+++ b/internal/strategy/concurrent/task.go
@@ -55,9 +55,14 @@ func (at *ActiveTask) RemainingTask() *types.Task {
 		return nil
 	}
 
+	at.SharedMaxOffsetMu.RLock()
+	sharedMax := at.SharedMaxOffset
+	at.SharedMaxOffsetMu.RUnlock()
+
 	return &types.Task{
-		Offset: current,
-		Length: stopAt - current,
+		Offset:          current,
+		Length:          stopAt - current,
+		SharedMaxOffset: sharedMax,
 	}
 }
 

--- a/internal/strategy/concurrent/task_test.go
+++ b/internal/strategy/concurrent/task_test.go
@@ -2,6 +2,7 @@ package concurrent
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -170,5 +171,34 @@ func TestActiveTask_GetSpeed_Decay(t *testing.T) {
 	speed = at.GetSpeed()
 	if speed < 99.0 || speed > 101.0 {
 		t.Errorf("Extreme decayed speed = %f, want ~100.0", speed)
+	}
+}
+
+func TestActiveTask_RemainingTask_PreservesSharedMaxOffset(t *testing.T) {
+	sharedMax := &atomic.Int64{}
+	sharedMax.Store(500)
+
+	at := &ActiveTask{
+		Task:            types.Task{Offset: 0, Length: 1000, SharedMaxOffset: sharedMax},
+		SharedMaxOffset: sharedMax,
+	}
+	at.CurrentOffset.Store(200)
+	at.StopAt.Store(1000)
+
+	remaining := at.RemainingTask()
+	if remaining == nil {
+		t.Fatal("RemainingTask returned nil")
+	}
+
+	if remaining.Offset != 500 {
+		t.Errorf("RemainingTask.Offset = %d, want 500 (from SharedMaxOffset)", remaining.Offset)
+	}
+
+	if remaining.Length != 500 {
+		t.Errorf("RemainingTask.Length = %d, want 500", remaining.Length)
+	}
+
+	if remaining.SharedMaxOffset != sharedMax {
+		t.Errorf("RemainingTask.SharedMaxOffset = %v, want %v", remaining.SharedMaxOffset, sharedMax)
 	}
 }

--- a/internal/strategy/concurrent/worker.go
+++ b/internal/strategy/concurrent/worker.go
@@ -166,18 +166,21 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 			resumeOnRetryOffset(&task, activeTask)
 		}
 
-		d.activeMu.Lock()
-		delete(d.activeTasks, id)
-		d.activeMu.Unlock()
-
 		if d.State != nil {
 			d.State.ActiveWorkers.Add(-1)
 		}
 
 		if lastErr != nil {
 			utils.Debug("Worker %d: task at offset %d failed after %d retries: %v", id, task.Offset, maxRetries, lastErr)
+			// Keep the activeTasks entry alive so saveStateSnapshot can account for
+			// this task in its remainingBytes computation. The entry is cleaned up
+			// by the caller (executeWorkers) after the snapshot is saved.
 			return lastErr
 		}
+
+		d.activeMu.Lock()
+		delete(d.activeTasks, id)
+		d.activeMu.Unlock()
 	}
 }
 
@@ -230,6 +233,9 @@ func (d *ConcurrentDownloader) downloadTask(ctx context.Context, rawurl string, 
 			return fmt.Errorf("server indicated success (200) but ignored range request (expected 206)")
 		}
 	} else if resp.StatusCode != http.StatusPartialContent {
+		if types.IsPermanentHTTPStatus(resp.StatusCode) {
+			return fmt.Errorf("unexpected status: %d: %w", resp.StatusCode, types.ErrPermanentHTTP)
+		}
 		return fmt.Errorf("unexpected status: %d", resp.StatusCode)
 	}
 

--- a/internal/strategy/concurrent/worker.go
+++ b/internal/strategy/concurrent/worker.go
@@ -172,15 +172,15 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 
 		if lastErr != nil {
 			utils.Debug("Worker %d: task at offset %d failed after %d retries: %v", id, task.Offset, maxRetries, lastErr)
-			
+
 			if remain := activeTask.RemainingTask(); remain != nil {
 				queue.Push(*remain)
 			}
-			
+
 			d.activeMu.Lock()
 			delete(d.activeTasks, id)
 			d.activeMu.Unlock()
-			
+
 			return lastErr
 		}
 

--- a/internal/strategy/concurrent/worker.go
+++ b/internal/strategy/concurrent/worker.go
@@ -172,9 +172,15 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 
 		if lastErr != nil {
 			utils.Debug("Worker %d: task at offset %d failed after %d retries: %v", id, task.Offset, maxRetries, lastErr)
-			// Keep the activeTasks entry alive so saveStateSnapshot can account for
-			// this task in its remainingBytes computation. The entry is cleaned up
-			// by the caller (executeWorkers) after the snapshot is saved.
+			
+			if remain := activeTask.RemainingTask(); remain != nil {
+				queue.Push(*remain)
+			}
+			
+			d.activeMu.Lock()
+			delete(d.activeTasks, id)
+			d.activeMu.Unlock()
+			
 			return lastErr
 		}
 


### PR DESCRIPTION
- **fix: defer activeTasks removal on error and handle permanent HTTP status codes in worker execution**
- **fix(strategy/concurrent): prevent phantom progress and handle 403 as permanent error**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved download state snapshots after failed tasks so outstanding bytes are preserved accurately.
  - Ensured permanent HTTP failures return a specific permanent-error classification.
  - Improved pause handling during retry backoff, including pause notifications and accurate zero-byte state reporting.
  - Improved task recovery and cleanup after failed or completed work.
  - Preserved shared download limits when resuming remaining work.

- **Tests**
  - Added coverage for pausing downloads while waiting to retry.
  - Added coverage for preserving shared download limits during task recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->