### PR TITLE
fix/tui graph cpu usage

### DIFF
--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -48,6 +48,7 @@ type GeneralSettings struct {
 	ThemePath                    *Setting `json:"theme_path"`
 	LogRetentionCount            *Setting `json:"log_retention_count"`
 	LiveSpeedGraph               *Setting `json:"live_speed_graph"`
+	ShowSpeedGraph               *Setting `json:"show_speed_graph"`
 }
 
 type NetworkSettings struct {
@@ -265,6 +266,7 @@ func (s *Settings) initializeCategoriesList() {
 				s.General.ThemePath,
 				s.General.LogRetentionCount,
 				s.General.LiveSpeedGraph,
+				s.General.ShowSpeedGraph,
 			},
 		},
 		{
@@ -654,6 +656,14 @@ func DefaultSettings() *Settings {
 				Type:         TypeBool,
 				DefaultValue: false,
 				Value:        false,
+			},
+			ShowSpeedGraph: &Setting{
+				Key:          "show_speed_graph",
+				Label:        "Show Speed Graph",
+				Description:  "Display the network activity graph on the dashboard. Disable to reduce CPU usage.",
+				Type:         TypeBool,
+				DefaultValue: true,
+				Value:        true,
 			},
 		},
 		Network: NetworkSettings{

--- a/internal/strategy/concurrent/worker.go
+++ b/internal/strategy/concurrent/worker.go
@@ -82,12 +82,12 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 
 			taskCtx, taskCancel := context.WithCancel(ctx)
 			now := time.Now()
-			
+
 			d.activeMu.Lock()
 			activeTask.Cancel = taskCancel
 			activeTask.StartTime = now
 			d.activeMu.Unlock()
-			
+
 			activeTask.WindowStart = now
 			activeTask.WindowBytes.Store(0)
 			activeTask.LastActivity.Store(now.UnixNano())

--- a/internal/tui/constants.go
+++ b/internal/tui/constants.go
@@ -49,9 +49,9 @@ const (
 	// === Graph Configuration ===
 	GraphAxisWidth      = 10
 	GraphStatsWidth     = 18
-	GraphHeadroom       = 1.1                    // Scale max speed by 110% for visual headroom
-	GraphUpdateInterval = 500 * time.Millisecond // Interval at which the speed history is updated
-	GraphHistoryPoints  = 60                     // 60 points * 0.5s = 30s of history
+	GraphHeadroom       = 1.1                     // Scale max speed by 110% for visual headroom
+	GraphUpdateInterval = 1000 * time.Millisecond // Interval at which the speed history is updated
+	GraphHistoryPoints  = 60                      // 60 points * 1s = 60s of history
 
 	// === Input Dimensions ===
 	InputWidth        = 40

--- a/internal/tui/cpu_bench_test.go
+++ b/internal/tui/cpu_bench_test.go
@@ -42,8 +42,9 @@ func benchModel(n int) *RootModel {
 		activeTab:    TabActive,
 		pinnedTab:    -1,
 		SpeedHistory: make([]float64, GraphHistoryPoints),
-		Settings:     settings,
-		list:         NewDownloadList(80, 20),
+		Settings:      settings,
+		list:          NewDownloadList(80, 20),
+		graphRenderer: NewGraphRenderer(),
 		// Seed some history so graph has data to render
 		lastSpeedHistoryUpdate: time.Now().Add(-time.Second),
 	}
@@ -118,19 +119,7 @@ func BenchmarkCPU_SpeedCalc_New(b *testing.B) {
 	}
 }
 
-// --- Benchmark 3: renderGraphBox every View vs cached ---
-
-func BenchmarkCPU_GraphRender_Old(b *testing.B) {
-	m := fullBenchModel(8)
-	stats := m.ComputeViewStats()
-	layout := CalculateDashboardLayout(m.width, m.height)
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		// OLD: re-rendered on every View() call
-		_ = m.renderGraphBox(layout.RightWidth, layout.GraphHeight, stats)
-	}
-}
+// --- Benchmark 3: renderGraphBox highly optimized ---
 
 func BenchmarkCPU_GraphRender_New(b *testing.B) {
 	m := fullBenchModel(8)

--- a/internal/tui/cpu_bench_test.go
+++ b/internal/tui/cpu_bench_test.go
@@ -139,14 +139,8 @@ func BenchmarkCPU_GraphRender_New(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		// NEW: only re-render when dirty or dimensions changed
-		if m.graphCacheDirty || m.cachedGraphWidth != layout.RightWidth || m.cachedGraphHeight != layout.GraphHeight || m.cachedGraphBox == "" {
-			m.cachedGraphBox = m.renderGraphBox(layout.RightWidth, layout.GraphHeight, stats)
-			m.cachedGraphWidth = layout.RightWidth
-			m.cachedGraphHeight = layout.GraphHeight
-			m.graphCacheDirty = false
-		}
-		_ = m.cachedGraphBox
+		// NEW: renderGraphBox uses highly optimized GraphRenderer with RLE
+		_ = m.renderGraphBox(layout.RightWidth, layout.GraphHeight, stats)
 	}
 }
 
@@ -193,10 +187,8 @@ func BenchmarkCPU_FullView_Old(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		// Simulate old per-event overhead before each View
-		m.cachedTotalSpeed = 0   // force stale (simulates no cache)
-		m.graphCacheDirty = true // force graph re-render every time
-		m.cachedGraphBox = ""
-		m.UpdateListItems() // OLD: called per progress event
+		m.cachedTotalSpeed = 0 // force stale (simulates no cache)
+		m.UpdateListItems()    // OLD: called per progress event
 		_ = m.View()
 	}
 }

--- a/internal/tui/cpu_bench_test.go
+++ b/internal/tui/cpu_bench_test.go
@@ -1,0 +1,215 @@
+package tui
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"charm.land/bubbles/v2/progress"
+	"github.com/SurgeDM/Surge/internal/config"
+	"github.com/SurgeDM/Surge/internal/tui/colors"
+	"github.com/SurgeDM/Surge/internal/types"
+)
+
+// benchModel builds a realistic RootModel with n active downloads for benchmarking.
+func benchModel(n int) *RootModel {
+	InitializeTUI()
+	IsTestMode = true
+
+	settings := config.DefaultSettings()
+	downloads := make([]*DownloadModel, n)
+	for i := range downloads {
+		id := fmt.Sprintf("dl-%d", i)
+		downloads[i] = &DownloadModel{
+			ID:       id,
+			Filename: fmt.Sprintf("file-%d.iso", i),
+			Total:    1024 * 1024 * 1024, // 1 GiB
+			Downloaded: int64(i) * 100 * 1024 * 1024,
+			Speed:    float64((i + 1)) * 5 * 1024 * 1024, // 5-40 MiB/s
+			started:  true,
+			progress: progress.New(
+				progress.WithSpringOptions(0.5, 0.1),
+				progress.WithColors(colors.ProgressStart(), colors.ProgressEnd()),
+				progress.WithScaled(true),
+			),
+		}
+	}
+
+	m := &RootModel{
+		downloads:    downloads,
+		width:        120,
+		height:       35,
+		activeTab:    TabActive,
+		pinnedTab:    -1,
+		SpeedHistory: make([]float64, GraphHistoryPoints),
+		Settings:     settings,
+		list:         NewDownloadList(80, 20),
+		// Seed some history so graph has data to render
+		lastSpeedHistoryUpdate: time.Now().Add(-time.Second),
+	}
+	for i := range m.SpeedHistory {
+		m.SpeedHistory[i] = float64(i) * 1024 * 1024
+	}
+	m.cachedTotalSpeed = m.calcTotalSpeedBps()
+	m.UpdateListItems()
+	return m
+}
+
+func benchProgressMsg(m *RootModel) types.DownloadEvent {
+	return types.DownloadEvent{
+		Type:        types.EventProgress,
+		DownloadID:  m.downloads[0].ID,
+		Downloaded:  m.downloads[0].Downloaded + 1024*1024,
+		Total:       m.downloads[0].Total,
+		Speed:       m.downloads[0].Speed,
+		Elapsed:     10 * time.Second,
+		Connections: 8,
+	}
+}
+
+// --- Benchmark 1: processProgressMsg ---
+// Old path called UpdateListItems() on every progress event.
+// New path skips it (list items hold live pointers).
+
+func BenchmarkCPU_ProgressMsg_Old(b *testing.B) {
+	m := benchModel(8)
+	msg := benchProgressMsg(m)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.processProgressMsg(msg)
+		m.UpdateListItems() // OLD: was called every progress event
+	}
+}
+
+func BenchmarkCPU_ProgressMsg_New(b *testing.B) {
+	m := benchModel(8)
+	msg := benchProgressMsg(m)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.processProgressMsg(msg) // NEW: no UpdateListItems
+	}
+}
+
+// --- Benchmark 2: calcTotalSpeedBps called 3x vs 1x per frame ---
+
+func BenchmarkCPU_SpeedCalc_Old(b *testing.B) {
+	m := benchModel(8)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// OLD: computed in processProgressMsg, footer, and renderGraphBox
+		_ = m.calcTotalSpeedBps()
+		_ = m.calcTotalSpeedBps()
+		_ = m.calcTotalSpeedBps()
+	}
+}
+
+func BenchmarkCPU_SpeedCalc_New(b *testing.B) {
+	m := benchModel(8)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// NEW: computed once, cached
+		m.cachedTotalSpeed = m.calcTotalSpeedBps()
+		_ = m.cachedTotalSpeed
+		_ = m.cachedTotalSpeed
+	}
+}
+
+// --- Benchmark 3: renderGraphBox every View vs cached ---
+
+func BenchmarkCPU_GraphRender_Old(b *testing.B) {
+	m := fullBenchModel(8)
+	stats := m.ComputeViewStats()
+	layout := CalculateDashboardLayout(m.width, m.height)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// OLD: re-rendered on every View() call
+		_ = m.renderGraphBox(layout.RightWidth, layout.GraphHeight, stats)
+	}
+}
+
+func BenchmarkCPU_GraphRender_New(b *testing.B) {
+	m := fullBenchModel(8)
+	stats := m.ComputeViewStats()
+	layout := CalculateDashboardLayout(m.width, m.height)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// NEW: only re-render when dirty or dimensions changed
+		if m.graphCacheDirty || m.cachedGraphWidth != layout.RightWidth || m.cachedGraphHeight != layout.GraphHeight || m.cachedGraphBox == "" {
+			m.cachedGraphBox = m.renderGraphBox(layout.RightWidth, layout.GraphHeight, stats)
+			m.cachedGraphWidth = layout.RightWidth
+			m.cachedGraphHeight = layout.GraphHeight
+			m.graphCacheDirty = false
+		}
+		_ = m.cachedGraphBox
+	}
+}
+
+// --- Benchmark 4: Full View() render (the combined effect) ---
+
+// fullBenchModel returns a properly-initialized RootModel (with help, keys, etc.)
+// populated with n active downloads.
+func fullBenchModel(n int) RootModel {
+	IsTestMode = true
+	InitializeTUI()
+	m := InitialRootModel(1701, "1.0.0", nil, nil, config.DefaultSettings(), false)
+	m.width = 120
+	m.height = 35
+	m.activeTab = TabActive
+
+	downloads := make([]*DownloadModel, n)
+	for i := range downloads {
+		downloads[i] = &DownloadModel{
+			ID:         fmt.Sprintf("dl-%d", i),
+			Filename:   fmt.Sprintf("file-%d.iso", i),
+			Total:      1024 * 1024 * 1024,
+			Downloaded: int64(i) * 100 * 1024 * 1024,
+			Speed:      float64(i+1) * 5 * 1024 * 1024,
+			started:    true,
+			progress: progress.New(
+				progress.WithSpringOptions(0.5, 0.1),
+				progress.WithColors(colors.ProgressStart(), colors.ProgressEnd()),
+				progress.WithScaled(true),
+			),
+		}
+	}
+	m.downloads = downloads
+	for i := range m.SpeedHistory {
+		m.SpeedHistory[i] = float64(i) * 1024 * 1024
+	}
+	m.cachedTotalSpeed = m.calcTotalSpeedBps()
+	m.UpdateListItems()
+	return m
+}
+
+func BenchmarkCPU_FullView_Old(b *testing.B) {
+	m := fullBenchModel(8)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Simulate old per-event overhead before each View
+		m.cachedTotalSpeed = 0   // force stale (simulates no cache)
+		m.graphCacheDirty = true // force graph re-render every time
+		m.cachedGraphBox = ""
+		m.UpdateListItems()      // OLD: called per progress event
+		_ = m.View()
+	}
+}
+
+func BenchmarkCPU_FullView_New(b *testing.B) {
+	m := fullBenchModel(8)
+	m.cachedTotalSpeed = m.calcTotalSpeedBps()
+	// Pre-warm graph cache (as would happen after first render)
+	_ = m.View()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// NEW: no list rebuild, speed cached, graph cached
+		_ = m.View()
+	}
+}

--- a/internal/tui/cpu_bench_test.go
+++ b/internal/tui/cpu_bench_test.go
@@ -21,12 +21,12 @@ func benchModel(n int) *RootModel {
 	for i := range downloads {
 		id := fmt.Sprintf("dl-%d", i)
 		downloads[i] = &DownloadModel{
-			ID:       id,
-			Filename: fmt.Sprintf("file-%d.iso", i),
-			Total:    1024 * 1024 * 1024, // 1 GiB
+			ID:         id,
+			Filename:   fmt.Sprintf("file-%d.iso", i),
+			Total:      1024 * 1024 * 1024, // 1 GiB
 			Downloaded: int64(i) * 100 * 1024 * 1024,
-			Speed:    float64((i + 1)) * 5 * 1024 * 1024, // 5-40 MiB/s
-			started:  true,
+			Speed:      float64((i + 1)) * 5 * 1024 * 1024, // 5-40 MiB/s
+			started:    true,
 			progress: progress.New(
 				progress.WithSpringOptions(0.5, 0.1),
 				progress.WithColors(colors.ProgressStart(), colors.ProgressEnd()),
@@ -196,7 +196,7 @@ func BenchmarkCPU_FullView_Old(b *testing.B) {
 		m.cachedTotalSpeed = 0   // force stale (simulates no cache)
 		m.graphCacheDirty = true // force graph re-render every time
 		m.cachedGraphBox = ""
-		m.UpdateListItems()      // OLD: called per progress event
+		m.UpdateListItems() // OLD: called per progress event
 		_ = m.View()
 	}
 }

--- a/internal/tui/graph.go
+++ b/internal/tui/graph.go
@@ -18,84 +18,154 @@ func graphColors() []color.Color {
 	}
 }
 
-// renderMultiLineGraph creates a multi-line bar graph with grid lines.
-// The graph scales data to fill the full width.
-// data: speed history data points
-// width, height: dimensions of the graph
-// maxVal: maximum value for scaling
-func renderMultiLineGraph(data []float64, width, height int, maxVal float64) string {
-	if width < 1 || height < 1 {
-		return ""
+var graphBlocks = []string{" ", "\u2581", "\u2582", "\u2583", "\u2584", "\u2585", "\u2586", "\u2588"}
+
+// GraphRenderer is a stateful, highly optimized component for rendering the network activity graph.
+// It caches the background grid and style objects, and uses run-length encoding to minimize ANSI escape sequences.
+// NOTE: This component is NOT safe for concurrent use.
+type GraphRenderer struct {
+	width, height int
+
+	// Caches
+	gridStyle lipgloss.Style
+	rowStyles []lipgloss.Style
+
+	// Base pristine grid (raw characters)
+	baseGrid [][]string
+
+	// Reusable buffers per frame
+	charBuf  [][]string
+	styleBuf [][]bool // false = grid style, true = block style (row color)
+
+	lastRender string
+}
+
+func NewGraphRenderer() *GraphRenderer {
+	return &GraphRenderer{
+		gridStyle: lipgloss.NewStyle().Foreground(colors.Gray()),
+	}
+}
+
+func (g *GraphRenderer) InvalidateCache() {
+	g.baseGrid = nil
+	g.lastRender = ""
+}
+
+func (g *GraphRenderer) resize(width, height int) {
+	if g.width == width && g.height == height && g.baseGrid != nil {
+		return
 	}
 
-	// Styles
-	gridStyle := lipgloss.NewStyle().Foreground(colors.Gray())
+	g.width = width
+	g.height = height
 
-	// 1. Prepare the canvas with a Grid
-	rows := make([][]string, height)
-	for i := range rows {
-		rows[i] = make([]string, width)
-		for j := range rows[i] {
-			if i == height-1 {
-				// Bottom row: solid baseline
-				rows[i][j] = gridStyle.Render("\u2500")
-			} else if i%2 == 0 {
-				rows[i][j] = gridStyle.Render("\u254c")
-			} else {
-				rows[i][j] = " "
-			}
-		}
-	}
-
-	// Block characters for partial fills
-	blocks := []string{" ", "\u2581", "\u2582", "\u2583", "\u2584", "\u2585", "\u2586", "\u2588"}
-
-	// Snapshot current palette colors once per render so the gradient is consistent
-	// across all rows and doesn't allocate on every iteration.
+	// 1. Build row styles
 	gradient := graphColors()
-
-	// Pre-calculate styles for every row to avoid re-creating them in the loop
-	// Optimization: Pre-render all possible block characters for each row style
-	// This avoids calling style.Render() width*height times
-	rowChars := make([][]string, height)
+	g.rowStyles = make([]lipgloss.Style, height)
 	for y := 0; y < height; y++ {
-		// Map height 'y' to an index in gradient
 		colorIdx := (y * len(gradient)) / height
 		if colorIdx >= len(gradient) {
 			colorIdx = len(gradient) - 1
 		}
-		style := lipgloss.NewStyle().Foreground(gradient[colorIdx])
+		g.rowStyles[y] = lipgloss.NewStyle().Foreground(gradient[colorIdx])
+	}
 
-		rowChars[y] = make([]string, len(blocks))
-		for k, b := range blocks {
-			rowChars[y][k] = style.Render(b)
+	// 2. Build base grid
+	g.baseGrid = make([][]string, height)
+	for i := range g.baseGrid {
+		g.baseGrid[i] = make([]string, width)
+		for j := range g.baseGrid[i] {
+			if i == height-1 {
+				g.baseGrid[i][j] = "\u2500"
+			} else if i%2 == 0 {
+				g.baseGrid[i][j] = "\u254c"
+			} else {
+				g.baseGrid[i][j] = " "
+			}
 		}
 	}
 
-	// 2. Scale data to fill full width
-	// Each data point spans multiple columns to fill the graph
-	if len(data) > 0 {
-		colsPerPoint := float64(width) / float64(len(data))
+	// 3. Allocate buffers (old buffers will be garbage collected)
+	g.charBuf = make([][]string, height)
+	g.styleBuf = make([][]bool, height)
+	for i := 0; i < height; i++ {
+		g.charBuf[i] = make([]string, width)
+		g.styleBuf[i] = make([]bool, width)
+	}
+}
 
-		for i, val := range data {
+// Render creates a multi-line bar graph with grid lines.
+func (g *GraphRenderer) Render(data []float64, width, height int, maxVal float64, isResizing bool) string {
+	if width < 1 || height < 1 {
+		return ""
+	}
+
+	if isResizing && g.lastRender != "" {
+		return g.lastRender
+	}
+
+	g.resize(width, height)
+
+	// 1. Deep copy pristine grid and zero style buffer
+	for i := 0; i < height; i++ {
+		copy(g.charBuf[i], g.baseGrid[i])
+		// Zeroing styleBuf (false = grid style)
+		for j := 0; j < width; j++ {
+			g.styleBuf[i][j] = false
+		}
+	}
+
+	// 2. Map data
+	if len(data) > 0 {
+		// Bug fix: maxVal <= 0 causes NaN
+		if maxVal <= 0 {
+			maxVal = 1
+		}
+
+		// Bug fix: Downsample if data > width to prevent column loss
+		var plotData []float64
+		if len(data) > width {
+			plotData = make([]float64, width)
+			chunkSize := float64(len(data)) / float64(width)
+			for i := 0; i < width; i++ {
+				start := int(float64(i) * chunkSize)
+				end := int(float64(i+1) * chunkSize)
+				if i == width-1 {
+					end = len(data) // Ensure tail data point is never dropped
+				}
+				if end > len(data) {
+					end = len(data)
+				}
+				maxInChunk := 0.0
+				for j := start; j < end; j++ {
+					if data[j] > maxInChunk {
+						maxInChunk = data[j]
+					}
+				}
+				plotData[i] = maxInChunk
+			}
+		} else {
+			plotData = data
+		}
+
+		colsPerPoint := float64(width) / float64(len(plotData))
+
+		for i, val := range plotData {
 			if val < 0 {
 				val = 0
 			}
-
 			pct := val / maxVal
 			if pct > 1.0 {
 				pct = 1.0
 			}
 			totalSubBlocks := pct * float64(height) * 8.0
 
-			// Calculate column range for this data point
 			startCol := int(float64(i) * colsPerPoint)
 			endCol := int(float64(i+1) * colsPerPoint)
 			if endCol > width {
 				endCol = width
 			}
 
-			// Draw the bar across all columns for this data point
 			for col := startCol; col < endCol; col++ {
 				for y := 0; y < height; y++ {
 					rowIndex := height - 1 - y
@@ -103,31 +173,64 @@ func renderMultiLineGraph(data []float64, width, height int, maxVal float64) str
 
 					var charIndex int
 					if rowValue <= 0 {
-						charIndex = 0 // Space
+						continue // Leave grid as is
 					} else if rowValue >= 8 {
-						charIndex = 7 // Full block (█)
+						charIndex = 7 // Full block
 					} else {
-						charIndex = int(rowValue) // Partial block
+						charIndex = int(rowValue)
 					}
 
-					// USE PRE-RENDERED CACHE
-					if charIndex > 0 { // Only render if not empty space (optimization)
-						rows[rowIndex][col] = rowChars[y][charIndex]
+					if charIndex > 0 {
+						g.charBuf[rowIndex][col] = graphBlocks[charIndex]
+						g.styleBuf[rowIndex][col] = true // Mark as block style
 					}
 				}
 			}
 		}
 	}
 
-	// 3. Join rows to create the graph
+	// 3. RLE & String Building
+	// Estimate 15 bytes per styled run (ansi code + char + ansi clear)
 	var graphBuilder strings.Builder
-	for i, row := range rows {
-		graphBuilder.WriteString(strings.Join(row, ""))
+	graphBuilder.Grow(width * height * 15)
+
+	for i := 0; i < height; i++ {
+		rowChars := g.charBuf[i]
+		rowStyles := g.styleBuf[i]
+
+		currentStr := rowChars[0]
+		currentStyleBlock := rowStyles[0]
+		runLen := 1
+
+		for j := 1; j < width; j++ {
+			if rowChars[j] == currentStr && rowStyles[j] == currentStyleBlock {
+				runLen++
+			} else {
+				// Emit previous run
+				if currentStyleBlock {
+					graphBuilder.WriteString(g.rowStyles[height-1-i].Render(strings.Repeat(currentStr, runLen)))
+				} else {
+					graphBuilder.WriteString(g.gridStyle.Render(strings.Repeat(currentStr, runLen)))
+				}
+
+				currentStr = rowChars[j]
+				currentStyleBlock = rowStyles[j]
+				runLen = 1
+			}
+		}
+
+		// Emit final run for this row
+		if currentStyleBlock {
+			graphBuilder.WriteString(g.rowStyles[height-1-i].Render(strings.Repeat(currentStr, runLen)))
+		} else {
+			graphBuilder.WriteString(g.gridStyle.Render(strings.Repeat(currentStr, runLen)))
+		}
+
 		if i < height-1 {
 			graphBuilder.WriteRune('\n')
 		}
 	}
-	graphStr := graphBuilder.String()
 
-	return graphStr
+	g.lastRender = graphBuilder.String()
+	return g.lastRender
 }

--- a/internal/tui/graph.go
+++ b/internal/tui/graph.go
@@ -49,6 +49,7 @@ func NewGraphRenderer() *GraphRenderer {
 func (g *GraphRenderer) InvalidateCache() {
 	g.baseGrid = nil
 	g.lastRender = ""
+	g.gridStyle = lipgloss.NewStyle().Foreground(colors.Gray())
 }
 
 func (g *GraphRenderer) resize(width, height int) {

--- a/internal/tui/graph_test.go
+++ b/internal/tui/graph_test.go
@@ -1,0 +1,60 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/SurgeDM/Surge/internal/tui/colors"
+)
+
+func TestGraphRenderer_Aliasing(t *testing.T) {
+	g := NewGraphRenderer()
+	width, height := 10, 5
+	dataWithValues := []float64{10, 20, 30, 40, 50}
+	maxVal := 50.0
+
+	// Render with data to mutate buffers
+	g.Render(dataWithValues, width, height, maxVal, false)
+
+	// Render with empty data
+	emptyData := []float64{}
+	emptyOutput := g.Render(emptyData, width, height, maxVal, false)
+
+	// The empty output should contain the grid lines, not blocks
+	// If aliasing occurred, the emptyGrid would have been mutated and blocks would show up
+	if strings.Contains(emptyOutput, "\u2588") || strings.Contains(emptyOutput, "\u2584") {
+		t.Errorf("GraphRenderer aliased its base grid! Empty render contains blocks:\n%s", emptyOutput)
+	}
+}
+
+func TestGraphRenderer_GradientOutput(t *testing.T) {
+	g := NewGraphRenderer()
+	width, height := 10, 5
+	dataWithValues := []float64{100, 100, 100, 100, 100} // Full height bars
+
+	// The lowest visual row should be height-1 (the baseline), which uses colors.ProgressStart()
+	out := g.Render(dataWithValues, width, height, 100.0, false)
+
+	lines := strings.Split(out, "\n")
+	if len(lines) != height {
+		t.Fatalf("Expected %d lines, got %d", height, len(lines))
+	}
+
+	// Top row (visual index 0) should use ProgressEnd
+	// Bottom row (visual index height-1) should use ProgressStart
+	topStyle := lipgloss.NewStyle().Foreground(colors.ProgressEnd())
+	bottomStyle := lipgloss.NewStyle().Foreground(colors.ProgressStart())
+
+	topExpected := topStyle.Render(strings.Repeat("\u2588", width))
+	// The bottom row is drawn on top of the grid base, but the whole block uses the row style
+	bottomExpected := bottomStyle.Render(strings.Repeat("\u2588", width))
+
+	if lines[0] != topExpected {
+		t.Errorf("Top row rendered incorrectly.\nGot: %q\nWant: %q", lines[0], topExpected)
+	}
+
+	if lines[height-1] != bottomExpected {
+		t.Errorf("Bottom row rendered incorrectly.\nGot: %q\nWant: %q", lines[height-1], bottomExpected)
+	}
+}

--- a/internal/tui/graph_test.go
+++ b/internal/tui/graph_test.go
@@ -63,9 +63,7 @@ func TestGraphRenderer_Downsampling(t *testing.T) {
 	g := NewGraphRenderer()
 
 	data := make([]float64, 120)
-	for i := range data {
-		data[i] = float64(i)
-	}
+	data[119] = 120.0
 
 	out := g.Render(data, 10, 5, 120.0, false)
 	lines := strings.Split(out, "\n")
@@ -82,7 +80,7 @@ func TestGraphRenderer_ResizeCache(t *testing.T) {
 	data := []float64{10, 20, 30}
 	out1 := g.Render(data, 10, 5, 50.0, false)
 
-	out2 := g.Render(data, 10, 5, 50.0, true)
+	out2 := g.Render([]float64{99, 99}, 20, 10, 100.0, true)
 
 	if out1 != out2 {
 		t.Errorf("Cached render output during resize does not match initial render!")

--- a/internal/tui/graph_test.go
+++ b/internal/tui/graph_test.go
@@ -58,3 +58,33 @@ func TestGraphRenderer_GradientOutput(t *testing.T) {
 		t.Errorf("Bottom row rendered incorrectly.\nGot: %q\nWant: %q", lines[height-1], bottomExpected)
 	}
 }
+
+func TestGraphRenderer_Downsampling(t *testing.T) {
+	g := NewGraphRenderer()
+
+	data := make([]float64, 120)
+	for i := range data {
+		data[i] = float64(i)
+	}
+
+	out := g.Render(data, 10, 5, 120.0, false)
+	lines := strings.Split(out, "\n")
+
+	topExpected := lipgloss.NewStyle().Foreground(colors.ProgressEnd()).Render("█")
+	if !strings.HasSuffix(lines[0], topExpected) {
+		t.Errorf("Tail data point (119) was lost during downsampling! Expected max height on rightmost column.")
+	}
+}
+
+func TestGraphRenderer_ResizeCache(t *testing.T) {
+	g := NewGraphRenderer()
+
+	data := []float64{10, 20, 30}
+	out1 := g.Render(data, 10, 5, 50.0, false)
+
+	out2 := g.Render(data, 10, 5, 50.0, true)
+
+	if out1 != out2 {
+		t.Errorf("Cached render output during resize does not match initial render!")
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -159,6 +159,11 @@ type RootModel struct {
 	// Graph Data
 	SpeedHistory           []float64 // Stores the last ~60 ticks of speed data
 	lastSpeedHistoryUpdate time.Time // Last time SpeedHistory was updated (for 0.5s sampling)
+	cachedTotalSpeed       int64     // Cached total speed (bytes/s), updated once per progress batch
+	graphCacheDirty        bool      // True when SpeedHistory changed and graph needs re-render
+	cachedGraphBox         string    // Cached rendered graph box, only rebuilt when dirty
+	cachedGraphWidth       int       // Width used for the cached graph
+	cachedGraphHeight      int       // Height used for the cached graph
 
 	// Notification log system
 	logViewport viewport.Model // Scrollable log viewport

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -277,8 +277,7 @@ func NewDownloadModel(id string, url string, filename string, total int64) *Down
 // This should be called once per progress update, NOT per render frame.
 func (d *DownloadModel) UpdateETA() {
 	if d.Total <= 0 || d.Speed <= 0 {
-		d.lastETA = 0
-		return
+		return // Do not clear lastETA to preserve EMA history when speed drops to 0 momentarily
 	}
 
 	remaining := d.Total - d.Downloaded
@@ -287,8 +286,7 @@ func (d *DownloadModel) UpdateETA() {
 	// Clamp ETA to 24 hours max to prevent bonkers values
 	const maxETASeconds = 24 * 60 * 60
 	if etaSeconds > maxETASeconds || etaSeconds < 0 {
-		d.lastETA = 0
-		return
+		return // Preserve EMA history
 	}
 
 	etaDuration := time.Duration(etaSeconds) * time.Second

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -160,10 +160,8 @@ type RootModel struct {
 	SpeedHistory           []float64 // Stores the last ~60 ticks of speed data
 	lastSpeedHistoryUpdate time.Time // Last time SpeedHistory was updated (for 0.5s sampling)
 	cachedTotalSpeed       int64     // Cached total speed (bytes/s), updated once per progress batch
-	graphCacheDirty        bool      // True when SpeedHistory changed and graph needs re-render
-	cachedGraphBox         string    // Cached rendered graph box, only rebuilt when dirty
-	cachedGraphWidth       int       // Width used for the cached graph
-	cachedGraphHeight      int       // Height used for the cached graph
+	graphRenderer          *GraphRenderer
+	lastResizeTime         time.Time
 
 	// Notification log system
 	logViewport viewport.Model // Scrollable log viewport
@@ -520,7 +518,8 @@ func InitialRootModel(serverPort int, currentVersion string, service service.Dow
 		SettingsActiveTab:     0,
 		SettingsSelectedRow:   0,
 		SettingsFocusedPane:   1,
-		SpeedHistory:          make([]float64, GraphHistoryPoints),                          // 60 points of history (60s at 1s interval)
+		SpeedHistory:          make([]float64, GraphHistoryPoints), // 60 points of history (60s at 1s interval)
+		graphRenderer:         NewGraphRenderer(),
 		logViewport:           viewport.New(viewport.WithWidth(40), viewport.WithHeight(5)), // Default size, will be resized
 		logEntries:            make([]string, 0),
 		SettingsInput:         settingsInput,
@@ -755,6 +754,9 @@ func (m *RootModel) refreshThemeCaches() {
 	applyListTheme(&m.list)
 	applyFilepickerTheme(&m.filepicker)
 	m.logoCache = ""
+	if m.graphRenderer != nil {
+		m.graphRenderer.InvalidateCache()
+	}
 	// Rebuild progress bar colors for all existing downloads so the gradient
 	// matches the newly loaded palette rather than the one active at creation time.
 	for _, d := range m.downloads {
@@ -781,4 +783,8 @@ func applyFilepickerTheme(fp *filepicker.Model) {
 	fp.Styles.DisabledSelected = lipgloss.NewStyle().Foreground(colors.LightGray())
 	fp.Styles.FileSize = lipgloss.NewStyle().Foreground(colors.Gray()).Width(7).Align(lipgloss.Right)
 	fp.Styles.EmptyDirectory = lipgloss.NewStyle().Foreground(colors.Gray()).Padding(0, 2)
+}
+
+func (m RootModel) isResizing() bool {
+	return time.Since(m.lastResizeTime) < 200*time.Millisecond
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -97,9 +97,11 @@ type DownloadModel struct {
 	RateLimit     int64 // Speed limit in bytes/sec
 	RateLimitSet  bool  // Whether RateLimit is an explicit per-download override
 
-	StartTime time.Time
-	Elapsed   time.Duration
-	lastETA   time.Duration // EMA-smoothed ETA for UI stability
+	StartTime   time.Time
+	Elapsed     time.Duration
+	etaSpeed    float64       // Heavily smoothed speed strictly for stable ETA calculation
+	hasEtaSpeed bool          // True if etaSpeed has been seeded
+	lastETA     time.Duration // Last computed ETA for UI stability
 
 	progress progress.Model
 
@@ -279,22 +281,24 @@ func (d *DownloadModel) UpdateETA() {
 	}
 
 	remaining := d.Total - d.Downloaded
-	etaSeconds := float64(remaining) / d.Speed
+
+	if !d.hasEtaSpeed {
+		d.etaSpeed = d.Speed
+		d.hasEtaSpeed = true
+	} else {
+		const etaAlpha = 0.02
+		d.etaSpeed = etaAlpha*d.Speed + (1-etaAlpha)*d.etaSpeed
+	}
+
+	etaSeconds := float64(remaining) / d.etaSpeed
 
 	// Clamp ETA to 24 hours max to prevent bonkers values
 	const maxETASeconds = 24 * 60 * 60
 	if etaSeconds > maxETASeconds || etaSeconds < 0 {
-		return // Preserve EMA history
+		return // Keep previous displayed ETA; etaSpeed itself is already updated above
 	}
 
-	etaDuration := time.Duration(etaSeconds) * time.Second
-	// EMA smooth ETA to prevent jitter from speed fluctuations
-	if d.lastETA > 0 {
-		const etaAlpha = 0.3
-		d.lastETA = time.Duration(etaAlpha*float64(etaDuration) + (1-etaAlpha)*float64(d.lastETA))
-	} else {
-		d.lastETA = etaDuration
-	}
+	d.lastETA = time.Duration(etaSeconds * float64(time.Second))
 }
 
 func InitialRootModel(serverPort int, currentVersion string, service service.DownloadService, orchestrator *orchestrator.LifecycleManager, settings *config.Settings, noResume bool, currentCommit ...string) RootModel {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -520,7 +520,7 @@ func InitialRootModel(serverPort int, currentVersion string, service service.Dow
 		SettingsActiveTab:     0,
 		SettingsSelectedRow:   0,
 		SettingsFocusedPane:   1,
-		SpeedHistory:          make([]float64, GraphHistoryPoints),                          // 60 points of history (30s at 0.5s interval)
+		SpeedHistory:          make([]float64, GraphHistoryPoints),                          // 60 points of history (60s at 1s interval)
 		logViewport:           viewport.New(viewport.WithWidth(40), viewport.WithHeight(5)), // Default size, will be resized
 		logEntries:            make([]string, 0),
 		SettingsInput:         settingsInput,

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -273,6 +273,34 @@ func NewDownloadModel(id string, url string, filename string, total int64) *Down
 	}
 }
 
+// UpdateETA calculates the remaining time and applies EMA smoothing to prevent jitter.
+// This should be called once per progress update, NOT per render frame.
+func (d *DownloadModel) UpdateETA() {
+	if d.Total <= 0 || d.Speed <= 0 {
+		d.lastETA = 0
+		return
+	}
+
+	remaining := d.Total - d.Downloaded
+	etaSeconds := float64(remaining) / d.Speed
+
+	// Clamp ETA to 24 hours max to prevent bonkers values
+	const maxETASeconds = 24 * 60 * 60
+	if etaSeconds > maxETASeconds || etaSeconds < 0 {
+		d.lastETA = 0
+		return
+	}
+
+	etaDuration := time.Duration(etaSeconds) * time.Second
+	// EMA smooth ETA to prevent jitter from speed fluctuations
+	if d.lastETA > 0 {
+		const etaAlpha = 0.3
+		d.lastETA = time.Duration(etaAlpha*float64(etaDuration) + (1-etaAlpha)*float64(d.lastETA))
+	} else {
+		d.lastETA = etaDuration
+	}
+}
+
 func InitialRootModel(serverPort int, currentVersion string, service service.DownloadService, orchestrator *orchestrator.LifecycleManager, settings *config.Settings, noResume bool, currentCommit ...string) RootModel {
 	initialDarkBackground := true
 	if !IsTestMode {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -546,6 +546,7 @@ func InitialRootModel(serverPort int, currentVersion string, service service.Dow
 	InitAuthToken() // Cache auth token for TUI to avoid per-frame disk I/O
 
 	m.refreshThemeCaches()
+	m.cachedTotalSpeed = m.calcTotalSpeedBps()
 
 	return m
 }

--- a/internal/tui/process.go
+++ b/internal/tui/process.go
@@ -78,7 +78,6 @@ func (m *RootModel) processProgressMsg(msg types.DownloadEvent) tea.Cmd {
 			m.SpeedHistory = append(m.SpeedHistory[1:], smoothed)
 		}
 		m.lastSpeedHistoryUpdate = time.Now()
-		m.graphCacheDirty = true
 	}
 
 	// ponytail: list items hold *DownloadModel pointers — speed/progress are

--- a/internal/tui/process.go
+++ b/internal/tui/process.go
@@ -28,6 +28,9 @@ func (m *RootModel) processProgressMsg(msg types.DownloadEvent) tea.Cmd {
 	d.Connections = msg.Connections
 	d.rateLimited = msg.RateLimited
 
+	// Update smoothed ETA on every progress tick
+	d.UpdateETA()
+
 	// Keep "Resuming..." visible until we observe actual transfer.
 	if d.resuming && (d.Speed > 0 || d.Downloaded > prevDownloaded) {
 		d.resuming = false

--- a/internal/tui/process.go
+++ b/internal/tui/process.go
@@ -57,9 +57,6 @@ func (m *RootModel) processProgressMsg(msg types.DownloadEvent) tea.Cmd {
 		cmd = d.progress.SetPercent(percentage)
 	}
 
-	// Cache total speed for this frame so View() doesn't recompute it.
-	m.cachedTotalSpeed = m.calcTotalSpeedBps()
-
 	// Update speed graph history with EMA smoothing for smooth transitions
 	if time.Since(m.lastSpeedHistoryUpdate) >= GraphUpdateInterval {
 		totalSpeed := float64(m.cachedTotalSpeed)

--- a/internal/tui/process.go
+++ b/internal/tui/process.go
@@ -54,9 +54,12 @@ func (m *RootModel) processProgressMsg(msg types.DownloadEvent) tea.Cmd {
 		cmd = d.progress.SetPercent(percentage)
 	}
 
+	// Cache total speed for this frame so View() doesn't recompute it.
+	m.cachedTotalSpeed = m.calcTotalSpeedBps()
+
 	// Update speed graph history with EMA smoothing for smooth transitions
 	if time.Since(m.lastSpeedHistoryUpdate) >= GraphUpdateInterval {
-		totalSpeed := float64(m.calcTotalSpeedBps())
+		totalSpeed := float64(m.cachedTotalSpeed)
 		// EMA smooth against previous graph point for visual continuity
 		var smoothed float64
 		if m.Settings != nil && config.Resolve[bool](m.Settings.General.LiveSpeedGraph) {
@@ -72,9 +75,12 @@ func (m *RootModel) processProgressMsg(msg types.DownloadEvent) tea.Cmd {
 			m.SpeedHistory = append(m.SpeedHistory[1:], smoothed)
 		}
 		m.lastSpeedHistoryUpdate = time.Now()
+		m.graphCacheDirty = true
 	}
 
-	m.UpdateListItems()
+	// ponytail: list items hold *DownloadModel pointers — speed/progress are
+	// read live on every View() without a rebuild. UpdateListItems() is only
+	// needed for structural changes (start/pause/complete/error/tab switch).
 	return cmd
 }
 

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -105,6 +105,7 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
+		m.lastResizeTime = time.Now()
 
 		if m.state == SettingsState {
 			m.normalizeSettingsSelection()

--- a/internal/tui/update_events.go
+++ b/internal/tui/update_events.go
@@ -202,15 +202,24 @@ func (m RootModel) handleDownloadEvent(msg types.DownloadEvent) (tea.Model, tea.
 		}
 
 	case types.EventProgress:
+		if d := m.FindDownloadByID(msg.DownloadID); d != nil && !d.done && !d.paused {
+			d.Speed = msg.Speed
+		}
+		m.cachedTotalSpeed = m.calcTotalSpeedBps()
 		cmd := m.processProgressMsg(msg)
 		return m, cmd
 
 	case types.EventBatchProgress:
 		var cmds []tea.Cmd
 		for _, bm := range msg.BatchEvents {
-			cmds = append(cmds, m.processProgressMsg(bm))
+			if d := m.FindDownloadByID(bm.DownloadID); d != nil && !d.done && !d.paused {
+				d.Speed = bm.Speed
+			}
 		}
 		m.cachedTotalSpeed = m.calcTotalSpeedBps()
+		for _, bm := range msg.BatchEvents {
+			cmds = append(cmds, m.processProgressMsg(bm))
+		}
 		return m, tea.Batch(cmds...)
 
 	case types.EventComplete:

--- a/internal/tui/update_events.go
+++ b/internal/tui/update_events.go
@@ -210,6 +210,7 @@ func (m RootModel) handleDownloadEvent(msg types.DownloadEvent) (tea.Model, tea.
 		for _, bm := range msg.BatchEvents {
 			cmds = append(cmds, m.processProgressMsg(bm))
 		}
+		m.cachedTotalSpeed = m.calcTotalSpeedBps()
 		return m, tea.Batch(cmds...)
 
 	case types.EventComplete:
@@ -232,6 +233,7 @@ func (m RootModel) handleDownloadEvent(msg types.DownloadEvent) (tea.Model, tea.
 				m.addLogEntry(LogStyleComplete.Render(fmt.Sprintf("\u2714 Done: %s (%.2f MiB/s)", d.Filename, speed/float64(utils.MiB))))
 			}
 		}
+		m.cachedTotalSpeed = m.calcTotalSpeedBps()
 		m.UpdateListItems()
 		return m, tea.Batch(cmds...)
 
@@ -250,6 +252,7 @@ func (m RootModel) handleDownloadEvent(msg types.DownloadEvent) (tea.Model, tea.
 			m.downloads = append(m.downloads, newDownload)
 			m.addLogEntry(LogStyleError.Render("\u2716 Error: " + msg.Filename))
 		}
+		m.cachedTotalSpeed = m.calcTotalSpeedBps()
 		m.UpdateListItems()
 		return m, nil
 
@@ -264,6 +267,7 @@ func (m RootModel) handleDownloadEvent(msg types.DownloadEvent) (tea.Model, tea.
 			d.Speed = 0
 			m.addLogEntry(LogStylePaused.Render("\u23f8 Paused: " + d.Filename))
 		}
+		m.cachedTotalSpeed = m.calcTotalSpeedBps()
 		m.UpdateListItems()
 		return m, nil
 
@@ -304,6 +308,7 @@ func (m RootModel) handleDownloadEvent(msg types.DownloadEvent) (tea.Model, tea.
 			if msg.Filename != "" {
 				m.addLogEntry(LogStyleError.Render("\u2716 Removed: " + msg.Filename))
 			}
+			m.cachedTotalSpeed = m.calcTotalSpeedBps()
 			m.UpdateListItems()
 		}
 		return m, nil

--- a/internal/tui/update_events.go
+++ b/internal/tui/update_events.go
@@ -165,6 +165,9 @@ func (m RootModel) handleDownloadEvent(msg types.DownloadEvent) (tea.Model, tea.
 			d.StartTime = time.Now()
 			d.paused = false
 			d.pausing = false
+			d.hasEtaSpeed = false
+			d.etaSpeed = 0
+			d.lastETA = 0
 			var progressCmd tea.Cmd
 			if d.Total > 0 {
 				progressCmd = d.progress.SetPercent(0)
@@ -269,6 +272,9 @@ func (m RootModel) handleDownloadEvent(msg types.DownloadEvent) (tea.Model, tea.
 			d.paused = false
 			d.pausing = false
 			d.resuming = true
+			d.hasEtaSpeed = false
+			d.etaSpeed = 0
+			d.lastETA = 0
 			m.addLogEntry(LogStyleStarted.Render("\u25b6 Resumed: " + d.Filename))
 		}
 		m.UpdateListItems()

--- a/internal/tui/update_modals.go
+++ b/internal/tui/update_modals.go
@@ -594,6 +594,7 @@ func (m RootModel) updatePurgeConfirm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 		err := m.Service.Purge(targetID)
 
 		m.removeDownloadByID(targetID)
+		m.cachedTotalSpeed = m.calcTotalSpeedBps()
 		m.UpdateListItems()
 
 		if err != nil {
@@ -694,6 +695,7 @@ func (m RootModel) deleteDownload(targetID string) (tea.Model, tea.Cmd) {
 		m.removeDownloadByID(targetID)
 	}
 
+	m.cachedTotalSpeed = m.calcTotalSpeedBps()
 	m.UpdateListItems()
 	m, autoCmd := m.refreshAutoShutdown()
 	return m, autoCmd

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -509,6 +509,8 @@ func (m RootModel) View() tea.View {
 		}
 		if showGraph {
 			graphBox = m.renderGraphBox(layout.RightWidth, layout.GraphHeight, stats)
+		} else if layout.GraphHeight > 0 {
+			layout.DetailHeight += layout.GraphHeight
 		}
 		detailBox := renderBtopBox("", PaneTitleStyle.Render(" File Details "), detailContent, layout.RightWidth, layout.DetailHeight, colors.Gray())
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/tui/colors"
 	"github.com/SurgeDM/Surge/internal/tui/components"
 	"github.com/SurgeDM/Surge/internal/utils"
@@ -374,7 +375,7 @@ func (m RootModel) View() tea.View {
 	dimSep := lipgloss.NewStyle().Foreground(colors.Gray()).Render(" \u2502 ")
 
 	// Global speed indicator
-	speedBps := m.calcTotalSpeedBps()
+	speedBps := m.cachedTotalSpeed
 	speedGlyph := lipgloss.NewStyle().Foreground(colors.Cyan()).Render("\u2B07")
 	var speedVal string
 	if speedBps <= 0 {
@@ -501,11 +502,27 @@ func (m RootModel) View() tea.View {
 			layout.DetailHeight += layout.ChunkMapHeight
 		}
 
-		graphBox := m.renderGraphBox(layout.RightWidth, layout.GraphHeight, stats)
+		var graphBox string
+		showGraph := layout.GraphHeight >= layout.MinGraphHeight
+		if showGraph && m.Settings != nil {
+			showGraph = config.Resolve[bool](m.Settings.General.ShowSpeedGraph)
+		}
+		if showGraph {
+			// Only re-render when data or dimensions changed
+			if m.graphCacheDirty || m.cachedGraphWidth != layout.RightWidth || m.cachedGraphHeight != layout.GraphHeight || m.cachedGraphBox == "" {
+				graphBox = m.renderGraphBox(layout.RightWidth, layout.GraphHeight, stats)
+				m.cachedGraphBox = graphBox
+				m.cachedGraphWidth = layout.RightWidth
+				m.cachedGraphHeight = layout.GraphHeight
+				m.graphCacheDirty = false
+			} else {
+				graphBox = m.cachedGraphBox
+			}
+		}
 		detailBox := renderBtopBox("", PaneTitleStyle.Render(" File Details "), detailContent, layout.RightWidth, layout.DetailHeight, colors.Gray())
 
 		var rightParts []string
-		if layout.GraphHeight >= layout.MinGraphHeight {
+		if showGraph {
 			rightParts = append(rightParts, graphBox)
 		}
 		rightParts = append(rightParts, detailBox)

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -715,23 +715,8 @@ func renderFocusedDetails(d *DownloadModel, w int, spinnerView string) string {
 		} else if d.RateLimitSet {
 			speedStr += " (Limit: \u221E)"
 		}
-		if d.Total > 0 {
-			remaining := d.Total - d.Downloaded
-			etaSeconds := float64(remaining) / d.Speed
-			// Clamp ETA to 24 hours max to prevent bonkers values
-			const maxETASeconds = 24 * 60 * 60
-			if etaSeconds > maxETASeconds || etaSeconds < 0 {
-				etaStr = "\u221e"
-			} else {
-				etaDuration := time.Duration(etaSeconds) * time.Second
-				// EMA smooth ETA to prevent jitter from speed fluctuations
-				if d.lastETA > 0 {
-					const etaAlpha = 0.3
-					etaDuration = time.Duration(etaAlpha*float64(etaDuration) + (1-etaAlpha)*float64(d.lastETA))
-				}
-				d.lastETA = etaDuration
-				etaStr = formatDurationForUI(etaDuration)
-			}
+		if d.lastETA > 0 {
+			etaStr = formatDurationForUI(d.lastETA)
 		} else {
 			etaStr = "\u221e"
 		}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -715,7 +715,7 @@ func renderFocusedDetails(d *DownloadModel, w int, spinnerView string) string {
 		} else if d.RateLimitSet {
 			speedStr += " (Limit: \u221E)"
 		}
-		if d.lastETA > 0 {
+		if d.Speed > 0 && d.Total > 0 && d.lastETA > 0 {
 			etaStr = formatDurationForUI(d.lastETA)
 		} else {
 			etaStr = "\u221e"

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -508,16 +508,7 @@ func (m RootModel) View() tea.View {
 			showGraph = config.Resolve[bool](m.Settings.General.ShowSpeedGraph)
 		}
 		if showGraph {
-			// Only re-render when data or dimensions changed
-			if m.graphCacheDirty || m.cachedGraphWidth != layout.RightWidth || m.cachedGraphHeight != layout.GraphHeight || m.cachedGraphBox == "" {
-				graphBox = m.renderGraphBox(layout.RightWidth, layout.GraphHeight, stats)
-				m.cachedGraphBox = graphBox
-				m.cachedGraphWidth = layout.RightWidth
-				m.cachedGraphHeight = layout.GraphHeight
-				m.graphCacheDirty = false
-			} else {
-				graphBox = m.cachedGraphBox
-			}
+			graphBox = m.renderGraphBox(layout.RightWidth, layout.GraphHeight, stats)
 		}
 		detailBox := renderBtopBox("", PaneTitleStyle.Render(" File Details "), detailContent, layout.RightWidth, layout.DetailHeight, colors.Gray())
 

--- a/internal/tui/view_dashboard_graph.go
+++ b/internal/tui/view_dashboard_graph.go
@@ -128,7 +128,7 @@ func (m *RootModel) renderGraphBox(width, height int, stats ViewStats) string {
 	if hideGraphStats {
 		// No stats box - graph gets almost full width
 		graphAreaWidth, axisWidth := GetGraphAreaDimensions(width, true)
-		graphVisual := renderMultiLineGraph(graphData, graphAreaWidth, graphContentHeight, maxSpeed)
+		graphVisual := m.graphRenderer.Render(graphData, graphAreaWidth, graphContentHeight, maxSpeed, m.isResizing())
 
 		axisStyle := lipgloss.NewStyle().Width(axisWidth).Foreground(colors.Cyan()).Align(lipgloss.Right)
 		axisLines := buildAxisLines(graphContentHeight, axisStyle)
@@ -180,7 +180,7 @@ func (m *RootModel) renderGraphBox(width, height int, stats ViewStats) string {
 		statsBox := statsBoxStyle.Render(statsContent)
 
 		graphAreaWidth, axisWidth := GetGraphAreaDimensions(width, false)
-		graphVisual := renderMultiLineGraph(graphData, graphAreaWidth, graphContentHeight, maxSpeed)
+		graphVisual := m.graphRenderer.Render(graphData, graphAreaWidth, graphContentHeight, maxSpeed, m.isResizing())
 
 		axisStyle := lipgloss.NewStyle().Width(axisWidth).Foreground(colors.Cyan()).Align(lipgloss.Right)
 		axisLines := buildAxisLines(graphContentHeight, axisStyle)

--- a/internal/tui/view_dashboard_graph.go
+++ b/internal/tui/view_dashboard_graph.go
@@ -42,7 +42,7 @@ func (m *RootModel) renderGraphBox(width, height int, stats ViewStats) string {
 	}
 
 	// Determine Max Speed for scaling
-	currentSpeedBps := float64(m.calcTotalSpeedBps())
+	currentSpeedBps := float64(m.cachedTotalSpeed)
 	topSpeedBps := 0.0
 	for _, s := range m.SpeedHistory {
 		if s > topSpeedBps {

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -713,3 +713,54 @@ func TestFooter_NoLineOverflowAtVariousSizes(t *testing.T) {
 		}
 	}
 }
+
+func TestView_ETAFlickerBug(t *testing.T) {
+	InitializeTUI()
+	m := InitialRootModel(1701, "1.0.0", nil, orchestrator.NewLifecycleManager(nil, nil, nil), nil, false)
+	m.width = 120
+	m.height = 35
+
+	d := &DownloadModel{
+		ID:         "flicker-test",
+		Filename:   "flicker.iso",
+		Total:      1000 * 1024 * 1024,
+		Downloaded: 500 * 1024 * 1024,
+		Speed:      10 * 1024 * 1024, // 10 MB/s
+	}
+	m.downloads = []*DownloadModel{d}
+	m.SelectedDownloadID = d.ID
+	m.activeTab = TabActive
+	m.UpdateListItems()
+
+	// Initial View should set the ETA cache to the raw ETA (500MB / 10MB/s = 50s)
+	// We do it once to initialize it.
+	d.UpdateETA()
+
+	if d.lastETA != 50*time.Second {
+		t.Fatalf("expected initial ETA to be 50s, got %v", d.lastETA)
+	}
+
+	// Now speed drastically drops to 1 MB/s (raw ETA becomes 500s)
+	d.Speed = 1 * 1024 * 1024
+
+	// Process ONE progress message (as it would happen every 150ms in reality)
+	d.UpdateETA()
+
+	// With EMA alpha = 0.3, the new ETA should be:
+	// 0.3 * 500s + 0.7 * 50s = 150s + 35s = 185s
+	expectedSmoothed := 185 * time.Second
+	if d.lastETA != expectedSmoothed {
+		t.Fatalf("expected ETA to be smoothed to %v, got %v", expectedSmoothed, d.lastETA)
+	}
+
+	// In the old bug, calling View() 10 times would instantly converge the ETA
+	// Let's call View() 10 times (simulating spinner ticks or terminal resizing)
+	for i := 0; i < 10; i++ {
+		m.View()
+	}
+
+	// Since View() should be side-effect free, lastETA should not change!
+	if d.lastETA != expectedSmoothed {
+		t.Fatalf("ETA drifted during View() calls! View() is causing side effects. Got: %v", d.lastETA)
+	}
+}

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -12,6 +12,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/SurgeDM/Surge/internal/tui/colors"
+	"github.com/SurgeDM/Surge/internal/types"
 )
 
 var ansiEscapeRE = regexp.MustCompile(`\x1b\[[0-9;]*m`)
@@ -746,10 +747,17 @@ func TestView_ETAFlickerBug(t *testing.T) {
 	// Process ONE progress message (as it would happen every 150ms in reality)
 	d.UpdateETA()
 
-	// With EMA alpha = 0.3, the new ETA should be:
-	// 0.3 * 500s + 0.7 * 50s = 150s + 35s = 185s
-	expectedSmoothed := 185 * time.Second
-	if d.lastETA != expectedSmoothed {
+	// With EMA alpha = 0.02 on etaSpeed:
+	// d.etaSpeed = 0.02 * 1MB/s + 0.98 * 10MB/s = 9.82 MB/s
+	// ETA = 500MB / 9.82 MB/s = 50.916496945s
+	expectedSmoothed := time.Duration(50.916496945 * float64(time.Second))
+
+	// Use a small tolerance for floating point imprecision
+	diff := d.lastETA - expectedSmoothed
+	if diff < 0 {
+		diff = -diff
+	}
+	if diff > time.Millisecond {
 		t.Fatalf("expected ETA to be smoothed to %v, got %v", expectedSmoothed, d.lastETA)
 	}
 
@@ -762,5 +770,39 @@ func TestView_ETAFlickerBug(t *testing.T) {
 	// Since View() should be side-effect free, lastETA should not change!
 	if d.lastETA != expectedSmoothed {
 		t.Fatalf("ETA drifted during View() calls! View() is causing side effects. Got: %v", d.lastETA)
+	}
+}
+
+func TestUpdateETA_ResetOnResume(t *testing.T) {
+	m := InitialRootModel(1701, "1.0.0", nil, orchestrator.NewLifecycleManager(nil, nil, nil), nil, false)
+
+	d := &DownloadModel{
+		ID:         "resume-test",
+		Filename:   "test.iso",
+		Total:      1000 * 1024 * 1024,
+		Downloaded: 500 * 1024 * 1024,
+		Speed:      10 * 1024 * 1024,
+	}
+	m.downloads = []*DownloadModel{d}
+
+	// 1. Initial speed
+	d.UpdateETA()
+	if !d.hasEtaSpeed || d.etaSpeed != 10*1024*1024 {
+		t.Fatalf("expected ETA speed to seed correctly")
+	}
+
+	// 2. Simulate pause and resume
+	m.updateEvents(types.DownloadEvent{Type: types.EventPaused, DownloadID: d.ID})
+	m.updateEvents(types.DownloadEvent{Type: types.EventResumed, DownloadID: d.ID})
+
+	if d.hasEtaSpeed || d.etaSpeed != 0 || d.lastETA != 0 {
+		t.Fatalf("expected EventResumed to wipe ETA state, got has=%v, speed=%v, eta=%v", d.hasEtaSpeed, d.etaSpeed, d.lastETA)
+	}
+
+	// 3. New speed on resume
+	d.Speed = 5 * 1024 * 1024
+	d.UpdateETA()
+	if d.etaSpeed != 5*1024*1024 {
+		t.Fatalf("expected ETA speed to re-seed entirely at new speed, got %v", d.etaSpeed)
 	}
 }

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -763,13 +763,14 @@ func TestView_ETAFlickerBug(t *testing.T) {
 
 	// In the old bug, calling View() 10 times would instantly converge the ETA
 	// Let's call View() 10 times (simulating spinner ticks or terminal resizing)
+	snapshot := d.lastETA
 	for i := 0; i < 10; i++ {
 		m.View()
 	}
 
 	// Since View() should be side-effect free, lastETA should not change!
-	if d.lastETA != expectedSmoothed {
-		t.Fatalf("ETA drifted during View() calls! View() is causing side effects. Got: %v", d.lastETA)
+	if d.lastETA != snapshot {
+		t.Fatalf("ETA drifted during View() calls! View() is causing side effects. Got: %v, Expected: %v", d.lastETA, snapshot)
 	}
 }
 

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -612,6 +612,7 @@ func TestFooter_ActiveSpeedShowsMBps(t *testing.T) {
 	m.downloads = []*DownloadModel{
 		{Speed: 2.5 * 1024 * 1024},
 	}
+	m.cachedTotalSpeed = int64(2.5 * 1024 * 1024)
 
 	last := footerLine(m)
 	if !strings.Contains(last, "MiB/s") {
@@ -631,6 +632,7 @@ func TestFooter_ActiveSpeedShowsKBps(t *testing.T) {
 	m.downloads = []*DownloadModel{
 		{Speed: 512 * 1024},
 	}
+	m.cachedTotalSpeed = 512 * 1024
 
 	last := footerLine(m)
 	if !strings.Contains(last, "KiB/s") {


### PR DESCRIPTION
- **perf: optimize TUI rendering by caching total speed and graph output and add ShowSpeedGraph setting**
- **fix: eliminate ETA calculation side effects in View() by moving smoothing logic to progress update cycles**
- **fix: preserve ETA history during transient speed drops and update display conditions**
- **perf: increase speed graph update interval to 1s to provide 60s of history**
- **refactor: replace graph caching with a stateful, RLE-optimized renderer for improved TUI performance**
- **fix: reset ETA calculation state upon download resume and improve stability with smoothed speed tracking**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to show or hide the dashboard speed graph, enabled by default.
  - Extended the displayed speed history to approximately 60 seconds.
  - Improved graph rendering during resizing and with large datasets.

- **Bug Fixes**
  - Stabilized ETA calculations and reset ETA state correctly when downloads resume.
  - Prevented ETA values from flickering during dashboard updates.

- **Performance**
  - Reduced repeated calculations and unnecessary dashboard list updates for smoother live progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->