### PR TITLE
feat: add adaptive_concurrency_interval to settings UI formatting labels

### DIFF
--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -448,6 +448,7 @@ type SettingMeta struct {
 	Label           string      // Human-readable label
 	Description     string      // Help text displayed in right pane
 	Type            SettingType // "string", "int", "int64", "bool", "duration", "float64", "auth_token", "link"
+	Unit            SettingUnit // Display and input unit used by the UI
 	RequiresRestart bool        // Whether changing this setting requires an application restart
 }
 
@@ -470,6 +471,7 @@ func GetSettingsMetadata() map[string][]SettingMeta {
 					Label:           set.Label,
 					Description:     set.Description,
 					Type:            set.Type,
+					Unit:            set.Unit,
 					RequiresRestart: set.NeedsRestart,
 				})
 			}
@@ -782,6 +784,7 @@ func DefaultSettings() *Settings {
 				Label:        "Min Chunk Size",
 				Description:  "Minimum download chunk size in MiB (e.g., 2).",
 				Type:         TypeInt64,
+				Unit:         UnitMegabytes,
 				DefaultValue: int64(2 * utils.MiB),
 				Value:        int64(2 * utils.MiB),
 				ValidateFunc: func(val any) error {
@@ -801,6 +804,7 @@ func DefaultSettings() *Settings {
 				Label:        "Worker Buffer Size",
 				Description:  "I/O buffer size per worker in KiB (e.g., 512).",
 				Type:         TypeInt,
+				Unit:         UnitKilobytes,
 				DefaultValue: int(512 * utils.KiB),
 				Value:        int(512 * utils.KiB),
 				ValidateFunc: func(val any) error {
@@ -819,6 +823,7 @@ func DefaultSettings() *Settings {
 				Label:        "Dial Hedge Count",
 				Description:  "Number of extra connections to dial pre-emptively; 0 disables connection prewarming (0-16).",
 				Type:         TypeInt,
+				Unit:         UnitConnections,
 				DefaultValue: 4,
 				Value:        4,
 				ValidateFunc: func(val any) error {
@@ -837,6 +842,7 @@ func DefaultSettings() *Settings {
 				Label:        "Global Rate Limit",
 				Description:  "Cap total download bandwidth (e.g., 10MB/s, 80Mbps). Use 0 to disable.",
 				Type:         TypeString,
+				Unit:         UnitMegabytesPerSecond,
 				DefaultValue: "0",
 				Value:        "0",
 				ValidateFunc: func(val any) error {
@@ -849,6 +855,7 @@ func DefaultSettings() *Settings {
 				Label:        "Default Download Rate Limit",
 				Description:  "Default cap per download (e.g., 2MB/s). Use 0 to disable.",
 				Type:         TypeString,
+				Unit:         UnitMegabytesPerSecond,
 				DefaultValue: "0",
 				Value:        "0",
 				ValidateFunc: func(val any) error {
@@ -863,6 +870,7 @@ func DefaultSettings() *Settings {
 				Label:        "Max Task Retries",
 				Description:  "Number of times to retry a failed chunk before giving up.",
 				Type:         TypeInt,
+				Unit:         UnitRetries,
 				DefaultValue: 3,
 				Value:        3,
 				ValidateFunc: func(val any) error {
@@ -881,6 +889,7 @@ func DefaultSettings() *Settings {
 				Label:        "Slow Worker Threshold",
 				Description:  "Restart workers slower than this fraction of mean speed (0.0-1.0, 0 disables relative slow-worker checks).",
 				Type:         TypeFloat64,
+				Unit:         UnitRatio,
 				DefaultValue: 0.3,
 				Value:        0.3,
 				ValidateFunc: func(val any) error {
@@ -906,6 +915,7 @@ func DefaultSettings() *Settings {
 				Label:        "Slow Worker Grace",
 				Description:  "Grace period before checking worker speed (e.g., 5s, 0 checks immediately).",
 				Type:         TypeDuration,
+				Unit:         UnitSeconds,
 				DefaultValue: 5 * time.Second,
 				Value:        5 * time.Second,
 				ValidateFunc: func(val any) error {
@@ -931,6 +941,7 @@ func DefaultSettings() *Settings {
 				Label:        "Stall Timeout",
 				Description:  "Restart workers with no data for this duration (e.g., 5s, 0 disables stall detection).",
 				Type:         TypeDuration,
+				Unit:         UnitSeconds,
 				DefaultValue: 3 * time.Second,
 				Value:        3 * time.Second,
 				ValidateFunc: func(val any) error {
@@ -956,6 +967,7 @@ func DefaultSettings() *Settings {
 				Label:        "Speed EMA Alpha",
 				Description:  "Exponential moving average smoothing factor (0.0-1.0, 0 disables smoothing).",
 				Type:         TypeFloat64,
+				Unit:         UnitRatio,
 				DefaultValue: 0.3,
 				Value:        0.3,
 				ValidateFunc: func(val any) error {
@@ -981,6 +993,7 @@ func DefaultSettings() *Settings {
 				Label:        "Adaptive Concurrency Interval",
 				Description:  "Halve connections when throttled, add one connection per interval, and split small tail ranges among idle workers on healthy hosts; 0 disables adaptation (0s or 1s-60s).",
 				Type:         TypeDuration,
+				Unit:         UnitSeconds,
 				DefaultValue: types.DefaultAdaptiveConcurrencyInterval,
 				Value:        types.DefaultAdaptiveConcurrencyInterval,
 				ValidateFunc: func(val any) error {

--- a/internal/config/settings_schema.go
+++ b/internal/config/settings_schema.go
@@ -19,12 +19,29 @@ const (
 	TypeCustomCategoryAdd SettingType = "custom_category_add"
 )
 
+// SettingUnit describes the unit used by the settings UI to display and edit a value.
+// It is independent of SettingType, which describes the value's stored Go type.
+type SettingUnit string
+
+const (
+	UnitNone               SettingUnit = ""
+	UnitSeconds            SettingUnit = "seconds"
+	UnitMinutes            SettingUnit = "minutes"
+	UnitKilobytes          SettingUnit = "kilobytes"
+	UnitMegabytes          SettingUnit = "megabytes"
+	UnitMegabytesPerSecond SettingUnit = "megabytes_per_second"
+	UnitConnections        SettingUnit = "connections"
+	UnitRetries            SettingUnit = "retries"
+	UnitRatio              SettingUnit = "ratio"
+)
+
 type Setting struct {
 	Key          string      `json:"key"`
 	Label        string      `json:"label"`
 	Description  string      `json:"description"`
 	NeedsRestart bool        `json:"needs_restart"`
 	Type         SettingType `json:"type"`
+	Unit         SettingUnit `json:"unit"`
 
 	Value        any `json:"value"`
 	DefaultValue any `json:"default_value"`

--- a/internal/tui/settings_unit_test.go
+++ b/internal/tui/settings_unit_test.go
@@ -56,6 +56,57 @@ func TestSettingsFloatResilience(t *testing.T) {
 	}
 }
 
+func TestDurationSettingsDeclareAnEditorUnit(t *testing.T) {
+	settings := config.DefaultSettings()
+	metadata := config.GetSettingsMetadata()
+
+	for category, settingMetadata := range metadata {
+		for _, meta := range settingMetadata {
+			if meta.Type != config.TypeDuration {
+				continue
+			}
+
+			setting := settings.FindSetting(category, meta.Key)
+			if setting == nil {
+				t.Fatalf("duration setting %q is missing from category %q", meta.Key, category)
+			}
+			var want string
+			switch meta.Unit {
+			case config.UnitSeconds:
+				setting.Value, want = 7*time.Second, "7"
+			case config.UnitMinutes:
+				setting.Value, want = 2*time.Minute, "2"
+			default:
+				t.Errorf("duration setting %q has unsupported editor unit %q", meta.Key, meta.Unit)
+				continue
+			}
+			if got := settingUnitSuffix(meta.Unit); got == "" {
+				t.Errorf("duration setting %q has no display suffix", meta.Key)
+			}
+
+			if got := formatSettingValueForEdit(setting.Value, meta.Type, meta.Unit, meta.Key, false); got != want {
+				t.Errorf("duration setting %q edit value = %q, want %q", meta.Key, got, want)
+			}
+		}
+	}
+}
+
+func TestDurationSettingsCanUseMinutesInTheEditor(t *testing.T) {
+	m := &RootModel{Settings: config.DefaultSettings()}
+	setting := m.Settings.Performance.SlowWorkerGracePeriod
+	setting.Unit = config.UnitMinutes
+
+	if got := formatSettingValueForEdit(2*time.Minute, setting.Type, setting.Unit, setting.Key, false); got != "2" {
+		t.Fatalf("minute duration edit value = %q, want %q", got, "2")
+	}
+	if err := m.setSettingValue("Performance", setting.Key, "2"); err != nil {
+		t.Fatalf("setSettingValue failed: %v", err)
+	}
+	if got := config.Resolve[time.Duration](setting); got != 2*time.Minute {
+		t.Errorf("minute duration = %v, want %v", got, 2*time.Minute)
+	}
+}
+
 func TestSetSettingValueConversions(t *testing.T) {
 	m := &RootModel{
 		Settings: config.DefaultSettings(),

--- a/internal/tui/update_settings.go
+++ b/internal/tui/update_settings.go
@@ -349,7 +349,11 @@ func (m RootModel) updateSettings(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.SettingsIsEditing = true
 			// Pre-fill with current value (without units)
 			values := m.getSettingsValues(currentCategory)
-			m.SettingsInput.SetValue(formatSettingValueForEdit(values[settingKey], typ, settingKey, false))
+			unit := config.UnitNone
+			if meta := m.getCurrentSettingMeta(); meta != nil {
+				unit = meta.Unit
+			}
+			m.SettingsInput.SetValue(formatSettingValueForEdit(values[settingKey], typ, unit, settingKey, false))
 			m.updateSettingsInputWidthForViewport()
 			m.SettingsInput.Focus()
 		}

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -347,7 +347,7 @@ func (m RootModel) renderSettingsDetailBlock(settingsMeta []config.SettingMeta, 
 
 	meta := settingsMeta[selectedRow]
 	value := settingsValues[meta.Key]
-	unit := m.getSettingUnit()
+	unit := settingUnitSuffix(meta.Unit)
 	unitStyle := lipgloss.NewStyle().Foreground(colors.Gray())
 
 	valueLabel := "Value: "
@@ -401,7 +401,7 @@ func (m RootModel) renderSettingsDetailBlock(settingsMeta []config.SettingMeta, 
 			)
 			valueLabel = ""
 		default:
-			valueStr = formatSettingValueForEdit(value, meta.Type, meta.Key, true)
+			valueStr = formatSettingValueForEdit(value, meta.Type, meta.Unit, meta.Key, true)
 			if valueStr != "\u221E" {
 				valueStr += unitStyle.Render(unit)
 			}
@@ -719,7 +719,7 @@ func (m *RootModel) setSettingValue(category, key, value string) error {
 			parsedVal = b
 		}
 	case config.TypeString, config.TypeAuthToken, config.TypeLink:
-		if key == "global_rate_limit" || key == "default_download_rate_limit" {
+		if setting.Unit == config.UnitMegabytesPerSecond {
 			if _, err := strconv.ParseFloat(value, 64); err == nil {
 				value += " MB/s"
 			}
@@ -729,7 +729,7 @@ func (m *RootModel) setSettingValue(category, key, value string) error {
 		}
 		parsedVal = value
 	case "int":
-		if key == "worker_buffer_size" {
+		if setting.Unit == config.UnitKilobytes {
 			v, err := strconv.ParseFloat(value, 64)
 			if err != nil {
 				return fmt.Errorf("invalid number")
@@ -744,7 +744,7 @@ func (m *RootModel) setSettingValue(category, key, value string) error {
 		}
 	case "int64":
 		// Handle KB/MB scaling gracefully if specified
-		if key == "min_chunk_size" {
+		if setting.Unit == config.UnitMegabytes {
 			v, err := strconv.ParseFloat(value, 64)
 			if err != nil {
 				return fmt.Errorf("invalid number")
@@ -758,8 +758,14 @@ func (m *RootModel) setSettingValue(category, key, value string) error {
 			parsedVal = v
 		}
 	case config.TypeDuration:
-		if _, err := strconv.ParseFloat(value, 64); err == nil {
-			value += "s"
+		if setting.Unit == config.UnitSeconds || setting.Unit == config.UnitMinutes {
+			if _, err := strconv.ParseFloat(value, 64); err == nil {
+				if setting.Unit == config.UnitMinutes {
+					value += "m"
+				} else {
+					value += "s"
+				}
+			}
 		}
 		v, err := time.ParseDuration(value)
 		if err != nil {
@@ -877,23 +883,23 @@ func (m RootModel) getSettingsCount() int {
 	return 0
 }
 
-// getSettingUnit returns the unit suffix for the currently selected setting
-func (m RootModel) getSettingUnit() string {
-	key := m.getCurrentSettingKey()
-	switch key {
-	case "min_chunk_size":
+func settingUnitSuffix(unit config.SettingUnit) string {
+	switch unit {
+	case config.UnitMegabytes:
 		return " MB"
-	case "worker_buffer_size":
+	case config.UnitKilobytes:
 		return " KB"
-	case "dial_hedge_count":
+	case config.UnitConnections:
 		return " conns"
-	case "max_task_retries":
+	case config.UnitRetries:
 		return " retries"
-	case "slow_worker_grace_period", "stall_timeout", "adaptive_concurrency_interval":
+	case config.UnitSeconds:
 		return " seconds"
-	case "slow_worker_threshold", "speed_ema_alpha":
+	case config.UnitMinutes:
+		return " minutes"
+	case config.UnitRatio:
 		return " (0.0-1.0)"
-	case "global_rate_limit", "default_download_rate_limit":
+	case config.UnitMegabytesPerSecond:
 		return " MB/s"
 	default:
 		return ""
@@ -901,19 +907,20 @@ func (m RootModel) getSettingUnit() string {
 }
 
 // formatSettingValueForEdit returns a plain value without units for editing
-func formatSettingValueForEdit(value interface{}, typ config.SettingType, key string, truncate bool) string {
-	switch key {
-	case "min_chunk_size":
+func formatSettingValueForEdit(value interface{}, typ config.SettingType, unit config.SettingUnit, key string, truncate bool) string {
+	switch unit {
+	case config.UnitMegabytes:
 		if v, ok := asFloat64(value); ok {
 			mb := v / float64(utils.MiB)
 			return fmt.Sprintf("%.1f", mb)
 		}
-	case "worker_buffer_size":
+	case config.UnitKilobytes:
 		if v, ok := asFloat64(value); ok {
 			kb := v / float64(utils.KiB)
 			return fmt.Sprintf("%.0f", kb)
 		}
-	case "slow_worker_grace_period", "stall_timeout", "adaptive_concurrency_interval":
+
+	case config.UnitSeconds:
 		if v, ok := asFloat64(value); ok {
 			// Values might be duration or pure float64 depending on decode/init paths.
 			// The settings parse logic handles both, but for UI string we want raw seconds.
@@ -925,7 +932,11 @@ func formatSettingValueForEdit(value interface{}, typ config.SettingType, key st
 			}
 			return fmt.Sprintf("%.0f", secs)
 		}
-	case "global_rate_limit", "default_download_rate_limit":
+	case config.UnitMinutes:
+		if v, ok := asFloat64(value); ok {
+			return fmt.Sprintf("%.0f", time.Duration(v).Minutes())
+		}
+	case config.UnitMegabytesPerSecond:
 		if vStr, ok := value.(string); ok && vStr != "" {
 			if parsed, err := utils.ParseRateLimitValue(vStr); err == nil {
 				if parsed == 0 {

--- a/internal/tui/view_settings.go
+++ b/internal/tui/view_settings.go
@@ -889,7 +889,7 @@ func (m RootModel) getSettingUnit() string {
 		return " conns"
 	case "max_task_retries":
 		return " retries"
-	case "slow_worker_grace_period", "stall_timeout":
+	case "slow_worker_grace_period", "stall_timeout", "adaptive_concurrency_interval":
 		return " seconds"
 	case "slow_worker_threshold", "speed_ema_alpha":
 		return " (0.0-1.0)"
@@ -913,7 +913,7 @@ func formatSettingValueForEdit(value interface{}, typ config.SettingType, key st
 			kb := v / float64(utils.KiB)
 			return fmt.Sprintf("%.0f", kb)
 		}
-	case "slow_worker_grace_period", "stall_timeout":
+	case "slow_worker_grace_period", "stall_timeout", "adaptive_concurrency_interval":
 		if v, ok := asFloat64(value); ok {
 			// Values might be duration or pure float64 depending on decode/init paths.
 			// The settings parse logic handles both, but for UI string we want raw seconds.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Settings now display appropriate unit suffixes, including seconds, minutes, data rates, connections, retries, and ratios.
  * Duration settings support clearer editing in either seconds or minutes.
  * The adaptive concurrency interval displays and edits using a clear raw-seconds format.
  * Settings consistently use their configured units for display and editing.
  * Unit labels and authentication-token text are easier to read with improved contrast.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->