### PR TITLE
refactor(concurrent): introduce authoritative VerifiedProgress and harden completion lifecycle

### DIFF
--- a/internal/progress/accuracy_test.go
+++ b/internal/progress/accuracy_test.go
@@ -126,8 +126,12 @@ func TestRestoreBitmap_ShortBitmapRecoversWithoutPanic(t *testing.T) {
 
 	state.RecalculateProgress([]types.Task{{Offset: 0, Length: chunkSize}})
 
-	if got := state.GetChunkState(0); got != types.ChunkPending {
-		t.Fatalf("chunk 0 state after recalc = %v, want Pending", got)
+	if got := state.GetChunkState(0); got != types.ChunkCompleted {
+		t.Fatalf("chunk 0 state after recalc = %v, want Completed", got)
+	}
+	_, _, _, _, prog := state.GetBitmap()
+	if len(prog) == 0 || prog[0] != chunkSize {
+		t.Fatalf("chunk 0 progress after recalc = %v, want full %d", prog, chunkSize)
 	}
 	if got := state.GetChunkState(1); got != types.ChunkCompleted {
 		t.Fatalf("chunk 1 state after recalc = %v, want Completed", got)

--- a/internal/progress/bitmap.go
+++ b/internal/progress/bitmap.go
@@ -294,6 +294,25 @@ func (b *BitmapTracker) RecalculateProgress(totalSize int64, remainingTasks []ty
 		}
 	}
 
+	// Restore-time ChunkCompleted bits mean the bytes are already on disk.
+	// Remaining coverage must not un-complete them before the status rewrite.
+	for i := 0; i < b.width; i++ {
+		if types.ChunkStatus(b.chunkStatus[i].Load()) != types.ChunkCompleted {
+			continue
+		}
+		chunkStart := int64(i) * b.actualChunkSize
+		chunkEnd := chunkStart + b.actualChunkSize
+		if chunkEnd > totalSize {
+			chunkEnd = totalSize
+		}
+		chunkSize := chunkEnd - chunkStart
+		current := b.chunkProgress[i].Load()
+		if current < chunkSize {
+			total += chunkSize - current
+			b.chunkProgress[i].Store(chunkSize)
+		}
+	}
+
 	for i := 0; i < b.width; i++ {
 		chunkStart := int64(i) * b.actualChunkSize
 		chunkEnd := chunkStart + b.actualChunkSize

--- a/internal/progress/bitmap_test.go
+++ b/internal/progress/bitmap_test.go
@@ -133,6 +133,50 @@ func TestBitmapTracker_RecalculateProgress(t *testing.T) {
 	}
 }
 
+func TestBitmapTracker_RecalculateProgress_RestoredCompletedStaysFull(t *testing.T) {
+	bt := &BitmapTracker{}
+	totalSize := int64(1000)
+	chunkSize := int64(250)
+	bt.InitBitmap(totalSize, chunkSize)
+
+	// Restore marked chunk 1 complete; remaining still covers it and half of chunk 2.
+	bt.SetChunkState(1, types.ChunkCompleted)
+	tasks := []types.Task{
+		{Offset: 250, Length: 250}, // chunk 1 fully covered
+		{Offset: 500, Length: 125}, // chunk 2 half remaining
+	}
+
+	totalVerified := bt.RecalculateProgress(totalSize, tasks)
+	// full-minus-remaining would be 1000-375=625; restoring chunk 1 adds 250 → 875.
+	if totalVerified != 875 {
+		t.Errorf("expected totalVerified 875, got %d", totalVerified)
+	}
+
+	if bt.GetChunkState(0) != types.ChunkCompleted {
+		t.Errorf("chunk 0 should stay completed (no remaining)")
+	}
+	if bt.GetChunkState(1) != types.ChunkCompleted {
+		t.Errorf("chunk 1 restored Completed must stay Completed")
+	}
+	if bt.GetChunkState(2) != types.ChunkDownloading {
+		t.Errorf("chunk 2 partial must not be starved")
+	}
+	if bt.GetChunkState(3) != types.ChunkCompleted {
+		t.Errorf("chunk 3 should stay completed")
+	}
+
+	_, _, _, _, prog := bt.GetBitmapSnapshot(totalSize, true)
+	if len(prog) != 4 {
+		t.Fatalf("expected 4 chunk progress entries, got %d", len(prog))
+	}
+	if prog[1] != chunkSize {
+		t.Errorf("chunk 1 progress = %d, want full %d", prog[1], chunkSize)
+	}
+	if prog[2] != 125 {
+		t.Errorf("chunk 2 progress = %d, want 125 (partial not zeroed)", prog[2])
+	}
+}
+
 // =============================================================================
 // Benchmarks
 // =============================================================================

--- a/internal/progress/bytes.go
+++ b/internal/progress/bytes.go
@@ -3,10 +3,16 @@ package progress
 import "sync/atomic"
 
 // ByteTracker handles thread-safe lock-free byte counting.
+// Cache line padding (64 bytes) isolates the high-frequency write counter
+// (Downloaded) from read-mostly counters (VerifiedProgress, TotalSize), eliminating
+// multicore false sharing / MESI cache line bouncing during batch flushes.
 type ByteTracker struct {
-	Downloaded       atomic.Int64
+	Downloaded atomic.Int64
+	_          [56]byte // pad Downloaded (8B) to its own 64B cache line
+
 	VerifiedProgress atomic.Int64
 	TotalSize        atomic.Int64 // Updated dynamically if size is discovered during download
+	_                [48]byte     // pad read counters (16B) to the next 64B cache line
 }
 
 // SetTotalSize initializes the total size.

--- a/internal/scheduler/main_test.go
+++ b/internal/scheduler/main_test.go
@@ -2,13 +2,29 @@
 package scheduler
 
 import (
-	"go.uber.org/goleak"
+	"fmt"
+	"net/http"
+	"os"
 	"testing"
+
+	"github.com/SurgeDM/Surge/internal/transport"
+	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m,
-		goleak.IgnoreTopFunction("sync.runtime_notifyListWait"),
-		goleak.IgnoreTopFunction("github.com/SurgeDM/Surge/internal/scheduler.safeSendProgress"),
-	)
+	code := m.Run()
+	http.DefaultClient.CloseIdleConnections()
+	transport.DefaultNetworkPool.CloseAll()
+	if code == 0 {
+		if err := goleak.Find(
+			goleak.IgnoreTopFunction("sync.runtime_notifyListWait"),
+			goleak.IgnoreTopFunction("github.com/SurgeDM/Surge/internal/scheduler.safeSendProgress"),
+			goleak.IgnoreTopFunction("net/http.(*persistConn).writeLoop"),
+			goleak.IgnoreTopFunction("net/http.(*persistConn).readLoop"),
+		); err != nil {
+			fmt.Fprintf(os.Stderr, "goleak: Errors on successful test run: %v\n", err)
+			os.Exit(1)
+		}
+	}
+	os.Exit(code)
 }

--- a/internal/strategy/concurrent/completion_monitor_cancel_test.go
+++ b/internal/strategy/concurrent/completion_monitor_cancel_test.go
@@ -17,7 +17,7 @@ import (
 func TestRunCompletionMonitor_DownloadedCancelsActives(t *testing.T) {
 	const fileSize int64 = 1024
 	queue := NewTaskQueue()
-	state := progress.New("monitor-downloaded-cancel", fileSize)
+	state := progress.New("monitor-downloaded-not-key", fileSize)
 	state.Bytes.Downloaded.Store(fileSize)
 
 	taskCtx1, cancel1 := context.WithCancel(context.Background())
@@ -40,19 +40,26 @@ func TestRunCompletionMonitor_DownloadedCancelsActives(t *testing.T) {
 
 	select {
 	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("completion monitor did not return after Downloaded reached file size")
+		t.Fatal("completion monitor returned on Downloaded without VerifiedProgress")
+	case <-time.After(300 * time.Millisecond):
 	}
 
 	select {
 	case <-taskCtx1.Done():
+		t.Fatal("active task 0 was cancelled on Downloaded-full VP-short")
 	default:
-		t.Fatal("active task 0 was not cancelled")
 	}
 	select {
 	case <-taskCtx2.Done():
+		t.Fatal("active task 1 was cancelled on Downloaded-full VP-short")
 	default:
-		t.Fatal("active task 1 was not cancelled")
+	}
+
+	monCancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("completion monitor did not exit after parent cancel")
 	}
 }
 
@@ -93,16 +100,23 @@ func TestRunCompletionMonitor_IdleCompletionStillCloses(t *testing.T) {
 	}
 }
 
-func TestRunCompletionMonitor_VerifiedProgressIsNotCompletionKey(t *testing.T) {
+func TestRunCompletionMonitor_VerifiedProgressCancelsActivesAndDrains(t *testing.T) {
 	const fileSize int64 = 1024
 	queue := NewTaskQueue()
-	state := progress.New("monitor-vp-not-done", fileSize)
+	queue.Push(types.Task{Offset: 0, Length: 100})
+	queue.Push(types.Task{Offset: 100, Length: 100})
+	state := progress.New("monitor-vp-done", fileSize)
 	state.Bytes.VerifiedProgress.Store(fileSize)
 	state.Bytes.Downloaded.Store(0)
 
+	taskCtx1, cancel1 := context.WithCancel(context.Background())
+	taskCtx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel1()
+	defer cancel2()
+
 	d := &ConcurrentDownloader{
 		State:       state,
-		activeTasks: map[int]*ActiveTask{},
+		activeTasks: map[int]*ActiveTask{0: {Cancel: cancel1}, 1: {Cancel: cancel2}},
 	}
 
 	monCtx, monCancel := context.WithCancel(context.Background())
@@ -110,20 +124,83 @@ func TestRunCompletionMonitor_VerifiedProgressIsNotCompletionKey(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		d.runCompletionMonitor(monCtx, queue, fileSize, 2)
+		d.runCompletionMonitor(monCtx, queue, fileSize, 4)
 	}()
 
 	select {
 	case <-done:
-		t.Fatal("completion monitor returned on VerifiedProgress without Downloaded")
+	case <-time.After(2 * time.Second):
+		t.Fatal("completion monitor did not return after VerifiedProgress reached file size")
+	}
+
+	select {
+	case <-taskCtx1.Done():
+	default:
+		t.Fatal("active task 0 was not cancelled")
+	}
+	select {
+	case <-taskCtx2.Done():
+	default:
+		t.Fatal("active task 1 was not cancelled")
+	}
+	if remaining := queue.DrainRemaining(); len(remaining) != 0 {
+		t.Fatalf("VP path left %d queued tasks: %+v", len(remaining), remaining)
+	}
+	if !d.completing.Load() {
+		t.Fatal("completing was not set on the VP path")
+	}
+}
+
+func TestRunCompletionMonitor_IdleVPShortDoesNotComplete(t *testing.T) {
+	const fileSize int64 = 1024
+	queue := NewTaskQueue()
+	state := progress.New("monitor-idle-vp-short", fileSize)
+
+	d := &ConcurrentDownloader{
+		State:       state,
+		activeTasks: map[int]*ActiveTask{},
+	}
+
+	workerDone := make(chan struct{})
+	go func() {
+		defer close(workerDone)
+		_, _ = queue.Pop()
+	}()
+	deadline := time.Now().Add(time.Second)
+	for queue.IdleWorkers() != 1 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if queue.IdleWorkers() != 1 {
+		t.Fatal("queue worker did not become idle")
+	}
+
+	monCtx, monCancel := context.WithCancel(context.Background())
+	defer monCancel()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		d.runCompletionMonitor(monCtx, queue, fileSize, 1)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("completion monitor returned while idle with VP below file size")
 	case <-time.After(300 * time.Millisecond):
 	}
 
 	monCancel()
 	select {
+	case <-workerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("idle waiter did not unblock after parent cancel")
+	}
+	select {
 	case <-done:
 	case <-time.After(time.Second):
 		t.Fatal("completion monitor did not exit after parent cancel")
+	}
+	if d.completing.Load() {
+		t.Fatal("parent cancel must not set completing")
 	}
 }
 
@@ -131,7 +208,7 @@ func TestRunCompletionMonitor_NilCancelDoesNotPanic(t *testing.T) {
 	const fileSize int64 = 1024
 	queue := NewTaskQueue()
 	state := progress.New("monitor-nil-cancel", fileSize)
-	state.Bytes.Downloaded.Store(fileSize)
+	state.Bytes.VerifiedProgress.Store(fileSize)
 
 	taskCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -219,7 +296,7 @@ func TestRunCompletionMonitor_CompletionCancelDoesNotRequeue(t *testing.T) {
 		time.Sleep(time.Millisecond)
 	}
 
-	state.Bytes.Downloaded.Store(fileSize)
+	state.Bytes.VerifiedProgress.Store(fileSize)
 	monDone := make(chan struct{})
 	go func() {
 		defer close(monDone)

--- a/internal/strategy/concurrent/completion_monitor_cancel_test.go
+++ b/internal/strategy/concurrent/completion_monitor_cancel_test.go
@@ -2,10 +2,16 @@ package concurrent
 
 import (
 	"context"
+	"net/http"
+	"os"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/SurgeDM/Surge/internal/progress"
+	"github.com/SurgeDM/Surge/internal/testutil"
+	"github.com/SurgeDM/Surge/internal/transport"
+	"github.com/SurgeDM/Surge/internal/types"
 )
 
 func TestRunCompletionMonitor_DownloadedCancelsActives(t *testing.T) {
@@ -156,5 +162,86 @@ func TestRunCompletionMonitor_NilCancelDoesNotPanic(t *testing.T) {
 	case <-taskCtx.Done():
 	default:
 		t.Fatal("non-nil Cancel was not invoked")
+	}
+}
+
+func TestRunCompletionMonitor_CompletionCancelDoesNotRequeue(t *testing.T) {
+	const fileSize int64 = 1024
+	var startedOnce sync.Once
+	started := make(chan struct{})
+	server := testutil.NewHTTPServerT(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Range", "bytes 0-1023/1024")
+		w.WriteHeader(http.StatusPartialContent)
+		w.(http.Flusher).Flush()
+		startedOnce.Do(func() { close(started) })
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	outFile, err := os.CreateTemp(t.TempDir(), "completion-no-requeue-*.surge")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = outFile.Close() }()
+
+	state := progress.New("completion-no-requeue", fileSize)
+	d := NewConcurrentDownloader("completion-no-requeue", nil, state, &types.RuntimeConfig{
+		MaxTaskRetries: 3,
+	})
+	d.hostLimiter = transport.NewHostRateLimiter()
+
+	queue := NewTaskQueue()
+	queue.Push(types.Task{Offset: 0, Length: fileSize})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	workerErr := make(chan error, 1)
+	go func() {
+		workerErr <- d.worker(ctx, 0, []string{server.URL}, outFile, queue, fileSize, server.Client())
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not start the tarpit GET")
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		d.activeMu.Lock()
+		at := d.activeTasks[0]
+		registered := at != nil && at.Cancel != nil
+		d.activeMu.Unlock()
+		if registered {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	state.Bytes.Downloaded.Store(fileSize)
+	monDone := make(chan struct{})
+	go func() {
+		defer close(monDone)
+		d.runCompletionMonitor(ctx, queue, fileSize, 4)
+	}()
+
+	select {
+	case err := <-workerErr:
+		if err != nil {
+			t.Fatalf("worker err=%v, want nil after completion cancel", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker hung after completion cancel (likely requeued onto the tarpit)")
+	}
+
+	select {
+	case <-monDone:
+	case <-time.After(time.Second):
+		t.Fatal("completion monitor did not exit")
+	}
+
+	if remaining := queue.DrainRemaining(); len(remaining) != 0 {
+		t.Fatalf("completion cancel requeued %d tasks: %+v", len(remaining), remaining)
 	}
 }

--- a/internal/strategy/concurrent/completion_monitor_cancel_test.go
+++ b/internal/strategy/concurrent/completion_monitor_cancel_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/SurgeDM/Surge/internal/types"
 )
 
-func TestRunCompletionMonitor_DownloadedCancelsActives(t *testing.T) {
+func TestRunCompletionMonitor_DownloadedDoesNotCancelActives(t *testing.T) {
 	const fileSize int64 = 1024
 	queue := NewTaskQueue()
 	state := progress.New("monitor-downloaded-not-key", fileSize)

--- a/internal/strategy/concurrent/completion_monitor_cancel_test.go
+++ b/internal/strategy/concurrent/completion_monitor_cancel_test.go
@@ -1,0 +1,160 @@
+package concurrent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/SurgeDM/Surge/internal/progress"
+)
+
+func TestRunCompletionMonitor_DownloadedCancelsActives(t *testing.T) {
+	const fileSize int64 = 1024
+	queue := NewTaskQueue()
+	state := progress.New("monitor-downloaded-cancel", fileSize)
+	state.Bytes.Downloaded.Store(fileSize)
+
+	taskCtx1, cancel1 := context.WithCancel(context.Background())
+	taskCtx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel1()
+	defer cancel2()
+
+	d := &ConcurrentDownloader{
+		State:       state,
+		activeTasks: map[int]*ActiveTask{0: {Cancel: cancel1}, 1: {Cancel: cancel2}},
+	}
+
+	monCtx, monCancel := context.WithCancel(context.Background())
+	defer monCancel()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		d.runCompletionMonitor(monCtx, queue, fileSize, 4)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("completion monitor did not return after Downloaded reached file size")
+	}
+
+	select {
+	case <-taskCtx1.Done():
+	default:
+		t.Fatal("active task 0 was not cancelled")
+	}
+	select {
+	case <-taskCtx2.Done():
+	default:
+		t.Fatal("active task 1 was not cancelled")
+	}
+}
+
+func TestRunCompletionMonitor_IdleCompletionStillCloses(t *testing.T) {
+	queue := NewTaskQueue()
+	d := &ConcurrentDownloader{activeTasks: map[int]*ActiveTask{}}
+
+	workerDone := make(chan struct{})
+	go func() {
+		defer close(workerDone)
+		_, _ = queue.Pop()
+	}()
+	deadline := time.Now().Add(time.Second)
+	for queue.IdleWorkers() != 1 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if queue.IdleWorkers() != 1 {
+		t.Fatal("queue worker did not become idle")
+	}
+
+	monCtx, monCancel := context.WithCancel(context.Background())
+	defer monCancel()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		d.runCompletionMonitor(monCtx, queue, 1, 1)
+	}()
+
+	select {
+	case <-workerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("idle completion did not close the queue")
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("completion monitor did not exit on idle completion")
+	}
+}
+
+func TestRunCompletionMonitor_VerifiedProgressIsNotCompletionKey(t *testing.T) {
+	const fileSize int64 = 1024
+	queue := NewTaskQueue()
+	state := progress.New("monitor-vp-not-done", fileSize)
+	state.Bytes.VerifiedProgress.Store(fileSize)
+	state.Bytes.Downloaded.Store(0)
+
+	d := &ConcurrentDownloader{
+		State:       state,
+		activeTasks: map[int]*ActiveTask{},
+	}
+
+	monCtx, monCancel := context.WithCancel(context.Background())
+	defer monCancel()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		d.runCompletionMonitor(monCtx, queue, fileSize, 2)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("completion monitor returned on VerifiedProgress without Downloaded")
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	monCancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("completion monitor did not exit after parent cancel")
+	}
+}
+
+func TestRunCompletionMonitor_NilCancelDoesNotPanic(t *testing.T) {
+	const fileSize int64 = 1024
+	queue := NewTaskQueue()
+	state := progress.New("monitor-nil-cancel", fileSize)
+	state.Bytes.Downloaded.Store(fileSize)
+
+	taskCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	d := &ConcurrentDownloader{
+		State: state,
+		activeTasks: map[int]*ActiveTask{
+			0: {},
+			1: {Cancel: nil},
+			2: {Cancel: cancel},
+		},
+	}
+
+	monCtx, monCancel := context.WithCancel(context.Background())
+	defer monCancel()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		d.runCompletionMonitor(monCtx, queue, fileSize, 4)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("completion monitor panicked or hung on nil Cancel")
+	}
+	select {
+	case <-taskCtx.Done():
+	default:
+		t.Fatal("non-nil Cancel was not invoked")
+	}
+}

--- a/internal/strategy/concurrent/downloader.go
+++ b/internal/strategy/concurrent/downloader.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/SurgeDM/Surge/internal/progress"
@@ -47,6 +48,9 @@ type ConcurrentDownloader struct {
 	soft403Progress    int64
 	soft403Since       time.Time
 	concurrencyGate    *adaptiveConcurrencyGate
+	// completing is set when the completion monitor has decided the download
+	// is done. Worker taskCtx cancel is then a completion signal, not a stall.
+	completing atomic.Bool
 }
 
 const (
@@ -295,6 +299,7 @@ func (d *ConcurrentDownloader) Download(ctx context.Context, rawurl string, cand
 	d.soft403Progress = 0
 	d.soft403Since = time.Time{}
 	d.soft403Mu.Unlock()
+	d.completing.Store(false)
 
 	if d.hostLimiter == nil {
 		d.hostLimiter = transport.DefaultHostRateLimiter
@@ -596,6 +601,9 @@ func (d *ConcurrentDownloader) runCompletionMonitor(ctx context.Context, queue *
 			}
 			isDone := queue.Len() == 0 && (int(queue.IdleWorkers()+parked) == numConns || (d.State != nil && d.State.Bytes.Downloaded.Load() >= fileSize))
 			if isDone {
+				// Mark first so a cancelled worker does not treat this as a
+				// health stall and Push after Close.
+				d.completing.Store(true)
 				// Close wakes Pop waiters; Body.Read needs the registered cancel.
 				d.activeMu.Lock()
 				for _, at := range d.activeTasks {

--- a/internal/strategy/concurrent/downloader.go
+++ b/internal/strategy/concurrent/downloader.go
@@ -596,6 +596,14 @@ func (d *ConcurrentDownloader) runCompletionMonitor(ctx context.Context, queue *
 			}
 			isDone := queue.Len() == 0 && (int(queue.IdleWorkers()+parked) == numConns || (d.State != nil && d.State.Bytes.Downloaded.Load() >= fileSize))
 			if isDone {
+				// Close wakes Pop waiters; Body.Read needs the registered cancel.
+				d.activeMu.Lock()
+				for _, at := range d.activeTasks {
+					if at != nil && at.Cancel != nil {
+						at.Cancel()
+					}
+				}
+				d.activeMu.Unlock()
 				queue.Close()
 				return
 			}

--- a/internal/strategy/concurrent/downloader.go
+++ b/internal/strategy/concurrent/downloader.go
@@ -593,22 +593,33 @@ func (d *ConcurrentDownloader) runCompletionMonitor(ctx context.Context, queue *
 			queue.Close()
 			return
 		case <-ticker.C:
-			// Completion condition:
-			// 1. Queue is empty (no pending retries)
-			// AND
-			// 2. All workers are idle OR we've accounted for all bytes
-			// Ensure queue is empty (no pending retries) before considering byte count.
-			// This protects against cutting off active retries even if byte count seems high (due to overlaps etc).
+			if d.State != nil && d.State.Bytes.VerifiedProgress.Load() >= fileSize {
+				// Mark first so a cancelled worker does not treat this as a
+				// health stall and Push after Close.
+				d.completing.Store(true)
+				d.activeMu.Lock()
+				for _, at := range d.activeTasks {
+					if at != nil && at.Cancel != nil {
+						at.Cancel()
+					}
+				}
+				d.activeMu.Unlock()
+				queue.Close()
+				// Close only unblocks Pop waiters; already-queued leftovers
+				// would otherwise restick workers after 100%.
+				queue.DrainRemaining()
+				return
+			}
 			parked := int64(0)
 			if d.concurrencyGate != nil {
 				parked = d.concurrencyGate.parkedWorkers()
 			}
-			isDone := queue.Len() == 0 && (int(queue.IdleWorkers()+parked) == numConns || (d.State != nil && d.State.Bytes.Downloaded.Load() >= fileSize))
+			isDone := queue.Len() == 0 && int(queue.IdleWorkers()+parked) == numConns
+			if isDone && d.State != nil && d.State.Bytes.VerifiedProgress.Load() < fileSize {
+				isDone = false
+			}
 			if isDone {
-				// Mark first so a cancelled worker does not treat this as a
-				// health stall and Push after Close.
 				d.completing.Store(true)
-				// Close wakes Pop waiters; Body.Read needs the registered cancel.
 				d.activeMu.Lock()
 				for _, at := range d.activeTasks {
 					if at != nil && at.Cancel != nil {
@@ -706,12 +717,29 @@ func (d *ConcurrentDownloader) saveStateSnapshot(destPath string, fileSize int64
 	}
 
 	if remainingBytes == 0 {
-		utils.Debug("Download state save requested at completion boundary; finalizing as completed")
-		d.State.Resume()
-		_, _ = d.State.FinalizeSession(fileSize)
+		if d.State == nil {
+			return nil
+		}
+		if d.State.Bytes.VerifiedProgress.Load() >= fileSize {
+			utils.Debug("Download state save requested at completion boundary; finalizing as completed")
+			d.State.Resume()
+			_, _ = d.State.FinalizeSession(fileSize)
+			return nil
+		}
+		utils.Debug("Download pause at remainingBytes=0 but VP=%d < fileSize=%d; saving state for resume",
+			d.State.Bytes.VerifiedProgress.Load(), fileSize)
+	}
+
+	computedDownloaded := fileSize - remainingBytes
+	if remainingBytes == 0 {
+		computedDownloaded = d.State.Bytes.VerifiedProgress.Load()
+	}
+	if d.State == nil {
+		if emitPauseEvent {
+			return types.ErrPaused
+		}
 		return nil
 	}
-	computedDownloaded := fileSize - remainingBytes
 
 	// Calculate total elapsed time
 	totalElapsed := d.State.FinalizePauseSession(computedDownloaded)

--- a/internal/strategy/concurrent/downloader.go
+++ b/internal/strategy/concurrent/downloader.go
@@ -486,18 +486,22 @@ func (d *ConcurrentDownloader) getEffectiveSizeForWorkers(fileSize int64, savedS
 func (d *ConcurrentDownloader) setupTasks(destPath string, fileSize, chunkSize int64, numConns int, outFile *os.File, savedState *types.DownloadRecord, isResume bool) ([]types.Task, error) {
 	if isResume {
 		if d.State != nil {
-			d.State.Bytes.Downloaded.Store(savedState.Downloaded)
-			d.State.Bytes.VerifiedProgress.Store(savedState.Downloaded)
 			d.State.SetSavedElapsed(time.Duration(savedState.Elapsed))
-			d.State.SyncSessionStart()
 
 			if len(savedState.ChunkBitmap) > 0 && savedState.ActualChunkSize > 0 {
 				d.State.RestoreBitmap(savedState.ChunkBitmap, savedState.ActualChunkSize)
 				d.State.RecalculateProgress(savedState.Tasks)
-				d.State.Bytes.Downloaded.Store(d.State.Bytes.VerifiedProgress.Load())
-				d.State.SyncSessionStart()
+				downloaded := savedState.Downloaded
+				if vp := d.State.Bytes.VerifiedProgress.Load(); downloaded < vp {
+					downloaded = vp
+				}
+				d.State.Bytes.Downloaded.Store(downloaded)
 				utils.Debug("Restored chunk map: size %d", savedState.ActualChunkSize)
+			} else {
+				d.State.Bytes.Downloaded.Store(savedState.Downloaded)
+				d.State.Bytes.VerifiedProgress.Store(savedState.Downloaded)
 			}
+			d.State.SyncSessionStart()
 		}
 		utils.Debug("Resuming from saved state: %d tasks, %d bytes downloaded", len(savedState.Tasks), savedState.Downloaded)
 		return savedState.Tasks, nil

--- a/internal/strategy/concurrent/downloader_helpers_test.go
+++ b/internal/strategy/concurrent/downloader_helpers_test.go
@@ -12,34 +12,6 @@ import (
 	"github.com/SurgeDM/Surge/internal/types"
 )
 
-func TestHandlePause_CompletionBoundary(t *testing.T) {
-	tmpDir := testutil.SetupStateDB(t)
-	cleanup := func() {}
-	defer cleanup()
-
-	fileSize := int64(1000)
-	destPath := filepath.Join(tmpDir, "test.bin")
-	state := progress.New("test-id", fileSize)
-	downloader := &ConcurrentDownloader{
-		ID:      "test-id",
-		State:   state,
-		Runtime: &types.RuntimeConfig{},
-	}
-
-	queue := NewTaskQueue()
-	// No tasks in queue means remainingBytes == 0
-	state.Bytes.VerifiedProgress.Store(fileSize)
-
-	err := downloader.handlePause(destPath, fileSize, queue, nil)
-	if err != nil {
-		t.Fatalf("handlePause returned error on completion boundary: %v", err)
-	}
-
-	if state.IsPaused() {
-		t.Errorf("State should not be paused on completion boundary")
-	}
-}
-
 func TestHandlePause_Normal(t *testing.T) {
 	tmpDir := testutil.SetupStateDB(t)
 	cleanup := func() {}

--- a/internal/strategy/concurrent/downloader_helpers_test.go
+++ b/internal/strategy/concurrent/downloader_helpers_test.go
@@ -274,33 +274,6 @@ func TestSetupTasks_BitmapRestoration(t *testing.T) {
 	}
 }
 
-func TestHandlePause_CompletionFinalization(t *testing.T) {
-	tmpDir := testutil.SetupStateDB(t)
-	cleanup := func() {}
-	defer cleanup()
-
-	fileSize := int64(1000)
-	destPath := filepath.Join(tmpDir, "test.bin")
-	progState := progress.New("test-id", fileSize)
-	downloader := &ConcurrentDownloader{
-		ID:    "test-id",
-		State: progState,
-	}
-
-	queue := NewTaskQueue()
-	// No tasks left
-	progState.Bytes.VerifiedProgress.Store(fileSize)
-
-	err := downloader.handlePause(destPath, fileSize, queue, nil)
-	if err != nil {
-		t.Errorf("Expected nil error for completion boundary, got %v", err)
-	}
-
-	if progState.IsPaused() {
-		t.Error("Should have resumed state for completion")
-	}
-}
-
 func TestSaveStateSnapshot_PersistsActiveAndQueuedTasks(t *testing.T) {
 	tmpDir := testutil.SetupStateDB(t)
 	cleanup := func() {}

--- a/internal/strategy/concurrent/downloader_helpers_test.go
+++ b/internal/strategy/concurrent/downloader_helpers_test.go
@@ -28,6 +28,7 @@ func TestHandlePause_CompletionBoundary(t *testing.T) {
 
 	queue := NewTaskQueue()
 	// No tasks in queue means remainingBytes == 0
+	state.Bytes.VerifiedProgress.Store(fileSize)
 
 	err := downloader.handlePause(destPath, fileSize, queue, nil)
 	if err != nil {
@@ -288,6 +289,7 @@ func TestHandlePause_CompletionFinalization(t *testing.T) {
 
 	queue := NewTaskQueue()
 	// No tasks left
+	progState.Bytes.VerifiedProgress.Store(fileSize)
 
 	err := downloader.handlePause(destPath, fileSize, queue, nil)
 	if err != nil {

--- a/internal/strategy/concurrent/early_eof_requeue_test.go
+++ b/internal/strategy/concurrent/early_eof_requeue_test.go
@@ -1,0 +1,183 @@
+package concurrent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/SurgeDM/Surge/internal/progress"
+	"github.com/SurgeDM/Surge/internal/testutil"
+	"github.com/SurgeDM/Surge/internal/transport"
+	"github.com/SurgeDM/Surge/internal/types"
+	"github.com/SurgeDM/Surge/internal/utils"
+)
+
+func TestDownloadTask_EarlyEOF_ChunkedPartial(t *testing.T) {
+	const rangeLen int64 = 32 * 1024
+	const partial int64 = 8 * 1024
+
+	server := testutil.NewHTTPServerT(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start, end, err := parseTestByteRange(r.Header.Get("Range"))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusRequestedRangeNotSatisfiable)
+			return
+		}
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, rangeLen))
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(make([]byte, partial))
+		w.(http.Flusher).Flush()
+	}))
+	defer server.Close()
+
+	outFile, err := os.CreateTemp(t.TempDir(), "early-eof-chunked-*.surge")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = outFile.Close() }()
+
+	task := types.Task{Offset: 0, Length: rangeLen}
+	active := &ActiveTask{Task: task}
+	active.CurrentOffset.Store(task.Offset)
+	active.StopAt.Store(task.Offset + task.Length)
+	d := NewConcurrentDownloader("early-eof-chunked", nil, nil, &types.RuntimeConfig{})
+
+	err = d.downloadTask(
+		context.Background(),
+		server.URL,
+		outFile,
+		active,
+		make([]byte, types.WorkerBuffer),
+		server.Client(),
+		rangeLen,
+	)
+	if err == nil {
+		t.Fatal("expected early EOF error")
+	}
+	if types.IsPermanentHTTPError(err) {
+		t.Fatalf("early EOF must be retryable, got permanent: %v", err)
+	}
+	if !strings.Contains(err.Error(), "early EOF") {
+		t.Fatalf("err=%v, want early EOF", err)
+	}
+	if got, want := active.CurrentOffset.Load(), active.StopAt.Load(); got >= want {
+		t.Fatalf("offset %d >= StopAt %d, want a short read", got, want)
+	}
+}
+
+func TestDownloadTask_EarlyEOF_UnexpectedEOFNotMasked(t *testing.T) {
+	const rangeLen int64 = 32 * 1024
+	const partial int64 = 8 * 1024
+
+	server := testutil.NewHTTPServerT(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", strconv.FormatInt(rangeLen, 10))
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes 0-%d/%d", rangeLen-1, rangeLen))
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(make([]byte, partial))
+	}))
+	defer server.Close()
+
+	outFile, err := os.CreateTemp(t.TempDir(), "early-eof-unexpected-*.surge")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = outFile.Close() }()
+
+	task := types.Task{Offset: 0, Length: rangeLen}
+	active := &ActiveTask{Task: task}
+	active.CurrentOffset.Store(task.Offset)
+	active.StopAt.Store(task.Offset + task.Length)
+	d := NewConcurrentDownloader("early-eof-unexpected", nil, nil, &types.RuntimeConfig{})
+
+	err = d.downloadTask(
+		context.Background(),
+		server.URL,
+		outFile,
+		active,
+		make([]byte, types.WorkerBuffer),
+		server.Client(),
+		rangeLen,
+	)
+	if err == nil {
+		t.Fatal("expected read error")
+	}
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("err=%v, want io.ErrUnexpectedEOF", err)
+	}
+	if !strings.Contains(err.Error(), "read error:") {
+		t.Fatalf("err=%v, want read error: prefix", err)
+	}
+	if strings.Contains(err.Error(), "early EOF") {
+		t.Fatalf("unexpected EOF must not be masked as early EOF: %v", err)
+	}
+}
+
+func TestEarlyEOF_DownloadFailsOverToHealthyMirror(t *testing.T) {
+	tmpDir, cleanup := initTestState(t)
+	defer cleanup()
+
+	fileSize := int64(256 * utils.KiB)
+	partial := int64(64 * utils.KiB)
+
+	eofServer := testutil.NewHTTPServerT(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start, end, err := parseTestByteRange(r.Header.Get("Range"))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusRequestedRangeNotSatisfiable)
+			return
+		}
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, fileSize))
+		w.WriteHeader(http.StatusPartialContent)
+		toSend := partial
+		if remaining := end - start + 1; toSend > remaining {
+			toSend = remaining
+		}
+		_, _ = w.Write(make([]byte, toSend))
+		w.(http.Flusher).Flush()
+	}))
+	defer eofServer.Close()
+
+	healthy := testutil.NewMockServerT(t,
+		testutil.WithFileSize(fileSize),
+		testutil.WithRangeSupport(true),
+	)
+	defer healthy.Close()
+
+	destPath := filepath.Join(tmpDir, "early_eof_failover.bin")
+	workingPath := destPath + types.IncompleteSuffix
+	if f, err := os.Create(workingPath); err != nil {
+		t.Fatal(err)
+	} else {
+		_ = f.Close()
+	}
+
+	state := progress.New("early-eof-failover", fileSize)
+	d := NewConcurrentDownloader("early-eof-failover", nil, state, &types.RuntimeConfig{
+		MaxConnectionsPerDownload: 1,
+		Workers:                   1,
+		MinChunkSize:              fileSize,
+		MaxTaskRetries:            2,
+		DialHedgeCount:            0,
+	})
+	d.hostLimiter = transport.NewHostRateLimiter()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	err := d.Download(ctx, eofServer.URL, []string{healthy.URL()}, []string{healthy.URL()}, destPath, fileSize)
+	if err != nil {
+		t.Fatalf("Download failed: %v", err)
+	}
+	if got := state.Bytes.Downloaded.Load(); got != fileSize {
+		t.Errorf("Downloaded = %d, want %d", got, fileSize)
+	}
+	if err := testutil.VerifyFileSize(workingPath, fileSize); err != nil {
+		t.Error(err)
+	}
+}

--- a/internal/strategy/concurrent/early_eof_requeue_test.go
+++ b/internal/strategy/concurrent/early_eof_requeue_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -125,8 +126,10 @@ func TestEarlyEOF_DownloadFailsOverToHealthyMirror(t *testing.T) {
 
 	fileSize := int64(256 * utils.KiB)
 	partial := int64(64 * utils.KiB)
+	var eofHits atomic.Int64
 
 	eofServer := testutil.NewHTTPServerT(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		eofHits.Add(1)
 		start, end, err := parseTestByteRange(r.Header.Get("Range"))
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusRequestedRangeNotSatisfiable)
@@ -173,6 +176,9 @@ func TestEarlyEOF_DownloadFailsOverToHealthyMirror(t *testing.T) {
 	err := d.Download(ctx, eofServer.URL, []string{healthy.URL()}, []string{healthy.URL()}, destPath, fileSize)
 	if err != nil {
 		t.Fatalf("Download failed: %v", err)
+	}
+	if eofHits.Load() < 1 {
+		t.Fatal("expected the early-EOF primary to be contacted")
 	}
 	if got := state.Bytes.Downloaded.Load(); got != fileSize {
 		t.Errorf("Downloaded = %d, want %d", got, fileSize)

--- a/internal/strategy/concurrent/handlepause_vp_guard_test.go
+++ b/internal/strategy/concurrent/handlepause_vp_guard_test.go
@@ -1,0 +1,92 @@
+package concurrent
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/SurgeDM/Surge/internal/progress"
+	"github.com/SurgeDM/Surge/internal/types"
+)
+
+func TestHandlePause_RemainingZeroButVPLessThanFileSize_SavesStateNotFinalize(t *testing.T) {
+	tmpDir, cleanup := initTestState(t)
+	defer cleanup()
+
+	fileSize := int64(1000)
+	destPath := filepath.Join(tmpDir, "vp_guard.bin")
+	progState := progress.New("vp-guard", fileSize)
+	progState.Bytes.VerifiedProgress.Store(500)
+
+	d := &ConcurrentDownloader{
+		ID:      "vp-guard",
+		State:   progState,
+		Runtime: &types.RuntimeConfig{},
+	}
+
+	queue := NewTaskQueue()
+	err := d.handlePause(destPath, fileSize, queue, nil)
+	if !errors.Is(err, types.ErrPaused) {
+		t.Fatalf("expected ErrPaused (save state for resume), got %v", err)
+	}
+	if got := progState.Bytes.VerifiedProgress.Load(); got != 500 {
+		t.Fatalf("VP = %d, want 500 (must not raise to fileSize)", got)
+	}
+}
+
+func TestHandlePause_RemainingZeroAndVPEqualsFileSize_Finalizes(t *testing.T) {
+	tmpDir, cleanup := initTestState(t)
+	defer cleanup()
+
+	fileSize := int64(1000)
+	destPath := filepath.Join(tmpDir, "vp_equal.bin")
+	progState := progress.New("vp-equal", fileSize)
+	progState.Bytes.VerifiedProgress.Store(fileSize)
+
+	d := &ConcurrentDownloader{
+		ID:      "vp-equal",
+		State:   progState,
+		Runtime: &types.RuntimeConfig{},
+	}
+
+	err := d.handlePause(destPath, fileSize, NewTaskQueue(), nil)
+	if err != nil {
+		t.Fatalf("expected nil (finalize), got %v", err)
+	}
+	if progState.IsPaused() {
+		t.Error("state should not be paused — should be finalized as completed")
+	}
+}
+
+func TestHandlePause_NilState_RemainingZero_NoPanic(t *testing.T) {
+	tmpDir, cleanup := initTestState(t)
+	defer cleanup()
+
+	d := &ConcurrentDownloader{ID: "nil-state"}
+	err := d.handlePause(filepath.Join(tmpDir, "nil_state.bin"), 1000, NewTaskQueue(), nil)
+	if err != nil {
+		t.Fatalf("expected nil for nil-state completion boundary, got %v", err)
+	}
+}
+
+func TestSaveStateSnapshot_NilState_RemainingTasksNoPanic(t *testing.T) {
+	tmpDir, cleanup := initTestState(t)
+	defer cleanup()
+
+	fileSize := int64(1000)
+	destPath := filepath.Join(tmpDir, "nil_state_remain.bin")
+	d := &ConcurrentDownloader{ID: "nil-state-remain"}
+
+	queueFalse := NewTaskQueue()
+	queueFalse.Push(types.Task{Offset: 0, Length: fileSize})
+	if err := d.saveStateSnapshot(destPath, fileSize, queueFalse, nil, false); err != nil {
+		t.Fatalf("emit=false nil State: %v", err)
+	}
+
+	queueTrue := NewTaskQueue()
+	queueTrue.Push(types.Task{Offset: 0, Length: fileSize})
+	err := d.saveStateSnapshot(destPath, fileSize, queueTrue, nil, true)
+	if !errors.Is(err, types.ErrPaused) {
+		t.Fatalf("emit=true nil State: got %v, want ErrPaused", err)
+	}
+}

--- a/internal/strategy/concurrent/main_test.go
+++ b/internal/strategy/concurrent/main_test.go
@@ -2,10 +2,27 @@
 package concurrent
 
 import (
-	"go.uber.org/goleak"
+	"fmt"
+	"net/http"
+	"os"
 	"testing"
+
+	"github.com/SurgeDM/Surge/internal/transport"
+	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	code := m.Run()
+	http.DefaultClient.CloseIdleConnections()
+	transport.DefaultNetworkPool.CloseAll()
+	if code == 0 {
+		if err := goleak.Find(
+			goleak.IgnoreTopFunction("net/http.(*persistConn).writeLoop"),
+			goleak.IgnoreTopFunction("net/http.(*persistConn).readLoop"),
+		); err != nil {
+			fmt.Fprintf(os.Stderr, "goleak: Errors on successful test run: %v\n", err)
+			os.Exit(1)
+		}
+	}
+	os.Exit(code)
 }

--- a/internal/strategy/concurrent/permanent_http_test.go
+++ b/internal/strategy/concurrent/permanent_http_test.go
@@ -1,0 +1,162 @@
+package concurrent
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/SurgeDM/Surge/internal/testutil"
+	"github.com/SurgeDM/Surge/internal/transport"
+	"github.com/SurgeDM/Surge/internal/types"
+)
+
+func TestDownloadTask_PermanentStatusMatrix(t *testing.T) {
+	cases := []struct {
+		name        string
+		status      int
+		permanent   bool
+		soft403     bool
+		rateLimited bool
+	}{
+		{"401", http.StatusUnauthorized, true, false, false},
+		{"403", http.StatusForbidden, false, true, false},
+		{"404", http.StatusNotFound, true, false, false},
+		{"410", http.StatusGone, true, false, false},
+		{"416", http.StatusRequestedRangeNotSatisfiable, true, false, false},
+		{"429", http.StatusTooManyRequests, false, false, true},
+		{"500", http.StatusInternalServerError, false, false, false},
+		{"503", http.StatusServiceUnavailable, false, false, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := testutil.NewHTTPServerT(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+			}))
+			defer server.Close()
+
+			outFile, err := os.CreateTemp(t.TempDir(), "permanent-status-*.surge")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = outFile.Close() }()
+
+			d := NewConcurrentDownloader("permanent-status-"+tc.name, nil, nil, &types.RuntimeConfig{
+				MaxTaskRetries: 1,
+			})
+			task := types.Task{Offset: 0, Length: 1024}
+			active := &ActiveTask{Task: task}
+			active.CurrentOffset.Store(task.Offset)
+			active.StopAt.Store(task.Offset + task.Length)
+
+			err = d.downloadTask(
+				context.Background(),
+				server.URL,
+				outFile,
+				active,
+				make([]byte, 32*1024),
+				server.Client(),
+				1024,
+			)
+			if err == nil {
+				t.Fatal("expected error for non-success status")
+			}
+
+			if got := types.IsPermanentHTTPError(err); got != tc.permanent {
+				t.Fatalf("IsPermanentHTTPError=%v, want %v (err=%v)", got, tc.permanent, err)
+			}
+			if got := errors.Is(err, errSoftForbidden); got != tc.soft403 {
+				t.Fatalf("errSoftForbidden=%v, want %v (err=%v)", got, tc.soft403, err)
+			}
+			var rlErr *rateLimitError
+			if got := errors.As(err, &rlErr); got != tc.rateLimited {
+				t.Fatalf("rateLimitError=%v, want %v (err=%v)", got, tc.rateLimited, err)
+			}
+		})
+	}
+}
+
+func TestWorker_PermanentHTTPOneShot(t *testing.T) {
+	statuses := []int{
+		http.StatusNotFound,
+		http.StatusUnauthorized,
+		http.StatusRequestedRangeNotSatisfiable,
+	}
+	for _, status := range statuses {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			runPermanentHTTPWorker(t, status, false)
+		})
+	}
+}
+
+func TestWorker_PermanentHTTPReleasesConcurrencyGate(t *testing.T) {
+	runPermanentHTTPWorker(t, http.StatusNotFound, true)
+}
+
+func runPermanentHTTPWorker(t *testing.T, status int, checkGate bool) {
+	t.Helper()
+
+	const rangeLen int64 = 1024
+	var requests atomic.Int64
+	server := testutil.NewHTTPServerT(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(status)
+	}))
+	defer server.Close()
+
+	outFile, err := os.CreateTemp(t.TempDir(), "permanent-http-worker-*.surge")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = outFile.Close() }()
+
+	d := NewConcurrentDownloader("permanent-http-worker", nil, nil, &types.RuntimeConfig{
+		MaxTaskRetries: 3,
+	})
+	d.hostLimiter = transport.NewHostRateLimiter()
+	if checkGate {
+		d.concurrencyGate = newAdaptiveConcurrencyGate(1, 0)
+	}
+
+	queue := NewTaskQueue()
+	original := types.Task{Offset: 0, Length: rangeLen}
+	queue.Push(original)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	err = d.worker(ctx, 0, []string{server.URL}, outFile, queue, rangeLen, server.Client())
+	elapsed := time.Since(start)
+
+	if !types.IsPermanentHTTPError(err) {
+		t.Fatalf("worker err=%v, want permanent HTTP", err)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("requests=%d, want 1 (retries must not burn)", got)
+	}
+	if elapsed >= types.RetryBaseDelay {
+		t.Fatalf("elapsed %v, want < %v (no single-mirror backoff)", elapsed, types.RetryBaseDelay)
+	}
+
+	remaining := queue.DrainRemaining()
+	if len(remaining) != 1 {
+		t.Fatalf("residual tasks=%d, want 1", len(remaining))
+	}
+	if remaining[0].Offset != original.Offset || remaining[0].Length != original.Length {
+		t.Fatalf("residual %+v, want untouched range %+v", remaining[0], original)
+	}
+
+	if checkGate {
+		acquireCtx, acquireCancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer acquireCancel()
+		if !d.concurrencyGate.acquire(acquireCtx) {
+			t.Fatal("concurrency gate permit leaked after permanent HTTP")
+		}
+		d.concurrencyGate.release()
+	}
+}

--- a/internal/strategy/concurrent/permanent_http_test.go
+++ b/internal/strategy/concurrent/permanent_http_test.go
@@ -139,7 +139,7 @@ func runPermanentHTTPWorker(t *testing.T, status int, checkGate bool) {
 	if got := requests.Load(); got != 1 {
 		t.Fatalf("requests=%d, want 1 (retries must not burn)", got)
 	}
-	if elapsed >= types.RetryBaseDelay {
+	if elapsed >= 2*types.RetryBaseDelay {
 		t.Fatalf("elapsed %v, want < %v (no single-mirror backoff)", elapsed, types.RetryBaseDelay)
 	}
 

--- a/internal/strategy/concurrent/prewarm_test.go
+++ b/internal/strategy/concurrent/prewarm_test.go
@@ -2,9 +2,12 @@ package concurrent
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -32,15 +35,15 @@ func TestConcurrentDownloader_PrewarmConnections(t *testing.T) {
 		testutil.WithRangeSupport(true),
 		testutil.WithHandler(func(w http.ResponseWriter, r *http.Request) {
 			mu.Lock()
-			defer mu.Unlock()
-
 			rng := r.Header.Get("Range")
 			if rng == "bytes=0-0" {
 				prewarmSeen = true
 			} else if rng != "" {
-				// Actual download request usually has a real range
 				downloadSeen = true
 			}
+			mu.Unlock()
+
+			serveRequestedRange(w, r, fileSize)
 		}),
 	)
 	defer server.Close()
@@ -76,4 +79,68 @@ func TestConcurrentDownloader_PrewarmConnections(t *testing.T) {
 	if !downloadSeen {
 		t.Error("Expected to see download requests, but none were recorded")
 	}
+}
+
+func serveRequestedRange(w http.ResponseWriter, r *http.Request, fileSize int64) {
+	rng := r.Header.Get("Range")
+	if rng == "" {
+		w.Header().Set("Content-Length", strconv.FormatInt(fileSize, 10))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(make([]byte, fileSize))
+		return
+	}
+
+	start, end, err := parseInclusiveByteRange(rng, fileSize)
+	if err != nil {
+		w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
+		return
+	}
+
+	length := end - start + 1
+	w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, fileSize))
+	w.Header().Set("Content-Length", strconv.FormatInt(length, 10))
+	w.WriteHeader(http.StatusPartialContent)
+	if _, err := w.Write(make([]byte, length)); err != nil {
+		return
+	}
+}
+
+func parseInclusiveByteRange(rangeHeader string, fileSize int64) (int64, int64, error) {
+	if !strings.HasPrefix(rangeHeader, "bytes=") {
+		return 0, 0, fmt.Errorf("invalid range prefix")
+	}
+
+	parts := strings.Split(strings.TrimPrefix(rangeHeader, "bytes="), "-")
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("invalid range format")
+	}
+
+	var start, end int64
+	var err error
+	if parts[0] == "" {
+		end = fileSize - 1
+		start, err = strconv.ParseInt(parts[1], 10, 64)
+		if err != nil {
+			return 0, 0, err
+		}
+		start = fileSize - start
+	} else {
+		start, err = strconv.ParseInt(parts[0], 10, 64)
+		if err != nil {
+			return 0, 0, err
+		}
+		if parts[1] == "" {
+			end = fileSize - 1
+		} else {
+			end, err = strconv.ParseInt(parts[1], 10, 64)
+			if err != nil {
+				return 0, 0, err
+			}
+		}
+	}
+
+	if start < 0 || end >= fileSize || start > end {
+		return 0, 0, fmt.Errorf("range out of bounds")
+	}
+	return start, end, nil
 }

--- a/internal/strategy/concurrent/resume_antiregression_vp_guard_test.go
+++ b/internal/strategy/concurrent/resume_antiregression_vp_guard_test.go
@@ -1,0 +1,138 @@
+package concurrent
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/SurgeDM/Surge/internal/progress"
+	"github.com/SurgeDM/Surge/internal/types"
+)
+
+// buildCompletedBitmap encodes a 2-bit-per-chunk bitmap marking the first
+// numCompleted chunks as ChunkCompleted (status=2).
+func buildCompletedBitmap(totalSize, chunkSize int64, numCompleted int) []byte {
+	numChunks := int((totalSize + chunkSize - 1) / chunkSize)
+	if numChunks <= 0 {
+		return nil
+	}
+	bytesNeeded := (numChunks + 3) / 4
+	bm := make([]byte, bytesNeeded)
+	for i := 0; i < numCompleted && i < numChunks; i++ {
+		byteIndex := i / 4
+		bitOffset := (i % 4) * 2
+		bm[byteIndex] |= byte(types.ChunkCompleted) << bitOffset
+	}
+	return bm
+}
+
+func resumeSetup(t *testing.T, id string, fileSize, chunkSize int64, saved *types.DownloadRecord) *progress.DownloadProgress {
+	t.Helper()
+	tmpDir, cleanup := initTestState(t)
+	t.Cleanup(cleanup)
+
+	destPath := filepath.Join(tmpDir, id+".bin")
+	state := progress.New(id, fileSize)
+	d := &ConcurrentDownloader{ID: id, State: state}
+	if _, err := d.setupTasks(destPath, fileSize, chunkSize, 4, nil, saved, true); err != nil {
+		t.Fatalf("setupTasks failed: %v", err)
+	}
+	return state
+}
+
+func TestResume_BitmapTrust_InflatedDownloadedDoesNotOverrideVP(t *testing.T) {
+	fileSize := int64(10000)
+	chunkSize := int64(1000)
+	saved := &types.DownloadRecord{
+		Downloaded:      fileSize,
+		ActualChunkSize: chunkSize,
+		ChunkBitmap:     buildCompletedBitmap(fileSize, chunkSize, 5),
+		Tasks:           []types.Task{{Offset: 5000, Length: 5000}},
+	}
+
+	state := resumeSetup(t, "inflate-multi", fileSize, chunkSize, saved)
+	vp := state.Bytes.VerifiedProgress.Load()
+	downloaded := state.Bytes.Downloaded.Load()
+
+	if vp != 5000 {
+		t.Errorf("VP = %d, want 5000 (bitmap truth, not inflated Downloaded)", vp)
+	}
+	if downloaded != fileSize {
+		t.Errorf("Downloaded = %d, want %d (max(saved, VP) keeps inflated saved)", downloaded, fileSize)
+	}
+	if got := state.Session.GetSessionStartBytesForTest(); got != vp {
+		t.Errorf("SessionStartBytes = %d, want VP %d", got, vp)
+	}
+}
+
+func TestResume_BitmapTrust_SingleChunkVPZeroInflatedDownloaded(t *testing.T) {
+	fileSize := int64(58000000)
+	chunkSize := fileSize
+	saved := &types.DownloadRecord{
+		Downloaded:      fileSize,
+		ActualChunkSize: chunkSize,
+		ChunkBitmap:     buildCompletedBitmap(fileSize, chunkSize, 0),
+		Tasks:           []types.Task{{Offset: 0, Length: fileSize}},
+	}
+
+	state := resumeSetup(t, "inflate-single", fileSize, chunkSize, saved)
+	vp := state.Bytes.VerifiedProgress.Load()
+	downloaded := state.Bytes.Downloaded.Load()
+
+	if vp != 0 {
+		t.Errorf("VP = %d, want 0 (no chunk Completed — do not fall back to saved Downloaded)", vp)
+	}
+	if downloaded != fileSize {
+		t.Errorf("Downloaded = %d, want %d", downloaded, fileSize)
+	}
+	if got := state.Session.GetSessionStartBytesForTest(); got != vp {
+		t.Errorf("SessionStartBytes = %d, want VP %d", got, vp)
+	}
+}
+
+func TestResume_NoBitmap_LegacyVPEqualsDownloaded(t *testing.T) {
+	fileSize := int64(10000)
+	chunkSize := int64(1000)
+	saved := &types.DownloadRecord{
+		Downloaded: 7000,
+		Tasks:      []types.Task{{Offset: 7000, Length: 3000}},
+	}
+
+	state := resumeSetup(t, "legacy-nobitmap", fileSize, chunkSize, saved)
+	vp := state.Bytes.VerifiedProgress.Load()
+	downloaded := state.Bytes.Downloaded.Load()
+
+	if vp != 7000 {
+		t.Errorf("VP = %d, want 7000 (legacy: VP = saved Downloaded)", vp)
+	}
+	if downloaded != 7000 {
+		t.Errorf("Downloaded = %d, want 7000", downloaded)
+	}
+	if got := state.Session.GetSessionStartBytesForTest(); got != vp {
+		t.Errorf("SessionStartBytes = %d, want VP %d", got, vp)
+	}
+}
+
+func TestResume_BitmapTrust_AllZeroBitmapBenignRegression(t *testing.T) {
+	fileSize := int64(10000)
+	chunkSize := int64(1000)
+	saved := &types.DownloadRecord{
+		Downloaded:      9000,
+		ActualChunkSize: chunkSize,
+		ChunkBitmap:     buildCompletedBitmap(fileSize, chunkSize, 0),
+		Tasks:           []types.Task{{Offset: 0, Length: fileSize}},
+	}
+
+	state := resumeSetup(t, "allzero-bitmap", fileSize, chunkSize, saved)
+	vp := state.Bytes.VerifiedProgress.Load()
+	downloaded := state.Bytes.Downloaded.Load()
+
+	if vp != 0 {
+		t.Errorf("VP = %d, want 0 (all-zero bitmap is Recalculate truth)", vp)
+	}
+	if downloaded != 9000 {
+		t.Errorf("Downloaded = %d, want 9000 (max(saved, VP) keeps saved)", downloaded)
+	}
+	if got := state.Session.GetSessionStartBytesForTest(); got != vp {
+		t.Errorf("SessionStartBytes = %d, want VP %d", got, vp)
+	}
+}

--- a/internal/strategy/concurrent/resume_stopat_clamp_test.go
+++ b/internal/strategy/concurrent/resume_stopat_clamp_test.go
@@ -28,6 +28,33 @@ func TestRetryStopAt_ClampedToActiveStopAt(t *testing.T) {
 	}
 }
 
+func TestClampWriteToStopAt(t *testing.T) {
+	tests := []struct {
+		name         string
+		offset       int64
+		newlyWritten int64
+		stopAt       int64
+		wantOffset   int64
+		wantWritten  int64
+	}{
+		{name: "within bound", offset: 40, newlyWritten: 10, stopAt: 50, wantOffset: 40, wantWritten: 10},
+		{name: "exact bound", offset: 50, newlyWritten: 10, stopAt: 50, wantOffset: 50, wantWritten: 10},
+		{name: "overshoot reduces written", offset: 60, newlyWritten: 20, stopAt: 50, wantOffset: 50, wantWritten: 10},
+		{name: "overshoot equals excess", offset: 60, newlyWritten: 10, stopAt: 50, wantOffset: 50, wantWritten: 0},
+		{name: "overshoot zeros written", offset: 60, newlyWritten: 5, stopAt: 50, wantOffset: 50, wantWritten: 0},
+		{name: "zero write overshoot", offset: 70, newlyWritten: 0, stopAt: 50, wantOffset: 50, wantWritten: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotOffset, gotWritten := clampWriteToStopAt(tt.offset, tt.newlyWritten, tt.stopAt)
+			if gotOffset != tt.wantOffset || gotWritten != tt.wantWritten {
+				t.Fatalf("clampWriteToStopAt(%d, %d, %d)=(%d, %d), want (%d, %d)",
+					tt.offset, tt.newlyWritten, tt.stopAt, gotOffset, gotWritten, tt.wantOffset, tt.wantWritten)
+			}
+		})
+	}
+}
+
 func TestResumeOnRetryOffset_NoProgressClampsToStopAt(t *testing.T) {
 	task := types.Task{Offset: 10, Length: 80}
 	active := &ActiveTask{Task: task}

--- a/internal/strategy/concurrent/resume_stopat_clamp_test.go
+++ b/internal/strategy/concurrent/resume_stopat_clamp_test.go
@@ -1,0 +1,49 @@
+package concurrent
+
+import (
+	"testing"
+
+	"github.com/SurgeDM/Surge/internal/types"
+)
+
+func TestRetryStopAt_ClampedToActiveStopAt(t *testing.T) {
+	task := types.Task{Offset: 0, Length: 80}
+	active := &ActiveTask{Task: task}
+	active.CurrentOffset.Store(20)
+	active.StopAt.Store(50)
+
+	resumeOnRetryOffset(&task, active)
+
+	if task.Offset+task.Length > active.StopAt.Load() {
+		t.Fatalf("task end=%d not clamped to StopAt=%d", task.Offset+task.Length, active.StopAt.Load())
+	}
+	if task.Offset != 20 {
+		t.Fatalf("task.Offset=%d, want 20 (current)", task.Offset)
+	}
+	if task.Length != 30 {
+		t.Fatalf("task.Length=%d, want 30", task.Length)
+	}
+	if active.Task != task {
+		t.Fatal("activeTask.Task was not published")
+	}
+}
+
+func TestResumeOnRetryOffset_NoProgressClampsToStopAt(t *testing.T) {
+	task := types.Task{Offset: 10, Length: 80}
+	active := &ActiveTask{Task: task}
+	active.CurrentOffset.Store(10)
+	active.StopAt.Store(40)
+
+	resumeOnRetryOffset(&task, active)
+
+	if task.Offset+task.Length > active.StopAt.Load() {
+		t.Fatalf("task end=%d not clamped to StopAt=%d (no-progress case)",
+			task.Offset+task.Length, active.StopAt.Load())
+	}
+	if task.Offset != 10 {
+		t.Fatalf("task.Offset=%d, want 10 (no progress)", task.Offset)
+	}
+	if task.Length != 30 {
+		t.Fatalf("task.Length=%d, want 30 (clamped even with no progress)", task.Length)
+	}
+}

--- a/internal/strategy/concurrent/worker.go
+++ b/internal/strategy/concurrent/worker.go
@@ -511,6 +511,12 @@ func (d *ConcurrentDownloader) downloadTask(ctx context.Context, rawurl string, 
 		}
 	}
 
+	// Clean io.EOF with offset still short of StopAt is a truncated body,
+	// not success. UnexpectedEOF stays on the read-error path above.
+	if offset < activeTask.StopAt.Load() {
+		return fmt.Errorf("early EOF: read up to %d, expected %d", offset, activeTask.StopAt.Load())
+	}
+
 	return nil
 }
 

--- a/internal/strategy/concurrent/worker.go
+++ b/internal/strategy/concurrent/worker.go
@@ -160,6 +160,10 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 			}
 
 			if wasExternallyCancelled && lastErr != nil {
+				if d.completing.Load() {
+					lastErr = nil
+					break
+				}
 				currentMirrorIdx = (currentMirrorIdx + 1) % len(mirrors)
 				utils.Debug("Worker %d: Health check cancelled task, rotating from mirror %s to %s", id, mirrors[(currentMirrorIdx+len(mirrors)-1)%len(mirrors)], mirrors[currentMirrorIdx])
 
@@ -249,6 +253,10 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 		d.activeMu.Unlock()
 		if d.concurrencyGate != nil {
 			d.concurrencyGate.release()
+		}
+
+		if d.completing.Load() {
+			return nil
 		}
 
 		if throttledRequeue != nil {
@@ -513,8 +521,9 @@ func (d *ConcurrentDownloader) downloadTask(ctx context.Context, rawurl string, 
 
 	// Clean io.EOF with offset still short of StopAt is a truncated body,
 	// not success. UnexpectedEOF stays on the read-error path above.
-	if offset < activeTask.StopAt.Load() {
-		return fmt.Errorf("early EOF: read up to %d, expected %d", offset, activeTask.StopAt.Load())
+	stopAt := activeTask.StopAt.Load()
+	if offset < stopAt {
+		return fmt.Errorf("early EOF: read up to %d, expected %d", offset, stopAt)
 	}
 
 	return nil

--- a/internal/strategy/concurrent/worker.go
+++ b/internal/strategy/concurrent/worker.go
@@ -51,6 +51,13 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 			return nil
 		}
 
+		if d.State != nil && d.State.Bytes.VerifiedProgress.Load() >= totalSize {
+			if d.concurrencyGate != nil {
+				d.concurrencyGate.release()
+			}
+			return nil
+		}
+
 		if d.State != nil {
 			d.State.ActiveWorkers.Add(1)
 		}
@@ -66,6 +73,14 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 		activeTask.LastActivity.Store(now.UnixNano())
 
 		d.activeMu.Lock()
+		if d.State != nil && d.State.Bytes.VerifiedProgress.Load() >= totalSize {
+			d.activeMu.Unlock()
+			d.State.ActiveWorkers.Add(-1)
+			if d.concurrencyGate != nil {
+				d.concurrencyGate.release()
+			}
+			return nil
+		}
 		d.activeTasks[id] = activeTask
 		d.activeMu.Unlock()
 
@@ -469,11 +484,13 @@ func (d *ConcurrentDownloader) downloadTask(ctx context.Context, rawurl string, 
 
 			now := time.Now()
 			offset += int64(readSoFar)
-
 			newlyWritten := int64(readSoFar)
 
+			offset, newlyWritten = clampWriteToStopAt(offset, newlyWritten, activeTask.StopAt.Load())
 			activeTask.CurrentOffset.Store(offset)
 			activeTask.RangeMu.Unlock()
+
+			offset, newlyWritten = clampWriteToStopAt(offset, newlyWritten, activeTask.StopAt.Load())
 			activeTask.WindowBytes.Add(newlyWritten)
 			activeTask.LastActivity.Store(now.UnixNano())
 
@@ -593,12 +610,32 @@ func (d *ConcurrentDownloader) StealWork(queue *TaskQueue) bool {
 	return true
 }
 
+func clampWriteToStopAt(offset, newlyWritten, stopAt int64) (int64, int64) {
+	if offset > stopAt {
+		excess := offset - stopAt
+		offset = stopAt
+		if newlyWritten > excess {
+			newlyWritten -= excess
+		} else {
+			newlyWritten = 0
+		}
+	}
+	return offset, newlyWritten
+}
+
 func resumeOnRetryOffset(task *types.Task, activeTask *ActiveTask) {
 	current := activeTask.CurrentOffset.Load()
-	if current > task.Offset {
-		oldStart := task.Offset
-		task.Offset = current
-		task.Length = oldStart + task.Length - current
-		activeTask.Task = *task
+	origEnd := task.Offset + task.Length
+	stopAt := activeTask.StopAt.Load()
+	effectiveEnd := stopAt
+	if origEnd < effectiveEnd {
+		effectiveEnd = origEnd
 	}
+	length := effectiveEnd - current
+	if length < 0 {
+		length = 0
+	}
+	task.Offset = current
+	task.Length = length
+	activeTask.Task = *task
 }

--- a/internal/strategy/concurrent/worker.go
+++ b/internal/strategy/concurrent/worker.go
@@ -219,6 +219,13 @@ func (d *ConcurrentDownloader) worker(ctx context.Context, id int, mirrors []str
 				break
 			}
 
+			// Permanent HTTP (404/401/410/416): stop without burning
+			// GetMaxTaskRetries or the single-mirror backoff. 403 stays
+			// errSoftForbidden so confirmation-then-escalate still runs.
+			if types.IsPermanentHTTPError(lastErr) {
+				break
+			}
+
 			genericAttempt++
 			if genericAttempt >= maxRetries {
 				break

--- a/internal/strategy/concurrent/worker_vp_early_exit_test.go
+++ b/internal/strategy/concurrent/worker_vp_early_exit_test.go
@@ -1,0 +1,48 @@
+package concurrent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/SurgeDM/Surge/internal/progress"
+	"github.com/SurgeDM/Surge/internal/transport"
+	"github.com/SurgeDM/Surge/internal/types"
+)
+
+func TestWorker_VPEarlyExitReleasesGateWithoutInsert(t *testing.T) {
+	const totalSize int64 = 1024
+	state := progress.New("vp-early-exit", totalSize)
+	state.Bytes.VerifiedProgress.Store(totalSize)
+
+	d := NewConcurrentDownloader("vp-early-exit", nil, state, &types.RuntimeConfig{})
+	d.hostLimiter = transport.NewHostRateLimiter()
+	d.concurrencyGate = newAdaptiveConcurrencyGate(1, 0)
+
+	queue := NewTaskQueue()
+	queue.Push(types.Task{Offset: 0, Length: totalSize})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if err := d.worker(ctx, 0, []string{"http://127.0.0.1:1"}, nil, queue, totalSize, nil); err != nil {
+		t.Fatalf("worker err=%v, want nil", err)
+	}
+
+	d.activeMu.Lock()
+	n := len(d.activeTasks)
+	d.activeMu.Unlock()
+	if n != 0 {
+		t.Fatalf("activeTasks len=%d, want 0 (failed path must not insert)", n)
+	}
+	if got := state.ActiveWorkers.Load(); got != 0 {
+		t.Fatalf("ActiveWorkers=%d, want 0", got)
+	}
+
+	acqCtx, acqCancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer acqCancel()
+	if !d.concurrencyGate.acquire(acqCtx) {
+		t.Fatal("gate permit leaked: subsequent acquire did not succeed")
+	}
+	d.concurrencyGate.release()
+}

--- a/internal/strategy/concurrent/worker_vp_early_exit_test.go
+++ b/internal/strategy/concurrent/worker_vp_early_exit_test.go
@@ -38,6 +38,9 @@ func TestWorker_VPEarlyExitReleasesGateWithoutInsert(t *testing.T) {
 	if got := state.ActiveWorkers.Load(); got != 0 {
 		t.Fatalf("ActiveWorkers=%d, want 0", got)
 	}
+	if remaining := queue.DrainRemaining(); len(remaining) != 0 {
+		t.Fatalf("popped task was pushed back: %+v", remaining)
+	}
 
 	acqCtx, acqCancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer acqCancel()


### PR DESCRIPTION
Following up on discussions in #632, this PR introduces **`VerifiedProgress` (VP) as the single authoritative Source of Truth (SoT)** for download completion, pause/resume accounting, and worker lifecycles.

When previously refactoring our engine to adopt `VerifiedProgress`, I encountered and debugged these exact edge-case pitfalls behind #579 / #624. They ultimately broke down into 5 interconnected root causes:

- **HedgeWork Lacking Progress Guards:** Idle workers popping hedged tasks lacked a physical progress check (`VP >= totalSize`), firing redundant HTTP requests that triggered 404/429 storms (#632 removed hedging to mitigate this, though with VP as SoT it can be cleanly revisited later).
- **Permanent HTTP (404) Burning Retries:** 404 status codes wrapped in `ErrPermanentHTTP` still went through generic sleep-retries 3 times, worsening server rate limits.
- **Completion Monitor Missing Active Cancel:** `runCompletionMonitor` only called `queue.Close()`, failing to cancel in-flight workers stuck in `resp.Body.Read()` or retry sleeps.
- **Spurious Error Propagation & State Inconsistency:** Trailing hedged/retrying workers eventually failing 404 bubbled up errors to `Download()`, causing UI failure reports even after main workers had already written all data.
- **Early-EOF Silent Data Loss & Fragile Counters:** Server-side premature `io.EOF` before `StopAt` silently returned `nil` (dropping bytes), while completion relied on a volatile `Downloaded` counter rather than on-disk physical verification.

Most of these issues ultimately stemmed from the **lack of a single authoritative physical pointer**, which led different subsystems (Queue, Worker, Monitor, Resume) into desynchronized state guesswork.

By establishing `VerifiedProgress` (grounded in physical `WriteAt` and bitmap deduplication) as the strong SoT, this PR cleans up these module boundaries:
- **Completion & Workers are decoupled:** A download strictly completes when $VP \ge FileSize$. In-flight workers are actively canceled on completion, and workers check VP on pop to exit early and cleanly release concurrency gates.
- **Errors fail fast or retry safely:** 404s break out immediately, Early-EOFs are caught and requeued, and spurious trailing errors can no longer fail a finished download.
- **Resume is decoupled:** Restored progress is recomputed strictly from physical chunk bitmaps, ensuring on-disk completed chunks are never accidentally erased or overwritten by remaining task overlaps.

---

### Side note on future ideas

While intentionally excluded here to keep this PR focused and clean, this solid VP foundation opens the door for future improvements—such as safely re-introducing end-game hedging without race conditions, or evolving the concurrency gate from goroutine blocking to lightweight connection draining (Drain) for better TCP/TLS socket reuse.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download completion detection using verified progress.
  * Preserved completed chunks and accurate progress when resuming downloads.
  * Improved handling of early connection termination, HTTP errors, retries, and partial responses.
  * Prevented tasks from being incorrectly requeued or workers from continuing after completion.
  * Improved pause, resume, and state snapshot behavior at completion boundaries.

* **Performance**
  * Reduced contention when tracking download progress.

* **Tests**
  * Added extensive coverage for resume, retries, completion, cancellation, HTTP errors, and early-termination scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->