### PR TITLE
test: eliminate flaky sleep synchronization

### DIFF
--- a/.github/workflows/core-lint.yml
+++ b/.github/workflows/core-lint.yml
@@ -28,5 +28,9 @@ jobs:
           go-version: '1.25.0'
       - name: golangci-lint
         run: go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run
+      - name: flakylint
+        run: |
+          go install github.com/malikov73/flakylint/cmd/flakylint@v0.2.0
+          flakylint ./...
       - name: unicode lint
         run: go test ./internal/lint/...

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -14,7 +14,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/SurgeDM/Surge/internal/config"
 	"github.com/SurgeDM/Surge/internal/scheduler"
@@ -984,6 +983,8 @@ func TestAddCmd_HasGetAlias(t *testing.T) {
 // startHTTPServer Integration Tests
 // =============================================================================
 
+const testHTTPServerToken = "cmd-test-http-token"
+
 func TestStartHTTPServer_HealthEndpoint(t *testing.T) {
 	requireTCPListener(t)
 	// Create listener
@@ -995,15 +996,12 @@ func TestStartHTTPServer_HealthEndpoint(t *testing.T) {
 
 	// Start server in background
 	svc := service.NewLocalDownloadService(nil) // Mock service with nil pool/chan for health check
-	go startHTTPServer(ln, port, "", svc, "")
+	go startHTTPServer(ln, port, "", svc, testHTTPServerToken)
 	t.Cleanup(func() {
 		if globalHTTPServer != nil {
 			_ = globalHTTPServer.Close()
 		}
 	})
-
-	// Give server time to start
-	time.Sleep(50 * time.Millisecond)
 
 	// Test health endpoint
 	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/health", port))
@@ -1041,14 +1039,12 @@ func TestStartHTTPServer_HasCORSHeaders(t *testing.T) {
 	port := ln.Addr().(*net.TCPAddr).Port
 
 	svc := service.NewLocalDownloadService(nil)
-	go startHTTPServer(ln, port, "", svc, "")
+	go startHTTPServer(ln, port, "", svc, testHTTPServerToken)
 	t.Cleanup(func() {
 		if globalHTTPServer != nil {
 			_ = globalHTTPServer.Close()
 		}
 	})
-	time.Sleep(50 * time.Millisecond)
-
 	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/health", port))
 	if err != nil {
 		t.Fatalf("Request failed: %v", err)
@@ -1069,14 +1065,12 @@ func TestStartHTTPServer_OptionsRequest(t *testing.T) {
 	port := ln.Addr().(*net.TCPAddr).Port
 
 	svc := service.NewLocalDownloadService(nil)
-	go startHTTPServer(ln, port, "", svc, "")
+	go startHTTPServer(ln, port, "", svc, testHTTPServerToken)
 	t.Cleanup(func() {
 		if globalHTTPServer != nil {
 			_ = globalHTTPServer.Close()
 		}
 	})
-	time.Sleep(50 * time.Millisecond)
-
 	req, _ := http.NewRequest(http.MethodOptions, fmt.Sprintf("http://127.0.0.1:%d/download", port), nil)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -1099,18 +1093,14 @@ func TestStartHTTPServer_DownloadEndpoint_MethodNotAllowed(t *testing.T) {
 	port := ln.Addr().(*net.TCPAddr).Port
 
 	svc := service.NewLocalDownloadService(nil)
-	go startHTTPServer(ln, port, "", svc, "")
+	go startHTTPServer(ln, port, "", svc, testHTTPServerToken)
 	t.Cleanup(func() {
 		if globalHTTPServer != nil {
 			_ = globalHTTPServer.Close()
 		}
 	})
-	time.Sleep(50 * time.Millisecond)
-
-	token := ensureAuthToken()
-
 	req, _ := http.NewRequest(http.MethodPut, fmt.Sprintf("http://127.0.0.1:%d/download", port), nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Authorization", "Bearer "+testHTTPServerToken)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -1132,17 +1122,15 @@ func TestStartHTTPServer_DownloadEndpoint_BadRequest(t *testing.T) {
 	port := ln.Addr().(*net.TCPAddr).Port
 
 	svc := service.NewLocalDownloadService(nil)
-	go startHTTPServer(ln, port, "", svc, "")
+	go startHTTPServer(ln, port, "", svc, testHTTPServerToken)
 	t.Cleanup(func() {
 		if globalHTTPServer != nil {
 			_ = globalHTTPServer.Close()
 		}
 	})
-	time.Sleep(50 * time.Millisecond)
-
 	// POST with invalid JSON
 	req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("http://127.0.0.1:%d/download", port), bytes.NewBufferString("not json"))
-	req.Header.Set("Authorization", "Bearer "+ensureAuthToken())
+	req.Header.Set("Authorization", "Bearer "+testHTTPServerToken)
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
@@ -1165,17 +1153,15 @@ func TestStartHTTPServer_DownloadEndpoint_MissingURL(t *testing.T) {
 	port := ln.Addr().(*net.TCPAddr).Port
 
 	svc := service.NewLocalDownloadService(nil)
-	go startHTTPServer(ln, port, "", svc, "")
+	go startHTTPServer(ln, port, "", svc, testHTTPServerToken)
 	t.Cleanup(func() {
 		if globalHTTPServer != nil {
 			_ = globalHTTPServer.Close()
 		}
 	})
-	time.Sleep(50 * time.Millisecond)
-
 	// POST with missing URL
 	req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("http://127.0.0.1:%d/download", port), bytes.NewBufferString(`{"path": "/downloads"}`))
-	req.Header.Set("Authorization", "Bearer "+ensureAuthToken())
+	req.Header.Set("Authorization", "Bearer "+testHTTPServerToken)
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
@@ -1198,16 +1184,14 @@ func TestStartHTTPServer_NotFoundEndpoint(t *testing.T) {
 	port := ln.Addr().(*net.TCPAddr).Port
 
 	svc := service.NewLocalDownloadService(nil)
-	go startHTTPServer(ln, port, "", svc, "")
+	go startHTTPServer(ln, port, "", svc, testHTTPServerToken)
 	t.Cleanup(func() {
 		if globalHTTPServer != nil {
 			_ = globalHTTPServer.Close()
 		}
 	})
-	time.Sleep(50 * time.Millisecond)
-
 	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/nonexistent", port), nil)
-	req.Header.Set("Authorization", "Bearer "+ensureAuthToken())
+	req.Header.Set("Authorization", "Bearer "+testHTTPServerToken)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("Request failed: %v", err)

--- a/internal/orchestrator/event_bus_test.go
+++ b/internal/orchestrator/event_bus_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/SurgeDM/Surge/internal/types"
@@ -58,66 +59,29 @@ func TestEventBus_MultipleSubscribers(t *testing.T) {
 }
 
 func TestEventBus_ProgressMsgDropBehavior(t *testing.T) {
-	eb := NewEventBus()
-	defer eb.Shutdown()
+	synctest.Test(t, func(t *testing.T) {
+		eb := &EventBus{listeners: []chan types.DownloadEvent{make(chan types.DownloadEvent, 1)}}
+		eb.listeners[0] <- types.DownloadEvent{}
 
-	// Subscriber that doesn't read from the channel (will block quickly)
-	_, cleanup := eb.Subscribe()
-	defer cleanup()
-
-	// Fill the buffer (size 100 for outCh) by publishing 100 items
-	for i := 0; i < 100; i++ {
-		_ = eb.Publish(types.DownloadEvent{})
-	}
-
-	// Give the broadcast loop time to fill the subscriber's channel buffer
-	time.Sleep(100 * time.Millisecond)
-
-	// Publish a progress message. It should be dropped immediately without blocking for 1s.
-	start := time.Now()
-	msg := types.DownloadEvent{
-		Type: types.EventProgress, DownloadID: "test"}
-	_ = eb.Publish(msg)
-
-	// Since it's a progress message and the subscriber channel is full, it should drop it and return quickly.
-	// Wait a little bit to ensure broadcastLoop processed it.
-	time.Sleep(50 * time.Millisecond)
-	elapsed := time.Since(start)
-
-	if elapsed >= 1*time.Second {
-		t.Errorf("publish of ProgressMsg took too long (%v), it should be dropped immediately", elapsed)
-	}
+		start := time.Now()
+		eb.broadcastMsg(types.DownloadEvent{Type: types.EventProgress, DownloadID: "test"})
+		if elapsed := time.Since(start); elapsed != 0 {
+			t.Fatalf("progress event wait = %v, want 0", elapsed)
+		}
+	})
 }
 
 func TestEventBus_CriticalMsgWaitBehavior(t *testing.T) {
-	eb := NewEventBus()
-	defer eb.Shutdown()
+	synctest.Test(t, func(t *testing.T) {
+		eb := &EventBus{listeners: []chan types.DownloadEvent{make(chan types.DownloadEvent, 1)}}
+		eb.listeners[0] <- types.DownloadEvent{}
 
-	// Subscriber that doesn't read
-	_, cleanup := eb.Subscribe()
-	defer cleanup()
-
-	// Fill buffer
-	for i := 0; i < 100; i++ {
-		_ = eb.Publish(types.DownloadEvent{})
-	}
-
-	// Give the broadcast loop time to fill the subscriber's channel buffer
-	time.Sleep(100 * time.Millisecond)
-
-	// Publish a critical message (not progress). It should block for up to 1 second before dropping.
-	start := time.Now()
-	msg := types.DownloadEvent{Message: "critical"}
-	_ = eb.Publish(msg)
-
-	// Wait for processing
-	time.Sleep(1200 * time.Millisecond)
-	elapsed := time.Since(start)
-
-	// broadcastLoop should take at least 1s to try sending to a blocked subscriber
-	if elapsed < 1*time.Second {
-		t.Errorf("broadcast loop did not wait 1s for critical message, elapsed: %v", elapsed)
-	}
+		start := time.Now()
+		eb.broadcastMsg(types.DownloadEvent{Message: "critical"})
+		if elapsed := time.Since(start); elapsed != time.Second {
+			t.Fatalf("critical event wait = %v, want 1s", elapsed)
+		}
+	})
 }
 
 func TestEventBus_ShutdownCleanly(t *testing.T) {

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/SurgeDM/Surge/internal/progress"
@@ -528,61 +529,56 @@ func TestScheduler_GracefulShutdown_PausesAll(t *testing.T) {
 }
 
 func TestScheduler_GracefulShutdown_WaitsPastSoftTimeout(t *testing.T) {
-	ch := make(chan types.DownloadEvent, 10)
-	pool := New(ch, 1)
+	synctest.Test(t, func(t *testing.T) {
+		ch := make(chan types.DownloadEvent, 10)
+		pool := New(ch, 1)
 
-	ps := progress.New("wait-test-id", 1000)
-	pool.mu.Lock()
-	ad := &activeDownload{
-		config: types.DownloadRecord{
-			ID:            "wait-test-id",
-			ProgressState: ps,
-		},
-	}
-	ad.running.Store(true)
-	pool.downloads["wait-test-id"] = ad
-	pool.mu.Unlock()
+		ps := progress.New("wait-test-id", 1000)
+		pool.mu.Lock()
+		ad := &activeDownload{config: types.DownloadRecord{ID: "wait-test-id", ProgressState: ps}}
+		ad.running.Store(true)
+		pool.downloads["wait-test-id"] = ad
+		pool.mu.Unlock()
 
-	origSoftTimeout := gracefulShutdownPauseSoftTimeout
-	origPollInterval := gracefulShutdownPausePollInterval
-	origHardTimeout := gracefulShutdownPauseHardTimeout
-	gracefulShutdownPauseSoftTimeout = 30 * time.Millisecond
-	gracefulShutdownPausePollInterval = 5 * time.Millisecond
-	gracefulShutdownPauseHardTimeout = 5 * time.Second
-	defer func() {
-		gracefulShutdownPauseSoftTimeout = origSoftTimeout
-		gracefulShutdownPausePollInterval = origPollInterval
-		gracefulShutdownPauseHardTimeout = origHardTimeout
-	}()
+		origSoftTimeout := gracefulShutdownPauseSoftTimeout
+		origPollInterval := gracefulShutdownPausePollInterval
+		origHardTimeout := gracefulShutdownPauseHardTimeout
+		gracefulShutdownPauseSoftTimeout = 30 * time.Millisecond
+		gracefulShutdownPausePollInterval = 5 * time.Millisecond
+		gracefulShutdownPauseHardTimeout = 5 * time.Second
+		defer func() {
+			gracefulShutdownPauseSoftTimeout = origSoftTimeout
+			gracefulShutdownPausePollInterval = origPollInterval
+			gracefulShutdownPauseHardTimeout = origHardTimeout
+		}()
 
-	done := make(chan struct{})
-	go func() {
-		pool.GracefulShutdown()
-		close(done)
-	}()
+		done := make(chan struct{})
+		go func() {
+			pool.GracefulShutdown()
+			close(done)
+		}()
+		synctest.Wait()
+		if !ps.IsPausing() {
+			t.Fatal("expected graceful shutdown to set pausing=true")
+		}
 
-	deadline := time.Now().Add(250 * time.Millisecond)
-	for !ps.IsPausing() && time.Now().Before(deadline) {
-		time.Sleep(2 * time.Millisecond)
-	}
-	if !ps.IsPausing() {
-		t.Fatal("expected graceful shutdown to set pausing=true")
-	}
+		time.Sleep(gracefulShutdownPauseSoftTimeout + 20*time.Millisecond)
+		synctest.Wait()
+		select {
+		case <-done:
+			t.Fatal("GracefulShutdown returned before pausing was cleared")
+		default:
+		}
 
-	// Wait beyond the soft timeout. Shutdown should still be blocked.
-	time.Sleep(gracefulShutdownPauseSoftTimeout + 20*time.Millisecond)
-	select {
-	case <-done:
-		t.Fatal("GracefulShutdown returned before pausing was cleared")
-	default:
-	}
-
-	ps.SetPausing(false)
-	select {
-	case <-done:
-	case <-time.After(500 * time.Millisecond):
-		t.Fatal("GracefulShutdown did not return after pausing was cleared")
-	}
+		ps.SetPausing(false)
+		time.Sleep(gracefulShutdownPausePollInterval)
+		synctest.Wait()
+		select {
+		case <-done:
+		default:
+			t.Fatal("GracefulShutdown did not return after pausing was cleared")
+		}
+	})
 }
 
 func TestScheduler_GracefulShutdown_ClearsStalePausingWithoutWorker(t *testing.T) {

--- a/internal/service/local_service_test.go
+++ b/internal/service/local_service_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/SurgeDM/Surge/internal/types"
 )
 
-func setupTestService(t *testing.T) (*LocalDownloadService, *httptest.Server, string) {
+func setupTestService(t *testing.T) (*LocalDownloadService, *httptest.Server, string, <-chan string) {
 	testutil.SetupStateDB(t)
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -40,20 +40,22 @@ func setupTestService(t *testing.T) (*LocalDownloadService, *httptest.Server, st
 
 	// Mock event worker to handle EventRemoved
 	ch, cleanup := eb.Subscribe()
+	removed := make(chan string, 10)
 	go func() {
 		for e := range ch {
 			if e.Type == types.EventRemoved {
 				_ = store.DeleteState(e.DownloadID)
+				removed <- e.DownloadID
 			}
 		}
 	}()
 	t.Cleanup(cleanup)
 
-	return svc, ts, tmpDir
+	return svc, ts, tmpDir, removed
 }
 
 func TestLocalDownloadService_AddWithID_UsesProvidedID(t *testing.T) {
-	svc, globalTs, tmpDir := setupTestService(t)
+	svc, globalTs, tmpDir, _ := setupTestService(t)
 	defer globalTs.Close()
 	t.Cleanup(func() { _ = svc.Shutdown() })
 
@@ -94,7 +96,7 @@ func TestLocalDownloadService_AddWithID_UsesProvidedID(t *testing.T) {
 }
 
 func TestLocalDownloadService_StreamEvents(t *testing.T) {
-	svc, ts, tmpDir := setupTestService(t)
+	svc, ts, tmpDir, _ := setupTestService(t)
 	defer ts.Close()
 
 	ch, cleanup, err := svc.StreamEvents(context.Background())
@@ -134,7 +136,7 @@ func TestLocalDownloadService_StreamEvents(t *testing.T) {
 }
 
 func TestLocalDownloadService_RateLimits(t *testing.T) {
-	svc, ts, tmpDir := setupTestService(t)
+	svc, ts, tmpDir, _ := setupTestService(t)
 	defer ts.Close()
 	t.Cleanup(func() { _ = svc.Shutdown() })
 
@@ -192,9 +194,6 @@ func TestLocalDownloadService_RateLimits(t *testing.T) {
 	// Add a download and set its specific rate limit
 	id, _ := svc.Add(rateTs.URL, tmpDir, "rate.txt", nil, nil, false, 1, 0)
 
-	// Wait briefly for the download to be picked up by the scheduler
-	time.Sleep(100 * time.Millisecond)
-
 	err = svc.SetRateLimit(id, 2000)
 	if err != nil {
 		t.Errorf("SetRateLimit failed: %v", err)
@@ -218,7 +217,7 @@ func TestLocalDownloadService_RateLimits(t *testing.T) {
 }
 
 func TestLocalDownloadService_Purge(t *testing.T) {
-	svc, ts, tmpDir := setupTestService(t)
+	svc, ts, tmpDir, _ := setupTestService(t)
 	defer ts.Close()
 	t.Cleanup(func() { _ = svc.Shutdown() })
 
@@ -241,9 +240,6 @@ func TestLocalDownloadService_Purge(t *testing.T) {
 
 	id, _ := svc.AddWithID(purgeTs.URL, tmpDir, "purge.txt", nil, nil, "purge-id", false, 1, 0)
 
-	// Wait a tiny bit for the file to be created
-	time.Sleep(100 * time.Millisecond)
-
 	status, err := svc.GetStatus(id)
 	if err != nil {
 		t.Fatalf("GetStatus failed: %v", err)
@@ -255,9 +251,6 @@ func TestLocalDownloadService_Purge(t *testing.T) {
 		t.Errorf("Purge failed: %v", err)
 	}
 
-	// Wait a tiny bit to ensure worker exited and no re-creation happened
-	time.Sleep(100 * time.Millisecond)
-
 	// Check that the file was deleted
 	if _, err := os.Stat(filepath.Join(tmpDir, "purge.txt")); !os.IsNotExist(err) {
 		t.Errorf("file purge.txt was not deleted")
@@ -268,7 +261,7 @@ func TestLocalDownloadService_Purge(t *testing.T) {
 }
 
 func TestLocalDownloadService_HistoryAndList(t *testing.T) {
-	svc, ts, tmpDir := setupTestService(t)
+	svc, ts, tmpDir, _ := setupTestService(t)
 	defer ts.Close()
 	t.Cleanup(func() { _ = svc.Shutdown() })
 
@@ -361,7 +354,7 @@ func TestLocalDownloadService_HistoryAndList(t *testing.T) {
 }
 
 func TestLocalDownloadService_Delete(t *testing.T) {
-	svc, ts, tmpDir := setupTestService(t)
+	svc, ts, tmpDir, removed := setupTestService(t)
 	defer ts.Close()
 	t.Cleanup(func() { _ = svc.Shutdown() })
 
@@ -372,7 +365,14 @@ func TestLocalDownloadService_Delete(t *testing.T) {
 		t.Errorf("Delete failed: %v", err)
 	}
 
-	time.Sleep(100 * time.Millisecond)
+	select {
+	case removedID := <-removed:
+		if removedID != id {
+			t.Fatalf("removed download ID = %q, want %q", removedID, id)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for removal event to be processed")
+	}
 
 	// Check if it's gone
 	_, err = svc.GetStatus(id)

--- a/internal/strategy/concurrent/concurrent_test.go
+++ b/internal/strategy/concurrent/concurrent_test.go
@@ -360,10 +360,12 @@ func TestConcurrentDownloader_Cancellation(t *testing.T) {
 	defer cleanup()
 
 	fileSize := int64(10 * utils.MiB)
+	requestStarted := make(chan struct{}, 1)
 	server := testutil.NewMockServerT(t,
 		testutil.WithFileSize(fileSize),
 		testutil.WithRangeSupport(true),
 		testutil.WithByteLatency(100*time.Microsecond),
+		testutil.WithRequestStarted(requestStarted),
 	)
 	defer server.Close()
 
@@ -385,7 +387,7 @@ func TestConcurrentDownloader_Cancellation(t *testing.T) {
 		done <- downloader.Download(ctx, server.URL(), nil, nil, destPath, fileSize)
 	}()
 
-	time.Sleep(200 * time.Millisecond)
+	<-requestStarted
 	cancel()
 
 	select {

--- a/internal/strategy/concurrent/concurrent_test.go
+++ b/internal/strategy/concurrent/concurrent_test.go
@@ -387,7 +387,11 @@ func TestConcurrentDownloader_Cancellation(t *testing.T) {
 		done <- downloader.Download(ctx, server.URL(), nil, nil, destPath, fileSize)
 	}()
 
-	<-requestStarted
+	select {
+	case <-requestStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Request did not start in time")
+	}
 	cancel()
 
 	select {

--- a/internal/strategy/single/downloader_test.go
+++ b/internal/strategy/single/downloader_test.go
@@ -448,10 +448,12 @@ func TestSingleDownloader_Download_Cancellation(t *testing.T) {
 
 	// Large file with latency
 	fileSize := int64(5 * utils.MiB)
+	requestStarted := make(chan struct{}, 1)
 	server := testutil.NewMockServerT(t,
 		testutil.WithFileSize(fileSize),
 		testutil.WithRangeSupport(false),
 		testutil.WithByteLatency(500*time.Microsecond),
+		testutil.WithRequestStarted(requestStarted),
 	)
 	defer server.Close()
 
@@ -473,15 +475,13 @@ func TestSingleDownloader_Download_Cancellation(t *testing.T) {
 		done <- downloader.Download(ctx, server.URL(), destPath, fileSize, "cancel.bin")
 	}()
 
-	// Cancel after a short delay
-	time.Sleep(100 * time.Millisecond)
+	<-requestStarted
 	cancel()
 
 	select {
 	case err := <-done:
-		// Accept context.Canceled or wrapped errors
-		if err != nil && err != context.Canceled && err.Error() != "context canceled" {
-			t.Logf("Expected context.Canceled, got: %v", err)
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context cancellation error, got: %v", err)
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("Download didn't respond to cancellation")

--- a/internal/strategy/single/downloader_test.go
+++ b/internal/strategy/single/downloader_test.go
@@ -475,7 +475,11 @@ func TestSingleDownloader_Download_Cancellation(t *testing.T) {
 		done <- downloader.Download(ctx, server.URL(), destPath, fileSize, "cancel.bin")
 	}()
 
-	<-requestStarted
+	select {
+	case <-requestStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Request did not start in time")
+	}
 	cancel()
 
 	select {

--- a/internal/testutil/mock_server.go
+++ b/internal/testutil/mock_server.go
@@ -21,16 +21,17 @@ type MockServer struct {
 	Server *httptest.Server
 
 	// Configuration
-	FileSize          int64         // Size of the served file
-	SupportsRanges    bool          // Whether to support HTTP Range requests
-	ContentType       string        // Content-Type header value
-	Filename          string        // Filename in Content-Disposition header
-	RandomData        bool          // If true, serve random data; otherwise serve zeros
-	Latency           time.Duration // Artificial latency per request
-	ByteLatency       time.Duration // Latency per byte (simulates slow connection)
-	FailAfterBytes    int64         // Fail connection after this many bytes (0 = no fail)
-	FailOnNthRequest  int           // Fail on Nth request (0 = don't fail)
-	MaxConcurrentReqs int           // Max concurrent requests (0 = unlimited)
+	FileSize          int64           // Size of the served file
+	SupportsRanges    bool            // Whether to support HTTP Range requests
+	ContentType       string          // Content-Type header value
+	Filename          string          // Filename in Content-Disposition header
+	RandomData        bool            // If true, serve random data; otherwise serve zeros
+	Latency           time.Duration   // Artificial latency per request
+	ByteLatency       time.Duration   // Latency per byte (simulates slow connection)
+	FailAfterBytes    int64           // Fail connection after this many bytes (0 = no fail)
+	FailOnNthRequest  int             // Fail on Nth request (0 = don't fail)
+	MaxConcurrentReqs int             // Max concurrent requests (0 = unlimited)
+	RequestStarted    chan<- struct{} // Optional notification when request handling begins
 
 	// Tracking
 	RequestCount   atomic.Int64
@@ -127,6 +128,14 @@ func WithFailOnNthRequest(n int) MockServerOption {
 func WithMaxConcurrentRequests(n int) MockServerOption {
 	return func(m *MockServer) {
 		m.MaxConcurrentReqs = n
+	}
+}
+
+// WithRequestStarted notifies ch when the server begins handling a request.
+// The notification is non-blocking, so callers should provide a buffered channel.
+func WithRequestStarted(ch chan<- struct{}) MockServerOption {
+	return func(m *MockServer) {
+		m.RequestStarted = ch
 	}
 }
 
@@ -250,6 +259,12 @@ func (m *MockServer) connectionCount() int64 {
 }
 
 func (m *MockServer) handleRequest(w http.ResponseWriter, r *http.Request) {
+	if m.RequestStarted != nil {
+		select {
+		case m.RequestStarted <- struct{}{}:
+		default:
+		}
+	}
 	if m.CustomHandler != nil {
 		m.CustomHandler(w, r)
 		return
@@ -486,6 +501,12 @@ func (s *StreamingMockServer) handleStreamingRequest(w http.ResponseWriter, r *h
 	s.RequestCount.Add(1)
 	s.trackRequest(r)
 	defer s.ActiveRequests.Add(-1)
+	if s.RequestStarted != nil {
+		select {
+		case s.RequestStarted <- struct{}{}:
+		default:
+		}
+	}
 
 	// Track request number for fail-on-nth logic
 	s.requestCountMu.Lock()

--- a/internal/utils/debug_test.go
+++ b/internal/utils/debug_test.go
@@ -13,20 +13,13 @@ import (
 )
 
 func TestDebug_CreatesLogFile(t *testing.T) {
-	// Note: Debug uses sync.Once, so we can only test it once per test run
-	// This test verifies that the debug function creates a log file
-
-	// Ensure logs directory exists
-	logsDir := config.GetLogsDir()
-	if err := os.MkdirAll(logsDir, 0o755); err != nil {
-		t.Fatalf("Failed to create logs directory: %v", err)
-	}
+	logsDir := t.TempDir()
+	utils.CloseDebug()
+	utils.ConfigureDebug(logsDir)
+	t.Cleanup(utils.CloseDebug)
 
 	// Call Debug
 	utils.Debug("Test message from unit test")
-
-	// Wait a moment for file to be created
-	time.Sleep(100 * time.Millisecond)
 
 	// Check if any debug log file was created
 	entries, err := os.ReadDir(logsDir)
@@ -43,7 +36,7 @@ func TestDebug_CreatesLogFile(t *testing.T) {
 	}
 
 	if !found {
-		t.Log("Note: Debug log file may not be created on first run due to sync.Once behavior")
+		t.Fatal("Debug did not create a log file")
 	}
 }
 


### PR DESCRIPTION
## Summary

- replace the 19 flakylint-reported sleep assertions with deterministic synchronization or virtual time
- add observable request/removal signals for cancellation and service tests
- make flakylint a blocking Core Lint check

## Root cause

Tests used wall-clock sleeps to wait for asynchronous work, which flakes under CI load.

## Validation

- flakylint ./...
- go test -race ./...
- actionlint .github/workflows/core-lint.yml
- repeated race-enabled runs of synchronization-sensitive tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by replacing fixed delays and wall-clock timing with deterministic synchronization.
  * Strengthened cancellation, shutdown, event handling, logging, and HTTP server integration coverage.
  * Standardized test authorization and temporary resource cleanup.
  * Enhanced test-server monitoring with request-start notifications and concurrency tracking.
* **Chores**
  * Added automated linting to detect flaky tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->