### PR TITLE
Systemd service option

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,7 @@
           wants = ["network-online.target"];
 
           serviceConfig = {
-            ExecStart = "${pkgs.surge}/bin/surge service __run";
+            ExecStart = "${pkgs.surge}/bin/surge server start --is-system-service";
 
             Restart = "on-failure";
             RestartSec = "5s";

--- a/flake.nix
+++ b/flake.nix
@@ -3,31 +3,64 @@
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-  outputs = { self, nixpkgs }:
-    let
-      version = "0.8.5";
-      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
-      forEachSystem = f: nixpkgs.lib.genAttrs systems (system:
-        f nixpkgs.legacyPackages.${system}
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    version = "0.11.2";
+    systems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
+    forEachSystem = f:
+      nixpkgs.lib.genAttrs systems (
+        system:
+          f nixpkgs.legacyPackages.${system}
       );
-    in
-    {
-      packages = forEachSystem (pkgs: rec {
-        surge = pkgs.callPackage ./package.nix { src = self; inherit version; };
-        default = surge;
-      });
+  in {
+    packages = forEachSystem (pkgs: rec {
+      surge = pkgs.callPackage ./package.nix {
+        src = self;
+        inherit version;
+      };
+      default = surge;
+    });
 
-      overlays.default = final: _prev: {
-        surge = final.callPackage ./package.nix { src = self; inherit version; };
+    overlays.default = final: _prev: {
+      surge = final.callPackage ./package.nix {
+        src = self;
+        inherit version;
+      };
+    };
+
+    nixosModules.default = {
+      lib,
+      pkgs,
+      config,
+      ...
+    }: let
+      cfg = config.programs.surge;
+    in {
+      options.programs.surge = {
+        enable = lib.mkEnableOption "surge download manager";
+        systemd.enable = lib.mkEnableOption "enable systemd service";
       };
 
-      nixosModules.default = { lib, pkgs, config, ... }: {
-        options.programs.surge.enable = lib.mkEnableOption "surge download manager";
+      config = lib.mkIf cfg.enable {
+        nixpkgs.overlays = [self.overlays.default];
+        environment.systemPackages = [pkgs.surge];
+        systemd.services.surge = lib.mkIf cfg.systemd.enable {
+          description = "Surge Download Manager";
 
-        config = lib.mkIf config.programs.surge.enable {
-          nixpkgs.overlays = [ self.overlays.default ];
-          environment.systemPackages = [ pkgs.surge ];
+          wantedBy = ["multi-user.target"];
+          after = ["network-online.target"];
+          wants = ["network-online.target"];
+
+          serviceConfig = {
+            ExecStart = "${pkgs.surge}/bin/surge service __run";
+
+            Restart = "on-failure";
+            RestartSec = "5s";
+          };
         };
       };
     };
+  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,7 @@
     in {
       options.programs.surge = {
         enable = lib.mkEnableOption "surge download manager";
-        systemd.enable = lib.mkEnableOption "enable systemd service";
+        systemd.enable = lib.mkEnableOption "systemd service";
       };
 
       config = lib.mkIf cfg.enable {


### PR DESCRIPTION
Updated the version number to reflect the latest and added the surge systemd service integration as a nix option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to enable Surge’s systemd service independently.
  - The service starts after network availability, runs Surge in service mode, and automatically restarts after failures.
  - Surge is installed automatically when enabled through the NixOS module.

- **Chores**
  - Updated the flake release version to 0.11.2.
  - Modernized configuration formatting without changing package or overlay behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->