### PR TITLE
fix(concurrent): avoid extra initial remainder request

### DIFF
--- a/internal/strategy/concurrent/chunk_test.go
+++ b/internal/strategy/concurrent/chunk_test.go
@@ -23,6 +23,7 @@ func TestTaskRangeAssignment(t *testing.T) {
 		numConns  int
 		wantChunk int64
 		wantTasks int
+		wantLast  int64
 	}{
 		{
 			name:      "Exact division",
@@ -30,6 +31,7 @@ func TestTaskRangeAssignment(t *testing.T) {
 			numConns:  4,
 			wantChunk: 25 * utils.MiB,
 			wantTasks: 4,
+			wantLast:  25 * utils.MiB,
 		},
 		{
 			name:     "Uneven division",
@@ -38,11 +40,11 @@ func TestTaskRangeAssignment(t *testing.T) {
 			// 100MB / 4 = 25MB. 123 bytes remainder.
 			// Calculation: (104857600 + 123) / 4 = 26214430.
 			// Aligned: 26214430 / 4096 * 4096 = 26214400 (25MB).
-			// So chunk size is 25MB.
-			// 4 tasks of 25MB = 100MB.
-			// Remainder 123 bytes -> 5th task.
+			// So chunk size is 25MB. The final primary task absorbs the
+			// 123-byte remainder instead of creating a fifth request.
 			wantChunk: 25 * utils.MiB,
-			wantTasks: 5,
+			wantTasks: 4,
+			wantLast:  25*utils.MiB + 123,
 		},
 		{
 			name:      "Small file",
@@ -50,6 +52,31 @@ func TestTaskRangeAssignment(t *testing.T) {
 			numConns:  2,
 			wantChunk: 5 * utils.MiB,
 			wantTasks: 2,
+			wantLast:  5 * utils.MiB,
+		},
+		{
+			name:      "Tiny file",
+			fileSize:  512 * utils.KiB,
+			numConns:  4,
+			wantChunk: 1 * utils.MiB,
+			wantTasks: 1,
+			wantLast:  512 * utils.KiB,
+		},
+		{
+			name:      "One worker absorbs remainder",
+			fileSize:  10*utils.MiB + 123,
+			numConns:  1,
+			wantChunk: 10 * utils.MiB,
+			wantTasks: 1,
+			wantLast:  10*utils.MiB + 123,
+		},
+		{
+			name:      "Minimum chunk limits task count",
+			fileSize:  2 * utils.MiB,
+			numConns:  4,
+			wantChunk: 1 * utils.MiB,
+			wantTasks: 2,
+			wantLast:  1 * utils.MiB,
 		},
 	}
 
@@ -61,16 +88,18 @@ func TestTaskRangeAssignment(t *testing.T) {
 			assert.InDelta(t, tt.wantChunk, chunkSize, float64(types.AlignSize), "Chunk size mismatch")
 
 			// specific verification for task creation
-			tasks := createTasks(tt.fileSize, chunkSize)
+			tasks := createInitialTasks(tt.fileSize, chunkSize, tt.numConns)
 			assert.Equal(t, tt.wantTasks, len(tasks), "Task count mismatch")
 
 			// Verify task continuity
 			var total int64
 			for i, task := range tasks {
 				assert.Equal(t, total, task.Offset, "Task offset mismatch at index %d", i)
+				assert.Greater(t, task.Length, int64(0), "Task length must be positive at index %d", i)
 				total += task.Length
 			}
 			assert.Equal(t, tt.fileSize, total, "Total task length mismatch")
+			assert.Equal(t, tt.wantLast, tasks[len(tasks)-1].Length, "Final task length mismatch")
 		})
 	}
 }

--- a/internal/strategy/concurrent/chunk_test.go
+++ b/internal/strategy/concurrent/chunk_test.go
@@ -1,6 +1,7 @@
 package concurrent
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/SurgeDM/Surge/internal/types"
@@ -190,4 +191,51 @@ func TestCalculateChunkSize_EdgeCases(t *testing.T) {
 		got := dSmall.calculateChunkSize(1*utils.KiB, 1)
 		assert.Equal(t, int64(types.AlignSize), got, "Should be bumped to AlignSize")
 	})
+}
+
+func TestCreateInitialTasks_NeverExceedsNumConns(t *testing.T) {
+	runtime := &types.RuntimeConfig{
+		MinChunkSize: 1 * utils.MiB,
+	}
+	d := &ConcurrentDownloader{
+		Runtime: runtime,
+	}
+
+	// Matrix of file sizes and numConns to test
+	fileSizes := []int64{
+		1,                               // tiny
+		types.AlignSize - 1,             // almost aligned
+		types.AlignSize,                 // perfectly aligned
+		1 * utils.MiB,                   // small
+		1*utils.MiB + 1,                 // slight remainder
+		10*utils.MiB + 12345,            // medium remainder
+		100 * utils.MiB,                 // large aligned
+		100*utils.MiB + types.AlignSize, // large aligned + 1 alignment block
+		500*utils.MiB - 1,               // large unaligned
+	}
+
+	conns := []int{1, 2, 3, 4, 7, 8, 15, 16, 32, 64}
+
+	for _, size := range fileSizes {
+		for _, numConns := range conns {
+			name := fmt.Sprintf("Size_%d_Conns_%d", size, numConns)
+			t.Run(name, func(t *testing.T) {
+				chunkSize := d.calculateChunkSize(size, numConns)
+				tasks := createInitialTasks(size, chunkSize, numConns)
+
+				// STRICT PROPERTY 1: Task count must NEVER exceed numConns
+				if len(tasks) > numConns {
+					t.Fatalf("Strict violation: generated %d tasks, which exceeds numConns limit %d", len(tasks), numConns)
+				}
+				assert.LessOrEqual(t, len(tasks), numConns, "Task count must not exceed numConns")
+
+				// STRICT PROPERTY 2: Sum of tasks must EXACTLY equal total file size
+				var total int64
+				for _, task := range tasks {
+					total += task.Length
+				}
+				assert.Equal(t, size, total, "Total lengths of all tasks must equal file size (no data loss)")
+			})
+		}
+	}
 }

--- a/internal/strategy/concurrent/downloader.go
+++ b/internal/strategy/concurrent/downloader.go
@@ -205,6 +205,18 @@ func createTasks(fileSize, chunkSize int64) []types.Task {
 	return tasks
 }
 
+// createInitialTasks keeps parallel downloads within their worker request
+// budget by assigning any alignment remainder to the last primary range.
+func createInitialTasks(fileSize, chunkSize int64, maxTasks int) []types.Task {
+	tasks := createTasks(fileSize, chunkSize)
+	if maxTasks <= 0 || len(tasks) <= maxTasks {
+		return tasks
+	}
+
+	tasks[maxTasks-1].Length = fileSize - tasks[maxTasks-1].Offset
+	return tasks[:maxTasks]
+}
+
 func (d *ConcurrentDownloader) applyClientSettings(client *http.Client) {
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		if len(via) >= 10 {
@@ -288,7 +300,7 @@ func (d *ConcurrentDownloader) Download(ctx context.Context, rawurl string, cand
 		d.State.InitBitmap(fileSize, chunkSize)
 	}
 
-	tasks, err := d.setupTasks(destPath, fileSize, chunkSize, outFile, savedState, isResume)
+	tasks, err := d.setupTasks(destPath, fileSize, chunkSize, numConns, outFile, savedState, isResume)
 	if err != nil {
 		return err
 	}
@@ -393,7 +405,7 @@ func (d *ConcurrentDownloader) getEffectiveSizeForWorkers(fileSize int64, savedS
 	return fileSize
 }
 
-func (d *ConcurrentDownloader) setupTasks(destPath string, fileSize, chunkSize int64, outFile *os.File, savedState *types.DownloadRecord, isResume bool) ([]types.Task, error) {
+func (d *ConcurrentDownloader) setupTasks(destPath string, fileSize, chunkSize int64, numConns int, outFile *os.File, savedState *types.DownloadRecord, isResume bool) ([]types.Task, error) {
 	if isResume {
 		if d.State != nil {
 			d.State.Bytes.Downloaded.Store(savedState.Downloaded)
@@ -420,7 +432,10 @@ func (d *ConcurrentDownloader) setupTasks(destPath string, fileSize, chunkSize i
 		d.State.Bytes.Downloaded.Store(0)
 		d.State.SyncSessionStart()
 	}
-	return createTasks(fileSize, chunkSize), nil
+	if d.Runtime.SequentialDownload {
+		return createTasks(fileSize, chunkSize), nil
+	}
+	return createInitialTasks(fileSize, chunkSize, numConns), nil
 }
 
 func (d *ConcurrentDownloader) startHelpers(ctx context.Context, wg *sync.WaitGroup, queue *TaskQueue, fileSize int64, numConns int) {

--- a/internal/strategy/concurrent/downloader_helpers_test.go
+++ b/internal/strategy/concurrent/downloader_helpers_test.go
@@ -126,7 +126,7 @@ func TestSetupTasks_NewDownload(t *testing.T) {
 		Runtime: &types.RuntimeConfig{},
 	}
 
-	tasks, err := downloader.setupTasks(destPath, fileSize, chunkSize, f, nil, false)
+	tasks, err := downloader.setupTasks(destPath, fileSize, chunkSize, 2, f, nil, false)
 	if err != nil {
 		t.Fatalf("setupTasks failed: %v", err)
 	}
@@ -232,7 +232,7 @@ func TestSetupTasks_BitmapRestoration(t *testing.T) {
 	// 1. InitBitmap
 	progState.InitBitmap(fileSize, chunkSize)
 	// 2. setupTasks (which calls RestoreBitmap)
-	_, err := downloader.setupTasks(destPath, fileSize, chunkSize, f, savedState, true)
+	_, err := downloader.setupTasks(destPath, fileSize, chunkSize, 1, f, savedState, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/strategy/concurrent/signed_range_test.go
+++ b/internal/strategy/concurrent/signed_range_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -24,7 +25,11 @@ func TestInitialRangesStayWithinWorkerRequestBudget(t *testing.T) {
 	}
 	downloader := NewConcurrentDownloader("signed-range-budget", nil, nil, runtime)
 
-	var requests atomic.Int64
+	var (
+		requests atomic.Int64
+		mu       sync.Mutex
+		ranges   [][2]int64
+	)
 	server := testutil.NewHTTPServerT(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestNumber := requests.Add(1)
 		if requestNumber > workers {
@@ -37,6 +42,10 @@ func TestInitialRangesStayWithinWorkerRequestBudget(t *testing.T) {
 			http.Error(w, "invalid range", http.StatusRequestedRangeNotSatisfiable)
 			return
 		}
+
+		mu.Lock()
+		ranges = append(ranges, [2]int64{start, end})
+		mu.Unlock()
 
 		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, fileSize))
 		w.WriteHeader(http.StatusPartialContent)
@@ -79,6 +88,26 @@ func TestInitialRangesStayWithinWorkerRequestBudget(t *testing.T) {
 
 	if got := requests.Load(); got != workers {
 		t.Fatalf("initial range requests = %d, want %d", got, workers)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(ranges) != len(tasks) {
+		t.Fatalf("recorded ranges count %d != tasks count %d", len(ranges), len(tasks))
+	}
+	for i, task := range tasks {
+		wantStart := task.Offset
+		wantEnd := task.Offset + task.Length - 1
+		if ranges[i][0] != wantStart || ranges[i][1] != wantEnd {
+			t.Errorf("task %d: recorded range [%d-%d] doesn't match expected [%d-%d]",
+				i, ranges[i][0], ranges[i][1], wantStart, wantEnd)
+		}
+	}
+	if len(ranges) > 0 {
+		finalEnd := ranges[len(ranges)-1][1]
+		if finalEnd != fileSize-1 {
+			t.Errorf("final range ends at %d, want %d", finalEnd, fileSize-1)
+		}
 	}
 }
 

--- a/internal/strategy/concurrent/signed_range_test.go
+++ b/internal/strategy/concurrent/signed_range_test.go
@@ -1,0 +1,103 @@
+package concurrent
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/SurgeDM/Surge/internal/testutil"
+	"github.com/SurgeDM/Surge/internal/types"
+)
+
+func TestInitialRangesStayWithinWorkerRequestBudget(t *testing.T) {
+	const workers = 3
+	fileSize := int64(workers*types.AlignSize + 123)
+	runtime := &types.RuntimeConfig{
+		MaxConnectionsPerDownload: workers,
+		Workers:                   workers,
+		MinChunkSize:              types.AlignSize,
+	}
+	downloader := NewConcurrentDownloader("signed-range-budget", nil, nil, runtime)
+
+	var requests atomic.Int64
+	server := testutil.NewHTTPServerT(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestNumber := requests.Add(1)
+		if requestNumber > workers {
+			http.Error(w, "request budget exceeded", http.StatusNotFound)
+			return
+		}
+
+		start, end, err := parseTestByteRange(r.Header.Get("Range"))
+		if err != nil || start < 0 || end < start || end >= fileSize {
+			http.Error(w, "invalid range", http.StatusRequestedRangeNotSatisfiable)
+			return
+		}
+
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, fileSize))
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(make([]byte, end-start+1))
+	}))
+	defer server.Close()
+
+	outFile, err := os.CreateTemp(t.TempDir(), "signed-range-*.surge")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = outFile.Close() }()
+
+	numConns := downloader.getInitialConnections(fileSize)
+	if numConns != workers {
+		t.Fatalf("initial connections = %d, want %d", numConns, workers)
+	}
+	chunkSize := downloader.determineChunkSize(fileSize, numConns)
+	tasks, err := downloader.setupTasks(outFile.Name(), fileSize, chunkSize, numConns, outFile, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, task := range tasks {
+		active := &ActiveTask{Task: task}
+		active.CurrentOffset.Store(task.Offset)
+		active.StopAt.Store(task.Offset + task.Length)
+
+		if err := downloader.downloadTask(
+			context.Background(),
+			server.URL,
+			outFile,
+			active,
+			make([]byte, types.WorkerBuffer),
+			server.Client(),
+			fileSize,
+		); err != nil {
+			t.Fatalf("initial range request %d of %d failed: %v", requests.Load(), workers, err)
+		}
+	}
+
+	if got := requests.Load(); got != workers {
+		t.Fatalf("initial range requests = %d, want %d", got, workers)
+	}
+}
+
+func parseTestByteRange(header string) (int64, int64, error) {
+	value, ok := strings.CutPrefix(header, "bytes=")
+	if !ok {
+		return 0, 0, fmt.Errorf("missing bytes prefix")
+	}
+	startText, endText, ok := strings.Cut(value, "-")
+	if !ok {
+		return 0, 0, fmt.Errorf("missing range separator")
+	}
+	start, err := strconv.ParseInt(startText, 10, 64)
+	if err != nil {
+		return 0, 0, err
+	}
+	end, err := strconv.ParseInt(endText, 10, 64)
+	if err != nil {
+		return 0, 0, err
+	}
+	return start, end, nil
+}


### PR DESCRIPTION
## Summary

- cap new parallel downloads at one initial range per actual worker
- fold division/alignment remainder into the final primary range
- leave saved resume tasks and sequential chunking unchanged

## Why

The aligned chunk size can leave a small (N+1)th remainder task after N primary ranges. Request-sensitive signed URLs can reject that extra HTTP range request even though the primary ranges are valid.

## Testing

- `go test ./internal/strategy/concurrent -run '^(TestInitialRangesStayWithinWorkerRequestBudget|TestTaskRangeAssignment)$' -count=1`
- `go test ./internal/strategy/concurrent -count=1`
- `go vet ./...`
- `go test ./internal/lint/... -count=1`
- `go build ./...`
- all Go packages except `cmd` and `internal/probe` (the two reproduced Windows baseline failures)

`go test ./... -count=1 -timeout 90s` passed every other package. On this Windows host, `cmd` still fails its dummy batch-editor test and `internal/probe` still reports a DNS resolver goroutine; both failures reproduce on the audited base. The race detector was unavailable because the host has no CGO toolchain, WSL, or running Docker daemon.

## Coordination

This patch touches `internal/strategy/concurrent/downloader.go` alongside open #550 and #580. Both current merge trees are clean, and the concurrent package passes on each combined tree.

Addresses the initial partitioning case in #579. Runtime hedging, permanent HTTP retry handling, and connection prewarming remain out of scope.

Assistance disclosure: This contribution was developed with AI assistance (OpenAI Codex).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved parallel download task allocation to respect the configured worker limit.
  * Reduced unnecessary task creation while preserving complete file coverage.
  * Improved handling of uneven file sizes, small downloads, and single-worker transfers.

* **Bug Fixes**
  * Corrected byte-range assignment for concurrent and signed-range downloads.
  * Ensured remainder data is included in the final download task without creating extra requests.
  * Ensured downloads fully cover the requested file without invalid or empty ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->