### PR TITLE
fix(scheduler): prioritize physical success over late pause and guard completion boundary

### DIFF
--- a/internal/scheduler/manager.go
+++ b/internal/scheduler/manager.go
@@ -18,6 +18,8 @@ import (
 	"github.com/SurgeDM/Surge/internal/utils"
 )
 
+const terminalSendTimeout = 3 * time.Second
+
 // safeSendProgress sends msg on ch, recovering from panics caused by sending
 // on a closed channel (which can happen during shutdown).
 func safeSendProgress(ch chan<- types.DownloadEvent, msg types.DownloadEvent, doneCh <-chan struct{}) {
@@ -33,7 +35,18 @@ func safeSendProgress(ch chan<- types.DownloadEvent, msg types.DownloadEvent, do
 		case <-doneCh:
 		}
 	} else {
-		ch <- msg
+		select {
+		case ch <- msg:
+			return
+		default:
+		}
+		timer := time.NewTimer(terminalSendTimeout)
+		defer timer.Stop()
+		select {
+		case ch <- msg:
+		case <-timer.C:
+			utils.Debug("safeSendProgress: timed out delivering terminal event %v", msg.Type)
+		}
 	}
 }
 

--- a/internal/scheduler/manager.go
+++ b/internal/scheduler/manager.go
@@ -24,29 +24,18 @@ const terminalSendTimeout = 3 * time.Second
 // on a closed channel (which can happen during shutdown).
 func safeSendProgress(ch chan<- types.DownloadEvent, msg types.DownloadEvent, doneCh <-chan struct{}) {
 	defer func() { _ = recover() }()
-	if doneCh != nil {
-		select {
-		case ch <- msg:
-			return
-		default:
-		}
-		select {
-		case ch <- msg:
-		case <-doneCh:
-		}
-	} else {
-		select {
-		case ch <- msg:
-			return
-		default:
-		}
-		timer := time.NewTimer(terminalSendTimeout)
-		defer timer.Stop()
-		select {
-		case ch <- msg:
-		case <-timer.C:
-			utils.Debug("safeSendProgress: timed out delivering terminal event %v", msg.Type)
-		}
+	select {
+	case ch <- msg:
+		return
+	default:
+	}
+	timer := time.NewTimer(terminalSendTimeout)
+	defer timer.Stop()
+	select {
+	case ch <- msg:
+	case <-doneCh:
+	case <-timer.C:
+		utils.Debug("safeSendProgress: timed out delivering event %v", msg.Type)
 	}
 }
 

--- a/internal/scheduler/manager.go
+++ b/internal/scheduler/manager.go
@@ -263,14 +263,15 @@ func RunDownload(ctx context.Context, cfg *types.DownloadRecord) error {
 		}
 	}
 
-	// Only send completion if NO error AND not paused.
+	// Return typed pause error rather than normalizing to nil so callers
+	// can distinguish a clean pause from successful completion or errors.
 	if errors.Is(downloadErr, types.ErrPaused) {
 		utils.Debug("Download paused cleanly")
-		return nil // Return nil so worker can remove it from active map
+		return downloadErr
 	}
 
-	isPaused := progState != nil && progState.IsPaused()
-	if downloadErr == nil && !isPaused {
+	// Physical download success takes precedence over late-arriving pause signals.
+	if downloadErr == nil {
 		var elapsed time.Duration
 		if progState != nil {
 			_, elapsed = progState.FinalizeSession(effectiveTotalSize)
@@ -287,6 +288,7 @@ func RunDownload(ctx context.Context, cfg *types.DownloadRecord) error {
 
 		if cfg.ProgressCh != nil {
 			rateLimit, rateLimitSet := currentRateLimit()
+			// EventComplete is terminal-reliable and must not be dropped due to canceled context.
 			safeSendProgress(cfg.ProgressCh, types.DownloadEvent{
 				Type:         types.EventComplete,
 				DownloadID:   cfg.ID,
@@ -296,15 +298,14 @@ func RunDownload(ctx context.Context, cfg *types.DownloadRecord) error {
 				AvgSpeed:     avgSpeed,
 				RateLimit:    rateLimit,
 				RateLimitSet: rateLimitSet,
-			}, ctx.Done())
+			}, nil)
 		}
-	} else if downloadErr != nil && !isPaused {
-		// Verify it's not a cancellation error
-		if errors.Is(downloadErr, context.Canceled) || errors.Is(downloadErr, context.DeadlineExceeded) {
-			utils.Debug("Download canceled cleanly")
-			return downloadErr
-		}
-		// EventError is emitted by the scheduler's worker() after all retries are exhausted.
+		return nil
+	}
+
+	if errors.Is(downloadErr, context.Canceled) || errors.Is(downloadErr, context.DeadlineExceeded) {
+		utils.Debug("Download canceled cleanly")
+		return downloadErr
 	}
 
 	return downloadErr

--- a/internal/scheduler/manager_test.go
+++ b/internal/scheduler/manager_test.go
@@ -733,3 +733,46 @@ func TestSendPausedFallbackWaitsForFullChannel(t *testing.T) {
 	default:
 	}
 }
+
+func TestSafeSendProgress_CompleteTerminalReliableAgainstCanceledContext(t *testing.T) {
+	ch := make(chan types.DownloadEvent, 1)
+	// Fill buffer with 1 item so channel is full
+	ch <- types.DownloadEvent{Type: types.EventStarted}
+
+	completeEvent := types.DownloadEvent{
+		Type:       types.EventComplete,
+		DownloadID: "test-id",
+	}
+
+	sent := make(chan struct{})
+	go func() {
+		// Terminal-reliable send passes nil for doneCh
+		safeSendProgress(ch, completeEvent, nil)
+		close(sent)
+	}()
+
+	// Verify safeSendProgress does not immediately discard the event
+	select {
+	case <-sent:
+		t.Fatal("expected safeSendProgress to wait for channel buffer, but returned immediately")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Drain initial event to free channel buffer
+	first := <-ch
+	if first.Type != types.EventStarted {
+		t.Fatalf("expected EventStarted, got %v", first.Type)
+	}
+
+	// Wait for safeSendProgress to finish delivering EventComplete
+	select {
+	case <-sent:
+	case <-time.After(1 * time.Second):
+		t.Fatal("timed out waiting for safeSendProgress to deliver event")
+	}
+
+	second := <-ch
+	if second.Type != types.EventComplete {
+		t.Fatalf("expected EventComplete, got %v", second.Type)
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -839,9 +839,9 @@ func sendPausedFallback(ch chan<- types.DownloadEvent, cfg *types.DownloadRecord
 		downloaded = state.Bytes.Downloaded.Load()
 		rateLimit, rateLimitSet = state.GetRateLimit()
 	}
-	// A nil error and no pending snapshot means the concurrent downloader
-	// already queued EventPaused and consumed the delivery handshake.
-	if runErr == nil && pending == nil {
+	// A nil error (or typed ErrPaused) and no pending snapshot means the
+	// concurrent downloader already queued EventPaused and consumed the delivery handshake.
+	if (runErr == nil || errors.Is(runErr, types.ErrPaused)) && pending == nil {
 		return
 	}
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -268,6 +268,10 @@ func (p *Scheduler) GetAll() []types.DownloadRecord {
 func (p *Scheduler) Pause(downloadID string) bool {
 	p.mu.RLock()
 	ad, exists := p.downloads[downloadID]
+	var configTotal int64
+	if exists && ad != nil {
+		configTotal = ad.config.TotalSize
+	}
 	p.mu.RUnlock()
 
 	if !exists || ad == nil {
@@ -276,19 +280,33 @@ func (p *Scheduler) Pause(downloadID string) bool {
 
 	// Set paused flag and cancel context
 	if ad.config.ProgressState != nil {
+		prog := progress.CfgProgress(&ad.config)
+
+		// Completion boundary guard: if done or verified progress reached positive total, no-op return true.
+		if prog.Done.Load() {
+			return true
+		}
+		total := prog.Bytes.TotalSize.Load()
+		if total <= 0 {
+			total = configTotal
+		}
+		if total > 0 && prog.Bytes.VerifiedProgress.Load() >= total {
+			return true
+		}
+
 		// Idempotency: If already paused, do nothing.
-		if progress.CfgProgress(&ad.config).IsPaused() {
+		if prog.IsPaused() {
 			return true
 		}
 		// If transition is already in progress, still ensure worker context is canceled.
-		if progress.CfgProgress(&ad.config).IsPausing() {
+		if prog.IsPausing() {
 			if ad.cancel != nil {
 				ad.cancel()
 			}
 			return true
 		}
-		progress.CfgProgress(&ad.config).SetPausing(true) // Mark as transitioning to pause
-		progress.CfgProgress(&ad.config).Pause()
+		prog.SetPausing(true) // Mark as transitioning to pause
+		prog.Pause()
 	}
 	// Always cancel worker context as a safety net (single downloader does not set state cancel itself).
 	if ad.cancel != nil {
@@ -672,9 +690,10 @@ func (p *Scheduler) worker() {
 		}
 		p.mu.Unlock()
 
-		// Logic:
-		// 1. If Pause() was called: State.IsPaused() is true. We keep the task in p.downloads (so it can be resumed).
-		// 2. If finished/error: We remove from p.downloads.
+		// Outcome priority:
+		// 1. If err == nil (successful download): Clear stale pause, mark Done, remove from downloads.
+		// 2. If paused (ErrPaused or pause requested with cancel): Keep in downloads for potential resume.
+		// 3. If other error: Retry or emit EventError.
 
 		isPaused := localCfg.ProgressState != nil && progress.CfgProgress(&localCfg).IsPaused()
 
@@ -683,10 +702,26 @@ func (p *Scheduler) worker() {
 			progress.CfgProgress(&localCfg).SetPausing(false)
 		}
 
-		if isPaused {
+		// A clean pause outcome only occurs on typed ErrPaused or when a pause was requested
+		// and the download terminated due to context cancellation.
+		isPauseResult := errors.Is(err, types.ErrPaused) || (isPaused && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)))
+
+		if err == nil {
+			// Physical success takes precedence over late-arriving pause signals.
+			// Clear any stale paused flag, mark Done, and remove from tracking maps.
+			if localCfg.ProgressState != nil {
+				prog := progress.CfgProgress(&localCfg)
+				prog.Paused.Store(false)
+				prog.Done.Store(true)
+			}
+			p.mu.Lock()
+			delete(p.downloads, localCfg.ID)
+			delete(p.downloadLimiters, localCfg.ID)
+			p.mu.Unlock()
+		} else if isPauseResult {
 			utils.Debug("Scheduler: Download %s paused cleanly", localCfg.ID)
 			sendPausedFallback(localCfg.ProgressCh, &localCfg, err, p.progressDone)
-		} else if err != nil {
+		} else {
 			p.mu.Lock()
 			delete(p.downloads, localCfg.ID)
 
@@ -784,18 +819,6 @@ func (p *Scheduler) worker() {
 			if errEvent != nil {
 				safeSendProgress(localCfg.ProgressCh, *errEvent, p.progressDone)
 			}
-		} else {
-			// Only mark as done if not paused
-			if localCfg.ProgressState != nil {
-				progress.CfgProgress(&localCfg).Done.Store(true)
-			}
-			// Note: DownloadCompleteMsg is sent by the progress reporter when it detects Done=true
-
-			// Clean up from tracking
-			p.mu.Lock()
-			delete(p.downloads, localCfg.ID)
-			delete(p.downloadLimiters, localCfg.ID)
-			p.mu.Unlock()
 		}
 		// If paused, we keep it in downloads map for potential resume
 		p.wg.Done()

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"testing"
 	"testing/synctest"
@@ -1079,5 +1080,253 @@ func TestWorker_SkipsRetriesOnPermanentError(t *testing.T) {
 
 	if errorCount != 1 {
 		t.Errorf("expected exactly 1 EventError for permanent failure, got %d", errorCount)
+	}
+}
+
+func TestScheduler_PauseAtVerified_EndgameMatrix(t *testing.T) {
+	tests := []struct {
+		name         string
+		done         bool
+		totalSize    int64
+		liveTotal    int64
+		vp           int64
+		wantReturn   bool
+		wantCanceled bool
+		wantPaused   bool
+		wantPausing  bool
+	}{
+		{
+			name:         "Done is true: no-op guard",
+			done:         true,
+			totalSize:    1000,
+			liveTotal:    1000,
+			vp:           500,
+			wantReturn:   true,
+			wantCanceled: false,
+			wantPaused:   false,
+			wantPausing:  false,
+		},
+		{
+			name:         "Live total known and VP >= total: no-op guard",
+			done:         false,
+			totalSize:    1000,
+			liveTotal:    1000,
+			vp:           1000,
+			wantReturn:   true,
+			wantCanceled: false,
+			wantPaused:   false,
+			wantPausing:  false,
+		},
+		{
+			name:         "VP < total: normal pause proceeds",
+			done:         false,
+			totalSize:    1000,
+			liveTotal:    1000,
+			vp:           900,
+			wantReturn:   true,
+			wantCanceled: true,
+			wantPaused:   true,
+			wantPausing:  true,
+		},
+		{
+			name:         "Total unknown: arbitrary VP must not be treated as complete",
+			done:         false,
+			totalSize:    0,
+			liveTotal:    0,
+			vp:           5000,
+			wantReturn:   true,
+			wantCanceled: true,
+			wantPaused:   true,
+			wantPausing:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			progState := progress.New("guard-test", tc.totalSize)
+			if tc.done {
+				progState.Done.Store(true)
+			}
+			if tc.liveTotal > 0 {
+				progState.Bytes.TotalSize.Store(tc.liveTotal)
+			}
+			if tc.vp > 0 {
+				progState.Bytes.VerifiedProgress.Store(tc.vp)
+			}
+
+			canceled := false
+			pool := New(make(chan types.DownloadEvent, 10), 1)
+			t.Cleanup(func() { pool.GracefulShutdown() })
+
+			pool.mu.Lock()
+			pool.downloads["guard-test"] = &activeDownload{
+				config: types.DownloadRecord{
+					ID:            "guard-test",
+					TotalSize:     tc.totalSize,
+					ProgressState: progState,
+				},
+				cancel: func() {
+					canceled = true
+				},
+			}
+			pool.mu.Unlock()
+
+			res := pool.Pause("guard-test")
+			if res != tc.wantReturn {
+				t.Errorf("Pause() = %v, want %v", res, tc.wantReturn)
+			}
+			if canceled != tc.wantCanceled {
+				t.Errorf("canceled = %v, want %v", canceled, tc.wantCanceled)
+			}
+			if progState.IsPaused() != tc.wantPaused {
+				t.Errorf("IsPaused() = %v, want %v", progState.IsPaused(), tc.wantPaused)
+			}
+			if progState.IsPausing() != tc.wantPausing {
+				t.Errorf("IsPausing() = %v, want %v", progState.IsPausing(), tc.wantPausing)
+			}
+		})
+	}
+}
+
+func TestScheduler_WorkerEndgameSuccessClearsPause(t *testing.T) {
+	ch := make(chan types.DownloadEvent, 16)
+	pool := New(ch, 1)
+	t.Cleanup(func() { pool.GracefulShutdown() })
+
+	body := []byte("worker endgame success")
+	server := testutil.NewHTTPServerT(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		_, _ = w.Write(body)
+	}))
+	defer server.Close()
+
+	id := "test-endgame-success"
+	state := progress.New(id, int64(len(body)))
+	// Simulate late Pause arriving right as physical download completes
+	state.SetPausing(true)
+	state.Paused.Store(true)
+
+	tmpDir := t.TempDir()
+	destPath := filepath.Join(tmpDir, "endgame.bin")
+	if f, err := os.Create(destPath + types.IncompleteSuffix); err == nil {
+		_ = f.Close()
+	}
+
+	pool.Add(types.DownloadRecord{
+		ID:            id,
+		URL:           server.URL,
+		OutputPath:    tmpDir,
+		Filename:      "endgame.bin",
+		DestPath:      destPath,
+		ProgressState: state,
+		ProgressCh:    ch,
+		Runtime:       types.DefaultRuntimeConfig(),
+		TotalSize:     int64(len(body)),
+		SupportsRange: false,
+	})
+
+	// Deterministic wait for worker to complete via WaitGroup
+	done := make(chan struct{})
+	go func() {
+		pool.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for worker completion")
+	}
+
+	if !state.Done.Load() {
+		t.Error("expected state.Done to be true on successful endgame completion")
+	}
+	if state.IsPaused() {
+		t.Error("expected stale Paused flag to be cleared on successful endgame completion")
+	}
+	if state.IsPausing() {
+		t.Error("expected Pausing flag to be cleared on successful endgame completion")
+	}
+
+	// Verify EventComplete received and download removed from active pool
+	pool.mu.RLock()
+	_, inDownloads := pool.downloads[id]
+	pool.mu.RUnlock()
+	if inDownloads {
+		t.Error("completed download must be removed from pool.downloads")
+	}
+
+	var completeReceived bool
+	for len(ch) > 0 {
+		msg := <-ch
+		if msg.Type == types.EventError {
+			t.Fatalf("unexpected EventError: %+v", msg)
+		}
+		if msg.Type == types.EventPaused {
+			t.Fatalf("unexpected EventPaused when physical download completed: %+v", msg)
+		}
+		if msg.Type == types.EventComplete {
+			completeReceived = true
+		}
+	}
+	if !completeReceived {
+		t.Error("expected EventComplete to be emitted")
+	}
+}
+
+func TestScheduler_WorkerRealErrorWithPauseFlagDoesNotSwallowError(t *testing.T) {
+	ch := make(chan types.DownloadEvent, 16)
+	pool := New(ch, 1)
+	t.Cleanup(func() { pool.GracefulShutdown() })
+
+	server := testutil.NewHTTPServerT(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	id := "test-error-not-swallowed"
+	state := progress.New(id, 0)
+	// Simulate isPaused == true when worker finishes with a real error
+	state.Paused.Store(true)
+
+	pool.Add(types.DownloadRecord{
+		ID:            id,
+		URL:           server.URL,
+		ProgressState: state,
+		ProgressCh:    ch,
+		Runtime:       types.DefaultRuntimeConfig(),
+	})
+
+	// Deterministic wait for worker to complete via WaitGroup
+	done := make(chan struct{})
+	go func() {
+		pool.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for worker completion")
+	}
+
+	// Drain events: must receive EventError, must NOT receive EventPaused
+	var errorReceived bool
+	for len(ch) > 0 {
+		msg := <-ch
+		if msg.Type == types.EventPaused {
+			t.Fatalf("real error must not be swallowed into EventPaused: %+v", msg)
+		}
+		if msg.Type == types.EventError {
+			errorReceived = true
+		}
+	}
+	if !errorReceived {
+		t.Error("expected EventError to be emitted for real error despite isPaused=true")
+	}
+
+	pool.mu.RLock()
+	_, inDownloads := pool.downloads[id]
+	pool.mu.RUnlock()
+	if inDownloads {
+		t.Error("failed download must not be retained in pool.downloads")
 	}
 }


### PR DESCRIPTION
Patch for handling concurrency races between download completion, error, and pause in the scheduler state machine, preventing completed tasks from getting stuck as paused or silently swallowing real errors.

While testing the verified progress branch (PR #633), an edge case popped into mind: what happens if the frontend looks like it's almost done, the backend has already finished downloading, but before the completion event syncs over, someone clicks pause? Turns out the current logic ends up swallowing the completion state entirely—the file is fully downloaded on disk, but the scheduler misclassifies it as paused, leaving it permanently stuck in the active pool.

Digging a bit deeper, we found a few similar state machine gaps around here: real errors get swallowed as normal pauses when a pause happens concurrently (so no retries or error events), the final `EventComplete` can get dropped if the context is canceled, and there's a data race when `Pause()` reads `TotalSize`.

(Generated by AI for state transition matrix)

| Overlapping States | Realistic Scenario | Current Behavior & Consequence |
| :--- | :--- | :--- |
| **Complete + Pause** | User reflexively clicks pause right as the bar hits 100%, or a batch-pause script overlaps with the download finishing | The `!isPaused` gate suppresses completion; the file is fully downloaded, but the task gets permanently stuck as paused |
| **Error + Pause** | A download hits a 403, network drop, or disk write failure, and the user happens to click pause (or pauses all) at that exact moment | `isPaused` masks the error; real failures get treated as clean pauses, so no retries happen and no error is reported |
| **Complete + Cancel** | The download finishes and emits completion right as the context is canceled, while the event channel has slight backpressure under load | The terminal `EventComplete` gets randomly dropped by the non-blocking select due to the canceled context |
| **Pause + Worker Exit** | `Pause()` is called concurrently while the worker is exiting and updating config metadata | Reading `TotalSize` outside the lock races with the worker write |

Our fix here is: let physical success (`downloadErr == nil`) take final precedence so a completed download always finalizes, tighten the worker pause check to only match clean context cancellations or typed `ErrPaused` so real errors can still surface and retry, pass `nil` as the done channel for `EventComplete` so it doesn't get dropped by a canceled context, and snapshot `TotalSize` under lock to eliminate the race.

*(P.S. Completely independent of PR #633. Added `if total > 0 && prog.Bytes.VerifiedProgress.Load() >= total` mainly for forward compatibility once #633 lands.)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved download pause handling so completed downloads are not paused at the completion boundary.
  - Distinguished clean pauses from successful completions and other errors.
  - Ensured successfully finished downloads are consistently marked complete after a previous pause request.
  - Preserved relevant errors during cancellation and deadline handling.
  - Improved reliability of completion event delivery when progress channels are busy or cancellation occurs.
  - Prevented duplicate paused notifications in applicable pause scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->