### PR TITLE
fix extension download duplication

### DIFF
--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -430,8 +430,37 @@ const BROWSER_METHOD_OVERRIDE_HEADERS = new Set([
 ]);
 const BROWSER_REJECTED_METHODS = new Set(['connect', 'trace', 'track']);
 
+const SAFE_DOWNLOAD_LOG_FIELDS = new Set([
+  'id',
+  'status',
+  'outcome',
+  'state',
+  'totalBytes',
+  'forwardedHeaderCount',
+]);
+const SAFE_DOWNLOAD_LOG_URL_FIELDS = new Set(['url', 'base']);
+
+function redactUrlQuery(value: string): string {
+  try {
+    const url = new URL(value);
+    url.search = '';
+    url.hash = '';
+    return url.toString();
+  } catch {
+    return value.split(/[?#]/, 1)[0] ?? '';
+  }
+}
+
 function logDownload(message: string, details: Record<string, unknown>): void {
-  console.debug(`[Surge] download ${message}`, details);
+  const safeDetails: Record<string, unknown> = {};
+  for (const [name, value] of Object.entries(details)) {
+    if (SAFE_DOWNLOAD_LOG_URL_FIELDS.has(name) && typeof value === 'string') {
+      safeDetails[name] = redactUrlQuery(value);
+    } else if (SAFE_DOWNLOAD_LOG_FIELDS.has(name)) {
+      safeDetails[name] = value;
+    }
+  }
+  console.debug(`[Surge] download ${message}`, safeDetails);
 }
 
 function buildBrowserDownloadHeaders(headers: Record<string, string>): { name: string; value: string }[] | undefined {
@@ -637,21 +666,6 @@ async function handleDownloadCreated(downloadItem: {
     logDownload('ignored extension-created download', { id: downloadItem.id, url: downloadItem.url });
     return;
   }
-  if (interceptingUrls.has(downloadItem.url)) {
-    // A second browser download ID is a real download, not a duplicate event
-    // for the first ID. Cancel it so it cannot continue alongside the handoff
-    // already in progress for this URL.
-    try {
-      await browser.downloads.cancel(downloadItem.id);
-      await browser.downloads.erase({ id: downloadItem.id } as any).catch(() => {});
-      logDownload('cancelled: handoff already in progress', { id: downloadItem.id, url: downloadItem.url });
-    } catch {
-      logDownload('could not cancel duplicate while handoff is in progress', { id: downloadItem.id, url: downloadItem.url });
-    }
-    return;
-  }
-  interceptingUrls.add(downloadItem.url);
-  try {
   if (!await isInterceptEnabled()) {
     logDownload('ignored: interception disabled', { id: downloadItem.id, url: downloadItem.url });
     return;
@@ -679,6 +693,21 @@ async function handleDownloadCreated(downloadItem: {
     return;
   }
 
+  if (interceptingUrls.has(downloadItem.url)) {
+    // A second browser download ID is a real download, not a duplicate event
+    // for the first ID. Cancel it so it cannot continue alongside the handoff
+    // already in progress for this URL.
+    try {
+      await browser.downloads.cancel(downloadItem.id);
+      await browser.downloads.erase({ id: downloadItem.id } as any).catch(() => {});
+      logDownload('cancelled: handoff already in progress', { id: downloadItem.id, url: downloadItem.url });
+    } catch {
+      logDownload('could not cancel duplicate while handoff is in progress', { id: downloadItem.id, url: downloadItem.url });
+    }
+    return;
+  }
+  interceptingUrls.add(downloadItem.url);
+  try {
   // Once health has passed, cancel the browser download immediately before any
   // additional async work so the browser does not race ahead of the handoff.
   try {

--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -638,7 +638,16 @@ async function handleDownloadCreated(downloadItem: {
     return;
   }
   if (interceptingUrls.has(downloadItem.url)) {
-    logDownload('ignored: handoff already in progress', { id: downloadItem.id, url: downloadItem.url });
+    // A second browser download ID is a real download, not a duplicate event
+    // for the first ID. Cancel it so it cannot continue alongside the handoff
+    // already in progress for this URL.
+    try {
+      await browser.downloads.cancel(downloadItem.id);
+      await browser.downloads.erase({ id: downloadItem.id } as any).catch(() => {});
+      logDownload('cancelled: handoff already in progress', { id: downloadItem.id, url: downloadItem.url });
+    } catch {
+      logDownload('could not cancel duplicate while handoff is in progress', { id: downloadItem.id, url: downloadItem.url });
+    }
     return;
   }
   interceptingUrls.add(downloadItem.url);

--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -1,6 +1,6 @@
 import { defineBackground } from 'wxt/utils/define-background';
 import { normalizeToken, normalizeServerUrl } from './popup/lib/utils';
-import { DownloadStatus, HistoryEntry } from './popup/store/types';
+import type { DownloadStatus, HistoryEntry } from './popup/store/types';
 import {
   STORAGE_KEYS,
   readStoredNumber,
@@ -63,6 +63,8 @@ const pendingDuplicates = new Map<string, PendingDup>();
 
 // Dedupes rapid onCreated events for the same browser download ID.
 const processedIds = new Set<number>();
+// Coalesces duplicate onCreated events that use different browser download IDs.
+const interceptingUrls = new Set<string>();
 
 // ---------------------------------------------------------------------------
 // Storage helpers
@@ -428,6 +430,10 @@ const BROWSER_METHOD_OVERRIDE_HEADERS = new Set([
 ]);
 const BROWSER_REJECTED_METHODS = new Set(['connect', 'trace', 'track']);
 
+function logDownload(message: string, details: Record<string, unknown>): void {
+  console.debug(`[Surge] download ${message}`, details);
+}
+
 function buildBrowserDownloadHeaders(headers: Record<string, string>): { name: string; value: string }[] | undefined {
   const browserHeaders = Object.entries(headers)
     .filter(([name, value]) => {
@@ -449,15 +455,19 @@ async function fallbackToBrowser(
 ): Promise<HandoffResult> {
   const enabled = await storageGetBoolean(STORAGE_KEYS.FALLBACK_TO_BROWSER);
   if (enabled === false) {
+    logDownload('browser fallback disabled', { url, surgeError });
     return { success: false, outcome: 'failed', error: surgeError, surgeError };
   }
 
   try {
     const headers = buildBrowserDownloadHeaders(capturedHeaders);
-    await browser.downloads.download(headers ? { url, headers } : { url });
+    logDownload('starting browser fallback', { url, forwardedHeaderCount: headers?.length ?? 0 });
+    const id = await browser.downloads.download(headers ? { url, headers } : { url });
+    logDownload('browser fallback started', { id, url });
     return { success: true, outcome: 'browser', surgeError };
   } catch (error) {
     const fallbackError = error instanceof Error ? error.message : String(error);
+    logDownload('browser fallback failed', { url, fallbackError });
     return {
       success: false,
       outcome: 'failed',
@@ -477,9 +487,13 @@ async function sendToSurge(
   options?: { skipApproval?: boolean },
 ): Promise<HandoffResult> {
   const base = await getBaseUrl();
-  if (!base) return fallbackToBrowser(url, 'Server not running', headers);
+  if (!base) {
+    logDownload('Surge handoff skipped: server unavailable', { url });
+    return fallbackToBrowser(url, 'Server not running', headers);
+  }
 
   try {
+    logDownload('starting Surge handoff', { url, base });
     const resp = await fetch(`${base}/download`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...(await authHeaders()) },
@@ -495,12 +509,15 @@ async function sendToSurge(
 
     if (resp.ok) {
       const data = await resp.json().catch(() => ({}));
+      logDownload('Surge handoff succeeded', { url, status: resp.status, filename: data.filename });
       return { success: true, outcome: 'surge', filename: data.filename };
     }
     const error = await resp.text().catch(() => '') || `Server returned ${resp.status}`;
+    logDownload('Surge handoff failed', { url, status: resp.status, error });
     return fallbackToBrowser(url, error, headers);
   } catch (error) {
     const surgeError = error instanceof Error ? error.message : String(error);
+    logDownload('Surge handoff failed', { url, surgeError });
     return fallbackToBrowser(url, surgeError, headers);
   }
 }
@@ -616,27 +633,55 @@ async function isDuplicateDownload(url: string): Promise<boolean> {
 async function handleDownloadCreated(downloadItem: {
   id: number; url: string; filename?: string; state?: string; startTime?: string; totalBytes?: number; byExtensionId?: string;
 }): Promise<void> {
-  if (downloadItem.byExtensionId === browser.runtime.id) return;
-  if (!await isInterceptEnabled()) return;
-  if (shouldSkipUrl(downloadItem.url)) return;
-  if (!isFreshDownload(downloadItem)) return;
+  if (downloadItem.byExtensionId === browser.runtime.id) {
+    logDownload('ignored extension-created download', { id: downloadItem.id, url: downloadItem.url });
+    return;
+  }
+  if (interceptingUrls.has(downloadItem.url)) {
+    logDownload('ignored: handoff already in progress', { id: downloadItem.id, url: downloadItem.url });
+    return;
+  }
+  interceptingUrls.add(downloadItem.url);
+  try {
+  if (!await isInterceptEnabled()) {
+    logDownload('ignored: interception disabled', { id: downloadItem.id, url: downloadItem.url });
+    return;
+  }
+  if (shouldSkipUrl(downloadItem.url)) {
+    logDownload('ignored: unsupported URL', { id: downloadItem.id, url: downloadItem.url });
+    return;
+  }
+  if (!isFreshDownload(downloadItem)) {
+    logDownload('ignored: stale download', { id: downloadItem.id, url: downloadItem.url, state: downloadItem.state });
+    return;
+  }
 
   const minFileSizeMB = await getMinFileSizeMB();
   const minSizeInBytes = minFileSizeMB * 1024 * 1024;
   if (minSizeInBytes > 0 && downloadItem.totalBytes !== undefined && downloadItem.totalBytes > 0 && downloadItem.totalBytes < minSizeInBytes) {
+    logDownload('ignored: below size threshold', { id: downloadItem.id, url: downloadItem.url, totalBytes: downloadItem.totalBytes });
     return; // File is smaller than minimum size threshold; let browser handle it.
   }
 
   // Only intercept when Surge is actually reachable. If the daemon is offline,
   // leave the browser download alone so normal downloads keep working.
-  if (!await checkHealthSilent()) return;
+  if (!await checkHealthSilent()) {
+    logDownload('ignored: Surge unavailable', { id: downloadItem.id, url: downloadItem.url });
+    return;
+  }
 
   // Once health has passed, cancel the browser download immediately before any
   // additional async work so the browser does not race ahead of the handoff.
   try {
     await browser.downloads.cancel(downloadItem.id);
+  } catch {
+    logDownload('handoff aborted: browser cancellation failed', { id: downloadItem.id, url: downloadItem.url });
+    return; // The original browser download is still active.
+  }
+  logDownload('browser download cancelled', { id: downloadItem.id, url: downloadItem.url });
+  try {
     await browser.downloads.erase({ id: downloadItem.id } as any);
-  } catch { /* already completed or removed - ignore */ }
+  } catch { /* already removed - ignore */ }
 
   const { filename, directory } = extractPathInfo(downloadItem);
   const duplicateDisplayName = filename || downloadItem.url.split('/').pop()?.split('?')[0] || 'Unknown file';
@@ -645,6 +690,7 @@ async function handleDownloadCreated(downloadItem: {
   // Check for duplicates in the extension BEFORE sending to server.
   // This way the TUI never sees a duplicate prompt.
   if (await isDuplicateDownload(downloadItem.url)) {
+    logDownload('queued duplicate confirmation', { id: downloadItem.id, url: downloadItem.url });
     pendingDuplicateCounter = await queueDuplicateDownload({
       pendingDuplicates,
       pendingDuplicateCounter,
@@ -662,11 +708,15 @@ async function handleDownloadCreated(downloadItem: {
 
   // Force empty filename hint for backend - rely on backend prober.
   const result = await sendToSurge(downloadItem.url, '', directory, headers);
+  logDownload('handoff complete', { id: downloadItem.id, url: downloadItem.url, outcome: result.outcome });
 
   if (result.outcome === 'surge') {
     await tryOpenPopup();
   }
   await notifyHandoffResult(result, duplicateDisplayName);
+  } finally {
+    interceptingUrls.delete(downloadItem.url);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -969,7 +1019,17 @@ export default defineBackground(() => {
   browser.downloads.onCreated.addListener((downloadItem: {
     id: number; url: string; filename?: string; state?: string; startTime?: string; totalBytes?: number; byExtensionId?: string;
   }) => {
-    if (processedIds.has(downloadItem.id)) return;
+    logDownload('created', {
+      id: downloadItem.id,
+      url: downloadItem.url,
+      byExtensionId: downloadItem.byExtensionId,
+      state: downloadItem.state,
+      totalBytes: downloadItem.totalBytes,
+    });
+    if (processedIds.has(downloadItem.id)) {
+      logDownload('ignored: duplicate event ID', { id: downloadItem.id, url: downloadItem.url });
+      return;
+    }
     processedIds.add(downloadItem.id);
     setTimeout(() => processedIds.delete(downloadItem.id), 120_000);
     handleDownloadCreated(downloadItem).catch(err =>
@@ -1082,6 +1142,7 @@ export const __test__ = {
     pendingDuplicateCounter = 0;
     pendingDuplicates.clear();
     processedIds.clear();
+    interceptingUrls.clear();
   },
   handleDownloadCreated,
   captureHeaders,

--- a/extension/test/intercept.test.ts
+++ b/extension/test/intercept.test.ts
@@ -135,6 +135,52 @@ describe('download interception naming', () => {
     expect(downloadCall).toBeUndefined();
   });
 
+  it('does not hand off a download that the browser could not cancel', async () => {
+    (browser.downloads.cancel as import('vitest').Mock).mockRejectedValue(new Error('Already complete'));
+    mockFetch.mockResolvedValue({ ok: true });
+
+    await __test__.handleDownloadCreated({
+      id: 790,
+      url: 'https://example.com/already-complete.zip',
+      startTime: new Date().toISOString(),
+    });
+
+    expect(browser.downloads.download).not.toHaveBeenCalled();
+    expect(mockFetch.mock.calls.some(call => call[0].includes('/download'))).toBe(false);
+  });
+
+  it('coalesces concurrent interception attempts for the same URL', async () => {
+    let releaseCancel: () => void = () => {};
+    (browser.downloads.cancel as import('vitest').Mock).mockImplementation(() => new Promise<void>((resolve) => {
+      releaseCancel = resolve;
+    }));
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/health')) return Promise.resolve({ ok: true });
+      if (url.includes('/list')) return Promise.resolve({ ok: true, json: async () => [] });
+      if (url.includes('/download')) return Promise.resolve({ ok: true, json: async () => ({ filename: 'once.zip' }) });
+      return Promise.resolve({ ok: false });
+    });
+
+    const first = __test__.handleDownloadCreated({
+      id: 791,
+      url: 'https://example.com/once.zip',
+      startTime: new Date().toISOString(),
+    });
+    await vi.waitFor(() => expect(browser.downloads.cancel).toHaveBeenCalledOnce());
+    const second = __test__.handleDownloadCreated({
+      id: 792,
+      url: 'https://example.com/once.zip',
+      startTime: new Date().toISOString(),
+    });
+
+    await second;
+    releaseCancel();
+    await first;
+
+    expect(browser.downloads.cancel).toHaveBeenCalledOnce();
+    expect(mockFetch.mock.calls.filter(call => call[0].includes('/download'))).toHaveLength(1);
+  });
+
   describe('browser fallback', () => {
     const failedItem = {
       id: 8001,

--- a/extension/test/intercept.test.ts
+++ b/extension/test/intercept.test.ts
@@ -151,9 +151,11 @@ describe('download interception naming', () => {
 
   it('coalesces concurrent interception attempts for the same URL', async () => {
     let releaseCancel: () => void = () => {};
-    (browser.downloads.cancel as import('vitest').Mock).mockImplementation(() => new Promise<void>((resolve) => {
-      releaseCancel = resolve;
-    }));
+    (browser.downloads.cancel as import('vitest').Mock)
+      .mockImplementationOnce(() => new Promise<void>((resolve) => {
+        releaseCancel = resolve;
+      }))
+      .mockResolvedValue(undefined);
     mockFetch.mockImplementation((url: string) => {
       if (url.includes('/health')) return Promise.resolve({ ok: true });
       if (url.includes('/list')) return Promise.resolve({ ok: true, json: async () => [] });
@@ -177,7 +179,8 @@ describe('download interception naming', () => {
     releaseCancel();
     await first;
 
-    expect(browser.downloads.cancel).toHaveBeenCalledOnce();
+    expect(browser.downloads.cancel).toHaveBeenCalledTimes(2);
+    expect(browser.downloads.cancel).toHaveBeenCalledWith(792);
     expect(mockFetch.mock.calls.filter(call => call[0].includes('/download'))).toHaveLength(1);
   });
 

--- a/internal/orchestrator/manager.go
+++ b/internal/orchestrator/manager.go
@@ -40,6 +40,15 @@ type LifecycleManager struct {
 	// large batch of downloads does not flood the network with HEAD requests.
 	probeSem     chan struct{}
 	shutdownOnce sync.Once
+	inflightMu   sync.Mutex
+	inflight     map[string]*inflightEnqueue
+}
+
+type inflightEnqueue struct {
+	done     chan struct{}
+	id       string
+	filename string
+	err      error
 }
 
 const (
@@ -112,6 +121,7 @@ func NewLifecycleManager(pool *scheduler.Scheduler, eventBus *EventBus, settings
 		aggregator:          aggregator,
 		isNameActive:        activeCheck,
 		probeSem:            sem,
+		inflight:            make(map[string]*inflightEnqueue),
 	}
 }
 
@@ -201,7 +211,34 @@ func (mgr *LifecycleManager) enqueueResolved(ctx context.Context, req *DownloadR
 	if req.Path == "" {
 		return "", "", types.ErrDestRequired
 	}
+	if requestID != "" {
+		return mgr.enqueueNew(ctx, req, requestID)
+	}
 
+	key := req.URL + "\x00" + req.Path
+	mgr.inflightMu.Lock()
+	if existing := mgr.inflight[key]; existing != nil {
+		mgr.inflightMu.Unlock()
+		select {
+		case <-existing.done:
+			return existing.id, existing.filename, existing.err
+		case <-ctx.Done():
+			return "", "", fmt.Errorf("enqueue aborted while waiting for matching request: %w", ctx.Err())
+		}
+	}
+	entry := &inflightEnqueue{done: make(chan struct{})}
+	mgr.inflight[key] = entry
+	mgr.inflightMu.Unlock()
+
+	entry.id, entry.filename, entry.err = mgr.enqueueNew(ctx, req, requestID)
+	mgr.inflightMu.Lock()
+	delete(mgr.inflight, key)
+	close(entry.done)
+	mgr.inflightMu.Unlock()
+	return entry.id, entry.filename, entry.err
+}
+
+func (mgr *LifecycleManager) enqueueNew(ctx context.Context, req *DownloadRequest, requestID string) (string, string, error) {
 	settings := mgr.GetSettings()
 
 	// Throttle concurrent probes — acquire a semaphore slot before probing.

--- a/internal/orchestrator/manager.go
+++ b/internal/orchestrator/manager.go
@@ -43,6 +43,10 @@ type LifecycleManager struct {
 	shutdownOnce sync.Once
 	inflightMu   sync.Mutex
 	inflight     map[string]*inflightEnqueue
+	// Test hooks make concurrent enqueue tests deterministic without affecting
+	// production behavior.
+	inflightJoinHook  func()
+	inflightStartHook func()
 }
 
 type inflightEnqueue struct {
@@ -220,6 +224,9 @@ func (mgr *LifecycleManager) enqueueResolved(ctx context.Context, req *DownloadR
 	mgr.inflightMu.Lock()
 	if existing := mgr.inflight[key]; existing != nil {
 		mgr.inflightMu.Unlock()
+		if mgr.inflightJoinHook != nil {
+			mgr.inflightJoinHook()
+		}
 		select {
 		case <-existing.done:
 			return existing.id, existing.filename, existing.err
@@ -230,6 +237,9 @@ func (mgr *LifecycleManager) enqueueResolved(ctx context.Context, req *DownloadR
 	entry := &inflightEnqueue{done: make(chan struct{})}
 	mgr.inflight[key] = entry
 	mgr.inflightMu.Unlock()
+	if mgr.inflightStartHook != nil {
+		mgr.inflightStartHook()
+	}
 
 	entry.id, entry.filename, entry.err = mgr.enqueueNew(ctx, req, requestID)
 	mgr.inflightMu.Lock()

--- a/internal/orchestrator/manager.go
+++ b/internal/orchestrator/manager.go
@@ -8,6 +8,7 @@ import (
 	neturl "net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -215,7 +216,7 @@ func (mgr *LifecycleManager) enqueueResolved(ctx context.Context, req *DownloadR
 		return mgr.enqueueNew(ctx, req, requestID)
 	}
 
-	key := req.URL + "\x00" + req.Path
+	key := enqueueCoalescingKey(req)
 	mgr.inflightMu.Lock()
 	if existing := mgr.inflight[key]; existing != nil {
 		mgr.inflightMu.Unlock()
@@ -236,6 +237,38 @@ func (mgr *LifecycleManager) enqueueResolved(ctx context.Context, req *DownloadR
 	close(entry.done)
 	mgr.inflightMu.Unlock()
 	return entry.id, entry.filename, entry.err
+}
+
+// enqueueCoalescingKey includes every request field that can affect the queued
+// download. Requests that merely share a URL and destination may still have a
+// different filename, authentication headers, or scheduling options and must
+// therefore be enqueued independently.
+func enqueueCoalescingKey(req *DownloadRequest) string {
+	var key strings.Builder
+	writeString := func(value string) {
+		fmt.Fprintf(&key, "%d:%s", len(value), value)
+	}
+	writeString(req.URL)
+	writeString(req.Filename)
+	writeString(req.Path)
+	fmt.Fprintf(&key, "%d:", len(req.Mirrors))
+	for _, mirror := range req.Mirrors {
+		writeString(mirror)
+	}
+
+	headerNames := make([]string, 0, len(req.Headers))
+	for name := range req.Headers {
+		headerNames = append(headerNames, name)
+	}
+	sort.Strings(headerNames)
+	fmt.Fprintf(&key, "%d:", len(headerNames))
+	for _, name := range headerNames {
+		writeString(name)
+		writeString(req.Headers[name])
+	}
+
+	fmt.Fprintf(&key, "%t:%t:%d:%d", req.IsExplicitCategory, req.SkipApproval, req.Workers, req.MinChunkSize)
+	return key.String()
 }
 
 func (mgr *LifecycleManager) enqueueNew(ctx context.Context, req *DownloadRequest, requestID string) (string, string, error) {

--- a/internal/orchestrator/manager_test.go
+++ b/internal/orchestrator/manager_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -123,6 +124,52 @@ func TestLifecycleManager_EnqueueWithID(t *testing.T) {
 
 	if id != customID {
 		t.Errorf("expected custom ID %s, got %s", customID, id)
+	}
+}
+
+func TestLifecycleManager_EnqueueCoalescesConcurrentRequests(t *testing.T) {
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	var requests atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		started <- struct{}{}
+		<-release
+		w.Header().Set("Content-Length", "1")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	pool := scheduler.New(make(chan types.DownloadEvent, 10), 1)
+	mgr := NewLifecycleManager(pool, nil, nil)
+	defer mgr.Shutdown()
+
+	req := &DownloadRequest{URL: ts.URL + "/duplicate.bin", Filename: "duplicate.bin", Path: t.TempDir()}
+	type result struct {
+		id  string
+		err error
+	}
+	results := make(chan result, 2)
+	go func() {
+		id, _, err := mgr.Enqueue(context.Background(), req)
+		results <- result{id, err}
+	}()
+	<-started
+	go func() {
+		id, _, err := mgr.Enqueue(context.Background(), req)
+		results <- result{id, err}
+	}()
+	close(release)
+
+	first, second := <-results, <-results
+	if first.err != nil || second.err != nil {
+		t.Fatalf("Enqueue errors = %v, %v", first.err, second.err)
+	}
+	if first.id == "" || first.id != second.id {
+		t.Fatalf("enqueue ids = %q, %q; want one shared id", first.id, second.id)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("probe requests = %d, want 1", got)
 	}
 }
 

--- a/internal/orchestrator/manager_test.go
+++ b/internal/orchestrator/manager_test.go
@@ -143,6 +143,8 @@ func TestLifecycleManager_EnqueueCoalescesConcurrentRequests(t *testing.T) {
 	pool := scheduler.New(make(chan types.DownloadEvent, 10), 1)
 	mgr := NewLifecycleManager(pool, nil, nil)
 	defer mgr.Shutdown()
+	joined := make(chan struct{}, 1)
+	mgr.inflightJoinHook = func() { joined <- struct{}{} }
 
 	req := &DownloadRequest{URL: ts.URL + "/duplicate.bin", Filename: "duplicate.bin", Path: t.TempDir()}
 	type result struct {
@@ -159,6 +161,7 @@ func TestLifecycleManager_EnqueueCoalescesConcurrentRequests(t *testing.T) {
 		id, _, err := mgr.Enqueue(context.Background(), req)
 		results <- result{id, err}
 	}()
+	<-joined
 	close(release)
 
 	first, second := <-results, <-results
@@ -187,6 +190,8 @@ func TestLifecycleManager_EnqueueDoesNotCoalesceDifferentRequests(t *testing.T) 
 	pool := scheduler.New(make(chan types.DownloadEvent, 10), 1)
 	mgr := NewLifecycleManager(pool, nil, nil)
 	defer mgr.Shutdown()
+	entered := make(chan struct{}, 2)
+	mgr.inflightStartHook = func() { entered <- struct{}{} }
 
 	dest := t.TempDir()
 	type result struct {
@@ -202,10 +207,10 @@ func TestLifecycleManager_EnqueueDoesNotCoalesceDifferentRequests(t *testing.T) 
 			results <- result{finalFilename, err}
 		}(filename)
 	}
-	// Probes to the same host are deliberately serialized. Release the first
-	// request before waiting for the second handler entry, otherwise the
-	// second probe remains blocked on the per-host probe lock.
-	<-started
+	// Wait until both requests have passed the in-flight map before releasing
+	// the first same-host probe; the probe layer serializes hosts deliberately.
+	<-entered
+	<-entered
 	close(release)
 	<-started
 	first, second := <-results, <-results

--- a/internal/orchestrator/manager_test.go
+++ b/internal/orchestrator/manager_test.go
@@ -173,6 +173,48 @@ func TestLifecycleManager_EnqueueCoalescesConcurrentRequests(t *testing.T) {
 	}
 }
 
+func TestLifecycleManager_EnqueueDoesNotCoalesceDifferentRequests(t *testing.T) {
+	started := make(chan struct{}, 2)
+	release := make(chan struct{})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		started <- struct{}{}
+		<-release
+		w.Header().Set("Content-Length", "1")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	pool := scheduler.New(make(chan types.DownloadEvent, 10), 1)
+	mgr := NewLifecycleManager(pool, nil, nil)
+	defer mgr.Shutdown()
+
+	dest := t.TempDir()
+	type result struct {
+		filename string
+		err      error
+	}
+	results := make(chan result, 2)
+	for _, filename := range []string{"first.bin", "second.bin"} {
+		go func(filename string) {
+			_, finalFilename, err := mgr.Enqueue(context.Background(), &DownloadRequest{
+				URL: ts.URL + "/same-resource", Filename: filename, Path: dest,
+			})
+			results <- result{finalFilename, err}
+		}(filename)
+	}
+	<-started
+	<-started
+	close(release)
+	first, second := <-results, <-results
+	if first.err != nil || second.err != nil {
+		t.Fatalf("Enqueue errors = %v, %v", first.err, second.err)
+	}
+	if (first.filename != "first.bin" || second.filename != "second.bin") &&
+		(first.filename != "second.bin" || second.filename != "first.bin") {
+		t.Fatalf("resolved filenames = %q, %q; want both distinct requested names", first.filename, second.filename)
+	}
+}
+
 func TestLifecycleManager_IsNameActive(t *testing.T) {
 	activeFunc := func(dir, name string) bool {
 		return name == "active.txt"

--- a/internal/orchestrator/manager_test.go
+++ b/internal/orchestrator/manager_test.go
@@ -202,9 +202,12 @@ func TestLifecycleManager_EnqueueDoesNotCoalesceDifferentRequests(t *testing.T) 
 			results <- result{finalFilename, err}
 		}(filename)
 	}
-	<-started
+	// Probes to the same host are deliberately serialized. Release the first
+	// request before waiting for the second handler entry, otherwise the
+	// second probe remains blocked on the per-host probe lock.
 	<-started
 	close(release)
+	<-started
 	first, second := <-results, <-results
 	if first.err != nil || second.err != nil {
 		t.Fatalf("Enqueue errors = %v, %v", first.err, second.err)


### PR DESCRIPTION
- **fix duplicate downlaods in extension**
- **fix**
- **test: fix race condition in manager test by serializing host probe release signals**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate browser downloads when multiple interception events target the same URL.
  * Improved cancellation handling so failed browser cancellations do not trigger unintended handoffs or retries.
  * Coalesced identical concurrent download requests into a single download while preserving separate requests with different filenames.
  * Ensured canceled requests return promptly without affecting other downloads.
* **Reliability**
  * Improved download lifecycle handling and cleanup across browser and Surge download flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->