### PR TITLE
ci: fix required status checks blocking PRs

### DIFF
--- a/.github/workflows/core-build.yml
+++ b/.github/workflows/core-build.yml
@@ -10,8 +10,6 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - "extension/**"
 
 permissions:
   contents: write
@@ -22,8 +20,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      core: ${{ steps.filter.outputs.core }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            core:
+              - '!extension/**'
+              - '**'
+
   test:
     name: Test and Check (${{ matrix.os }})
+    needs: changes
+    if: needs.changes.outputs.core == 'true' || github.event_name != 'pull_request'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,21 +4,7 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "extension/**"
-      - "cmd/**"
-      - "internal/**"
-      - "**.go"
-      - "go.mod"
-      - "go.sum"
   pull_request:
-    paths:
-      - "extension/**"
-      - "cmd/**"
-      - "internal/**"
-      - "**.go"
-      - "go.mod"
-      - "go.sum"
   workflow_dispatch:
 
 permissions:
@@ -29,8 +15,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      backend_or_ext: ${{ steps.filter.outputs.backend_or_ext }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend_or_ext:
+              - 'extension/**'
+              - 'cmd/**'
+              - 'internal/**'
+              - '**.go'
+              - 'go.mod'
+              - 'go.sum'
+
   integration:
     name: Extension ↔ Surge Backend
+    needs: changes
+    if: needs.changes.outputs.backend_or_ext == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Replaced `paths-ignore` and `paths` filters with `dorny/paths-filter` in `core-build.yml` and `integration.yml`. This ensures that the workflows always trigger on PRs and correctly report a 'skipped' status (which satisfies GitHub Branch Protection requirements) when the modified paths don't warrant running the heavy jobs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated continuous integration workflows to evaluate changes more accurately.
  - Core checks now run when core-related files change or for non-pull-request events.
  - Integration checks now run for relevant backend or extension changes, as well as manual runs.
  - Pull requests are now consistently evaluated before determining which checks are needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->