### PR TITLE
feat: Parse clipboard curl strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ For a full reference, see the **[Themes Guide](docs/THEMES.md)**, **[Settings &a
 
 ### 1. Interactive TUI Mode
 
-Just run `surge` to enter the dashboard. This is where you can visualize progress, manage the queue, and see speed graphs. If you encounter any issues, press `?` to open the bug reporting wizard.
+Just run `surge` to enter the dashboard. This is where you can visualize progress, manage the queue, and see speed graphs. If you encounter any issues, press `?` to open the bug reporting wizard. You can also press `Shift + A` or use your terminal's paste shortcut to automatically parse a copied browser 'cURL' command straight into a new download.
 
 ```bash
 # Start the TUI

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -10,7 +10,7 @@ In the interactive TUI (launched simply via `surge`), you can manage your downlo
 
 While in the TUI Dashboard, you can rapidly add downloads using your clipboard:
 - Press `a` to manually type or paste a URL.
-- Press `Shift+A` (or use your terminal's paste shortcut `Ctrl+V`/`Cmd+V`) to automatically parse a copied browser **cURL** command (from "Copy as cURL"). Surge will extract the URL and all headers (like cookies and user-agents) and bypass the Mirrors field.
+- Press `Shift+A` to directly attempt to parse a copied browser **cURL** command (from "Copy as cURL"). Surge will extract the URL and all headers (like cookies and user-agents).
 
 ## CLI Commands
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,6 +1,18 @@
-# CLI Usage
+# Usage Guide
 
-Surge provides a robust Command Line Interface for automation and scripting. For configuration options, see [SETTINGS.md](SETTINGS.md).
+Surge has both a robust CLI and a fast Interactive TUI. For configuration options, see [SETTINGS.md](SETTINGS.md).
+
+## TUI Usage
+
+In the interactive TUI (launched simply via `surge`), you can manage your downloads through keyboard shortcuts. You can view all shortcuts in-app by pressing `?` (Help) or `Shift+?`.
+
+### Adding Downloads from Clipboard
+
+While in the TUI Dashboard, you can rapidly add downloads using your clipboard:
+- Press `a` to manually type or paste a URL.
+- Press `Shift+A` (or use your terminal's paste shortcut `Ctrl+V`/`Cmd+V`) to automatically parse a copied browser **cURL** command (from "Copy as cURL"). Surge will extract the URL and all headers (like cookies and user-agents) and bypass the Mirrors field.
+
+## CLI Commands
 
 ## Command Table
 

--- a/internal/clipboard/utils.go
+++ b/internal/clipboard/utils.go
@@ -1,6 +1,9 @@
 package clipboard
 
 import (
+	"regexp"
+	"strings"
+
 	"github.com/atotto/clipboard"
 )
 
@@ -15,4 +18,27 @@ func Read() (string, error) {
 // Write copies the given text to the system clipboard.
 func Write(text string) error {
 	return clipboardWriteAll(text)
+}
+
+// ParseCurl parses a standard cURL command string into a URL and headers.
+func ParseCurl(text string) (string, map[string]string) {
+	headers := make(map[string]string)
+	text = strings.TrimSpace(text)
+	if !strings.HasPrefix(text, "curl ") {
+		return "", headers
+	}
+
+	urlRe := regexp.MustCompile(`(?:^|\s)['"]?(https?://[^'"\s]+)['"]?`)
+	if match := urlRe.FindStringSubmatch(text); len(match) > 1 {
+		headerRe := regexp.MustCompile(`(?:-H|--header)\s+(?:'([^:]+):\s*([^']+)'|"([^:]+):\s*([^"]+)")`)
+		for _, m := range headerRe.FindAllStringSubmatch(text, -1) {
+			if m[1] != "" {
+				headers[strings.TrimSpace(m[1])] = strings.TrimSpace(m[2])
+			} else if m[3] != "" {
+				headers[strings.TrimSpace(m[3])] = strings.TrimSpace(m[4])
+			}
+		}
+		return match[1], headers
+	}
+	return "", headers
 }

--- a/internal/clipboard/utils.go
+++ b/internal/clipboard/utils.go
@@ -28,16 +28,18 @@ func ParseCurl(text string) (string, map[string]string) {
 		return "", headers
 	}
 
-	urlRe := regexp.MustCompile(`(?:^|\s)['"]?(https?://[^'"\s]+)['"]?`)
-	if match := urlRe.FindStringSubmatch(text); len(match) > 1 {
-		headerRe := regexp.MustCompile(`(?:-H|--header)\s+(?:'([^:]+):\s*([^']+)'|"([^:]+):\s*([^"]+)")`)
-		for _, m := range headerRe.FindAllStringSubmatch(text, -1) {
-			if m[1] != "" {
-				headers[strings.TrimSpace(m[1])] = strings.TrimSpace(m[2])
-			} else if m[3] != "" {
-				headers[strings.TrimSpace(m[3])] = strings.TrimSpace(m[4])
-			}
+	headerRe := regexp.MustCompile(`(?:-H|--header)\s+(?:'([^:]+):\s*([^']+)'|"([^:]+):\s*([^"]+)")`)
+	for _, m := range headerRe.FindAllStringSubmatch(text, -1) {
+		if m[1] != "" {
+			headers[strings.TrimSpace(m[1])] = strings.TrimSpace(m[2])
+		} else if m[3] != "" {
+			headers[strings.TrimSpace(m[3])] = strings.TrimSpace(m[4])
 		}
+	}
+
+	textWithoutHeaders := headerRe.ReplaceAllString(text, "")
+	urlRe := regexp.MustCompile(`(?:^|\s)['"]?(https?://[^'"\s]+)['"]?`)
+	if match := urlRe.FindStringSubmatch(textWithoutHeaders); len(match) > 1 {
 		return match[1], headers
 	}
 	return "", headers

--- a/internal/clipboard/utils_test.go
+++ b/internal/clipboard/utils_test.go
@@ -9,7 +9,7 @@ func TestParseCurl(t *testing.T) {
 	cmd := `curl 'https://i.ytimg.com/an_webp/8gaSCj1-6ck/mqdefault_6s.webp?du=3000' \
   -H 'sec-ch-ua-platform: "Linux"' \
   -H 'Referer: https://www.youtube.com/'`
-  
+
 	url, headers := ParseCurl(cmd)
 	if url != "https://i.ytimg.com/an_webp/8gaSCj1-6ck/mqdefault_6s.webp?du=3000" {
 		t.Errorf("unexpected URL: %v", url)
@@ -20,6 +20,20 @@ func TestParseCurl(t *testing.T) {
 		"Referer":            "https://www.youtube.com/",
 	}
 
+	if !reflect.DeepEqual(headers, expectedHeaders) {
+		t.Errorf("unexpected headers: %v", headers)
+	}
+}
+
+func TestParseCurl_HeaderBeforeURL(t *testing.T) {
+	cmd := `curl -H 'Referer: https://wrong.com' 'https://correct.com'`
+	url, headers := ParseCurl(cmd)
+	if url != "https://correct.com" {
+		t.Errorf("unexpected URL: %v", url)
+	}
+	expectedHeaders := map[string]string{
+		"Referer": "https://wrong.com",
+	}
 	if !reflect.DeepEqual(headers, expectedHeaders) {
 		t.Errorf("unexpected headers: %v", headers)
 	}

--- a/internal/clipboard/utils_test.go
+++ b/internal/clipboard/utils_test.go
@@ -1,0 +1,26 @@
+package clipboard
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseCurl(t *testing.T) {
+	cmd := `curl 'https://i.ytimg.com/an_webp/8gaSCj1-6ck/mqdefault_6s.webp?du=3000' \
+  -H 'sec-ch-ua-platform: "Linux"' \
+  -H 'Referer: https://www.youtube.com/'`
+  
+	url, headers := ParseCurl(cmd)
+	if url != "https://i.ytimg.com/an_webp/8gaSCj1-6ck/mqdefault_6s.webp?du=3000" {
+		t.Errorf("unexpected URL: %v", url)
+	}
+
+	expectedHeaders := map[string]string{
+		"sec-ch-ua-platform": `"Linux"`,
+		"Referer":            "https://www.youtube.com/",
+	}
+
+	if !reflect.DeepEqual(headers, expectedHeaders) {
+		t.Errorf("unexpected headers: %v", headers)
+	}
+}

--- a/internal/config/keymaps.go
+++ b/internal/config/keymaps.go
@@ -36,30 +36,30 @@ type KeyMap struct {
 
 // DashboardKeyMap defines keybindings for the main dashboard
 type DashboardKeyMap struct {
-	TabQueued      key.Binding
-	TabActive      key.Binding
-	TabDone        key.Binding
-	NextTab        key.Binding
-	PrevTab        key.Binding
-	Add            key.Binding
+	TabQueued        key.Binding
+	TabActive        key.Binding
+	TabDone          key.Binding
+	NextTab          key.Binding
+	PrevTab          key.Binding
+	Add              key.Binding
 	AddFromClipboard key.Binding
-	BatchImport    key.Binding
-	Search         key.Binding
-	Pause          key.Binding
-	Refresh        key.Binding
-	Delete         key.Binding
-	PurgeFile      key.Binding
-	Settings       key.Binding
-	SpeedLimits    key.Binding
-	Log            key.Binding
-	ToggleHelp     key.Binding
-	ReportBug      key.Binding
-	OpenFile       key.Binding
-	OpenFolder     key.Binding
-	Quit           key.Binding
-	ForceQuit      key.Binding
-	CategoryFilter key.Binding
-	PinTab         key.Binding
+	BatchImport      key.Binding
+	Search           key.Binding
+	Pause            key.Binding
+	Refresh          key.Binding
+	Delete           key.Binding
+	PurgeFile        key.Binding
+	Settings         key.Binding
+	SpeedLimits      key.Binding
+	Log              key.Binding
+	ToggleHelp       key.Binding
+	ReportBug        key.Binding
+	OpenFile         key.Binding
+	OpenFolder       key.Binding
+	Quit             key.Binding
+	ForceQuit        key.Binding
+	CategoryFilter   key.Binding
+	PinTab           key.Binding
 	// Navigation
 	Up   key.Binding
 	Down key.Binding

--- a/internal/config/keymaps.go
+++ b/internal/config/keymaps.go
@@ -42,6 +42,7 @@ type DashboardKeyMap struct {
 	NextTab        key.Binding
 	PrevTab        key.Binding
 	Add            key.Binding
+	AddFromClipboard key.Binding
 	BatchImport    key.Binding
 	Search         key.Binding
 	Pause          key.Binding
@@ -416,6 +417,10 @@ func DefaultKeyMap() *KeyMap {
 				key.WithKeys("a"),
 				key.WithHelp("a", "add download"),
 			),
+			AddFromClipboard: key.NewBinding(
+				key.WithKeys("A"),
+				key.WithHelp("A", "add from clipboard"),
+			),
 			BatchImport: key.NewBinding(
 				key.WithKeys("b", "B"),
 				key.WithHelp("b", "batch import"),
@@ -763,7 +768,7 @@ func (k DashboardKeyMap) ShortHelp() []key.Binding {
 func (k DashboardKeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.TabQueued, k.TabActive, k.TabDone, k.NextTab, k.PrevTab},
-		{k.Add, k.BatchImport, k.Search, k.CategoryFilter, k.Pause, k.Refresh, k.Delete, k.PurgeFile, k.Settings, k.SpeedLimits, k.PinTab},
+		{k.Add, k.AddFromClipboard, k.BatchImport, k.Search, k.CategoryFilter, k.Pause, k.Refresh, k.Delete, k.PurgeFile, k.Settings, k.SpeedLimits, k.PinTab},
 		{k.Log, k.OpenFile, k.OpenFolder, k.ReportBug, k.Quit},
 	}
 }

--- a/internal/tui/clipboard_paste_test.go
+++ b/internal/tui/clipboard_paste_test.go
@@ -49,3 +49,27 @@ func TestHandleClipboardPaste_CurlCommand(t *testing.T) {
 		t.Fatalf("expected headers to be set, got %v", m2.pendingHeaders)
 	}
 }
+
+func TestHandleClipboardPaste_CancelCurlThenStandardFlow(t *testing.T) {
+	m := RootModel{
+		inputs:   newInputModels(),
+		Settings: config.DefaultSettings(),
+	}
+
+	// 1. Paste cURL flow
+	curlCmd := `curl 'https://example.com/file.zip' -H 'User-Agent: test'`
+	updated, _ := m.handleClipboardPaste(curlCmd)
+	m2 := updated.(RootModel)
+
+	if m2.pendingHeaders == nil || m2.pendingHeaders["User-Agent"] != "test" {
+		t.Fatalf("expected headers to be set, got %v", m2.pendingHeaders)
+	}
+
+	// 2. Standard URL flow
+	updated2, _ := m2.handleClipboardPaste("https://example.com/other.zip")
+	m3 := updated2.(RootModel)
+
+	if m3.pendingHeaders != nil {
+		t.Fatalf("expected headers to be cleared, got %v", m3.pendingHeaders)
+	}
+}

--- a/internal/tui/clipboard_paste_test.go
+++ b/internal/tui/clipboard_paste_test.go
@@ -1,0 +1,51 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/SurgeDM/Surge/internal/config"
+)
+
+func TestHandleClipboardPaste_StandardURL(t *testing.T) {
+	m := RootModel{
+		inputs:   newInputModels(),
+		Settings: config.DefaultSettings(),
+	}
+
+	updated, _ := m.handleClipboardPaste("https://example.com/file.zip")
+	m2 := updated.(RootModel)
+
+	if m2.state != InputState {
+		t.Fatalf("expected InputState, got %v", m2.state)
+	}
+	if m2.hideMirrors {
+		t.Fatal("expected hideMirrors=false for standard URL")
+	}
+	if m2.inputs[0].Value() != "https://example.com/file.zip" {
+		t.Fatalf("expected url to be set, got %v", m2.inputs[0].Value())
+	}
+}
+
+func TestHandleClipboardPaste_CurlCommand(t *testing.T) {
+	m := RootModel{
+		inputs:   newInputModels(),
+		Settings: config.DefaultSettings(),
+	}
+
+	curlCmd := `curl 'https://example.com/file.zip' -H 'User-Agent: test'`
+	updated, _ := m.handleClipboardPaste(curlCmd)
+	m2 := updated.(RootModel)
+
+	if m2.state != InputState {
+		t.Fatalf("expected InputState, got %v", m2.state)
+	}
+	if !m2.hideMirrors {
+		t.Fatal("expected hideMirrors=true for curl command")
+	}
+	if m2.inputs[0].Value() != "https://example.com/file.zip" {
+		t.Fatalf("expected url to be set, got %v", m2.inputs[0].Value())
+	}
+	if m2.pendingHeaders == nil || m2.pendingHeaders["User-Agent"] != "test" {
+		t.Fatalf("expected headers to be set, got %v", m2.pendingHeaders)
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -127,6 +127,7 @@ type RootModel struct {
 	pinnedTab      int // -1=None, 0=Queued, 1=Active, 2=Done
 	inputs         []textinput.Model
 	focusedInput   int
+	hideMirrors    bool
 	purgeTargetID  string
 	removeTargetID string
 	// Service Interface

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -13,12 +13,15 @@ import (
 )
 
 func (m RootModel) updatePaste(msg tea.PasteMsg) (tea.Model, tea.Cmd) {
-	if m.state == DashboardState && m.searchActive {
-		var cmd tea.Cmd
-		m.searchInput, cmd = m.searchInput.Update(msg)
-		m.searchQuery = m.searchInput.Value()
-		m.UpdateListItems()
-		return m, cmd
+	if m.state == DashboardState {
+		if m.searchActive {
+			var cmd tea.Cmd
+			m.searchInput, cmd = m.searchInput.Update(msg)
+			m.searchQuery = m.searchInput.Value()
+			m.UpdateListItems()
+			return m, cmd
+		}
+		return m.handleClipboardPaste(msg.String())
 	}
 
 	switch m.state {

--- a/internal/tui/update_dashboard.go
+++ b/internal/tui/update_dashboard.go
@@ -112,6 +112,7 @@ func (m RootModel) updateDashboard(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.inputs[3].Blur()
 		m.inputs[1].SetValue("") // Clear mirrors
 		m.inputs[1].Blur()
+		m.pendingHeaders = nil // clear stale headers
 
 		url := ""
 		if config.Resolve[bool](m.Settings.General.ClipboardMonitor) {
@@ -408,11 +409,12 @@ func (m RootModel) handleClipboardPaste(text string) (tea.Model, tea.Cmd) {
 		if url == "" {
 			return m, nil
 		}
+		m.pendingHeaders = nil // clear stale headers
 		m.state = InputState
 		m.hideMirrors = false
 		m.focusedInput = 0
 		m.inputs[0].Focus()
-		
+
 		defaultDir := config.Resolve[string](m.Settings.General.DefaultDownloadDir)
 		if defaultDir == "" {
 			defaultDir = "."
@@ -430,13 +432,13 @@ func (m RootModel) handleClipboardPaste(text string) (tea.Model, tea.Cmd) {
 		if defaultDir == "" {
 			defaultDir = "."
 		}
-		
+
 		m.pendingHeaders = headers
 		m.state = InputState
 		m.hideMirrors = true
 		m.focusedInput = 0
 		m.inputs[0].Focus()
-		
+
 		m.inputs[2].SetValue(defaultDir)
 		m.inputs[2].Blur()
 		m.inputs[3].SetValue("")
@@ -444,7 +446,7 @@ func (m RootModel) handleClipboardPaste(text string) (tea.Model, tea.Cmd) {
 		m.inputs[1].SetValue("") // Clear mirrors
 		m.inputs[1].Blur()
 		m.inputs[0].SetValue(url)
-		
+
 		return m, nil
 	}
 }

--- a/internal/tui/update_dashboard.go
+++ b/internal/tui/update_dashboard.go
@@ -98,6 +98,7 @@ func (m RootModel) updateDashboard(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	// Add download
 	if key.Matches(msg, m.keys.Dashboard.Add) {
 		m.state = InputState
+		m.hideMirrors = false
 		m.focusedInput = 0
 		m.inputs[0].Focus()
 		// Use default download dir from settings
@@ -408,6 +409,7 @@ func (m RootModel) handleClipboardPaste(text string) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.state = InputState
+		m.hideMirrors = false
 		m.focusedInput = 0
 		m.inputs[0].Focus()
 		
@@ -425,27 +427,24 @@ func (m RootModel) handleClipboardPaste(text string) (tea.Model, tea.Cmd) {
 		return m, nil
 	} else {
 		defaultDir := config.Resolve[string](m.Settings.General.DefaultDownloadDir)
-		isDefaultPath := false
 		if defaultDir == "" {
 			defaultDir = "."
-			isDefaultPath = true
-		} else {
-			isDefaultPath = m.isDefaultDownloadPath(defaultDir)
 		}
 		
-		if d := m.checkForDuplicate(url); d != nil {
-			m.pendingURL = url
-			m.pendingMirrors = nil
-			m.pendingHeaders = headers
-			m.pendingPath = defaultDir
-			m.pendingIsDefaultPath = isDefaultPath
-			m.pendingFilename = ""
-			m.pendingWorkers = 0
-			m.pendingMinChunkSize = 0
-			m.duplicateInfo = d.Filename
-			m.state = DuplicateWarningState
-			return m, nil
-		}
-		return m.startDownload(url, nil, headers, defaultDir, isDefaultPath, "", "", 0, 0)
+		m.pendingHeaders = headers
+		m.state = InputState
+		m.hideMirrors = true
+		m.focusedInput = 0
+		m.inputs[0].Focus()
+		
+		m.inputs[2].SetValue(defaultDir)
+		m.inputs[2].Blur()
+		m.inputs[3].SetValue("")
+		m.inputs[3].Blur()
+		m.inputs[1].SetValue("") // Clear mirrors
+		m.inputs[1].Blur()
+		m.inputs[0].SetValue(url)
+		
+		return m, nil
 	}
 }

--- a/internal/tui/update_dashboard.go
+++ b/internal/tui/update_dashboard.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"strings"
+
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/list"
 	tea "charm.land/bubbletea/v2"
@@ -115,6 +117,15 @@ func (m RootModel) updateDashboard(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			url = clipboard.ReadURL()
 		}
 		m.inputs[0].SetValue(url)
+		return m, nil
+	}
+
+	// Add from clipboard
+	if key.Matches(msg, m.keys.Dashboard.AddFromClipboard) {
+		text, err := clipboard.Read()
+		if err == nil && text != "" {
+			return m.handleClipboardPaste(text)
+		}
 		return m, nil
 	}
 
@@ -383,4 +394,58 @@ func (m RootModel) updateDashboard(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	m.list, cmd = m.list.Update(msg)
 	return m, cmd
+}
+
+func (m RootModel) handleClipboardPaste(text string) (tea.Model, tea.Cmd) {
+	url, headers := clipboard.ParseCurl(text)
+	if url == "" {
+		if strings.HasPrefix(strings.TrimSpace(text), "http") {
+			url = strings.TrimSpace(text)
+		} else {
+			url = clipboard.ReadURL()
+		}
+		if url == "" {
+			return m, nil
+		}
+		m.state = InputState
+		m.focusedInput = 0
+		m.inputs[0].Focus()
+		
+		defaultDir := config.Resolve[string](m.Settings.General.DefaultDownloadDir)
+		if defaultDir == "" {
+			defaultDir = "."
+		}
+		m.inputs[2].SetValue(defaultDir)
+		m.inputs[2].Blur()
+		m.inputs[3].SetValue("")
+		m.inputs[3].Blur()
+		m.inputs[1].SetValue("") // Clear mirrors
+		m.inputs[1].Blur()
+		m.inputs[0].SetValue(url)
+		return m, nil
+	} else {
+		defaultDir := config.Resolve[string](m.Settings.General.DefaultDownloadDir)
+		isDefaultPath := false
+		if defaultDir == "" {
+			defaultDir = "."
+			isDefaultPath = true
+		} else {
+			isDefaultPath = m.isDefaultDownloadPath(defaultDir)
+		}
+		
+		if d := m.checkForDuplicate(url); d != nil {
+			m.pendingURL = url
+			m.pendingMirrors = nil
+			m.pendingHeaders = headers
+			m.pendingPath = defaultDir
+			m.pendingIsDefaultPath = isDefaultPath
+			m.pendingFilename = ""
+			m.pendingWorkers = 0
+			m.pendingMinChunkSize = 0
+			m.duplicateInfo = d.Filename
+			m.state = DuplicateWarningState
+			return m, nil
+		}
+		return m.startDownload(url, nil, headers, defaultDir, isDefaultPath, "", "", 0, 0)
+	}
 }

--- a/internal/tui/update_input.go
+++ b/internal/tui/update_input.go
@@ -40,18 +40,30 @@ func (m RootModel) updateInput(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 
 	if key.Matches(msg, m.keys.Input.Up) && m.focusedInput > 0 {
-		m.focusInput(m.focusedInput - 1)
+		next := m.focusedInput - 1
+		if m.hideMirrors && next == 1 {
+			next = 0
+		}
+		m.focusInput(next)
 		return m, nil
 	}
 
 	if key.Matches(msg, m.keys.Input.Down) && m.focusedInput < 3 {
-		m.focusInput(m.focusedInput + 1)
+		next := m.focusedInput + 1
+		if m.hideMirrors && next == 1 {
+			next = 2
+		}
+		m.focusInput(next)
 		return m, nil
 	}
 
 	if key.Matches(msg, m.keys.Input.Enter) {
 		if m.focusedInput < 3 {
-			m.focusInput(m.focusedInput + 1)
+			next := m.focusedInput + 1
+			if m.hideMirrors && next == 1 {
+				next = 2
+			}
+			m.focusInput(next)
 			return m, nil
 		}
 		return m.submitInputForm()
@@ -97,10 +109,13 @@ func (m RootModel) submitInputForm() (tea.Model, tea.Cmd) {
 	}
 	filename := m.inputs[3].Value()
 
+	// Check if pending headers were populated from cURL parser
+	headers := m.pendingHeaders
+	
 	if d := m.checkForDuplicate(url); d != nil {
 		m.pendingURL = url
 		m.pendingMirrors = mirrors
-		m.pendingHeaders = nil
+		m.pendingHeaders = headers
 		m.pendingPath = path
 		m.pendingIsDefaultPath = isDefaultPath
 		m.pendingFilename = filename
@@ -116,8 +131,9 @@ func (m RootModel) submitInputForm() (tea.Model, tea.Cmd) {
 	m.inputs[1].SetValue("")
 	m.inputs[2].SetValue(path) // Keep path for next download
 	m.inputs[3].SetValue("")
+	m.pendingHeaders = nil // Reset
 
-	return m.startDownload(url, mirrors, nil, path, isDefaultPath, filename, "", 0, 0)
+	return m.startDownload(url, mirrors, headers, path, isDefaultPath, filename, "", 0, 0)
 }
 
 // parseURLInput splits a comma-separated URL string into a primary URL and mirrors.

--- a/internal/tui/update_input.go
+++ b/internal/tui/update_input.go
@@ -111,7 +111,7 @@ func (m RootModel) submitInputForm() (tea.Model, tea.Cmd) {
 
 	// Check if pending headers were populated from cURL parser
 	headers := m.pendingHeaders
-	
+
 	if d := m.checkForDuplicate(url); d != nil {
 		m.pendingURL = url
 		m.pendingMirrors = mirrors

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -93,12 +93,36 @@ func (m RootModel) View() tea.View {
 	// These overlays sit on top of the dashboard or replace it
 
 	if m.state == InputState {
+		var activeInputs []textinput.Model
+		var activeLabels []string
+		
+		activeInputs = append(activeInputs, m.inputs[0])
+		activeLabels = append(activeLabels, "URL:")
+		
+		if !m.hideMirrors {
+			activeInputs = append(activeInputs, m.inputs[1])
+			activeLabels = append(activeLabels, "Mirrors:")
+		}
+		
+		activeInputs = append(activeInputs, m.inputs[2], m.inputs[3])
+		activeLabels = append(activeLabels, "Path:", "Filename:")
+
+		mappedFocus := m.focusedInput
+		if m.hideMirrors && m.focusedInput > 0 {
+			mappedFocus = m.focusedInput - 1
+		}
+		
+		browseHint := 2
+		if m.hideMirrors {
+			browseHint = 1
+		}
+
 		modal := components.AddDownloadModal{
 			Title:           "Add Download",
-			Inputs:          []textinput.Model{m.inputs[0], m.inputs[1], m.inputs[2], m.inputs[3]},
-			Labels:          []string{"URL:", "Mirrors:", "Path:", "Filename:"},
-			FocusedInput:    m.focusedInput,
-			BrowseHintIndex: 2,
+			Inputs:          activeInputs,
+			Labels:          activeLabels,
+			FocusedInput:    mappedFocus,
+			BrowseHintIndex: browseHint,
 			Help:            m.help,
 			HelpKeys:        m.keys.Input,
 			BorderColor:     colors.Pink(),

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -95,15 +95,15 @@ func (m RootModel) View() tea.View {
 	if m.state == InputState {
 		var activeInputs []textinput.Model
 		var activeLabels []string
-		
+
 		activeInputs = append(activeInputs, m.inputs[0])
 		activeLabels = append(activeLabels, "URL:")
-		
+
 		if !m.hideMirrors {
 			activeInputs = append(activeInputs, m.inputs[1])
 			activeLabels = append(activeLabels, "Mirrors:")
 		}
-		
+
 		activeInputs = append(activeInputs, m.inputs[2], m.inputs[3])
 		activeLabels = append(activeLabels, "Path:", "Filename:")
 
@@ -111,7 +111,7 @@ func (m RootModel) View() tea.View {
 		if m.hideMirrors && m.focusedInput > 0 {
 			mappedFocus = m.focusedInput - 1
 		}
-		
+
 		browseHint := 2
 		if m.hideMirrors {
 			browseHint = 1


### PR DESCRIPTION
Resolves #588\n\nAdds a lightweight regex parser for `curl` commands to extract the URL and headers. Ties it into `tea.PasteMsg` and a new `Shift+A` keybind. Reuses the `AddDownloadModal` but intelligently skips the Mirrors field when headers are injected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clipboard import support for direct URLs and copied browser cURL commands.
  * Automatically extracts and preserves request headers from cURL commands during downloads.
  * Added a dashboard shortcut (`A`, or `Shift + A` in the TUI) for importing clipboard content.
  * Hides the Mirrors field for cURL imports and improves input navigation.
  * Improved handling when switching between cURL commands and standard URLs.

* **Documentation**
  * Expanded usage guidance for CLI, TUI, and clipboard-based imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->