### PR TITLE
fix(tui): harden removal confirmation UX

### DIFF
--- a/internal/tui/components/confirmation_modal.go
+++ b/internal/tui/components/confirmation_modal.go
@@ -2,6 +2,7 @@ package components
 
 import (
 	"image/color"
+	"strings"
 
 	"github.com/SurgeDM/Surge/internal/tui/colors"
 	"github.com/SurgeDM/Surge/internal/utils"
@@ -49,10 +50,13 @@ func (m ConfirmationModal) renderBody(width int) string {
 
 	content := msg
 	if det != "" {
+		if !strings.Contains(det, "\x1b") {
+			det = getDetailStyle().Render(det)
+		}
 		content = lipgloss.JoinVertical(lipgloss.Center,
 			content,
 			"",
-			getDetailStyle().Render(det),
+			det,
 		)
 	}
 

--- a/internal/tui/delete_resilience_test.go
+++ b/internal/tui/delete_resilience_test.go
@@ -106,6 +106,25 @@ func TestUpdateDashboard_DeleteSuccess(t *testing.T) {
 	}
 }
 
+func TestUpdateListItems_SelectsNewLastItemAfterSelectedLastIsRemoved(t *testing.T) {
+	first := &DownloadModel{ID: "first-id", Filename: "first.zip", done: true}
+	last := &DownloadModel{ID: "last-id", Filename: "last.zip", done: true}
+	m := RootModel{
+		activeTab: TabDone,
+		downloads: []*DownloadModel{first, last},
+		list:      NewDownloadList(80, 20),
+	}
+	m.UpdateListItems()
+	m.list.Select(1)
+
+	m.removeDownloadByID(last.ID)
+	m.UpdateListItems()
+
+	if got := m.list.Index(); got != 0 {
+		t.Fatalf("list index after removing selected last item = %d, want 0", got)
+	}
+}
+
 func TestUpdateDashboard_DeleteOtherError(t *testing.T) {
 	dm := &DownloadModel{ID: "error-id", Filename: "error.zip", done: true}
 	svc := &mockService{deleteErr: errors.New("some other error")}

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -298,6 +298,16 @@ func (m *RootModel) UpdateListItems() {
 		}
 	}
 
+	// If the previously selected item was removed, ensure the cursor doesn't fall out of bounds
+	if !found && len(items) > 0 {
+		if m.list.Index() >= len(items) {
+			m.list.Select(len(items) - 1)
+		}
+		if m.list.Index() < 0 {
+			m.list.Select(0)
+		}
+	}
+
 	// Reset forced selection
 	m.SelectedDownloadID = ""
 }

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -931,10 +931,14 @@ func (m RootModel) viewPurgeConfirm() string {
 		filename = utils.Truncate(filename, 30)
 	}
 
+	filenameStyled := lipgloss.NewStyle().Foreground(colors.White()).Bold(true).Render(filename)
+	detailStyle := lipgloss.NewStyle().Foreground(colors.Magenta()).Bold(true)
+	detailStr := detailStyle.Render("File: ") + filenameStyled + detailStyle.Render("\nThis will also remove the downloaded file(s) from disk.")
+
 	modal := components.ConfirmationModal{
 		Title:            "Purge Download",
 		Message:          "Permanently delete this download?",
-		Detail:           fmt.Sprintf("File: %s\nThis will also remove the downloaded file(s) from disk.", filename),
+		Detail:           detailStr,
 		Keys:             m.keys.QuitConfirm, // QuitConfirm works as a general yes/no
 		Help:             m.help,
 		BorderColor:      colors.Red(),
@@ -944,7 +948,7 @@ func (m RootModel) viewPurgeConfirm() string {
 		NoLabel:          "No",
 	}
 
-	w, h := GetDynamicModalDimensions(m.width, m.height, 46, 8, 60, 12)
+	w, h := GetDynamicModalDimensions(m.width, m.height, 46, 8, 70, 12)
 	modal.Width = w
 	modal.Height = h
 
@@ -966,10 +970,14 @@ func (m RootModel) viewRemoveConfirm() string {
 		filename = utils.Truncate(filename, 30)
 	}
 
+	filenameStyled := lipgloss.NewStyle().Foreground(colors.White()).Bold(true).Render(filename)
+	detailStyle := lipgloss.NewStyle().Foreground(colors.Magenta()).Bold(true)
+	detailStr := detailStyle.Render("File: ") + filenameStyled + detailStyle.Render("\nThis paused or active download may lose progress data.")
+
 	modal := components.ConfirmationModal{
 		Title:            "Remove Download",
 		Message:          "Remove this download?",
-		Detail:           fmt.Sprintf("File: %s\nThis paused or active download may lose progress data.", filename),
+		Detail:           detailStr,
 		Keys:             m.keys.QuitConfirm, // QuitConfirm works as a general yes/no
 		Help:             m.help,
 		BorderColor:      colors.Orange(),
@@ -980,7 +988,7 @@ func (m RootModel) viewRemoveConfirm() string {
 		NoLabel:          "No",
 	}
 
-	w, h := GetDynamicModalDimensions(m.width, m.height, 46, 8, 60, 12)
+	w, h := GetDynamicModalDimensions(m.width, m.height, 46, 8, 70, 12)
 	modal.Width = w
 	modal.Height = h
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -933,7 +933,8 @@ func (m RootModel) viewPurgeConfirm() string {
 
 	filenameStyled := lipgloss.NewStyle().Foreground(colors.White()).Bold(true).Render(filename)
 	detailStyle := lipgloss.NewStyle().Foreground(colors.Magenta()).Bold(true)
-	detailStr := detailStyle.Render("File: ") + filenameStyled + detailStyle.Render("\nThis will also remove the downloaded file(s) from disk.")
+	warnStyle := lipgloss.NewStyle().Foreground(colors.Red()).Bold(true)
+	detailStr := detailStyle.Render("File: ") + filenameStyled + "\n" + warnStyle.Render("This will also remove the downloaded file(s) from disk.")
 
 	modal := components.ConfirmationModal{
 		Title:            "Purge Download",
@@ -972,7 +973,8 @@ func (m RootModel) viewRemoveConfirm() string {
 
 	filenameStyled := lipgloss.NewStyle().Foreground(colors.White()).Bold(true).Render(filename)
 	detailStyle := lipgloss.NewStyle().Foreground(colors.Magenta()).Bold(true)
-	detailStr := detailStyle.Render("File: ") + filenameStyled + detailStyle.Render("\nThis paused or active download may lose progress data.")
+	warnStyle := lipgloss.NewStyle().Foreground(colors.Red()).Bold(true)
+	detailStr := detailStyle.Render("File: ") + filenameStyled + "\n" + warnStyle.Render("This paused or active download may lose progress data.")
 
 	modal := components.ConfirmationModal{
 		Title:            "Remove Download",


### PR DESCRIPTION
## Summary
- clamp the list cursor after a selected download is removed
- allow confirmation details to preserve intentional styling
- emphasize destructive purge/remove warnings and give the dialogs enough width

## Verification
- go test ./internal/tui -count=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved pre-styled text in confirmation dialogs without applying duplicate formatting.
  * Improved list selection after removing items, keeping the cursor on a valid entry.
  * Updated purge and remove dialogs to display filenames and warning messages with clearer styling.

* **Style**
  * Increased the maximum width of purge and remove confirmation dialogs for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->