### PR TITLE
feat: add AppImage release artifact

### DIFF
--- a/.github/workflows/core-build.yml
+++ b/.github/workflows/core-build.yml
@@ -155,17 +155,22 @@ jobs:
           binary=$(find dist -type f -name surge -path '*linux*amd64*' -perm -111 -print -quit)
           test -n "$binary"
           curl -L --fail --retry 3 --output appimagetool \
-            https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
+            https://github.com/AppImage/appimagetool/releases/download/1.9.1/appimagetool-x86_64.AppImage
+          curl -L --fail --retry 3 --output runtime-x86_64 \
+            https://github.com/AppImage/type2-runtime/releases/download/20251108/runtime-x86_64
+          printf '%s\n' \
+            'ed4ce84f0d9caff66f50bcca6ff6f35aae54ce8135408b3fa33abfc3cb384eb0  appimagetool' \
+            '2fca8b443c92510f1483a883f60061ad09b46b978b2631c807cd873a47ec260d  runtime-x86_64' \
+            | sha256sum --check --strict
           chmod +x appimagetool
           ./scripts/package-appimage.sh "$binary" AppDir
           ARCH=x86_64 ./appimagetool --appimage-extract-and-run \
+            --runtime-file runtime-x86_64 \
             -u 'gh-releases-zsync|SurgeDM|Surge|latest|Surge_*_linux_x86_64.AppImage.zsync' \
             AppDir "Surge_${GITHUB_REF_NAME#v}_linux_x86_64.AppImage"
 
-      - name: Verify and upload AppImage
+      - name: Verify AppImage
         shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           appimage="Surge_${GITHUB_REF_NAME#v}_linux_x86_64.AppImage"
@@ -174,4 +179,12 @@ jobs:
           test -x squashfs-root/AppRun
           test -f squashfs-root/surge.desktop
           test -f squashfs-root/surge.png
-          gh release upload "$GITHUB_REF_NAME" "$appimage" "$appimage.zsync"
+
+      - name: Upload AppImage
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          appimage="Surge_${GITHUB_REF_NAME#v}_linux_x86_64.AppImage"
+          gh release upload "$GITHUB_REF_NAME" "$appimage" "$appimage.zsync" --clobber

--- a/.github/workflows/core-build.yml
+++ b/.github/workflows/core-build.yml
@@ -147,3 +147,31 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+
+      - name: Package AppImage
+        shell: bash
+        run: |
+          set -euo pipefail
+          binary=$(find dist -type f -name surge -path '*linux*amd64*' -perm -111 -print -quit)
+          test -n "$binary"
+          curl -L --fail --retry 3 --output appimagetool \
+            https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
+          chmod +x appimagetool
+          ./scripts/package-appimage.sh "$binary" AppDir
+          ARCH=x86_64 ./appimagetool --appimage-extract-and-run \
+            -u 'gh-releases-zsync|SurgeDM|Surge|latest|Surge_*_linux_x86_64.AppImage.zsync' \
+            AppDir "Surge_${GITHUB_REF_NAME#v}_linux_x86_64.AppImage"
+
+      - name: Verify and upload AppImage
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          appimage="Surge_${GITHUB_REF_NAME#v}_linux_x86_64.AppImage"
+          test -s "$appimage" && test -s "$appimage.zsync"
+          "./$appimage" --appimage-extract >/dev/null
+          test -x squashfs-root/AppRun
+          test -f squashfs-root/surge.desktop
+          test -f squashfs-root/surge.png
+          gh release upload "$GITHUB_REF_NAME" "$appimage" "$appimage.zsync"

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Surge is available on multiple platforms. Choose the method that works best for 
 | Platform / Method                  | Command / Instructions                                                           | Notes                                        |
 | :--------------------------------- | :------------------------------------------------------------------------------- | :------------------------------------------- |
 | **Prebuilt Binary**          | [Download from Releases](https://github.com/SurgeDM/Surge/releases/latest) | Easiest method. Just download and run.       |
+| **Linux AppImage**           | [Download from Releases](https://github.com/SurgeDM/Surge/releases/latest) | Portable x86_64 package with delta updates.  |
 | **Arch Linux (AUR)**         | `yay -S surge`                                                                 | Managed via AUR.                             |
 | **macOS / Linux (Homebrew)** | `brew install SurgeDM/tap/surge`                                      | Recommended for Mac/Linux users.             |
 | **Nix / NixOS**              | `nix run github:SurgeDM/Surge`                                        | Via Nix flake. NixOS config: `inputs.surge.packages.${pkgs.system}.default` |

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Surge is available on multiple platforms. Choose the method that works best for 
 | Platform / Method                  | Command / Instructions                                                           | Notes                                        |
 | :--------------------------------- | :------------------------------------------------------------------------------- | :------------------------------------------- |
 | **Prebuilt Binary**          | [Download from Releases](https://github.com/SurgeDM/Surge/releases/latest) | Easiest method. Just download and run.       |
-| **Linux AppImage**           | [Download from Releases](https://github.com/SurgeDM/Surge/releases/latest) | Portable x86_64 package with delta updates.  |
+| **Linux AppImage**           | [Download from Releases](https://github.com/SurgeDM/Surge/releases/latest) | Run `chmod +x Surge_..._linux_x86_64.AppImage`, then `./Surge_..._linux_x86_64.AppImage`. Supports delta updates. |
 | **Arch Linux (AUR)**         | `yay -S surge`                                                                 | Managed via AUR.                             |
 | **macOS / Linux (Homebrew)** | `brew install SurgeDM/tap/surge`                                      | Recommended for Mac/Linux users.             |
 | **Nix / NixOS**              | `nix run github:SurgeDM/Surge`                                        | Via Nix flake. NixOS config: `inputs.surge.packages.${pkgs.system}.default` |

--- a/packaging/appimage/AppRun
+++ b/packaging/appimage/AppRun
@@ -1,0 +1,3 @@
+#!/bin/sh
+HERE="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+exec "$HERE/surge" "$@"

--- a/packaging/appimage/surge.desktop
+++ b/packaging/appimage/surge.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=Surge
+Comment=Blazing fast TUI download manager
+Exec=surge
+Icon=surge
+Terminal=true
+Type=Application
+Categories=Network;

--- a/scripts/package-appimage.sh
+++ b/scripts/package-appimage.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eu
+
+binary=$1
+appdir=$2
+
+mkdir -p "$appdir"
+install -m 755 "$binary" "$appdir/surge"
+install -m 755 packaging/appimage/AppRun "$appdir/AppRun"
+install -m 644 packaging/appimage/surge.desktop "$appdir/surge.desktop"
+install -m 644 assets/logo.png "$appdir/surge.png"


### PR DESCRIPTION
Closes #613

## What changed

- package the existing static Linux amd64 `surge` binary as an AppImage in the existing Core Build and Release workflow
- publish the AppImage and its `.zsync` delta-update artifact to each tagged GitHub release
- add the required AppDir launcher, desktop entry, and icon metadata
- document the Linux AppImage in the README

## Why

The release pipeline already produces a portable static Linux binary. Wrapping that artifact with `appimagetool` adds the requested AppImage distribution without introducing a new runtime dependency, build workflow, or Go package. The embedded `gh-releases-zsync` metadata lets AppImage-aware clients discover the latest release.

## Validation

- `goreleaser check`
- `goreleaser release --snapshot --clean` (confirmed `dist/Surge_linux_amd64_v1/surge`)
- built an AppImage with the official `appimagetool`, generated `.zsync`, extracted it without FUSE, and checked `AppRun`, desktop entry, and icon
- `sh -n scripts/package-appimage.sh packaging/appimage/AppRun`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a portable Linux x86_64 AppImage package for Surge.
  - AppImage releases now include delta-update metadata for more efficient updates.
  - Added desktop integration, including an application launcher and icon.
  - AppImages can now be launched directly with their included executable and command-line arguments.

- **Documentation**
  - Added AppImage installation instructions with a link to the latest release.
  - Documented the commands needed to make the AppImage executable and launch it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->