### PR TITLE
fix(extension): retry failed handoffs in browser

### DIFF
--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -418,16 +418,25 @@ const BROWSER_REJECTED_HEADERS = new Set([
   'trailer',
   'transfer-encoding',
   'upgrade',
+  'user-agent',
   'via',
 ]);
+const BROWSER_METHOD_OVERRIDE_HEADERS = new Set([
+  'x-http-method',
+  'x-http-method-override',
+  'x-method-override',
+]);
+const BROWSER_REJECTED_METHODS = new Set(['connect', 'trace', 'track']);
 
 function buildBrowserDownloadHeaders(headers: Record<string, string>): { name: string; value: string }[] | undefined {
   const browserHeaders = Object.entries(headers)
-    .filter(([name]) => {
+    .filter(([name, value]) => {
       const normalizedName = name.toLowerCase();
       return !BROWSER_REJECTED_HEADERS.has(normalizedName)
         && !normalizedName.startsWith('proxy-')
-        && !normalizedName.startsWith('sec-');
+        && !normalizedName.startsWith('sec-')
+        && !(BROWSER_METHOD_OVERRIDE_HEADERS.has(normalizedName)
+          && value.split(',').some(method => BROWSER_REJECTED_METHODS.has(method.trim().toLowerCase())));
     })
     .map(([name, value]) => ({ name, value }));
   return browserHeaders.length > 0 ? browserHeaders : undefined;

--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -397,14 +397,55 @@ type HandoffResult =
   | { success: true; outcome: 'browser'; surgeError: string }
   | { success: false; outcome: 'failed'; error: string; surgeError: string; fallbackError?: string };
 
-async function fallbackToBrowser(url: string, surgeError: string): Promise<HandoffResult> {
+const BROWSER_REJECTED_HEADERS = new Set([
+  'accept-charset',
+  'accept-encoding',
+  'access-control-request-headers',
+  'access-control-request-method',
+  'connection',
+  'content-length',
+  'cookie',
+  'cookie2',
+  'date',
+  'dnt',
+  'expect',
+  'host',
+  'keep-alive',
+  'origin',
+  'referer',
+  'set-cookie',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+  'via',
+]);
+
+function buildBrowserDownloadHeaders(headers: Record<string, string>): { name: string; value: string }[] | undefined {
+  const browserHeaders = Object.entries(headers)
+    .filter(([name]) => {
+      const normalizedName = name.toLowerCase();
+      return !BROWSER_REJECTED_HEADERS.has(normalizedName)
+        && !normalizedName.startsWith('proxy-')
+        && !normalizedName.startsWith('sec-');
+    })
+    .map(([name, value]) => ({ name, value }));
+  return browserHeaders.length > 0 ? browserHeaders : undefined;
+}
+
+async function fallbackToBrowser(
+  url: string,
+  surgeError: string,
+  capturedHeaders: Record<string, string>,
+): Promise<HandoffResult> {
   const enabled = await storageGetBoolean(STORAGE_KEYS.FALLBACK_TO_BROWSER);
   if (enabled === false) {
     return { success: false, outcome: 'failed', error: surgeError, surgeError };
   }
 
   try {
-    await browser.downloads.download({ url });
+    const headers = buildBrowserDownloadHeaders(capturedHeaders);
+    await browser.downloads.download(headers ? { url, headers } : { url });
     return { success: true, outcome: 'browser', surgeError };
   } catch (error) {
     const fallbackError = error instanceof Error ? error.message : String(error);
@@ -427,7 +468,7 @@ async function sendToSurge(
   options?: { skipApproval?: boolean },
 ): Promise<HandoffResult> {
   const base = await getBaseUrl();
-  if (!base) return fallbackToBrowser(url, 'Server not running');
+  if (!base) return fallbackToBrowser(url, 'Server not running', headers);
 
   try {
     const resp = await fetch(`${base}/download`, {
@@ -448,10 +489,10 @@ async function sendToSurge(
       return { success: true, outcome: 'surge', filename: data.filename };
     }
     const error = await resp.text().catch(() => '') || `Server returned ${resp.status}`;
-    return fallbackToBrowser(url, error);
+    return fallbackToBrowser(url, error, headers);
   } catch (error) {
     const surgeError = error instanceof Error ? error.message : String(error);
-    return fallbackToBrowser(url, surgeError);
+    return fallbackToBrowser(url, surgeError, headers);
   }
 }
 
@@ -1034,6 +1075,7 @@ export const __test__ = {
     processedIds.clear();
   },
   handleDownloadCreated,
+  captureHeaders,
   reresolveActiveServerUrl,
   handleMessage,
 };

--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -392,19 +392,42 @@ async function fetchHistoryList(): Promise<{ data: HistoryEntry[]; authError: bo
   }
 }
 
-/**
- * Send a download request to the Surge backend.
- * Returns { success: true } or { success: false, error: string }.
- */
+type HandoffResult =
+  | { success: true; outcome: 'surge'; filename?: string }
+  | { success: true; outcome: 'browser'; surgeError: string }
+  | { success: false; outcome: 'failed'; error: string; surgeError: string; fallbackError?: string };
+
+async function fallbackToBrowser(url: string, surgeError: string): Promise<HandoffResult> {
+  const enabled = await storageGetBoolean(STORAGE_KEYS.FALLBACK_TO_BROWSER);
+  if (enabled === false) {
+    return { success: false, outcome: 'failed', error: surgeError, surgeError };
+  }
+
+  try {
+    await browser.downloads.download({ url });
+    return { success: true, outcome: 'browser', surgeError };
+  } catch (error) {
+    const fallbackError = error instanceof Error ? error.message : String(error);
+    return {
+      success: false,
+      outcome: 'failed',
+      error: `${surgeError}; browser fallback failed: ${fallbackError}`,
+      surgeError,
+      fallbackError,
+    };
+  }
+}
+
+/** Send a download to Surge, retrying it through the browser when configured. */
 async function sendToSurge(
   url: string,
   filename: string,
   directory: string,
   headers: Record<string, string>,
   options?: { skipApproval?: boolean },
-): Promise<{ success: boolean; filename?: string; error?: string }> {
+): Promise<HandoffResult> {
   const base = await getBaseUrl();
-  if (!base) return { success: false, error: 'Server not running' };
+  if (!base) return fallbackToBrowser(url, 'Server not running');
 
   try {
     const resp = await fetch(`${base}/download`, {
@@ -422,11 +445,13 @@ async function sendToSurge(
 
     if (resp.ok) {
       const data = await resp.json().catch(() => ({}));
-      return { success: true, filename: data.filename };
+      return { success: true, outcome: 'surge', filename: data.filename };
     }
-    return { success: false, error: await resp.text().catch(() => '') };
+    const error = await resp.text().catch(() => '') || `Server returned ${resp.status}`;
+    return fallbackToBrowser(url, error);
   } catch (error) {
-    return { success: false, error: error instanceof Error ? error.message : String(error) };
+    const surgeError = error instanceof Error ? error.message : String(error);
+    return fallbackToBrowser(url, surgeError);
   }
 }
 
@@ -475,6 +500,35 @@ async function isNotificationsEnabled(): Promise<boolean> {
   return enabled !== false; // Default to true if undefined
 }
 
+async function notifyHandoffResult(result: HandoffResult, filename: string): Promise<void> {
+  if (!await isNotificationsEnabled()) return;
+
+  if (result.outcome === 'surge') {
+    browser.notifications.create({
+      type: 'basic',
+      iconUrl: 'icons/icon48.png',
+      title: 'Surge',
+      message: `Download started: ${result.filename || filename}`,
+    });
+  } else if (result.outcome === 'browser') {
+    browser.notifications.create({
+      type: 'basic',
+      iconUrl: 'icons/icon48.png',
+      title: 'Surge',
+      message: `Surge handoff failed; browser retry started: ${filename}`,
+    });
+  } else {
+    browser.notifications.create({
+      type: 'basic',
+      iconUrl: 'icons/icon48.png',
+      title: 'Surge Error',
+      message: result.fallbackError
+        ? `Surge and browser handling failed: ${result.error}`
+        : `Failed to start download: ${result.surgeError}`,
+    });
+  }
+}
+
 async function getMinFileSizeMB(): Promise<number> {
   const result = await browser.storage.local.get(STORAGE_KEYS.MIN_FILE_SIZE);
   return readStoredNumber(result, STORAGE_KEYS.MIN_FILE_SIZE, 10);
@@ -510,8 +564,9 @@ async function isDuplicateDownload(url: string): Promise<boolean> {
 }
 
 async function handleDownloadCreated(downloadItem: {
-  id: number; url: string; filename?: string; state?: string; startTime?: string; totalBytes?: number;
+  id: number; url: string; filename?: string; state?: string; startTime?: string; totalBytes?: number; byExtensionId?: string;
 }): Promise<void> {
+  if (downloadItem.byExtensionId === browser.runtime.id) return;
   if (!await isInterceptEnabled()) return;
   if (shouldSkipUrl(downloadItem.url)) return;
   if (!isFreshDownload(downloadItem)) return;
@@ -558,26 +613,10 @@ async function handleDownloadCreated(downloadItem: {
   // Force empty filename hint for backend - rely on backend prober.
   const result = await sendToSurge(downloadItem.url, '', directory, headers);
 
-  if (result.success) {
+  if (result.outcome === 'surge') {
     await tryOpenPopup();
-    if (await isNotificationsEnabled()) {
-      browser.notifications.create({
-        type: 'basic',
-        iconUrl: 'icons/icon48.png',
-        title: 'Surge',
-        message: `Download started: ${result.filename || 'Unknown file'}`,
-      });
-    }
-  } else if (result.error) {
-    if (await isNotificationsEnabled()) {
-      browser.notifications.create({
-        type: 'basic',
-        iconUrl: 'icons/icon48.png',
-        title: 'Surge Error',
-        message: `Failed to start download: ${result.error}`,
-      });
-    }
   }
+  await notifyHandoffResult(result, duplicateDisplayName);
 }
 
 // ---------------------------------------------------------------------------
@@ -856,18 +895,11 @@ async function handleConfirmDuplicate(id: string): Promise<{ success: boolean; e
     {},
     { skipApproval: true },
   );
-  if (result.success) {
-    if (await isNotificationsEnabled()) {
-      browser.notifications.create({
-        type: 'basic',
-        iconUrl: 'icons/icon48.png',
-        title: 'Surge',
-        message: `Download started: ${pending.filename}`,
-      });
-    }
-  }
+  await notifyHandoffResult(result, pending.filename);
   await notifyNextPendingDuplicate();
-  return { success: result.success };
+  return result.outcome === 'failed'
+    ? { success: false, error: result.error }
+    : { success: true };
 }
 
 async function handleSkipDuplicate(id: string): Promise<{ success: boolean }> {
@@ -885,7 +917,7 @@ async function handleSkipDuplicate(id: string): Promise<{ success: boolean }> {
 export default defineBackground(() => {
   // Download interception
   browser.downloads.onCreated.addListener((downloadItem: {
-    id: number; url: string; filename?: string; state?: string; startTime?: string; totalBytes?: number;
+    id: number; url: string; filename?: string; state?: string; startTime?: string; totalBytes?: number; byExtensionId?: string;
   }) => {
     if (processedIds.has(downloadItem.id)) return;
     processedIds.add(downloadItem.id);

--- a/extension/entrypoints/popup/App.tsx
+++ b/extension/entrypoints/popup/App.tsx
@@ -17,6 +17,7 @@ import {
   setCurrentView,
   setInterceptEnabled,
   setNotificationsEnabled,
+  setFallbackToBrowser,
   setMinFileSize,
   handleSseEvent,
   setServerUrl,
@@ -74,6 +75,7 @@ export default function App() {
         STORAGE_KEYS.VERIFIED,
         STORAGE_KEYS.INTERCEPT,
         STORAGE_KEYS.NOTIFICATIONS,
+        STORAGE_KEYS.FALLBACK_TO_BROWSER,
         STORAGE_KEYS.MIN_FILE_SIZE,
       ]);
 
@@ -100,6 +102,7 @@ export default function App() {
 
       setInterceptEnabled(readStoredBoolean(storedValues, STORAGE_KEYS.INTERCEPT, true));
       setNotificationsEnabled(readStoredBoolean(storedValues, STORAGE_KEYS.NOTIFICATIONS, true));
+      setFallbackToBrowser(readStoredBoolean(storedValues, STORAGE_KEYS.FALLBACK_TO_BROWSER, true));
       setMinFileSize(readStoredNumber(storedValues, STORAGE_KEYS.MIN_FILE_SIZE, 10));
     } catch { /* ignore */ }
   }

--- a/extension/entrypoints/popup/components/SettingsView.tsx
+++ b/extension/entrypoints/popup/components/SettingsView.tsx
@@ -11,6 +11,7 @@ import {
   authValid, setAuthValid,
   interceptEnabled, setInterceptEnabled,
   notificationsEnabled, setNotificationsEnabled,
+  fallbackToBrowser, setFallbackToBrowser,
   minFileSize, setMinFileSize,
 } from '../store';
 import {
@@ -126,6 +127,10 @@ export default function SettingsView() {
     setNotificationsEnabled(checked);
     await browser.storage.local.set({ [STORAGE_KEYS.NOTIFICATIONS]: checked });
   };
+  const handleFallbackToggle = async (checked: boolean) => {
+    setFallbackToBrowser(checked);
+    await browser.storage.local.set({ [STORAGE_KEYS.FALLBACK_TO_BROWSER]: checked });
+  };
   const handleMinFileSizeChange = async (value: string) => {
     const num = parseFloat(value);
     if (!isNaN(num) && num >= 0) {
@@ -158,6 +163,17 @@ export default function SettingsView() {
               type="checkbox"
               checked={notificationsEnabled()}
               onChange={(e) => { void handleNotificationsToggle((e.target as HTMLInputElement).checked); }}
+            />
+            <span class="toggle-slider" />
+          </div>
+        </label>
+        <label class="toggle-row">
+          <span>Retry failed downloads in browser</span>
+          <div class="toggle">
+            <input
+              type="checkbox"
+              checked={fallbackToBrowser()}
+              onChange={(e) => { void handleFallbackToggle((e.target as HTMLInputElement).checked); }}
             />
             <span class="toggle-slider" />
           </div>

--- a/extension/entrypoints/popup/store/index.ts
+++ b/extension/entrypoints/popup/store/index.ts
@@ -87,6 +87,8 @@ const [interceptEnabled, setInterceptEnabled] = createSignal(true);
 export { interceptEnabled, setInterceptEnabled };
 const [notificationsEnabled, setNotificationsEnabled] = createSignal(true);
 export { notificationsEnabled, setNotificationsEnabled };
+const [fallbackToBrowser, setFallbackToBrowser] = createSignal(true);
+export { fallbackToBrowser, setFallbackToBrowser };
 const [minFileSize, setMinFileSize] = createSignal(10);
 export { minFileSize, setMinFileSize };
 

--- a/extension/lib/storage.ts
+++ b/extension/lib/storage.ts
@@ -5,6 +5,7 @@ export const STORAGE_KEYS = {
   SERVER_URL: 'serverUrl',
   DISCOVERED_SERVER_URL: 'discoveredServerUrl',
   NOTIFICATIONS: 'notificationsEnabled',
+  FALLBACK_TO_BROWSER: 'fallbackToBrowser',
   MIN_FILE_SIZE: 'minFileSize',
   PROFILES: 'serverProfiles',
   ACTIVE_PROFILE_ID: 'activeServerProfileId',

--- a/extension/test/intercept.test.ts
+++ b/extension/test/intercept.test.ts
@@ -166,12 +166,14 @@ describe('download interception naming', () => {
       }));
     });
 
-    it('forwards allowed captured headers while excluding Cookie from the browser retry', async () => {
+    it('forwards allowed captured headers while excluding rejected headers from the browser retry', async () => {
       __test__.captureHeaders({
         url: failedItem.url,
         requestHeaders: [
           { name: 'X-Download-Token', value: 'token-123' },
           { name: 'Cookie', value: 'session=secret' },
+          { name: 'User-Agent', value: 'Surge test agent' },
+          { name: 'X-HTTP-Method-Override', value: 'PATCH, TRACE' },
         ],
       });
 

--- a/extension/test/intercept.test.ts
+++ b/extension/test/intercept.test.ts
@@ -29,6 +29,7 @@ describe('download interception naming', () => {
       downloads: {
         cancel: vi.fn().mockResolvedValue(undefined),
         erase: vi.fn().mockResolvedValue(undefined),
+        download: vi.fn().mockResolvedValue(9001),
       },
       action: {
         openPopup: vi.fn().mockResolvedValue(undefined),
@@ -36,6 +37,7 @@ describe('download interception naming', () => {
         setBadgeBackgroundColor: vi.fn(),
       },
       runtime: {
+        id: 'surge-extension-id',
         getURL: vi.fn().mockReturnValue('chrome-extension://id/'),
         sendMessage: vi.fn().mockResolvedValue(undefined),
       },
@@ -131,6 +133,93 @@ describe('download interception naming', () => {
 
     const downloadCall = mockFetch.mock.calls.find(call => call[0].includes('/download'));
     expect(downloadCall).toBeUndefined();
+  });
+
+  describe('browser fallback', () => {
+    const failedItem = {
+      id: 8001,
+      url: 'https://example.com/fallback.zip',
+      filename: '/downloads/fallback.zip',
+      startTime: new Date().toISOString(),
+    };
+
+    beforeEach(() => {
+      mockFetch.mockImplementation(async (url: string) => {
+        if (url.includes('/health')) return { ok: true };
+        if (url.includes('/list')) return { ok: true, json: async () => [] };
+        if (url.includes('/download')) return {
+          ok: false,
+          status: 503,
+          text: async () => 'Surge unavailable',
+        };
+        return { ok: false };
+      });
+    });
+
+    it('starts one browser download when the Surge handoff fails by default', async () => {
+      await __test__.handleDownloadCreated(failedItem);
+
+      expect(browser.downloads.download).toHaveBeenCalledOnce();
+      expect(browser.downloads.download).toHaveBeenCalledWith({ url: failedItem.url });
+      expect(browser.notifications.create).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'Surge handoff failed; browser retry started: fallback.zip',
+      }));
+    });
+
+    it('preserves the Surge failure without retrying when fallback is disabled', async () => {
+      (browser.storage.local.get as import('vitest').Mock).mockImplementation((key: string) => {
+        if (key === 'interceptEnabled') return Promise.resolve({ interceptEnabled: true });
+        if (key === 'serverUrl') return Promise.resolve({ serverUrl: 'http://127.0.0.1:1700' });
+        if (key === 'minFileSize') return Promise.resolve({ minFileSize: 10 });
+        if (key === 'fallbackToBrowser') return Promise.resolve({ fallbackToBrowser: false });
+        return Promise.resolve({});
+      });
+
+      await __test__.handleDownloadCreated(failedItem);
+
+      expect(browser.downloads.download).not.toHaveBeenCalled();
+      expect(browser.notifications.create).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'Failed to start download: Surge unavailable',
+      }));
+    });
+
+    it('ignores downloads created by this extension so fallback cannot loop', async () => {
+      await __test__.handleDownloadCreated({
+        ...failedItem,
+        id: 8002,
+        byExtensionId: 'surge-extension-id',
+      });
+
+      expect(browser.downloads.cancel).not.toHaveBeenCalled();
+      expect(browser.downloads.download).not.toHaveBeenCalled();
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('reports both failures when the browser retry is rejected', async () => {
+      (browser.downloads.download as import('vitest').Mock).mockRejectedValue(new Error('Download blocked'));
+
+      await __test__.handleDownloadCreated(failedItem);
+
+      expect(browser.notifications.create).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'Surge and browser handling failed: Surge unavailable; browser fallback failed: Download blocked',
+      }));
+    });
+
+    it('does not start a browser retry after a successful Surge handoff', async () => {
+      mockFetch.mockImplementation(async (url: string) => {
+        if (url.includes('/health')) return { ok: true };
+        if (url.includes('/list')) return { ok: true, json: async () => [] };
+        if (url.includes('/download')) return {
+          ok: true,
+          json: async () => ({ filename: 'fallback.zip' }),
+        };
+        return { ok: false };
+      });
+
+      await __test__.handleDownloadCreated(failedItem);
+
+      expect(browser.downloads.download).not.toHaveBeenCalled();
+    });
   });
 
   describe('minimum file size guard', () => {

--- a/extension/test/intercept.test.ts
+++ b/extension/test/intercept.test.ts
@@ -166,6 +166,23 @@ describe('download interception naming', () => {
       }));
     });
 
+    it('forwards allowed captured headers while excluding Cookie from the browser retry', async () => {
+      __test__.captureHeaders({
+        url: failedItem.url,
+        requestHeaders: [
+          { name: 'X-Download-Token', value: 'token-123' },
+          { name: 'Cookie', value: 'session=secret' },
+        ],
+      });
+
+      await __test__.handleDownloadCreated(failedItem);
+
+      expect(browser.downloads.download).toHaveBeenCalledWith({
+        url: failedItem.url,
+        headers: [{ name: 'X-Download-Token', value: 'token-123' }],
+      });
+    });
+
     it('preserves the Surge failure without retrying when fallback is disabled', async () => {
       (browser.storage.local.get as import('vitest').Mock).mockImplementation((key: string) => {
         if (key === 'interceptEnabled') return Promise.resolve({ interceptEnabled: true });


### PR DESCRIPTION
Closes #468

## Summary

- add a default-enabled setting to retry failed Surge handoffs through the browser
- distinguish Surge success, browser fallback success, and total failure while preserving errors
- ignore extension-created download events to prevent fallback loops
- notify users when browser fallback starts or when both handoff paths fail
- cover fallback defaults, opt-out, recursion prevention, fallback rejection, and unchanged success/offline behavior

## Verification

- `npm test` — 73 tests passed, including the Go-backed SSE integration test
- `npm run lint`
- Chrome and Firefox production builds pass after temporarily accounting for the pre-existing type-only import blocker; that unrelated change is not included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to retry failed downloads in the browser.
  * Browser retries use relevant captured download information automatically.
  * Download notifications now distinguish successful handoffs, browser fallbacks, and complete failures.
  * Duplicate-download confirmations reflect the updated outcomes.

* **Bug Fixes**
  * Prevented the extension’s own downloads from being intercepted again.
  * Improved error details when both download methods fail.

* **Tests**
  * Added coverage for fallback behavior, opt-out settings, successful handoffs, and failure reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->