### PR TITLE
update nix hash

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777954456,
-        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "lastModified": 1785967620,
+        "narHash": "sha256-IItrdb7Puk05RqOBWZYFC5X6Wl1sJmCfh5MWVHw5iMM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "rev": "b7c2ada94fe99c15b0dbcf4d11fd7850b957a436",
         "type": "github"
       },
       "original": {

--- a/package.nix
+++ b/package.nix
@@ -8,7 +8,7 @@ buildGoModule {
   pname = "surge";
   inherit version src;
 
-  vendorHash = "sha256-tXJUr/URQZC+tNq+HOIuinaqbeElJMPWQH/MG1rY80I=";
+  vendorHash = "sha256-uZrSOcwfXJ9LwuHi+0wIjPBIsAdULU60GbWrJNV923s=";
 
   subPackages = ["."];
 


### PR DESCRIPTION
Nix got a wrong hash, see this error:
```
(glonass) [titus:/etc/nixos] % update
warning: Git tree '/etc/nixos' is dirty
warning: updating lock file "/etc/nixos/flake.lock":
• Updated input 'surge':
    'github:SurgeDM/Surge/f3165ce084859b2c783e82e02a9dd297c0eec52b?narHash=sha256-zlkNo%2BQZSacEsGmSBv/CwVyBjqiNeo6xjoTCVCCvsnA%3D' (2026-08-08)
  → 'github:L0rdCycl0p/Surge/a6ef0edc9736eba7405637c2bf11e3d8bb826062?narHash=sha256-c370WnvujLIpkM14USwQ1H5adAB4XuU1MHCe8fcnAtw%3D' (2026-08-08)
• Updated input 'surge/nixpkgs':
    'github:NixOS/nixpkgs/549bd84d6279f9852cae6225e372cc67fb91a4c1?narHash=sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9%2BhrDTkDU%3D' (2026-05-05)
  → 'github:NixOS/nixpkgs/b7c2ada94fe99c15b0dbcf4d11fd7850b957a436?narHash=sha256-IItrdb7Puk05RqOBWZYFC5X6Wl1sJmCfh5MWVHw5iMM%3D' (2026-08-05)
building the system configuration...
warning: Git tree '/etc/nixos' is dirty
error: hash mismatch in fixed-output derivation '/nix/store/2hm9c6bi0bwzz9g8a6z9mkh3azgjkx7z-surge-0.8.5-go-modules.drv':
         specified: sha256-tXJUr/URQZC+tNq+HOIuinaqbeElJMPWQH/MG1rY80I=
            got:    sha256-uZrSOcwfXJ9LwuHi+0wIjPBIsAdULU60GbWrJNV923s=
error: Cannot build '/nix/store/25dfhdc6a9vi48acg2kvarshgycwczb2-surge-0.8.5.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/303mggknjx6gpkvizj1csifhzy2mmabj-surge-0.8.5
error: Cannot build '/nix/store/nrqzrzkdkrims9hn008z6786pcydsjbf-system-path.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/pmdz574h1yk04gjm57l28n3yghfn2xfc-system-path
error: Cannot build '/nix/store/qhivnwkdzlgqacx7pbmp1h6jzwlx4lhs-nixos-system-glonass-26.11.20260723.e2587ca.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/d8vzr9ip34igf2zmx0j2whd6hzyp567d-nixos-system-glonass-26.11.20260723.e2587ca
Command 'nix --extra-experimental-features 'nix-command flakes' build --print-out-paths '/etc/nixos#nixosConfigurations."glonass".config.system.build.toplevel' --no-link' returned non-zero exit status 1.
(glonass) [titus:/etc/nixos] %
```

But now it works!
```
(glonass) [titus:/etc/nixos] % doas nix flake update surge
warning: Git tree '/etc/nixos' is dirty
warning: updating lock file "/etc/nixos/flake.lock":
• Updated input 'surge':
    'github:L0rdCycl0p/Surge/7f07d3f40bb05de66f045b7b67f2c82f4a5fc3ef?narHash=sha256-MTamLC65qrWHf1brOjFWa3Agr20ae%2B9tC6IK0wkrohA%3D' (2026-08-08)
  → 'github:L0rdCycl0p/Surge/fac18b9f21650b522d4448829bca76609a4cc5b8?narHash=sha256-8TtRVp%2BFUY8s8OrJ737fR4EcQeKOomZlgtV6IWNDkOw%3D' (2026-08-08)
(glonass) [titus:/etc/nixos] % update
warning: Git tree '/etc/nixos' is dirty
building the system configuration...
warning: Git tree '/etc/nixos' is dirty
Checking switch inhibitors... done
Skipping "/boot/EFI/systemd/systemd-bootx64.efi", same boot loader version in place already.
Skipping "/boot/EFI/BOOT/BOOTX64.EFI", same boot loader version in place already.
stopping the following units: polkit.service
activating the configuration...
setting up /etc...
reloading user units for titus...
reloading the following user units: dbus-broker.service
restarting the following user units: nixos-activation.service
restarting sysinit-reactivation.target
reloading the following units: dbus-broker.service
starting the following units: polkit.service
warning: the following units failed: NetworkManager-wait-online.service
× NetworkManager-wait-online.service - Network Manager Wait Online
     Loaded: loaded (/etc/systemd/system/NetworkManager-wait-online.service; enabled; preset: ignored)
    Drop-In: /nix/store/9a1kqbmw1yyml03hf7zprf6pnqwqbzp7-system-units/NetworkManager-wait-online.service.d
             └─overrides.conf
     Active: failed (Result: exit-code) since Sat 2026-08-08 22:01:02 CEST; 290ms ago
 Invocation: bc2e23ee45df46fbb22ad9e9153d0446
       Docs: man:NetworkManager-wait-online.service(8)
    Process: 109906 ExecStart=/nix/store/160fh1w4i6ypbnbd5cx3504xp14i5g2x-networkmanager-1.56.0/bin/nm-online -s -q (code=exited, status=1/FAILURE)
   Main PID: 109906 (code=exited, status=1/FAILURE)
         IP: 0B in, 0B out
         IO: 4.1M read, 0B written
   Mem peak: 6.8M
        CPU: 30ms

Aug 08 22:00:02 glonass systemd[1]: Starting Network Manager Wait Online...
Aug 08 22:01:02 glonass systemd[1]: NetworkManager-wait-online.service: Main process exited, code=exited, status=1/FAILURE
Aug 08 22:01:02 glonass systemd[1]: NetworkManager-wait-online.service: Failed with result 'exit-code'.
Aug 08 22:01:02 glonass systemd[1]: Failed to start Network Manager Wait Online.
Aug 08 22:01:02 glonass systemd[1]: NetworkManager-wait-online.service: Consumed 30ms CPU time over 1min 110ms wall clock time, 6.8M memory peak, 4.1M read from disk.
Command 'systemd-run -E LOCALE_ARCHIVE -E NIXOS_INSTALL_BOOTLOADER -E NIXOS_NO_CHECK --collect --no-ask-password --pipe --quiet --service-type=exec --unit=nixos-rebuild-switch-to-configuration /nix/store/l4xw5sg0nq42ll49q6bp3rvyg40y4l7p-nixos-system-glonass-26.11.20260723.e2587ca/bin/switch-to-configuration switch' returned non-zero exit status 4.
(glonass) [titus:/etc/nixos] %
```
Note: Ignore Network Manager, i don't know why this is, something with my bond

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package metadata to ensure the Surge Nix package builds correctly with its vendored Go dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->