### PR TITLE
fix: restore the star history chart in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,11 +293,11 @@ Distributed under the MIT License. See [LICENSE](https://github.com/SurgeDM/Surg
 ---
 
 <div align="center">
-<a href="https://star-history.com/#SurgeDM/Surge&Date">
+<a href="https://star-history.dera.page/#SurgeDM/Surge&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=SurgeDM/Surge&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=SurgeDM/Surge&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=SurgeDM/Surge&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=SurgeDM/Surge&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=SurgeDM/Surge&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=SurgeDM/Surge&type=Date" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README has been broken by GitHub stargazer API restrictions. This change points it to star-history.dera.page, which provides the same chart backed by an alternative data source that requires no API token, so the chart works again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README’s Star History chart links to use the new chart hosting domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->