### PR TITLE
fix(single): finalize total size for completed unknown-length downloads

### DIFF
--- a/internal/scheduler/manager_test.go
+++ b/internal/scheduler/manager_test.go
@@ -733,3 +733,100 @@ func TestSendPausedFallbackWaitsForFullChannel(t *testing.T) {
 	default:
 	}
 }
+
+func TestRunDownload_ChunkedSingleEmitsFinalWrittenSize(t *testing.T) {
+	tmpDir := t.TempDir()
+	body := []byte("streamed chunked dynamic archive content for manager test")
+	split := len(body) / 2
+
+	server := testutil.NewHTTPServerT(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("httptest writer does not implement http.Flusher")
+		}
+		flusher.Flush()
+		_, _ = w.Write(body[:split])
+		flusher.Flush()
+		_, _ = w.Write(body[split:])
+		flusher.Flush()
+	}))
+	defer server.Close()
+
+	destPath := filepath.Join(tmpDir, "chunked.bin")
+	if f, err := os.Create(destPath + types.IncompleteSuffix); err == nil {
+		_ = f.Close()
+	} else {
+		t.Fatal(err)
+	}
+
+	progressCh := make(chan types.DownloadEvent, 16)
+	progState := progress.New("chunked-single-manager-test", 0)
+
+	cfg := types.DownloadRecord{
+		URL:           server.URL,
+		OutputPath:    tmpDir,
+		Filename:      "chunked.bin",
+		ID:            "chunked-single-manager-test",
+		ProgressCh:    progressCh,
+		ProgressState: progState,
+		Runtime:       &types.RuntimeConfig{},
+		TotalSize:     0,
+		SupportsRange: false,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := RunDownload(ctx, &cfg)
+	if err != nil {
+		t.Fatalf("RunDownload failed: %v", err)
+	}
+
+	wantBytes := int64(len(body))
+
+	// Verify state
+	if progState.Bytes.TotalSize.Load() != wantBytes {
+		t.Errorf("progState.Bytes.TotalSize = %d, want %d", progState.Bytes.TotalSize.Load(), wantBytes)
+	}
+	if progState.Bytes.Downloaded.Load() != wantBytes {
+		t.Errorf("progState.Bytes.Downloaded = %d, want %d", progState.Bytes.Downloaded.Load(), wantBytes)
+	}
+	if progState.Bytes.VerifiedProgress.Load() != wantBytes {
+		t.Errorf("progState.Bytes.VerifiedProgress = %d, want %d", progState.Bytes.VerifiedProgress.Load(), wantBytes)
+	}
+
+	// Drain progress channel and check EventComplete
+	close(progressCh)
+	var completeEvents []*types.DownloadEvent
+	for msg := range progressCh {
+		if msg.Type == types.EventError {
+			t.Fatalf("unexpected EventError: %+v", msg)
+		}
+		if msg.Type == types.EventComplete {
+			copy := msg
+			completeEvents = append(completeEvents, &copy)
+		}
+	}
+
+	if len(completeEvents) != 1 {
+		t.Fatalf("expected exactly 1 EventComplete, got %d", len(completeEvents))
+	}
+	completeEvent := completeEvents[0]
+	if completeEvent.Total != wantBytes {
+		t.Errorf("EventComplete.Total = %d, want %d", completeEvent.Total, wantBytes)
+	}
+	if completeEvent.AvgSpeed <= 0 {
+		t.Errorf("EventComplete.AvgSpeed = %f, want > 0", completeEvent.AvgSpeed)
+	}
+
+	// Verify on-disk file content
+	workingPath := destPath + types.IncompleteSuffix
+	downloadedData, err := os.ReadFile(workingPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) failed: %v", workingPath, err)
+	}
+	if string(downloadedData) != string(body) {
+		t.Errorf("downloaded file content mismatch: got %q, want %q", string(downloadedData), string(body))
+	}
+}

--- a/internal/strategy/single/downloader.go
+++ b/internal/strategy/single/downloader.go
@@ -227,6 +227,13 @@ func (d *SingleDownloader) Download(ctx context.Context, rawurl, destPath string
 		return fmt.Errorf("sync error: %w", err)
 	}
 
+	if d.TotalSize <= 0 {
+		d.TotalSize = written
+		if d.State != nil {
+			d.State.Bytes.SetTotalSize(written)
+		}
+	}
+
 	if d.State != nil {
 		d.State.Bytes.Downloaded.Store(written)
 		d.State.Bytes.VerifiedProgress.Store(written)

--- a/internal/strategy/single/downloader_test.go
+++ b/internal/strategy/single/downloader_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -853,5 +854,94 @@ func TestThrottledReader_UsesLimiterErrorForCleanRead(t *testing.T) {
 	}
 	if !errors.Is(err, waitErr) {
 		t.Fatalf("Read error = %v, want %v", err, waitErr)
+	}
+}
+
+func TestSingleDownloader_Download_UnknownLength(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     []byte
+		wantSize int64
+	}{
+		{
+			name:     "chunked stream with content",
+			body:     []byte("hello chunked world from surge single stream downloader test"),
+			wantSize: int64(len("hello chunked world from surge single stream downloader test")),
+		},
+		{
+			name:     "empty stream",
+			body:     nil,
+			wantSize: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir, cleanup, err := testutil.TempDir("surge-chunked-single")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer cleanup()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				if flusher, ok := w.(http.Flusher); ok {
+					flusher.Flush()
+					if len(tt.body) > 0 {
+						split := len(tt.body) / 2
+						_, _ = w.Write(tt.body[:split])
+						flusher.Flush()
+						_, _ = w.Write(tt.body[split:])
+						flusher.Flush()
+					}
+				}
+			}))
+			defer server.Close()
+
+			destPath := filepath.Join(tmpDir, "output.bin")
+			if f, err := os.Create(destPath + types.IncompleteSuffix); err == nil {
+				_ = f.Close()
+			} else {
+				t.Fatal(err)
+			}
+
+			state := progress.New("unknown-single-test", 0)
+			initialStartTime := state.Session.StartTime()
+			downloader := NewSingleDownloader("unknown-single-id", nil, state, &types.RuntimeConfig{})
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			if err := downloader.Download(ctx, server.URL, destPath, 0, "output.bin"); err != nil {
+				t.Fatalf("Download failed: %v", err)
+			}
+
+			if downloader.TotalSize != tt.wantSize {
+				t.Errorf("downloader.TotalSize = %d, want %d", downloader.TotalSize, tt.wantSize)
+			}
+			if state.Bytes.TotalSize.Load() != tt.wantSize {
+				t.Errorf("state.Bytes.TotalSize = %d, want %d", state.Bytes.TotalSize.Load(), tt.wantSize)
+			}
+			if state.Bytes.Downloaded.Load() != tt.wantSize {
+				t.Errorf("state.Bytes.Downloaded = %d, want %d", state.Bytes.Downloaded.Load(), tt.wantSize)
+			}
+			if state.Bytes.VerifiedProgress.Load() != tt.wantSize {
+				t.Errorf("state.Bytes.VerifiedProgress = %d, want %d", state.Bytes.VerifiedProgress.Load(), tt.wantSize)
+			}
+			if !state.Session.StartTime().Equal(initialStartTime) {
+				t.Errorf("state.Session.StartTime() was reset")
+			}
+
+			if len(tt.body) > 0 {
+				workingPath := destPath + types.IncompleteSuffix
+				data, err := os.ReadFile(workingPath)
+				if err != nil {
+					t.Fatalf("ReadFile(%s) failed: %v", workingPath, err)
+				}
+				if string(data) != string(tt.body) {
+					t.Errorf("file content mismatch: got %q, want %q", string(data), string(tt.body))
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Hi!

I noticed an edge case when downloading files without a `Content-Length` header—such as downloading a GitHub repository `.zip` where the server packages the archive on the fly.

In this scenario, the engine correctly falls back to `SingleDownloader` and writes all data to disk. However, because `downloader.TotalSize` is initialized to `0` and never updated after `io.CopyBuffer` / `outFile.Sync()`, the final size is never recorded. This causes `EventComplete` to emit `Total: 0`, `master.gob` to persist `TotalSize: 0`, and the completion average speed to show `0.00 MiB/s`.

This patch simply assigns the written bytes to `downloader.TotalSize` and syncs `State.Bytes` after `outFile.Sync()` succeeds when `TotalSize <= 0`.

While this patch ensures on-disk persistence and final completion metadata are accurate, from a UX perspective, the in-flight progress bar during download might also warrant some design thought. (For reference, in GoAria we display an indeterminate shimmer animation with `--%` when the total size is unknown, though adapting that might be a bit involved for the TUI, so I kept this PR strictly focused on the core engine fix).

Let me know what you think!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved downloads from servers that don’t provide a file size upfront.
  - Download progress now reports the correct final total after completion.
  - Completion events include accurate file size and download speed.
  - Empty and streamed downloads now finish reliably without incorrect error states.
  - Downloaded file contents and progress tracking remain accurate for chunked responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->