### PR TITLE
fix issue 572

### DIFF
--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -46,15 +46,8 @@ func TestResolveDownloadID_Remote(t *testing.T) {
 
 	// 2. Mock active port file
 
-	tempDir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", tempDir)
-	t.Setenv("APPDATA", tempDir)
-	t.Setenv("HOME", tempDir)
-
-	if err := config.EnsureDirs(); err != nil {
-		t.Fatalf("EnsureDirs failed: %v", err)
-	}
-	store.Configure(filepath.Join(tempDir, "surge.db"))
+	setupIsolatedCmdState(t)
+	resetCommandConnectionState(t)
 	saveActivePort(port)
 	defer removeActivePort()
 

--- a/internal/lint/leak_test.go
+++ b/internal/lint/leak_test.go
@@ -18,7 +18,8 @@ func TestConfigLeakPrevention(t *testing.T) {
 		}
 
 		if d.IsDir() {
-			if d.Name() == "vendor" || d.Name() == ".git" || d.Name() == "node_modules" {
+			name := d.Name()
+			if name == "vendor" || name == "node_modules" || name == "testdata" || strings.HasPrefix(name, ".") || strings.HasPrefix(name, "_") {
 				return filepath.SkipDir
 			}
 			return nil
@@ -133,7 +134,8 @@ func TestGlobalGoleakEnforcement(t *testing.T) {
 		}
 
 		if d.IsDir() {
-			if d.Name() == "vendor" || d.Name() == ".git" || d.Name() == "node_modules" {
+			name := d.Name()
+			if name == "vendor" || name == "node_modules" || name == "testdata" || strings.HasPrefix(name, ".") || strings.HasPrefix(name, "_") {
 				return filepath.SkipDir
 			}
 


### PR DESCRIPTION
- **fix(concurrent): fix data race on ActiveTask fields by acquiring activeMu during retry**
- **fix(lint): ignore standard go toolchain hidden/build directories in leak tests**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Directory scanning now skips test fixtures and hidden or private directories.
  * Existing exclusions for dependency directories remain supported.
  * Improves scan accuracy by avoiding irrelevant files and folders.
  * Scan-related behavior is now more consistent across supported directory layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->