### PR TITLE
fix(concurrent): tolerate transient worker 403s

### DIFF
--- a/cmd/http_handler_test.go
+++ b/cmd/http_handler_test.go
@@ -330,14 +330,24 @@ func TestHandleDownload_SkipApprovalUsesLifecycleEnqueue(t *testing.T) {
 		GlobalProgressCh = nil
 	})
 
+	firstRange := make(chan string, 1)
 	probeServer := testutil.NewHTTPServerT(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if got := r.Header.Get("Range"); got != "bytes=0-0" {
-			t.Fatalf("Range header = %q, want bytes=0-0", got)
+		rangeHeader := r.Header.Get("Range")
+		select {
+		case firstRange <- rangeHeader:
+		default:
 		}
-		w.Header().Set("Content-Range", "bytes 0-0/7")
-		w.Header().Set("Content-Length", "1")
+		if rangeHeader == "bytes=0-0" {
+			w.Header().Set("Content-Range", "bytes 0-0/7")
+			w.Header().Set("Content-Length", "1")
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write([]byte("x"))
+			return
+		}
+		w.Header().Set("Content-Range", "bytes 0-6/7")
+		w.Header().Set("Content-Length", "7")
 		w.WriteHeader(http.StatusPartialContent)
-		_, _ = w.Write([]byte("x"))
+		_, _ = w.Write([]byte("content"))
 	}))
 	defer probeServer.Close()
 
@@ -372,6 +382,14 @@ func TestHandleDownload_SkipApprovalUsesLifecycleEnqueue(t *testing.T) {
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	select {
+	case got := <-firstRange:
+		if got != "bytes=0-0" {
+			t.Fatalf("first Range header = %q, want bytes=0-0", got)
+		}
+	default:
+		t.Fatal("expected lifecycle enqueue to probe the server")
 	}
 	configs := GlobalPool.GetAll()
 	if len(configs) != 1 {

--- a/internal/strategy/concurrent/downloader.go
+++ b/internal/strategy/concurrent/downloader.go
@@ -159,12 +159,10 @@ func (d *ConcurrentDownloader) shouldEscalate403(now time.Time) bool {
 	d.soft403Mu.Lock()
 	defer d.soft403Mu.Unlock()
 
-	if d.State == nil {
-		d.soft403Exhaustions++
-		return d.soft403Exhaustions >= soft403MaxExhaustions
+	progress := d.soft403Progress
+	if d.State != nil {
+		progress = d.State.Bytes.VerifiedProgress.Load()
 	}
-
-	progress := d.State.Bytes.VerifiedProgress.Load()
 	if progress != d.soft403Progress {
 		d.soft403Progress = progress
 		d.soft403Exhaustions = 0
@@ -186,7 +184,10 @@ func (d *ConcurrentDownloader) shouldEscalate403(now time.Time) bool {
 	}
 
 	// Progress can race the decision above; recheck before stopping healthy peers.
-	if progress = d.State.Bytes.VerifiedProgress.Load(); progress != d.soft403Progress {
+	if d.State != nil {
+		progress = d.State.Bytes.VerifiedProgress.Load()
+	}
+	if progress != d.soft403Progress {
 		d.soft403Progress = progress
 		d.soft403Exhaustions = 1
 		d.soft403Since = time.Time{}

--- a/internal/strategy/concurrent/downloader.go
+++ b/internal/strategy/concurrent/downloader.go
@@ -43,7 +43,18 @@ type ConcurrentDownloader struct {
 	bufPool            sync.Pool
 	Headers            map[string]string // Custom HTTP headers from browser (cookies, auth, etc.)
 	hostLimiter        *transport.HostRateLimiter
+	soft403Mu          sync.Mutex
+	soft403Exhaustions int
+	soft403Progress    int64
+	soft403Since       time.Time
 }
+
+const (
+	// Each exhaustion already includes the normal per-task retry burn. The
+	// confirmation window gives in-flight workers one final chance to advance.
+	soft403MaxExhaustions = 16
+	soft403ConfirmWindow  = 5 * time.Second
+)
 
 // NewConcurrentDownloader creates a new concurrent downloader with all required parameters
 func NewConcurrentDownloader(id string, progressCh chan<- types.DownloadEvent, progState *progress.DownloadProgress, runtime *types.RuntimeConfig) *ConcurrentDownloader {
@@ -144,6 +155,46 @@ func (d *ConcurrentDownloader) ReportMirrorError(url string) {
 	}
 }
 
+func (d *ConcurrentDownloader) shouldEscalate403(now time.Time) bool {
+	d.soft403Mu.Lock()
+	defer d.soft403Mu.Unlock()
+
+	if d.State == nil {
+		d.soft403Exhaustions++
+		return d.soft403Exhaustions >= soft403MaxExhaustions
+	}
+
+	progress := d.State.Bytes.VerifiedProgress.Load()
+	if progress != d.soft403Progress {
+		d.soft403Progress = progress
+		d.soft403Exhaustions = 0
+		d.soft403Since = time.Time{}
+	}
+
+	if d.soft403Exhaustions < soft403MaxExhaustions {
+		d.soft403Exhaustions++
+	}
+	if d.soft403Exhaustions < soft403MaxExhaustions {
+		return false
+	}
+	if d.soft403Since.IsZero() {
+		d.soft403Since = now
+		return false
+	}
+	if now.Before(d.soft403Since.Add(soft403ConfirmWindow)) {
+		return false
+	}
+
+	// Progress can race the decision above; recheck before stopping healthy peers.
+	if progress = d.State.Bytes.VerifiedProgress.Load(); progress != d.soft403Progress {
+		d.soft403Progress = progress
+		d.soft403Exhaustions = 1
+		d.soft403Since = time.Time{}
+		return false
+	}
+	return true
+}
+
 // calculateChunkSize determines optimal chunk size
 func (d *ConcurrentDownloader) calculateChunkSize(fileSize int64, numConns int) int64 {
 	// Safety check
@@ -237,6 +288,12 @@ func (d *ConcurrentDownloader) applyClientSettings(client *http.Client) {
 // Uses pre-probed metadata (file size already known)
 func (d *ConcurrentDownloader) Download(ctx context.Context, rawurl string, candidateMirrors []string, activeMirrors []string, destPath string, fileSize int64) error {
 	utils.Debug("ConcurrentDownloader.Download: %s -> %s (size: %d, mirrors: %d)", rawurl, destPath, fileSize, len(activeMirrors))
+
+	d.soft403Mu.Lock()
+	d.soft403Exhaustions = 0
+	d.soft403Progress = 0
+	d.soft403Since = time.Time{}
+	d.soft403Mu.Unlock()
 
 	if d.hostLimiter == nil {
 		d.hostLimiter = transport.DefaultHostRateLimiter

--- a/internal/strategy/concurrent/switch_429_test.go
+++ b/internal/strategy/concurrent/switch_429_test.go
@@ -412,6 +412,23 @@ func TestConcurrentDownloader_403DoesNotCancelHealthyWorker(t *testing.T) {
 	}
 }
 
+func TestSoft403NilStateWaitsForConfirmation(t *testing.T) {
+	downloader := NewConcurrentDownloader("soft403-nil-state", nil, nil, nil)
+	now := time.Unix(100, 0)
+
+	for i := 0; i < soft403MaxExhaustions; i++ {
+		if downloader.shouldEscalate403(now) {
+			t.Fatalf("escalated on exhaustion %d before confirmation", i+1)
+		}
+	}
+	if downloader.shouldEscalate403(now.Add(soft403ConfirmWindow - time.Nanosecond)) {
+		t.Fatal("escalated before the confirmation window elapsed")
+	}
+	if !downloader.shouldEscalate403(now.Add(soft403ConfirmWindow)) {
+		t.Fatal("did not escalate after the confirmation window elapsed")
+	}
+}
+
 func TestConcurrentDownloader_503WithRetryAfterTreatedAsThrottle(t *testing.T) {
 	tmpDir, cleanup := initTestState(t)
 	defer cleanup()

--- a/internal/strategy/concurrent/switch_429_test.go
+++ b/internal/strategy/concurrent/switch_429_test.go
@@ -351,6 +351,67 @@ func TestConcurrentDownloader_429DoesNotTearDownWithHealthyMirror(t *testing.T) 
 	}
 }
 
+func TestConcurrentDownloader_403DoesNotCancelHealthyWorker(t *testing.T) {
+	tmpDir, cleanup := initTestState(t)
+	defer cleanup()
+
+	const fileSize = int64(128 * utils.KiB)
+	const chunkSize = fileSize / 2
+	payload := make([]byte, chunkSize)
+	healthyDone := make(chan struct{})
+	var healthyDoneOnce sync.Once
+	var forbiddenRequests atomic.Int64
+
+	server := testutil.NewHTTPServerT(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Range") == "bytes=0-65535" {
+			select {
+			case <-time.After(100 * time.Millisecond):
+				healthyDoneOnce.Do(func() { close(healthyDone) })
+			case <-r.Context().Done():
+				return
+			}
+		} else if forbiddenRequests.Add(1) == 1 {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		} else {
+			select {
+			case <-healthyDone:
+			case <-r.Context().Done():
+				return
+			}
+		}
+
+		w.Header().Set("Content-Length", strconv.FormatInt(chunkSize, 10))
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(payload)
+	}))
+	defer server.Close()
+
+	destPath := filepath.Join(tmpDir, "soft403_healthy.bin")
+	if f, err := os.Create(destPath + types.IncompleteSuffix); err == nil {
+		_ = f.Close()
+	}
+
+	state := progress.New("soft403-healthy", fileSize)
+	downloader := NewConcurrentDownloader("soft403-healthy", nil, state, &types.RuntimeConfig{
+		MaxConnectionsPerDownload: 2,
+		Workers:                   2,
+		MinChunkSize:              chunkSize,
+		MaxTaskRetries:            1,
+		DialHedgeCount:            0,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := downloader.Download(ctx, server.URL, nil, nil, destPath, fileSize); err != nil {
+		t.Fatalf("Download failed after transient 403: %v", err)
+	}
+	if forbiddenRequests.Load() < 2 {
+		t.Fatal("expected the forbidden range to be retried after its soft limit")
+	}
+}
+
 func TestConcurrentDownloader_503WithRetryAfterTreatedAsThrottle(t *testing.T) {
 	tmpDir, cleanup := initTestState(t)
 	defer cleanup()

--- a/internal/strategy/concurrent/worker.go
+++ b/internal/strategy/concurrent/worker.go
@@ -20,6 +20,8 @@ var writeAtFn = func(f *os.File, b []byte, off int64) (int, error) {
 	return f.WriteAt(b, off)
 }
 
+var errSoftForbidden = errors.New("unexpected status: 403")
+
 // worker downloads tasks from the queue
 func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []string, file *os.File, queue *TaskQueue, totalSize int64, client *http.Client) error {
 	bufPtr := d.bufPool.Get().(*[]byte)
@@ -217,6 +219,13 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 			delete(d.activeTasks, id)
 			d.activeMu.Unlock()
 
+			if errors.Is(lastErr, errSoftForbidden) {
+				if !d.shouldEscalate403(time.Now()) {
+					continue
+				}
+				lastErr = fmt.Errorf("%v: %w", lastErr, types.ErrPermanentHTTP)
+			}
+
 			return lastErr
 		}
 
@@ -275,6 +284,9 @@ func (d *ConcurrentDownloader) downloadTask(ctx context.Context, rawurl string, 
 			return fmt.Errorf("server indicated success (200) but ignored range request (expected 206)")
 		}
 	} else if resp.StatusCode != http.StatusPartialContent {
+		if resp.StatusCode == http.StatusForbidden {
+			return errSoftForbidden
+		}
 		if types.IsPermanentHTTPStatus(resp.StatusCode) {
 			return fmt.Errorf("unexpected status: %d: %w", resp.StatusCode, types.ErrPermanentHTTP)
 		}


### PR DESCRIPTION
Closes #622.

## Summary

- treat HTTP 403 from concurrent range workers as a soft failure after the normal task retry burn
- requeue the unfinished range without cancelling healthy workers while verified progress continues
- escalate persistent no-progress 403s back to `ErrPermanentHTTP` after a bounded pressure window
- keep bootstrap and single-stream 403 classification unchanged

## Tests

- `go test ./... -count=1`
- focused regression repeated 20 times
- focused regression under the race detector

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of temporary HTTP 403 errors during downloads.
  * Prevented blocked download ranges from unnecessarily cancelling healthy ranges.
  * Added controlled retries and confirmation checks before stopping after repeated access failures.
  * Improved download validation by verifying the initial byte-range request.

* **Tests**
  * Added coverage for transient 403 responses, concurrent downloads, retry behavior, and initial range validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->