### PR TITLE
fix: persist and display download errors through restart

### DIFF
--- a/internal/orchestrator/events.go
+++ b/internal/orchestrator/events.go
@@ -241,6 +241,7 @@ func (mgr *LifecycleManager) StartEventWorker(ch <-chan types.DownloadEvent) {
 					URLHash:      urlHash,
 					DestPath:     destPath,
 					Filename:     filename,
+					Error:        err.Error(),
 					Status:       "error",
 					TotalSize:    m.Total,
 					Downloaded:   m.Total,
@@ -313,11 +314,21 @@ func (mgr *LifecycleManager) StartEventWorker(ch <-chan types.DownloadEvent) {
 
 		case types.EventError:
 			existing, _ := store.GetDownload(m.DownloadID)
-			if existing != nil {
-				existing.Status = "error"
-				if err := store.AddToMasterList(*existing); err != nil {
-					utils.Debug("Lifecycle: Failed to persist error state: %v", err)
-				}
+			if existing == nil {
+				existing = &types.DownloadRecord{ID: m.DownloadID}
+			}
+			existing.Status = "error"
+			if m.Err != nil {
+				existing.Error = m.Err.Error()
+			}
+			if m.Filename != "" {
+				existing.Filename = m.Filename
+			}
+			if m.DestPath != "" {
+				existing.DestPath = m.DestPath
+			}
+			if err := store.AddToMasterList(*existing); err != nil {
+				utils.Debug("Lifecycle: Failed to persist error state: %v", err)
 			}
 			if settings := mgr.GetSettings(); settings != nil && config.Resolve[bool](settings.General.DownloadCompleteNotification) {
 				filename := m.Filename

--- a/internal/orchestrator/events.go
+++ b/internal/orchestrator/events.go
@@ -327,6 +327,10 @@ func (mgr *LifecycleManager) StartEventWorker(ch <-chan types.DownloadEvent) {
 			if m.DestPath != "" {
 				existing.DestPath = m.DestPath
 			}
+			if m.URL != "" {
+				existing.URL = m.URL
+				existing.URLHash = store.URLHash(m.URL)
+			}
 			if err := store.AddToMasterList(*existing); err != nil {
 				utils.Debug("Lifecycle: Failed to persist error state: %v", err)
 			}

--- a/internal/service/local_service.go
+++ b/internal/service/local_service.go
@@ -198,6 +198,7 @@ func (s *LocalDownloadService) GetStatus(id string) (*types.DownloadStatus, erro
 			Progress:     progress,
 			Speed:        completedSpeedBps(*entry),
 			Status:       entry.Status,
+			Error:        entry.Error,
 			TimeTaken:    entry.TimeTaken,
 			AvgSpeed:     entry.AvgSpeed,
 			RateLimit:    entry.RateLimit,
@@ -349,14 +350,17 @@ func (s *LocalDownloadService) List() ([]types.DownloadStatus, error) {
 		activeConfigs := s.lifecycle.GetScheduler().GetAll()
 		for _, cfg := range activeConfigs {
 			statusStr := "downloading"
+			var errStr string
 			if st := s.lifecycle.GetScheduler().GetStatus(cfg.ID); st != nil {
 				statusStr = st.Status
+				errStr = st.Error
 			}
 			status := types.DownloadStatus{
 				ID:           cfg.ID,
 				URL:          cfg.URL,
 				Filename:     cfg.Filename,
 				Status:       statusStr,
+				Error:        errStr,
 				RateLimit:    cfg.RateLimit,
 				RateLimitSet: cfg.RateLimitSet,
 			}
@@ -379,6 +383,12 @@ func (s *LocalDownloadService) List() ([]types.DownloadStatus, error) {
 						status.Status = "paused"
 					} else if cp.Done.Load() {
 						status.Status = "completed"
+					}
+					// GetStatus and metric reads are separate snapshots; recheck errors
+					// so a worker failure between those reads is not reported as downloading.
+					if err := cp.GetError(); err != nil {
+						status.Status = "error"
+						status.Error = err.Error()
 					}
 					if status.Status == "downloading" {
 						sessionDownloaded := downloaded - sessionStart
@@ -417,6 +427,7 @@ func (s *LocalDownloadService) List() ([]types.DownloadStatus, error) {
 				Filename:     d.Filename,
 				DestPath:     d.DestPath,
 				Status:       d.Status,
+				Error:        d.Error,
 				TotalSize:    d.TotalSize,
 				Downloaded:   d.Downloaded,
 				Progress:     progress,

--- a/internal/service/local_service_test.go
+++ b/internal/service/local_service_test.go
@@ -301,6 +301,14 @@ func TestLocalDownloadService_HistoryAndList(t *testing.T) {
 		Filename: "db.txt",
 	})
 
+	// Seed an errored download to verify Error survives a DB round-trip via List/GetStatus.
+	testutil.SeedMasterList(t, types.DownloadRecord{
+		ID:       "db-error-id",
+		Status:   "error",
+		Error:    "connection reset by peer",
+		Filename: "failed.txt",
+	})
+
 	list, err := svc.List()
 	if err != nil {
 		t.Fatalf("List failed: %v", err)
@@ -308,6 +316,33 @@ func TestLocalDownloadService_HistoryAndList(t *testing.T) {
 
 	if len(list) < 2 {
 		t.Errorf("expected at least 2 items in list, got %d", len(list))
+	}
+
+	// Assert the errored record appears in List with its Error field propagated.
+	var errorFound *types.DownloadStatus
+	for i := range list {
+		if list[i].ID == "db-error-id" {
+			errorFound = &list[i]
+			break
+		}
+	}
+	if errorFound == nil {
+		t.Fatal("errored download missing from list")
+	}
+	if errorFound.Status != "error" {
+		t.Errorf("error record status = %q, want %q", errorFound.Status, "error")
+	}
+	if errorFound.Error != "connection reset by peer" {
+		t.Errorf("error record Error = %q, want %q", errorFound.Error, "connection reset by peer")
+	}
+
+	// Assert GetStatus also propagates Error for DB-backed records.
+	gotStatus, err := svc.GetStatus("db-error-id")
+	if err != nil {
+		t.Fatalf("GetStatus failed for error record: %v", err)
+	}
+	if gotStatus.Error != "connection reset by peer" {
+		t.Errorf("GetStatus Error = %q, want %q", gotStatus.Error, "connection reset by peer")
 	}
 
 	history, err := svc.History()

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -5,6 +5,7 @@ import (
 	engineprogress "github.com/SurgeDM/Surge/internal/progress"
 
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -412,6 +413,11 @@ func InitialRootModel(serverPort int, currentVersion string, service service.Dow
 				case "error":
 					dm.done = true
 					dm.started = true
+					if s.Error != "" {
+						dm.err = errors.New(s.Error)
+					} else {
+						dm.err = errors.New("download failed")
+					}
 				case "pausing":
 					dm.pausing = true
 					dm.started = true

--- a/internal/tui/startup_test.go
+++ b/internal/tui/startup_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -135,12 +136,64 @@ func TestTUI_Startup_LoadsErroredDownloadsIntoDoneTab(t *testing.T) {
 	testID := "tui-error-id"
 	testURL := "http://example.com/error.bin"
 	testDest := filepath.Join(tmpDir, "error.bin")
+	events := make(chan types.DownloadEvent, 1)
+	mgr := orchestrator.NewLifecycleManager(nil, nil, nil)
+	done := make(chan struct{})
+	go func() {
+		mgr.StartEventWorker(events)
+		close(done)
+	}()
+	events <- types.DownloadEvent{
+		Type:       types.EventError,
+		DownloadID: testID,
+		URL:        testURL,
+		DestPath:   testDest,
+		Filename:   filepath.Base(testDest),
+		Err:        errors.New("connection reset by peer"),
+	}
+	close(events)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("event worker did not stop")
+	}
+
+	m := InitialRootModel(1700, "test-version", service.NewLocalDownloadService(mgr), mgr, nil, false)
+
+	var found *DownloadModel
+	for _, d := range m.downloads {
+		if d.ID == testID {
+			found = d
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("TUI Model failed to load errored download")
+	}
+	if !found.done {
+		t.Fatal("expected errored download to appear in done tab")
+	}
+	if found.err == nil {
+		t.Fatal("expected errored download to retain its error")
+	}
+	if found.err.Error() != "connection reset by peer" {
+		t.Errorf("error = %q, want %q", found.err.Error(), "connection reset by peer")
+	}
+}
+
+func TestTUI_Startup_UsesFallbackForErroredDownloadWithoutMessage(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "surge-tui-error-fallback-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	setupTestEnv(t, tmpDir)
+
+	const testID = "tui-error-fallback-id"
 	if err := store.AddToMasterList(types.DownloadRecord{
 		ID:       testID,
-		URL:      testURL,
-		URLHash:  "dummy-hash",
-		DestPath: testDest,
-		Filename: filepath.Base(testDest),
+		Filename: "error.bin",
 		Status:   "error",
 	}); err != nil {
 		t.Fatal(err)
@@ -159,10 +212,12 @@ func TestTUI_Startup_LoadsErroredDownloadsIntoDoneTab(t *testing.T) {
 	}
 	if found == nil {
 		t.Fatal("TUI Model failed to load errored download")
-		return
 	}
-	if !found.done {
-		t.Fatal("expected errored download to appear in done tab")
+	if found.err == nil {
+		t.Fatal("expected fallback error")
+	}
+	if found.err.Error() != "download failed" {
+		t.Errorf("error = %q, want %q", found.err.Error(), "download failed")
 	}
 }
 


### PR DESCRIPTION
Hey there,

Following up on the ideas discussed in issue #591, it seems the bug stems from a few gaps in the error persistence and display chain: the `Error` field isn't persisted on `EventError`/`EventComplete` finalization failures, it's dropped during `GetStatus`/`List` reads, and `dm.err` isn't populated in the TUI during startup restoration.

I want to thank PR #595 for providing some great inspiration on how to tackle this. However, its simplified approach to `EventError` persistence unfortunately introduces some regressions to the core download logic. Specifically, it doesn't preserve chunk-level resume metadata via `SaveStateWithOptions` (meaning errored downloads can't be resumed), and its field-merge logic doesn't distinguish task-backed snapshots, which can overwrite legitimate `Downloaded=0` states.

So, building on the initial issue discussion and the inspiration from #595, I've put together a minimal patch here. It correctly persists the `Error` string on `EventError` (including handling the `existing == nil` case) and finalization failures, propagates it through `GetStatus`/`List` to the TUI, sets `dm.err` during startup restoration, and handles the `cp.GetError()` TOCTOU race. The store layer (`store/state.go`) and the delicate resume-snapshot logic (`SaveStateWithOptions`) are left completely untouched—this patch simply adds the `Error` field to the existing `AddToMasterList` calls, intentionally leaving the heavy lifting for backend state merges to PR #580.

This makes the fix completely independent but highly complementary to #580. Let's use this minimal patch to close the gap on the display side.

*(P.S. If this gets merged first, resolving the git conflict for PR #580 will be straightforward. The fallback branch in #580's `EventError` handler can just absorb the nil-handling and `Error` assignments introduced here. I'll gladly take care of rebasing #580 once this is in!)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Download failures now preserve their underlying error messages and relevant details.
  * Failed downloads are recorded automatically when needed.
  * Status, history, and terminal views now accurately show failed downloads and their error messages.
  * A clear fallback message is displayed when no specific error is available.
* **Tests**
  * Added coverage for error persistence, status reporting, history, and terminal interface behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->